### PR TITLE
docs(readme): point doc links to docs.cognee.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ to be a drop-in companion to the Python [`cognee`](https://github.com/topoterete
 
 
 <p align="center">
-  <a href="docs/getting-started.md">Getting Started</a>
+  <a href="https://docs.cognee.ai/rust/getting-started">Getting Started</a>
   ·
-  <a href="docs/README.md">Docs</a>
+  <a href="https://docs.cognee.ai">Docs</a>
   ·
-  <a href="docs/architecture.md">Architecture</a>
+  <a href="https://docs.cognee.ai/rust/architecture">Architecture</a>
   ·
   <a href="https://github.com/topoteretes/cognee">Python cognee</a>
 </p>
@@ -256,4 +256,4 @@ Cognee writes structured logs to **stdout** and (when a writable directory is
 available) to a rotating file, owned by the [`cognee-logging`](crates/logging/)
 crate (`cognee_logging::init_logging`, called by the CLI and HTTP server). The
 full env-var table (`COGNEE_LOG_*`, `RUST_LOG`/`LOG_LEVEL`, `LOG_FILE_NAME`) is
-documented in [`docs/configuration.md` → Logging](docs/configuration.md#logging).
+documented in [Configuration → Logging](https://docs.cognee.ai/rust/configuration#logging).


### PR DESCRIPTION
## Summary

The Rust docs are now published on the core docs site (`docs.cognee.ai/rust/*`). This repoints the README's documentation links from the in-repo `docs/*.md` files to the hosted pages.

### Changes
- Header nav: **Getting Started** → `docs.cognee.ai/rust/getting-started`, **Docs** → `docs.cognee.ai`, **Architecture** → `docs.cognee.ai/rust/architecture`.
- **Configuration → Logging** link → `docs.cognee.ai/rust/configuration#logging`.

### Left as a repo link
- The OpenTelemetry observability guide (`docs/observability/opentelemetry.md`) was **not** part of the migrated public subset, so its link stays repo-relative (valid on GitHub). The per-binding READMEs (`python/`, `capi/`, `ts/`) also remain repo links since they point at in-repo READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)