### PR TITLE
ci(release-plz): disable semver_check to stop the release-pr hang

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -26,6 +26,15 @@ dependencies_update = true
 # only open the release PR without publishing — useful for dry-run setups.)
 publish = true
 
+# Disable cargo-semver-checks. To detect API breaks it builds rustdoc for every
+# crate against its published baseline, which compiles the full native stack
+# (lbug's bundled C++ via cmake, ONNX runtime, protobuf) twice with no cache —
+# that made the `release-pr` job hang for 40-65+ min and stall the workflow
+# (see git history / the post-0.1.0 release-plz incident). It adds little value
+# pre-1.0 (any change can be breaking), so we skip it. Re-enable per-crate once
+# the API stabilizes and the heavy build is cached.
+semver_check = false
+
 # Single, top-level CHANGELOG.md. release-plz appends a section per release.
 # Switch to per-crate changelogs (`changelog_path` inside a `[[package]]`
 # block) only if a crate's history starts to drown out the others.


### PR DESCRIPTION
## Problem
After the first `0.1.0` crates.io publish, the **release-plz `release-pr` job started hanging for 40–65+ minutes** and stalling the workflow. Diagnosis (orphan processes captured at cancellation + run timeline):

- The `release-pr` step runs **`cargo-semver-checks`**, which builds rustdoc for every crate against its published baseline — compiling the **full native stack twice** (lbug's bundled C++ via `cmake`, ONNX runtime, protobuf), uncached.
- Before `0.1.0` was on crates.io there was no baseline, so runs finished in ~50s. After publish, every run does the heavy double build.
- Workspace-level `readme = "README.md"` means any root-README edit marks crates as changed, re-triggering it on ordinary doc PRs.
- With `concurrency.cancel-in-progress: false` and **no job timeout**, stuck runs held the lock for GitHub's 6-hour ceiling and queued behind each other (this is what left the v0.1.0 release PR un-reconciled).

## Fix
- `release-plz.toml`: **`semver_check = false`** at `[workspace]`. Pre-1.0 it adds little (any change can be breaking) and is the sole cause of the heavy build. `release-pr` now just diffs files and edits `Cargo.toml`/`CHANGELOG.md` — seconds, no compile.

## Follow-up (needs `workflow` scope — not in this PR)
I also recommend adding `timeout-minutes` to both jobs (20 for `release-plz-pr`, 45 for `release-plz-release`) as a safety net so a future stall can't block the workflow for hours. The push token here lacks the `workflow` scope, so that workflow-file edit is deferred — see the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)