### PR TITLE
fix(ts-sdk): four reported v0.1.1 bugs + cross-dataset dedup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.1.0"
+version = "0.1.1"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 authors = ["Topoteretes <support@cognee.ai>"]

--- a/crates/bindings-common/src/ops/datasets.rs
+++ b/crates/bindings-common/src/ops/datasets.rs
@@ -76,8 +76,13 @@ pub async fn has_data(
     state: &HandleState,
     dataset_id_str: &str,
 ) -> Result<serde_json::Value, SdkError> {
-    let dataset_id = Uuid::parse_str(dataset_id_str)
-        .map_err(|e| SdkError::Validation(format!("invalid dataset id UUID: {e}")))?;
+    let dataset_id = match Uuid::parse_str(dataset_id_str) {
+        Ok(id) => id,
+        // An unparseable id can never match a real dataset (all dataset ids are
+        // UUIDs), so it is simply "not present" → false. This matches the
+        // documented contract above and parity with an unknown-but-valid UUID.
+        Err(_) => return Ok(serde_json::Value::Bool(false)),
+    };
     let svc = state.services().await?;
     let owner_id = state.owner_id().await?;
 

--- a/crates/search/src/orchestration/dataset_scope.rs
+++ b/crates/search/src/orchestration/dataset_scope.rs
@@ -14,13 +14,35 @@ pub fn scope_context_by_datasets(
         .collect();
 
     for item in context {
-        if let Some(dataset_id) = item
+        // A content-addressed point can belong to several datasets; its full
+        // membership lives in the `dataset_ids` array (unioned on upsert). When
+        // present it is authoritative — assign the item to every requested
+        // dataset it belongs to. Fall back to the scalar `dataset_id` only for
+        // points written before the array existed (back-compat).
+        let member_ids: Option<Vec<&str>> = item
             .payload
-            .get("dataset_id")
-            .and_then(|value| value.as_str())
-            && let Some(scoped_items) = scoped_contexts.get_mut(dataset_id)
-        {
-            scoped_items.push(item.clone());
+            .get("dataset_ids")
+            .and_then(|value| value.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect());
+
+        match member_ids {
+            Some(ids) => {
+                for dataset_id in ids {
+                    if let Some(scoped_items) = scoped_contexts.get_mut(dataset_id) {
+                        scoped_items.push(item.clone());
+                    }
+                }
+            }
+            None => {
+                if let Some(dataset_id) = item
+                    .payload
+                    .get("dataset_id")
+                    .and_then(|value| value.as_str())
+                    && let Some(scoped_items) = scoped_contexts.get_mut(dataset_id)
+                {
+                    scoped_items.push(item.clone());
+                }
+            }
         }
     }
 
@@ -86,6 +108,38 @@ mod tests {
         assert_eq!(scoped.get(&dataset_b.to_string()).unwrap().len(), 1);
         assert_eq!(scoped[&dataset_a.to_string()][0].payload["text"], "A1");
         assert_eq!(scoped[&dataset_b.to_string()][0].payload["text"], "B1");
+    }
+
+    #[test]
+    fn scopes_shared_point_to_all_member_datasets() {
+        // A content-addressed point that belongs to two datasets (its
+        // `dataset_ids` union array lists both) must be assigned to BOTH scopes,
+        // not just one. Regression test for the cross-dataset dedup bug.
+        let dataset_a = Uuid::new_v4();
+        let dataset_b = Uuid::new_v4();
+
+        let context = vec![SearchItem {
+            id: Some(Uuid::new_v4()),
+            score: Some(0.9),
+            payload: json!({
+                "dataset_ids": [dataset_a.to_string(), dataset_b.to_string()],
+                "dataset_id": dataset_b.to_string(),
+                "text": "shared across A and B",
+            }),
+        }];
+
+        let scoped = super::scope_context_by_datasets(&context, &[dataset_a, dataset_b]);
+
+        assert_eq!(
+            scoped.get(&dataset_a.to_string()).unwrap().len(),
+            1,
+            "shared point must be retrievable when scoped to dataset A"
+        );
+        assert_eq!(
+            scoped.get(&dataset_b.to_string()).unwrap().len(),
+            1,
+            "shared point must be retrievable when scoped to dataset B"
+        );
     }
 
     #[test]

--- a/crates/vector/src/brute_force_vector_db.rs
+++ b/crates/vector/src/brute_force_vector_db.rs
@@ -133,10 +133,14 @@ impl VectorDB for BruteForceVectorDB {
             }
         }
 
-        // Upsert by id: replace existing, otherwise append.
+        // Upsert by id: replace existing, otherwise append. On replace, union
+        // dataset membership so a content-addressed point indexed under several
+        // datasets stays retrievable for all of them (cross-dataset dedup).
         for p in points {
             if let Some(existing) = coll.points.iter_mut().find(|x| x.id == p.id) {
-                *existing = p.clone();
+                let mut merged = p.clone();
+                merged.merge_dataset_membership(existing);
+                *existing = merged;
             } else {
                 coll.points.push(p.clone());
             }

--- a/crates/vector/src/lancedb_adapter.rs
+++ b/crates/vector/src/lancedb_adapter.rs
@@ -115,6 +115,40 @@ fn points_to_batch(
     .map_err(|e| VectorDBError::StorageError(format!("record batch build: {e}")))
 }
 
+/// Decode `id` + `metadata` columns from plain (non-vector-search) query
+/// batches into a map. Unlike [`search_results_from_batches`] this does not
+/// expect a `_distance` column, so it works for `query().only_if(..)` reads.
+/// Used to recover existing dataset membership before an upsert.
+fn id_metadata_from_batches(
+    batches: Vec<RecordBatch>,
+) -> VectorDBResult<HashMap<Uuid, HashMap<String, serde_json::Value>>> {
+    let mut out = HashMap::new();
+    for batch in batches {
+        let id_col = batch
+            .column_by_name("id")
+            .ok_or_else(|| VectorDBError::StorageError("missing id column".to_string()))?
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .ok_or_else(|| VectorDBError::StorageError("id column type mismatch".to_string()))?;
+        let metadata_col = batch
+            .column_by_name("metadata")
+            .ok_or_else(|| VectorDBError::StorageError("missing metadata column".to_string()))?
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| {
+                VectorDBError::StorageError("metadata column type mismatch".to_string())
+            })?;
+        for row in 0..batch.num_rows() {
+            let id = Uuid::from_slice(id_col.value(row))
+                .map_err(|e| VectorDBError::StorageError(format!("id is not a valid UUID: {e}")))?;
+            let metadata: HashMap<String, serde_json::Value> =
+                serde_json::from_str(metadata_col.value(row))?;
+            out.insert(id, metadata);
+        }
+    }
+    Ok(out)
+}
+
 fn search_results_from_batches(batches: Vec<RecordBatch>) -> VectorDBResult<Vec<SearchResult>> {
     let mut out = Vec::new();
     for batch in batches {
@@ -273,7 +307,6 @@ impl VectorDB for LanceDbAdapter {
         let name = collection_name(data_type, field_name);
         let dimension = self.resolved_dimension(&name).await?;
         let schema = build_schema(dimension);
-        let batch = points_to_batch(schema.clone(), dimension, &name, points)?;
         let table = self
             .connection
             .open_table(&name)
@@ -290,8 +323,43 @@ impl VectorDB for LanceDbAdapter {
                 format!("X'{hex}'")
             })
             .collect();
+        let predicate = format!("id IN ({})", id_values.join(", "));
+
+        // Read the membership of any existing rows we're about to replace, then
+        // union it into the incoming points. Point IDs are content-addressed, so
+        // the same point is re-indexed once per dataset; a plain delete+add
+        // would otherwise drop earlier datasets' `dataset_id` (cross-dataset
+        // dedup bug). Mirrors the in-memory adapters and Python's union upsert.
+        let existing = if id_values.is_empty() {
+            HashMap::new()
+        } else {
+            let stream = table
+                .query()
+                .only_if(predicate.clone())
+                .execute()
+                .await
+                .map_err(map_lance_err)?;
+            let batches: Vec<RecordBatch> = stream.try_collect().await.map_err(map_lance_err)?;
+            id_metadata_from_batches(batches)?
+        };
+        let merged_points: Vec<VectorPoint> = points
+            .iter()
+            .map(|p| {
+                let mut np = p.clone();
+                if let Some(prev_meta) = existing.get(&p.id) {
+                    let prev = VectorPoint {
+                        id: p.id,
+                        vector: Vec::new(),
+                        metadata: prev_meta.clone(),
+                    };
+                    np.merge_dataset_membership(&prev);
+                }
+                np
+            })
+            .collect();
+        let batch = points_to_batch(schema.clone(), dimension, &name, &merged_points)?;
+
         if !id_values.is_empty() {
-            let predicate = format!("id IN ({})", id_values.join(", "));
             table
                 .delete(predicate.as_str())
                 .await
@@ -476,6 +544,65 @@ mod tests {
         assert_eq!(results[0].metadata.get("kind").unwrap(), &json!("target"));
         // Cosine distance from target to itself ~= 0 → score ~= 1.
         assert!(results[0].score > 0.99);
+    }
+
+    #[tokio::test]
+    async fn upsert_unions_dataset_membership_across_datasets() {
+        // Regression for the cross-dataset dedup bug: re-indexing the same
+        // content-addressed id under a second dataset must not drop the first
+        // dataset's membership. After A then B, `dataset_ids` must hold both.
+        let (adapter, _dir) = fresh_adapter().await;
+        adapter
+            .create_collection("DocumentChunk", "text", 3)
+            .await
+            .unwrap();
+
+        let content_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, b"shared content");
+        let dataset_a = Uuid::new_v4();
+        let dataset_b = Uuid::new_v4();
+        let vector = vec![1.0, 0.0, 0.0];
+
+        let p_a = VectorPoint::new(content_id, vector.clone())
+            .with_metadata("dataset_id", json!(dataset_a.to_string()));
+        let p_b = VectorPoint::new(content_id, vector.clone())
+            .with_metadata("dataset_id", json!(dataset_b.to_string()));
+
+        adapter
+            .index_points("DocumentChunk", "text", &[p_a])
+            .await
+            .unwrap();
+        adapter
+            .index_points("DocumentChunk", "text", &[p_b])
+            .await
+            .unwrap();
+
+        // One physical row (content-addressed dedup) ...
+        assert_eq!(
+            adapter
+                .collection_size("DocumentChunk", "text")
+                .await
+                .unwrap(),
+            1
+        );
+        // ... carrying membership in BOTH datasets.
+        let results = adapter
+            .search_similar("DocumentChunk", "text", &vector, 5)
+            .await
+            .unwrap();
+        let members: Vec<String> = results[0]
+            .metadata
+            .get(crate::DATASET_IDS_KEY)
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(
+            members.contains(&dataset_a.to_string()) && members.contains(&dataset_b.to_string()),
+            "expected both datasets in membership, got {members:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/vector/src/lib.rs
+++ b/crates/vector/src/lib.rs
@@ -27,7 +27,9 @@ pub mod mock_vector_db;
 
 pub use brute_force_vector_db::BruteForceVectorDB;
 pub use error::{VectorDBError, VectorDBResult};
-pub use models::{CollectionConfig, DistanceMetric, SearchResult, VectorPoint};
+pub use models::{
+    CollectionConfig, DATASET_ID_KEY, DATASET_IDS_KEY, DistanceMetric, SearchResult, VectorPoint,
+};
 pub use vector_db_trait::VectorDB;
 
 #[cfg(feature = "pgvector")]

--- a/crates/vector/src/mock_vector_db.rs
+++ b/crates/vector/src/mock_vector_db.rs
@@ -198,10 +198,15 @@ impl VectorDB for MockVectorDB {
             }
         }
 
-        // Upsert points (replace if ID exists, otherwise append)
+        // Upsert points (replace if ID exists, otherwise append). On replace,
+        // union dataset membership so a content-addressed point indexed under
+        // several datasets stays retrievable for all of them (cross-dataset
+        // dedup parity with the brute-force / production adapters).
         for new_point in points {
             if let Some(existing) = collection.points.iter_mut().find(|p| p.id == new_point.id) {
-                *existing = new_point.clone();
+                let mut merged = new_point.clone();
+                merged.merge_dataset_membership(existing);
+                *existing = merged;
             } else {
                 collection.points.push(new_point.clone());
             }

--- a/crates/vector/src/models.rs
+++ b/crates/vector/src/models.rs
@@ -67,4 +67,65 @@ impl VectorPoint {
         self.metadata.insert(key.into(), value);
         self
     }
+
+    /// Accumulate the dataset membership recorded on a `previous` point (an
+    /// existing point with the same id) into `self`'s [`DATASET_IDS_KEY`] array.
+    ///
+    /// Point IDs are content-addressed (UUID v5 of the content), so the *same*
+    /// point is indexed once per dataset that contains that content. Vector
+    /// adapters upsert by id with full replacement, so a plain replace keeps
+    /// only the last dataset's scalar `dataset_id` and silently drops the
+    /// earlier datasets' membership — making the content unretrievable when a
+    /// search is scoped to one of those earlier datasets (the cross-dataset
+    /// dedup bug). Calling this in `index_points` upsert paths before replacing
+    /// an existing point keeps `dataset_ids` as the union of every dataset the
+    /// content belongs to, mirroring Python's `belongs_to_set` union semantics.
+    pub fn merge_dataset_membership(&mut self, previous: &VectorPoint) {
+        let mut ids: Vec<String> = Vec::new();
+        // `previous` first so membership order is stable (oldest dataset first).
+        collect_dataset_ids(previous, &mut ids);
+        collect_dataset_ids(self, &mut ids);
+        if !ids.is_empty() {
+            self.metadata.insert(
+                DATASET_IDS_KEY.to_string(),
+                serde_json::Value::Array(ids.into_iter().map(serde_json::Value::String).collect()),
+            );
+        }
+    }
+}
+
+/// Metadata key holding the array of dataset-ID strings a point belongs to.
+/// This is the union accumulated across every dataset the content-addressed
+/// point has been indexed under (see [`VectorPoint::merge_dataset_membership`]).
+pub const DATASET_IDS_KEY: &str = "dataset_ids";
+
+/// Scalar metadata key written by the cognify indexer for the single dataset
+/// currently being indexed. Retained for back-compat; the authoritative
+/// membership is the union in [`DATASET_IDS_KEY`].
+pub const DATASET_ID_KEY: &str = "dataset_id";
+
+/// Append every dataset-ID string recorded on `point` (from both the
+/// [`DATASET_IDS_KEY`] array and the scalar [`DATASET_ID_KEY`]) into `out`,
+/// skipping empties and duplicates.
+fn collect_dataset_ids(point: &VectorPoint, out: &mut Vec<String>) {
+    if let Some(arr) = point
+        .metadata
+        .get(DATASET_IDS_KEY)
+        .and_then(|v| v.as_array())
+    {
+        for v in arr {
+            if let Some(s) = v.as_str()
+                && !s.is_empty()
+                && !out.iter().any(|x| x == s)
+            {
+                out.push(s.to_string());
+            }
+        }
+    }
+    if let Some(s) = point.metadata.get(DATASET_ID_KEY).and_then(|v| v.as_str())
+        && !s.is_empty()
+        && !out.iter().any(|x| x == s)
+    {
+        out.push(s.to_string());
+    }
 }

--- a/crates/vector/src/pgvector_adapter.rs
+++ b/crates/vector/src/pgvector_adapter.rs
@@ -146,6 +146,48 @@ impl PgVectorAdapter {
             .join(",");
         format!("[{inner}]")
     }
+
+    /// Fetch the current `metadata` JSONB for the given points (by id) from
+    /// `coll`, keyed by id. Used to union dataset membership before an upsert so
+    /// re-indexing a content-addressed point under a new dataset does not drop
+    /// the datasets it already belonged to.
+    async fn fetch_metadata(
+        &self,
+        coll: &str,
+        points: &[VectorPoint],
+    ) -> VectorDBResult<HashMap<Uuid, HashMap<String, serde_json::Value>>> {
+        let mut out: HashMap<Uuid, HashMap<String, serde_json::Value>> = HashMap::new();
+        if points.is_empty() {
+            return Ok(out);
+        }
+        let placeholders: Vec<String> = (1..=points.len()).map(|i| format!("${i}::uuid")).collect();
+        let sql = format!(
+            r#"SELECT id, metadata FROM "{coll}" WHERE id IN ({})"#,
+            placeholders.join(", ")
+        );
+        let values: Vec<sea_orm::Value> = points.iter().map(|p| p.id.into()).collect();
+        let rows = self
+            .db
+            .query_all(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                &sql,
+                values,
+            ))
+            .await
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        for row in &rows {
+            let id: Uuid = row
+                .try_get("", "id")
+                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+            let metadata_val: serde_json::Value = row
+                .try_get("", "metadata")
+                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+            if let serde_json::Value::Object(map) = metadata_val {
+                out.insert(id, map.into_iter().collect());
+            }
+        }
+        Ok(out)
+    }
 }
 
 #[async_trait]
@@ -274,6 +316,14 @@ impl VectorDB for PgVectorAdapter {
 
         // Batch upsert in chunks to stay within parameter limits.
         for chunk in points.chunks(BATCH_SIZE) {
+            // Point IDs are content-addressed, so the same point is re-indexed
+            // once per dataset. A plain `metadata = EXCLUDED.metadata` overwrite
+            // would drop earlier datasets' `dataset_id` (cross-dataset dedup
+            // bug). Read the existing rows' membership and union it into the
+            // incoming points before upserting, mirroring the in-memory /
+            // lancedb adapters and Python's union semantics.
+            let existing = self.fetch_metadata(&coll, chunk).await?;
+
             let mut sql = format!(r#"INSERT INTO "{coll}" (id, vector, metadata) VALUES "#);
             let mut values: Vec<sea_orm::Value> = Vec::with_capacity(chunk.len() * 3);
             let mut idx = 1u32;
@@ -290,10 +340,21 @@ impl VectorDB for PgVectorAdapter {
                 ));
                 idx += 3;
 
+                let mut merged = pt.clone();
+                if let Some(prev_meta) = existing.get(&pt.id) {
+                    let prev = VectorPoint {
+                        id: pt.id,
+                        vector: Vec::new(),
+                        metadata: prev_meta.clone(),
+                    };
+                    merged.merge_dataset_membership(&prev);
+                }
+
                 values.push(pt.id.into());
                 values.push(Self::format_vector(&pt.vector).into());
                 let metadata_obj: serde_json::Value = serde_json::Value::Object(
-                    pt.metadata
+                    merged
+                        .metadata
                         .iter()
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect(),

--- a/crates/vector/tests/cross_dataset_dedup.rs
+++ b/crates/vector/tests/cross_dataset_dedup.rs
@@ -1,0 +1,102 @@
+//! Regression test for the cross-dataset dedup bug.
+//!
+//! Reported (TS SDK v0.1.1): "the same text added to multiple datasets is only
+//! cognified for the first dataset. Subsequent datasets have the item in the
+//! metadata DB but not in the vector store."
+//!
+//! Vector point IDs are content-addressed (UUID v5 of the content), so identical
+//! content produces the *same* point ID across datasets. The cognify indexer
+//! re-embeds and re-`index_points` that shared ID once per dataset, tagging it
+//! with a scalar `dataset_id`. Because every adapter upserts by ID with full
+//! replacement, the second dataset's upsert used to overwrite the first
+//! dataset's `dataset_id`, erasing its membership — so a search scoped to the
+//! first dataset could no longer retrieve the content.
+//!
+//! The fix accumulates membership into a `dataset_ids` union array on upsert.
+//! This test drives the **default** OSS adapter (`BruteForceVectorDB`) the way
+//! the cognify indexer does and asserts the shared point belongs to both
+//! datasets after the second dataset is indexed. It is fully offline (no LLM,
+//! no embedding network).
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+
+use cognee_vector::{BruteForceVectorDB, DATASET_IDS_KEY, VectorDB, VectorPoint};
+use serde_json::json;
+use uuid::Uuid;
+
+/// Build a chunk vector point exactly as `index_data_points` does: a
+/// content-addressed id, the embedding, and the scalar `dataset_id` tag.
+fn chunk_point(content_id: Uuid, dataset_id: Uuid, vector: Vec<f32>) -> VectorPoint {
+    VectorPoint::new(content_id, vector)
+        .with_metadata("field", json!("text"))
+        .with_metadata("text", json!("Goran je CTO u Topoteretes."))
+        .with_metadata("dataset_id", json!(dataset_id.to_string()))
+}
+
+#[tokio::test]
+async fn identical_content_in_two_datasets_keeps_both_memberships() {
+    let db = BruteForceVectorDB::new();
+    db.create_collection("DocumentChunk", "text", 3)
+        .await
+        .expect("create collection");
+
+    // Same text in dataset A and dataset B → identical content-addressed id.
+    let content_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, b"Goran je CTO u Topoteretes.");
+    let dataset_a = Uuid::new_v4();
+    let dataset_b = Uuid::new_v4();
+    let vector = vec![0.1, 0.2, 0.3];
+
+    // Cognify dataset A, then dataset B (B's upsert hits the same id).
+    db.index_points(
+        "DocumentChunk",
+        "text",
+        &[chunk_point(content_id, dataset_a, vector.clone())],
+    )
+    .await
+    .expect("index dataset A");
+    db.index_points(
+        "DocumentChunk",
+        "text",
+        &[chunk_point(content_id, dataset_b, vector.clone())],
+    )
+    .await
+    .expect("index dataset B");
+
+    // Exactly one physical point (content-addressed dedup is intentional)...
+    assert_eq!(
+        db.collection_size("DocumentChunk", "text").await.unwrap(),
+        1,
+        "content-addressed point should be deduplicated to a single physical row"
+    );
+
+    // ...but it must record membership in BOTH datasets.
+    let results = db
+        .search_similar("DocumentChunk", "text", &vector, 10)
+        .await
+        .expect("search");
+    assert_eq!(results.len(), 1);
+    let members: Vec<String> = results[0]
+        .metadata
+        .get(DATASET_IDS_KEY)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    assert!(
+        members.contains(&dataset_a.to_string()),
+        "dataset A membership was dropped when dataset B was cognified; \
+         dataset_ids = {members:?}"
+    );
+    assert!(
+        members.contains(&dataset_b.to_string()),
+        "dataset B membership missing; dataset_ids = {members:?}"
+    );
+}

--- a/ts/__tests__/repro_config_get.test.ts
+++ b/ts/__tests__/repro_config_get.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Repro for the v0.1.1 bug: high-level `Cognee.config.get()` returns an object
+ * whose documented camelCase fields (`llmModel`, `embeddingProvider`,
+ * `chunkSize`, ...) are all `undefined`.
+ *
+ * Mirrors the user's repro (/tmp/archive_extract/test.mjs section 2). Runs fully
+ * offline: config mutation is in-memory; no warm / LLM / network / model I/O.
+ */
+import { Cognee } from "../src/cognee";
+
+describe("repro: high-level config.get() camelCase read-back", () => {
+  it("returns the values set via the setters, keyed by the camelCase API", () => {
+    const c = new Cognee({ llm_model: "gpt-4o-mini" });
+    c.config.setLlmModel("gpt-4o");
+    c.config.setEmbeddingProvider("openai");
+    c.config.setEmbeddingModel("text-embedding-3-small");
+    c.config.setVectorDbProvider("brute-force");
+    c.config.setChunkSize(512);
+
+    const cfg = c.config.get();
+
+    // Log the raw returned shape so the failure mode is visible in test output.
+    // eslint-disable-next-line no-console
+    console.log("raw config.get() keys:", Object.keys(cfg).slice(0, 12));
+    // eslint-disable-next-line no-console
+    console.log(
+      "camelCase reads:",
+      JSON.stringify({
+        llmModel: cfg.llmModel,
+        embeddingProvider: cfg.embeddingProvider,
+        embeddingModel: cfg.embeddingModel,
+        vectorDbProvider: cfg.vectorDbProvider,
+        chunkSize: cfg.chunkSize,
+      })
+    );
+
+    expect(cfg.llmModel).toBe("gpt-4o");
+    expect(cfg.embeddingProvider).toBe("openai");
+    expect(cfg.embeddingModel).toBe("text-embedding-3-small");
+    expect(cfg.vectorDbProvider).toBe("brute-force");
+    expect(cfg.chunkSize).toBe(512);
+  });
+});

--- a/ts/__tests__/repro_constructor_camelcase.test.ts
+++ b/ts/__tests__/repro_constructor_camelcase.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Repro for the latent constructor bug surfaced while fixing config.get():
+ * `new Cognee({ llmModel: ... })` (camelCase, as documented in the class
+ * docstring and used in the example scripts) was silently ignored, because the
+ * native `cogneeNew` only understood snake_case `Settings` keys.
+ *
+ * Runs fully offline: config is in-memory; no warm / LLM / network.
+ */
+import { Cognee } from "../src/cognee";
+
+describe("repro: Cognee constructor accepts documented camelCase settings", () => {
+  it("applies camelCase keys (readable back via config.get())", () => {
+    const c = new Cognee({
+      llmModel: "gpt-4o-mini",
+      embeddingProvider: "mock",
+      vectorDbProvider: "brute-force",
+      chunkSize: 256,
+      // Public name whose Settings field is `embedding_model_name`.
+      embeddingModel: "text-embedding-3-small",
+    });
+
+    const cfg = c.config.get();
+    expect(cfg.llmModel).toBe("gpt-4o-mini");
+    expect(cfg.embeddingProvider).toBe("mock");
+    expect(cfg.vectorDbProvider).toBe("brute-force");
+    expect(cfg.chunkSize).toBe(256);
+    expect(cfg.embeddingModel).toBe("text-embedding-3-small");
+  });
+
+  it("still accepts raw snake_case keys (back-compat)", () => {
+    const c = new Cognee({ llm_model: "gpt-4o", chunk_size: 512 });
+    const cfg = c.config.get();
+    expect(cfg.llmModel).toBe("gpt-4o");
+    expect(cfg.chunkSize).toBe(512);
+  });
+
+  it("accepts a JSON string of camelCase settings", () => {
+    const c = new Cognee(JSON.stringify({ llmModel: "gpt-4.1", chunkSize: 128 }));
+    const cfg = c.config.get();
+    expect(cfg.llmModel).toBe("gpt-4.1");
+    expect(cfg.chunkSize).toBe(128);
+  });
+});

--- a/ts/__tests__/repro_datasets_has.test.ts
+++ b/ts/__tests__/repro_datasets_has.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Repro for bug: `datasets.has()` throws on a non-UUID string instead of
+ * returning `false`. Offline setup (MOCK_EMBEDDING, dummy key, temp SQLite),
+ * mirroring datasets.test.ts, but via the high-level Cognee class.
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { Cognee } from "../src/cognee";
+
+describe("datasets.has() with a non-UUID id (repro)", () => {
+  let tmpDir: string;
+  let c: Cognee;
+
+  beforeAll(async () => {
+    process.env.MOCK_EMBEDDING = "true";
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cognee-has-repro-"));
+    const dbPath = path.join(tmpDir, "cognee.db");
+    c = new Cognee({
+      system_root_directory: tmpDir,
+      data_root_directory: path.join(tmpDir, "data"),
+      relational_db_url: `sqlite:${dbPath}?mode=rwc`,
+      embedding_provider: "mock",
+      llm_api_key: "test-dummy-key",
+      default_user_email: "has_repro@example.com",
+    });
+    await c.warm();
+  });
+
+  afterAll(() => {
+    delete process.env.MOCK_EMBEDDING;
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  it("returns false for a non-UUID id instead of throwing", async () => {
+    await expect(c.datasets.has("nonexistent-id")).resolves.toBe(false);
+  });
+
+  it("returns false for a valid but unknown UUID", async () => {
+    await expect(
+      c.datasets.has("00000000-0000-0000-0000-000000000001")
+    ).resolves.toBe(false);
+  });
+});

--- a/ts/__tests__/repro_pipeline_addtask.test.ts
+++ b/ts/__tests__/repro_pipeline_addtask.test.ts
@@ -1,0 +1,26 @@
+import { Pipeline, TaskInfo, createTask, CogneeValue } from "../src";
+
+// Repro for the reported v0.1.1 bug: Pipeline.addTask(...) throws a Neon
+// "failed to downcast" error when tasks are added the way the README
+// documents (Appendix: low-level pipeline API):
+//   const task = createTask(fn);
+//   p.addTask(new TaskInfo(task));
+describe("repro: Pipeline.addTask downcast bug (README documented usage)", () => {
+  it("addTask accepts a TaskInfo wrapping a createTask result", () => {
+    const p = new Pipeline("repro-pipeline");
+
+    const task = createTask(
+      (v: CogneeValue) => (typeof v === "string" ? v : String(v)) + " | step-A",
+      { name: "append-step-a" }
+    );
+
+    // The exact failing call the user hit, mirroring ts/README.md.
+    expect(() => p.addTask(new TaskInfo(task))).not.toThrow();
+  });
+
+  it("addTask also accepts a bare createTask result (already a TaskInfo)", () => {
+    const p = new Pipeline("repro-pipeline-2");
+    const task = createTask((v: CogneeValue) => v, { name: "identity" });
+    expect(() => p.addTask(task)).not.toThrow();
+  });
+});

--- a/ts/src/cognee.ts
+++ b/ts/src/cognee.ts
@@ -50,6 +50,63 @@ import { wrapNativeError } from "./errors";
 // `cognee-ts-cloud` package (T15e). The OSS `cognee` package does not
 // expose them.
 
+/** Convert a single `snake_case` key to `camelCase`. */
+function snakeToCamel(key: string): string {
+  return key.replace(/_([a-z0-9])/g, (_m, c: string) => c.toUpperCase());
+}
+
+/**
+ * Rewrite the top-level keys of a config snapshot from `snake_case` (the wire
+ * shape returned by the native `getConfig`) to the documented `camelCase` API
+ * keys (`llm_model` -> `llmModel`, `chunk_size` -> `chunkSize`, ...), so the
+ * object returned by `config.get()` matches `CogneeConfigObject` / the setters.
+ */
+function configToCamel(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    out[snakeToCamel(k)] = v;
+  }
+  // The `setEmbeddingModel` setter writes the Rust `embedding_model_name`
+  // field, so the snapshot surfaces it as `embeddingModelName`. Expose an
+  // `embeddingModel` alias too so the read-back key matches the setter name.
+  if ("embeddingModelName" in out && !("embeddingModel" in out)) {
+    out.embeddingModel = out.embeddingModelName;
+  }
+  return out;
+}
+
+/** Convert a single `camelCase` key to `snake_case`. */
+function camelToSnake(key: string): string {
+  return key.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+}
+
+/**
+ * Public camelCase setting names whose `snake_case` form does NOT match the
+ * native `Settings` field. Keyed by the camelCase name the SDK documents
+ * (matching the `config.set*` setters and `config.get()` read-back); the value
+ * is the actual `Settings` field. Only `embeddingModel` differs (the field is
+ * `embedding_model_name`, mirroring `setEmbeddingModel`).
+ */
+const SETTINGS_KEY_ALIASES: Record<string, string> = {
+  embeddingModel: "embedding_model_name",
+};
+
+/**
+ * Normalize a constructor settings object so the documented camelCase keys
+ * (`llmModel`, `embeddingProvider`, `chunkSize`, ...) reach the native
+ * snake_case `Settings` deserializer. snake_case keys pass through unchanged
+ * (camel→snake is idempotent on them), so both spellings are accepted — fixing
+ * silently-ignored camelCase constructor args.
+ */
+function normalizeSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(settings)) {
+    const key = SETTINGS_KEY_ALIASES[k] ?? camelToSnake(k);
+    out[key] = v;
+  }
+  return out;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Cognee class
 // ─────────────────────────────────────────────────────────────────────────────
@@ -250,7 +307,16 @@ export class Cognee {
   readonly users: CogneeUserObject;
 
   constructor(settings?: object | string) {
-    this._handle = native.cogneeNew(settings);
+    // Accept the documented camelCase setting keys (e.g. `{ llmModel: ... }`)
+    // as well as raw snake_case. The native `cogneeNew` deserializes a
+    // snake_case `Settings`, so camelCase keys would otherwise be silently
+    // ignored. A JSON string is parsed, normalized, and forwarded as an object.
+    let normalized: object | string | undefined = settings;
+    if (settings != null) {
+      const obj = typeof settings === "string" ? JSON.parse(settings) : settings;
+      normalized = normalizeSettings(obj as Record<string, unknown>);
+    }
+    this._handle = native.cogneeNew(normalized);
 
     // ── config sub-object ────────────────────────────────────────────────────
     // Granular setters are sync and do not need try/catch.
@@ -327,7 +393,7 @@ export class Cognee {
         catch (e) { throw wrapNativeError(e); }
       },
       // Read-back
-      get: () => native.getConfig(h),
+      get: () => configToCamel(native.getConfig(h) as Record<string, unknown>),
     };
 
     // ── datasets sub-object ──────────────────────────────────────────────────

--- a/ts/src/pipeline.ts
+++ b/ts/src/pipeline.ts
@@ -30,7 +30,17 @@ export class Pipeline {
   }
 
   addTask(task: TaskInfo): this {
-    native.pipelineAddTask(this._box, task._box);
+    // `createTask`/`createIterTask`/`createBatchTask` already return a
+    // `TaskInfo`. The README also documents wrapping that result again with
+    // `new TaskInfo(task)`, which nests one TaskInfo inside another so that
+    // `_box` points at a JS `TaskInfo` instead of the native `NeonTaskInfo`
+    // JsBox. Unwrap any such nesting so both usages reach the native box and
+    // do not trigger a Neon downcast error.
+    let box: NativeBox = task._box;
+    while (box instanceof TaskInfo) {
+      box = box._box;
+    }
+    native.pipelineAddTask(this._box, box);
     return this;
   }
 


### PR DESCRIPTION
Fixes four bugs reported against `@cognee/cognee-ts` v0.1.1, plus a latent constructor bug surfaced while fixing #3. Each fix ships with a test that reproduces the original failure against the **local** build.

## Bugs fixed

### 1. Dedup blocks cross-dataset cognify (core)
The same text added to multiple datasets was only retrievable from the dataset cognified **last**. Vector point IDs are content-addressed (UUID5), so identical content yields the same point id; adapters upsert **replace-by-id**, so cognifying dataset B overwrote the shared point's scalar `dataset_id`, erasing dataset A's membership. Search scoping (`dataset_scope.rs`) read only that scalar, so the content became unretrievable when scoped to A.

**Fix:** accumulate membership into a unioned `dataset_ids` array on upsert across **all four** adapters (`brute_force`, `mock`, `lancedb`, `pgvector`); search scoping reads the array (scalar fallback). This mirrors Python's `belongs_to_set` union semantics — verified against the Python source — using dataset **UUIDs** to match the Rust scope-by-UUID convention (Python keys on NodeSet names).

### 2. `datasets.has()` threw on a non-UUID string
`has_data` did `Uuid::parse_str(...)?` and threw `SdkError::Validation`. It now treats an unparseable id as "not present" → `false`, matching its own documented contract. Fixed in the shared `bindings-common` layer, so the Python and C bindings benefit too.

### 3. `config.get()` returned `undefined` for all fields
The native snapshot is snake_case; the documented high-level API is camelCase. `get()` now converts keys to camelCase (plus an `embeddingModel` alias for the `embedding_model_name` field).

### 4. Pipeline `addTask()` Neon downcast error
The README's `new TaskInfo(createTask(...))` pattern double-wrapped a `TaskInfo`, so `_box` pointed at a JS object instead of the native `JsBox<NeonTaskInfo>`. `addTask` now unwraps any nested `TaskInfo` before forwarding to native.

### 5. (bonus) Constructor silently ignored camelCase settings
`new Cognee({ llmModel: ... })` (documented in the docstring and example scripts) was dropped because `cogneeNew` only understood snake_case `Settings`. The constructor now normalizes keys to snake_case (snake_case and JSON-string inputs still work).

## Verification
- **TS:** repro + regression suites pass — **50 passed / 1 skipped** (`config`, `pipeline`, `smoke`, `datasets`, and the 4 new repros). `tsc` clean.
- **Rust:** cross-dataset tests pass on the default `BruteForceVectorDB`, on `lancedb`, and on the search scope unit. `clippy` clean on `cognee-vector`, `cognee-search`, `cognee-bindings-common`.

## Caveat
The **pgvector** union compiles and reuses the verified read-merge logic, but was **not runtime-verified** (no live Postgres in the dev environment). Worth a CI run against Postgres. The default OSS path (`brute-force`) that the bug reports use is fully runtime-tested.

## Tests added
- `crates/vector/tests/cross_dataset_dedup.rs`
- inline tests in `lancedb_adapter.rs` and `dataset_scope.rs`
- `ts/__tests__/repro_{datasets_has,config_get,pipeline_addtask,constructor_camelcase}.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)