### PR TITLE
ci(ts-prebuild): cross-compile linux-arm64-gnu prebuilt

### DIFF
--- a/.github/workflows/ts-prebuild.yml
+++ b/.github/workflows/ts-prebuild.yml
@@ -164,9 +164,20 @@ jobs:
       - name: Build Neon addon (cross)
         if: matrix.cross
         working-directory: ts/cognee-ts-neon
+        # cognee-ts-neon stays a standalone workspace; ts/cognee-ts-neon/Cross.toml
+        # mounts the whole repo (volumes=COGNEE_REPO_ROOT) so its ../../crates
+        # path-deps resolve in the container, and selects a gcc-11 image for the
+        # arm64 target (lbug needs C++20 / libstdc++ 11). cross mounts the crate
+        # target at /target. Disable simsimd's advanced ARM SIMD kernels (SVE /
+        # NEON-bf16) the cross toolchain can't assemble.
         env:
-          ORT_CACHE_DIR: ${{ github.workspace }}/ts/cognee-ts-neon/target/ort-cache
-        run: cross build --release --target ${{ matrix.rust-target }}
+          ORT_CACHE_DIR: /target/ort-cache
+          COGNEE_REPO_ROOT: ${{ github.workspace }}
+        run: |
+          SVE="-DSIMSIMD_TARGET_NEON_I8=0 -DSIMSIMD_TARGET_NEON_F16=0 -DSIMSIMD_TARGET_NEON_BF16=0 -DSIMSIMD_TARGET_SVE=0 -DSIMSIMD_TARGET_SVE_I8=0 -DSIMSIMD_TARGET_SVE_F16=0 -DSIMSIMD_TARGET_SVE_BF16=0 -DSIMSIMD_TARGET_SVE2=0"
+          TGT_US=$(echo "${{ matrix.rust-target }}" | tr '-' '_')
+          export CFLAGS_${TGT_US}="$SVE" CXXFLAGS_${TGT_US}="$SVE"
+          cross build --release --target ${{ matrix.rust-target }}
 
       # Copy the built artifact into the platform package directory.
       - name: Copy artifact (Linux / macOS)
@@ -238,7 +249,10 @@ jobs:
     # cannot be used in a job `if:`) and the tag-trigger only exercises the
     # build-platform matrix above (which still warms the cache + verifies
     # cross-compile).
-    if: ${{ needs.check-token.outputs.has_token == 'true' }}
+    # always(): publish whatever platforms built, even if some matrix legs fail
+    # (not every platform's cross toolchain is solved yet). Publishing is
+    # idempotent and skips platforms whose artifact is absent.
+    if: ${{ always() && needs.check-token.outputs.has_token == 'true' }}
 
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/ci/cross/aarch64-gnu.Dockerfile
+++ b/ci/cross/aarch64-gnu.Dockerfile
@@ -1,0 +1,34 @@
+# Modern aarch64 cross image for building the TS Neon addon with cross-rs.
+#
+# cross-rs's stock image is Ubuntu 20.04 (gcc 9/10) — too old for the bundled
+# lbug C++ engine, which needs C++20 (<span>) AND libstdc++ 11's heterogeneous
+# unordered_map lookup. Ubuntu 22.04 ships a gcc-11 aarch64 cross toolchain
+# (glibc 2.35) that compiles lbug. We reuse the cross-rs image only for its
+# CMake toolchain file (cross points CMAKE_TOOLCHAIN_FILE at /opt/toolchain.cmake).
+#
+# Note: binaries produced here require glibc >= 2.35 on the target (Ubuntu
+# 22.04 / Debian 12 era).
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS crossbase
+
+FROM ubuntu:22.04
+COPY --from=crossbase /opt/toolchain.cmake /opt/toolchain.cmake
+ENV DEBIAN_FRONTEND=noninteractive
+# Cross toolchain env that cross-rs's stock images normally bake in. Without
+# these, Rust target links and cc-rs C builds fall back to the host gcc/ld and
+# fail with "Relocations in generic ELF (EM: 183) / file in wrong format".
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+    CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
+    AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar \
+    CROSS_TOOLCHAIN_PREFIX=aarch64-linux-gnu- \
+    CROSS_SYSROOT=/usr/aarch64-linux-gnu
+RUN apt-get update && \
+    apt-get install --assume-yes --no-install-recommends \
+        build-essential crossbuild-essential-arm64 cmake pkg-config libssl-dev \
+        curl unzip ca-certificates && \
+    curl -fsSL https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-x86_64.zip -o /tmp/protoc.zip && \
+    unzip -o /tmp/protoc.zip -d /usr/local bin/protoc 'include/*' && \
+    chmod +x /usr/local/bin/protoc && \
+    protoc --version && \
+    aarch64-linux-gnu-g++ --version | head -1 && \
+    rm -rf /var/lib/apt/lists/* /tmp/protoc.zip

--- a/ts/cognee-ts-neon/Cross.toml
+++ b/ts/cognee-ts-neon/Cross.toml
@@ -1,0 +1,45 @@
+# Cross-compilation config for the TS Neon addon (cross-rs).
+#
+# cognee-ts-neon is a standalone (nested) workspace, so cross-rs by default
+# mounts only that directory — leaving its path-deps (../../crates/*) and the
+# root Cargo.toml outside the container ("failed to find a workspace root").
+# `volumes` below mounts the whole repo (COGNEE_REPO_ROOT) at its host path so
+# those resolve, without folding the crate into the root workspace.
+#
+# The cross containers are also minimal Ubuntu images that lack the toolchain
+# the bundled lbug C++ engine needs; see ci/cross/aarch64-gnu.Dockerfile (a
+# gcc-11 image — lbug needs C++20 <span> + libstdc++ 11 heterogeneous lookup)
+# and the build-step env that disables simsimd's advanced ARM SIMD kernels.
+#
+#   - ORT_CACHE_DIR: writable in-container path for ort-sys to download into.
+#   - CFLAGS_*/CXXFLAGS_*: SIMSIMD_TARGET_*=0 disables SVE / NEON-bf16 kernels
+#     the cross toolchain can't assemble (basic NEON + serial fallbacks remain).
+
+[build.env]
+# Mount the whole repo (value of $COGNEE_REPO_ROOT) at the same path, so the
+# standalone neon workspace's ../../crates path-deps resolve in the container.
+volumes = ["COGNEE_REPO_ROOT"]
+passthrough = [
+    "CFLAGS_aarch64_unknown_linux_gnu",
+    "CXXFLAGS_aarch64_unknown_linux_gnu",
+    "CFLAGS_aarch64_unknown_linux_musl",
+    "CXXFLAGS_aarch64_unknown_linux_musl",
+    "ORT_CACHE_DIR",
+]
+
+# gcc-11 (Ubuntu 22.04) cross image — lbug needs libstdc++ 11. See the
+# Dockerfile for details. Build deps (cmake/protoc/libssl) are baked in.
+[target.aarch64-unknown-linux-gnu]
+dockerfile = "../../ci/cross/aarch64-gnu.Dockerfile"
+
+[target.x86_64-unknown-linux-musl]
+pre-build = [
+    "apt-get update && apt-get install --assume-yes --no-install-recommends libssl-dev pkg-config cmake curl unzip ca-certificates",
+    "curl -fsSL https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-x86_64.zip -o /tmp/protoc.zip && unzip -o /tmp/protoc.zip -d /usr/local bin/protoc 'include/*' && chmod +x /usr/local/bin/protoc && protoc --version",
+]
+
+[target.aarch64-unknown-linux-musl]
+pre-build = [
+    "apt-get update && apt-get install --assume-yes --no-install-recommends libssl-dev pkg-config cmake curl unzip ca-certificates",
+    "curl -fsSL https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-x86_64.zip -o /tmp/protoc.zip && unzip -o /tmp/protoc.zip -d /usr/local bin/protoc 'include/*' && chmod +x /usr/local/bin/protoc && protoc --version",
+]


### PR DESCRIPTION
## What

Makes the TS prebuild workflow actually cross-compile and publish the
`linux-arm64-gnu` native addon. Previously every non-`x64-gnu` matrix leg
failed, so only `linux-x64-gnu` was ever produced.

**`cognee-ts-neon` stays its own standalone workspace** — no `Cargo.toml`
changes.

## How

- **`ts/cognee-ts-neon/Cross.toml`** (new) — cross-rs reads its config from the
  workspace root, so it lives in the crate dir. `volumes = ["COGNEE_REPO_ROOT"]`
  mounts the whole repo into the build container so the standalone crate's
  `../../crates` path-deps (and the root `Cargo.toml` they inherit `edition`
  from) resolve. cross already auto-mounts the dependency crates individually —
  the only thing it omitted was the repo-root dir itself.
- **`ci/cross/aarch64-gnu.Dockerfile`** (new) — Ubuntu 22.04 **gcc-11** aarch64
  cross image. `lbug` needs C++20 `<span>` + libstdc++ 11 heterogeneous
  `unordered_map` lookup, which the stock focal (gcc 9/10) cross image lacks.
  Bakes in `build-essential`, `cmake`, a modern `protoc`, `libssl`, and the
  cross linker env.
- **Cross build step** — passes `COGNEE_REPO_ROOT`, points `ort-sys` at the
  mounted crate target (`/target/ort-cache`), and disables `simsimd`'s advanced
  ARM SIMD kernels (SVE / NEON-bf16) the cross toolchain can't assemble.
- **`publish: if always()`** — platforms that build still publish even when
  other (not-yet-solved) matrix legs fail; publishing is idempotent.

## Validation

Built locally end-to-end with this exact `Cross.toml`: `cross build` produces a
working `aarch64` `.node`. The resulting binary requires **glibc ≥ 2.35**
(Ubuntu 22.04 base).

## Not covered yet

`musl` (no static ORT / musl C++ toolchain) and `darwin`/`win32` (need their own
runners + lbug toolchain fixes) still fail their build legs — they just don't
publish, rather than blocking the ones that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)