### PR TITLE
chore(ts): bump cognee-ts and platform packages to 0.1.2

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/cognee-ts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Node.js bindings for the cognee AI-memory SDK",
   "license": "MIT OR Apache-2.0",
   "publishConfig": {
@@ -44,13 +44,13 @@
     "dotenv": "^16.6.1"
   },
   "optionalDependencies": {
-    "@cognee/neon-darwin-arm64": "0.1.0",
-    "@cognee/neon-darwin-x64": "0.1.0",
-    "@cognee/neon-linux-arm64-gnu": "0.1.0",
-    "@cognee/neon-linux-arm64-musl": "0.1.0",
-    "@cognee/neon-linux-x64-gnu": "0.1.0",
-    "@cognee/neon-linux-x64-musl": "0.1.0",
-    "@cognee/neon-win32-x64-msvc": "0.1.0"
+    "@cognee/neon-darwin-arm64": "0.1.2",
+    "@cognee/neon-darwin-x64": "0.1.2",
+    "@cognee/neon-linux-arm64-gnu": "0.1.2",
+    "@cognee/neon-linux-arm64-musl": "0.1.2",
+    "@cognee/neon-linux-x64-gnu": "0.1.2",
+    "@cognee/neon-linux-x64-musl": "0.1.2",
+    "@cognee/neon-win32-x64-msvc": "0.1.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",

--- a/ts/platform-packages/darwin-arm64/package.json
+++ b/ts/platform-packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Prebuilt cognee native addon for darwin-arm64 (aarch64-apple-darwin)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/darwin-x64/package.json
+++ b/ts/platform-packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Prebuilt cognee native addon for darwin-x64 (x86_64-apple-darwin)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/linux-arm64-gnu/package.json
+++ b/ts/platform-packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-linux-arm64-gnu",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Prebuilt cognee native addon for linux-arm64-gnu (aarch64-unknown-linux-gnu)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/linux-arm64-musl/package.json
+++ b/ts/platform-packages/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-linux-arm64-musl",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Prebuilt cognee native addon for linux-arm64-musl (aarch64-unknown-linux-musl)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/linux-x64-gnu/package.json
+++ b/ts/platform-packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-linux-x64-gnu",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Prebuilt cognee native addon for linux-x64-gnu (x86_64-unknown-linux-gnu)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/linux-x64-musl/package.json
+++ b/ts/platform-packages/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-linux-x64-musl",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Prebuilt cognee native addon for linux-x64-musl (x86_64-unknown-linux-musl)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/win32-x64-msvc/package.json
+++ b/ts/platform-packages/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-win32-x64-msvc",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Prebuilt cognee native addon for win32-x64-msvc (x86_64-pc-windows-msvc)",
   "main": "index.js",
   "os": [


### PR DESCRIPTION
## Summary

Release-prep version bump for the TypeScript SDK npm packages:

- `@cognee/cognee-ts`: **0.1.1 → 0.1.2** (0.1.1 already on the registry)
- All seven `@cognee/neon-<platform>` prebuilt packages: **0.1.0 → 0.1.2**
- The main package's `optionalDependencies` pins bumped to `0.1.2` in lockstep, so npm resolves the new prebuilt binaries.

All npm versions are now aligned at `0.1.2`.

## Build / publish notes

Platform binaries are not committed to git — they are produced by the build and placed into `platform-packages/<platform>/cognee_ts_neon.node` before publish. Locally built and staged for this release:

- `linux-x64-gnu` — native release build
- `linux-arm64-gnu` — cross-compiled via `cross` (gcc-11 image, SVE/NEON-bf16 kernels disabled), matching `ts-prebuild.yml`

The remaining platforms (darwin-x64/arm64, linux musl, win32) are built by the `ts-prebuild.yml` CI matrix on tag/dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)