### PR TITLE
fix(crates): drop readme.workspace so crates use the default local README

### DIFF
--- a/crates/bindings-common/Cargo.toml
+++ b/crates/bindings-common/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Shared facade (HandleState, CogneeServices, SdkError, wire helpers) consumed by the Python / JS / C API cognee bindings."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/chunking/Cargo.toml
+++ b/crates/chunking/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Text chunking and token counting for the cognee ingestion pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 description.workspace = true
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/cognify/Cargo.toml
+++ b/crates/cognify/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Knowledge-graph extraction (cognify) — turn ingested data into a graph for cognee."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Core pipeline primitives and orchestration types for the cognee AI-memory engine."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Relational metadata store (SQLite/Postgres via SeaORM) for the cognee AI-memory pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/delete/Cargo.toml
+++ b/crates/delete/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Deletion and orphan-sweep operations for the cognee knowledge graph."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/embedding/Cargo.toml
+++ b/crates/embedding/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Embedding-engine abstraction (ONNX, OpenAI, Ollama) for the cognee pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Knowledge-graph database abstraction (embedded Ladybug) for the cognee pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/http-server/Cargo.toml
+++ b/crates/http-server/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "HTTP server exposing the cognee add/cognify/search pipeline (single-user, no-auth)."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/ingestion/Cargo.toml
+++ b/crates/ingestion/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Data ingestion (add) — classify, deduplicate, and persist raw data for the cognee pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Cognee — an AI-memory pipeline that turns raw data into queryable knowledge graphs (umbrella crate)."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "LLM client abstraction (OpenAI-compatible) for the cognee AI-memory pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Structured logging and tracing setup for the cognee AI-memory pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/models/Cargo.toml
+++ b/crates/models/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Core domain data models (DataPoint, User, graph/vector entities) for the cognee AI-memory pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "OpenTelemetry tracing and metrics integration for the cognee pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/ontology/Cargo.toml
+++ b/crates/ontology/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Ontology loading and entity-type resolution for the cognee knowledge graph."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Context retrieval (search) over the cognee knowledge graph and vector store."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Session/conversation store (filesystem, Redis, SeaORM) for the cognee pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Pluggable file/blob storage abstraction (local filesystem + mock) for the cognee pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Opt-in product-analytics telemetry for the cognee AI-memory pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Shared utilities — deterministic IDs, hashing, and config helpers — for the cognee pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/vector/Cargo.toml
+++ b/crates/vector/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Vector-store abstraction with brute-force, LanceDB, and pgvector adapters for cognee."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/crates/visualization/Cargo.toml
+++ b/crates/visualization/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description = "Knowledge-graph visualization helpers for the cognee pipeline."
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 description.workspace = true
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

Every crate inherited `readme.workspace = true`. The workspace sets `readme = "README.md"`, which — interpreted from a member crate two levels down — resolves to `../../README.md`, a path **outside the package**. Each crate already ships its own `README.md`, so `cargo publish` fell back to the local copy but emitted a warning for all 21 published crates:

```
warning: readme `../../README.md` appears to be a path outside of the package,
but there is already a file named `README.md` in the root of the package.
```

## Fix

Drop the `readme.workspace = true` line from every crate that has a local `README.md` (25 crates). With **no** `readme` field, cargo's default behavior auto-detects the package-root `README.md` — identical result to setting it explicitly, but without restating the default. Packaging is now warning-free and the local `README.md` is still included in each tarball (verified via `cargo package`).

Crates **without** a local README (`test-utils`, `bench`, `examples`, `telemetry-emit` — all `publish = false`) keep inheriting the workspace readme and are untouched.

## Verification

- `cargo metadata` parses cleanly.
- `cargo package -p cognee-models` / `-p cognee-lib`: no readme warning; `README.md` present in the `.crate` tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)