### PR TITLE
perf(db): eliminate two N+1 query loops (has_edges, update_last_accessed)

### DIFF
--- a/crates/database/src/ops/data.rs
+++ b/crates/database/src/ops/data.rs
@@ -160,7 +160,7 @@ pub async fn update_last_accessed(
     }
 
     // Single UPDATE ... WHERE id IN (...) instead of N×(find + update) round-trips.
-    let hex_ids: Vec<String> = data_ids.iter().map(|id| uuid_hex::to_hex(*id)).collect();
+    let hex_ids: Vec<_> = data_ids.iter().map(|id| uuid_hex::to_hex(*id)).collect();
     data::Entity::update_many()
         .col_expr(data::Column::LastAccessed, Expr::value(Some(timestamp)))
         .filter(data::Column::Id.is_in(hex_ids))

--- a/crates/database/src/ops/data.rs
+++ b/crates/database/src/ops/data.rs
@@ -3,7 +3,7 @@ use cognee_models::{Data, Dataset};
 use cognee_utils::tracing_keys::{COGNEE_DB_ROW_COUNT, COGNEE_DB_SYSTEM};
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait,
-    IntoActiveModel, PaginatorTrait, QueryFilter,
+    IntoActiveModel, PaginatorTrait, QueryFilter, sea_query::Expr,
 };
 use tracing::{Span, instrument};
 use uuid::Uuid;
@@ -159,18 +159,14 @@ pub async fn update_last_accessed(
         return Ok(());
     }
 
-    for id in data_ids {
-        let model = data::Entity::find_by_id(uuid_hex::to_hex(*id))
-            .one(db)
-            .await
-            .map_err(map_sea_err)?;
-
-        if let Some(m) = model {
-            let mut active = m.into_active_model();
-            active.last_accessed = Set(Some(timestamp));
-            active.update(db).await.map_err(map_sea_err)?;
-        }
-    }
+    // Single UPDATE ... WHERE id IN (...) instead of N×(find + update) round-trips.
+    let hex_ids: Vec<String> = data_ids.iter().map(|id| uuid_hex::to_hex(*id)).collect();
+    data::Entity::update_many()
+        .col_expr(data::Column::LastAccessed, Expr::value(Some(timestamp)))
+        .filter(data::Column::Id.is_in(hex_ids))
+        .exec(db)
+        .await
+        .map_err(map_sea_err)?;
 
     Ok(())
 }

--- a/crates/database/tests/data_update_last_accessed.rs
+++ b/crates/database/tests/data_update_last_accessed.rs
@@ -1,0 +1,100 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression: `update_last_accessed` must update every targeted row in a single
+//! batched `UPDATE ... WHERE id IN (...)` (previously an N×(find + update) loop),
+//! while leaving untargeted rows untouched and treating non-existent ids as no-ops.
+//!
+//! Runs on in-memory SQLite, so it needs no external database.
+#![cfg(feature = "sqlite")]
+
+use chrono::{TimeZone, Utc};
+use cognee_database::ops::data::{create_data, get_data, update_last_accessed};
+use cognee_database::{connect, initialize};
+use cognee_models::Data;
+use uuid::Uuid;
+
+/// Insert a minimal `Data` row owned by `owner`, returning its id.
+async fn seed_data(db: &cognee_database::DatabaseConnection, owner: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+    let d = Data::builder(
+        id,
+        format!("data-{id}"),
+        "file:///tmp/raw",
+        "file:///tmp/raw",
+        "txt",
+        "text/plain",
+        format!("hash-{id}"),
+        owner,
+    )
+    .build();
+    create_data(db, d).await.expect("create_data");
+    id
+}
+
+#[tokio::test]
+async fn update_last_accessed_batches_and_is_selective() {
+    let db = connect("sqlite::memory:").await.expect("connect");
+    initialize(&db).await.expect("initialize");
+
+    let owner = Uuid::new_v4();
+    let id1 = seed_data(&db, owner).await;
+    let id2 = seed_data(&db, owner).await;
+    let untouched = seed_data(&db, owner).await;
+
+    // Sanity: all rows start with no last_accessed.
+    for id in [id1, id2, untouched] {
+        let row = get_data(&db, id).await.expect("get_data").expect("exists");
+        assert!(
+            row.last_accessed.is_none(),
+            "expected last_accessed to be unset initially"
+        );
+    }
+
+    let ts = Utc.with_ymd_and_hms(2025, 1, 2, 3, 4, 5).unwrap();
+
+    // Target id1 and id2, plus a non-existent id which must be a silent no-op.
+    let missing = Uuid::new_v4();
+    update_last_accessed(&db, &[id1, id2, missing], ts)
+        .await
+        .expect("update_last_accessed should succeed even with a non-existent id");
+
+    // Targeted rows now carry the timestamp.
+    for id in [id1, id2] {
+        let row = get_data(&db, id).await.expect("get_data").expect("exists");
+        assert_eq!(
+            row.last_accessed,
+            Some(ts),
+            "targeted row {id} should have the new last_accessed"
+        );
+    }
+
+    // The untargeted row is unchanged.
+    let row = get_data(&db, untouched)
+        .await
+        .expect("get_data")
+        .expect("exists");
+    assert!(
+        row.last_accessed.is_none(),
+        "untargeted row must not be modified"
+    );
+
+    // The non-existent id was not inserted.
+    assert!(
+        get_data(&db, missing).await.expect("get_data").is_none(),
+        "a non-existent id must remain absent (no upsert)"
+    );
+}
+
+#[tokio::test]
+async fn update_last_accessed_empty_is_noop() {
+    let db = connect("sqlite::memory:").await.expect("connect");
+    initialize(&db).await.expect("initialize");
+
+    // Empty batch must short-circuit without error.
+    update_last_accessed(&db, &[], Utc::now())
+        .await
+        .expect("empty update_last_accessed is a no-op");
+}

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -36,6 +36,9 @@ sea-orm = { version = "1.1", features = [
     "sqlx-postgres",
     "with-chrono",
     "with-json",
+    # `postgres-array` lets us bind `Vec<String>` as Postgres `text[]` params,
+    # used by `has_edges` to batch-check edges in a single `unnest(...)` query.
+    "postgres-array",
 ], optional = true }
 sea-orm-migration = { version = "1.1", features = [
     "runtime-tokio-rustls",

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -569,15 +569,21 @@ impl GraphDBTrait for PgGraphAdapter {
 
         // Collect the triples that exist, then filter the original input so each
         // returned edge keeps its properties (which aren't part of the lookup key).
-        let existing: HashSet<_> = rows
-            .into_iter()
-            .filter_map(|row| {
-                let s: String = row.try_get("", "s").ok()?;
-                let t: String = row.try_get("", "t").ok()?;
-                let r: String = row.try_get("", "r").ok()?;
-                Some((s, t, r))
-            })
-            .collect();
+        // A decode failure is a real error, so propagate it rather than silently
+        // dropping the row.
+        let mut existing: HashSet<_> = HashSet::with_capacity(rows.len());
+        for row in &rows {
+            let s: String = row
+                .try_get("", "s")
+                .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
+            let t: String = row
+                .try_get("", "t")
+                .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
+            let r: String = row
+                .try_get("", "r")
+                .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
+            existing.insert((s, t, r));
+        }
 
         let found = edges
             .iter()

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -21,7 +21,7 @@ use sea_orm::{ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, St
 use sea_orm_migration::MigratorTrait;
 use serde_json::{Value, json};
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use tracing::debug;
 
@@ -542,15 +542,49 @@ impl GraphDBTrait for PgGraphAdapter {
             return Ok(vec![]);
         }
 
-        // TODO: This is an N+1 query pattern (one round-trip per edge). For large
-        // edge lists, consider a single query using `unnest($1::text[], $2::text[],
-        // $3::text[])` to check all candidates in one statement.
-        let mut found = Vec::new();
-        for edge in edges {
-            if self.has_edge(&edge.0, &edge.1, &edge.2).await? {
-                found.push(edge.clone());
-            }
-        }
+        // Single round-trip regardless of batch size: pass the candidate
+        // (source, target, relationship) triples as three `text[]` arrays and let
+        // Postgres check existence for all of them at once via `unnest(...)` + `EXISTS`.
+        // This replaces the previous one-round-trip-per-edge loop.
+        let sources: Vec<String> = edges.iter().map(|e| e.0.clone()).collect();
+        let targets: Vec<String> = edges.iter().map(|e| e.1.clone()).collect();
+        let rels: Vec<String> = edges.iter().map(|e| e.2.clone()).collect();
+
+        let rows = self
+            .db
+            .query_all(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                "SELECT v.s, v.t, v.r \
+                 FROM unnest($1::text[], $2::text[], $3::text[]) AS v(s, t, r) \
+                 WHERE EXISTS ( \
+                     SELECT 1 FROM graph_edge e \
+                     WHERE e.source_id = v.s \
+                       AND e.target_id = v.t \
+                       AND e.relationship_name = v.r \
+                 )",
+                [sources.into(), targets.into(), rels.into()],
+            ))
+            .await
+            .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
+
+        // Collect the triples that exist, then filter the original input so each
+        // returned edge keeps its properties (which aren't part of the lookup key).
+        let existing: HashSet<(String, String, String)> = rows
+            .into_iter()
+            .filter_map(|row| {
+                let s: String = row.try_get("", "s").ok()?;
+                let t: String = row.try_get("", "t").ok()?;
+                let r: String = row.try_get("", "r").ok()?;
+                Some((s, t, r))
+            })
+            .collect();
+
+        let found = edges
+            .iter()
+            .filter(|e| existing.contains(&(e.0.clone(), e.1.clone(), e.2.clone())))
+            .cloned()
+            .collect();
+
         Ok(found)
     }
 

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -546,9 +546,9 @@ impl GraphDBTrait for PgGraphAdapter {
         // (source, target, relationship) triples as three `text[]` arrays and let
         // Postgres check existence for all of them at once via `unnest(...)` + `EXISTS`.
         // This replaces the previous one-round-trip-per-edge loop.
-        let sources: Vec<String> = edges.iter().map(|e| e.0.clone()).collect();
-        let targets: Vec<String> = edges.iter().map(|e| e.1.clone()).collect();
-        let rels: Vec<String> = edges.iter().map(|e| e.2.clone()).collect();
+        let sources: Vec<_> = edges.iter().map(|e| e.0.clone()).collect();
+        let targets: Vec<_> = edges.iter().map(|e| e.1.clone()).collect();
+        let rels: Vec<_> = edges.iter().map(|e| e.2.clone()).collect();
 
         let rows = self
             .db
@@ -569,7 +569,7 @@ impl GraphDBTrait for PgGraphAdapter {
 
         // Collect the triples that exist, then filter the original input so each
         // returned edge keeps its properties (which aren't part of the lookup key).
-        let existing: HashSet<(String, String, String)> = rows
+        let existing: HashSet<_> = rows
             .into_iter()
             .filter_map(|row| {
                 let s: String = row.try_get("", "s").ok()?;

--- a/crates/graph/tests/common/mod.rs
+++ b/crates/graph/tests/common/mod.rs
@@ -196,6 +196,83 @@ pub async fn test_has_edges(db: &dyn GraphDBTrait) {
     assert_eq!(found[0].2, "rel");
 }
 
+/// Equivalence + property-preservation check for the batched `has_edges`.
+///
+/// Asserts the set-based `has_edges` returns exactly the same subset as calling
+/// `has_edge` per candidate (the old per-edge behaviour) on a mixed present/absent
+/// batch, and that each returned edge keeps the *input* candidate's properties
+/// (not the differing properties stored in the DB) — proving the result is mapped
+/// back onto the input rather than reconstructed from the query.
+pub async fn test_has_edges_batch_equivalence(db: &dyn GraphDBTrait) {
+    db.delete_graph().await.unwrap();
+
+    let a = TestNode::new("ea", "A", "T", 0);
+    let b = TestNode::new("eb", "B", "T", 0);
+    db.add_nodes(&[&a, &b]).await.unwrap();
+
+    // Store edges with specific properties in the DB.
+    let mut stored_rel = HashMap::new();
+    stored_rel.insert(Cow::Borrowed("weight"), json!(99));
+    db.add_edge("ea", "eb", "rel", Some(stored_rel))
+        .await
+        .unwrap();
+
+    let mut stored_rel2 = HashMap::new();
+    stored_rel2.insert(Cow::Borrowed("since"), json!(1999));
+    db.add_edge("eb", "ea", "rel2", Some(stored_rel2))
+        .await
+        .unwrap();
+
+    // Candidates: two present (with *different* props than what's stored) and one absent.
+    let mut cand_a_props = HashMap::new();
+    cand_a_props.insert(Cow::Borrowed("weight"), json!(5));
+    let mut cand_c_props = HashMap::new();
+    cand_c_props.insert(Cow::Borrowed("since"), json!(2020));
+
+    let candidates: Vec<EdgeData> = vec![
+        ("ea".into(), "eb".into(), "rel".into(), cand_a_props.clone()), // present
+        ("ea".into(), "eb".into(), "nope".into(), HashMap::new()),      // absent
+        (
+            "eb".into(),
+            "ea".into(),
+            "rel2".into(),
+            cand_c_props.clone(),
+        ), // present
+    ];
+
+    let found = db.has_edges(&candidates).await.unwrap();
+
+    // Reference: the old per-edge behaviour.
+    let mut expected = Vec::new();
+    for c in &candidates {
+        if db.has_edge(&c.0, &c.1, &c.2).await.unwrap() {
+            expected.push((c.0.clone(), c.1.clone(), c.2.clone()));
+        }
+    }
+    let found_keys: Vec<(String, String, String)> = found
+        .iter()
+        .map(|e| (e.0.clone(), e.1.clone(), e.2.clone()))
+        .collect();
+    assert_eq!(
+        found_keys, expected,
+        "batched has_edges must match per-edge has_edge results"
+    );
+    assert_eq!(found.len(), 2);
+
+    // Properties must be the *input* candidate's, not the DB-stored ones.
+    let a_found = found
+        .iter()
+        .find(|e| e.2 == "rel")
+        .expect("present edge 'rel' should be returned");
+    assert_eq!(a_found.3.get("weight").unwrap().as_i64().unwrap(), 5);
+
+    let c_found = found
+        .iter()
+        .find(|e| e.2 == "rel2")
+        .expect("present edge 'rel2' should be returned");
+    assert_eq!(c_found.3.get("since").unwrap().as_i64().unwrap(), 2020);
+}
+
 pub async fn test_get_edges(db: &dyn GraphDBTrait) {
     db.delete_graph().await.unwrap();
 

--- a/crates/graph/tests/ladybug_integration.rs
+++ b/crates/graph/tests/ladybug_integration.rs
@@ -52,6 +52,7 @@ ladybug_test!(test_add_and_has_edge);
 ladybug_test!(test_add_edges_batch);
 ladybug_test!(test_edge_upsert_same_key);
 ladybug_test!(test_has_edges);
+ladybug_test!(test_has_edges_batch_equivalence);
 ladybug_test!(test_get_edges);
 ladybug_test!(test_get_neighbors);
 ladybug_test!(test_get_connections);

--- a/crates/graph/tests/pg_graph_integration.rs
+++ b/crates/graph/tests/pg_graph_integration.rs
@@ -58,6 +58,7 @@ pggraph_test!(test_add_and_has_edge);
 pggraph_test!(test_add_edges_batch);
 pggraph_test!(test_edge_upsert_same_key);
 pggraph_test!(test_has_edges);
+pggraph_test!(test_has_edges_batch_equivalence);
 pggraph_test!(test_get_edges);
 pggraph_test!(test_get_neighbors);
 pggraph_test!(test_get_connections);


### PR DESCRIPTION
Addresses **PR 1** of #21 (mirrored as topoteretes/cognee#3518): replace the two confirmed per-item round-trip loops with single set-based queries.

- **graph:** `PgGraphAdapter::has_edges` previously called `has_edge` once per edge (E round-trips). Now issues a single query that passes the candidate `(source, target, relationship)` triples as three `text[]` arrays and checks existence for all of them via `unnest(...) + EXISTS`. Results are mapped back onto the input edges so their properties are preserved. Constant 3 params / one round-trip regardless of batch size. Enables the `postgres-array` sea-orm feature to bind the arrays.

- **relational:** `update_last_accessed` previously looped `find_by_id` + `update` per id (2N round-trips). Now a single `update_many().col_expr(...).filter(Id.is_in(hex_ids))` → one `UPDATE ... WHERE id IN (...)`. Ids are hex-encoded via `uuid_hex::to_hex` so the filter matches stored keys.

### Tests
- SQLite test for `update_last_accessed`: targeted rows updated in one call, untargeted rows untouched, non-existent ids are no-ops, empty batch no-op.
- Postgres integration test `test_has_edges_batch_equivalence` (skips without `PGGRAPH_TEST_URL`): batched result equals per-edge `has_edge` results on a mixed present/absent batch, with input properties preserved.

**Verified locally:** both crates `cargo check` + `clippy -D warnings` clean; SQLite test green; both `has_edges` tests green against Docker `postgres:16`.

Scoped to PR 1 only — PR 2 (transactions + connection pool) and PR 3 (audit + minor items) to follow, as outlined in #21.

### `update_last_accessed` — SQLite test
<img width="937" height="592" alt="update_last_accessed SQLite test passing" src="https://github.com/user-attachments/assets/29677e8a-4d9d-41ae-a088-13bd45a5b597" />

### `has_edges` — Postgres integration test (via Docker)
<img width="943" height="799" alt="has_edges Postgres test passing" src="https://github.com/user-attachments/assets/1c980de8-5ae7-4dc0-af88-a94f10cc4523" />
