### PR TITLE
spike(wasm): Config 1 logic-only crates run on wasm32 (browser-verified)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,19 @@
 linker = "aarch64-linux-android21-clang++"
 ar = "llvm-ar"
 
+[target.wasm32-unknown-unknown]
+# WebAssembly (browser) spike — Config 1. getrandom 0.4 (pulled via uuid) uses
+# the post-0.3 backend-cfg system: it needs both the `wasm_js` cargo feature
+# (enabled in crates/utils/Cargo.toml under a wasm32 target block) AND this cfg
+# to select the JS-crypto backend. getrandom 0.2 (via rand 0.8) is handled
+# purely by its `js` feature and is unaffected by this flag.
+# See docs/spike-wasm-config1.md.
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+# `cargo test --target wasm32-unknown-unknown` runs the built wasm under this
+# runner (from `cargo install wasm-bindgen-cli`; executes via Node by default).
+# Only consulted by `cargo test`/`cargo run` — plain `cargo build` is unaffected.
+runner = "wasm-bindgen-test-runner"
+
 [env]
 # Route bundled CMake C/C++ builds (lbug's Ladybug tree) through ccache when it
 # is installed — scripts/ccache-launcher.sh is a transparent pass-through when

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,13 +7,10 @@ linker = "aarch64-linux-android21-clang++"
 ar = "llvm-ar"
 
 [target.wasm32-unknown-unknown]
-# WebAssembly (browser) spike — Config 1. getrandom 0.4 (pulled via uuid) uses
-# the post-0.3 backend-cfg system: it needs both the `wasm_js` cargo feature
-# (enabled in crates/utils/Cargo.toml under a wasm32 target block) AND this cfg
-# to select the JS-crypto backend. getrandom 0.2 (via rand 0.8) is handled
-# purely by its `js` feature and is unaffected by this flag.
-# See docs/spike-wasm-config1.md.
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+# WebAssembly (browser) spike — Config 1. The only getrandom in the wasm tree is
+# 0.2 (via rand 0.8), which is handled entirely by its `js` cargo feature
+# (crates/utils/Cargo.toml) and needs no rustflags. (uuid 1.23 does not pull
+# getrandom on wasm32-unknown, so the getrandom 0.4 backend-cfg is unnecessary.)
 # `cargo test --target wasm32-unknown-unknown` runs the built wasm under this
 # runner (from `cargo install wasm-bindgen-cli`; executes via Node by default).
 # Only consulted by `cargo test`/`cargo run` — plain `cargo build` is unaffected.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,10 +237,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust (stable) + wasm32 target
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
+
+      # rust-toolchain.toml pins the repo to 1.91, and that pin takes precedence
+      # over @stable — so `cargo build --target wasm32-unknown-unknown` runs under
+      # 1.91, not stable. The wasm32 std component must be on the *pinned*
+      # toolchain. `rustup target add` honors the rust-toolchain.toml override
+      # (exactly as scripts/check_all.sh does locally); the action's `targets:`
+      # input adds it to @stable instead, which is why CI hit
+      # `error[E0463]: can't find crate for std`.
+      - name: Add wasm32 target to the pinned toolchain
+        run: rustup target add wasm32-unknown-unknown
 
       - name: Install Node (for the wasm-bindgen test runner)
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,12 +259,27 @@ jobs:
           cargo build -p cognee-models -p cognee-utils --target wasm32-unknown-unknown
           cargo build -p cognee-chunking --no-default-features --features tiktoken --target wasm32-unknown-unknown
 
-      # Drift guard: type-check every wasm test target (wasm.rs, wasm_browser.rs
-      # and the shared wasm_smoke module). --no-run needs no runner, so it works
-      # before wasm-bindgen-cli is installed. A renamed DocumentChunk field or a
-      # changed chunk_text signature breaks here instead of slipping through.
+      # Drift guard: type-check every wasm test target. --no-run needs no runner,
+      # so it works before wasm-bindgen-cli is installed.
       - name: Type-check wasm test targets (drift guard)
-        run: cargo test -p cognee-chunking --features tiktoken --target wasm32-unknown-unknown --no-run
+        run: |
+          # utils/models have no wasm-specific tests, but this compiles their wasm
+          # *test* build — which is what this PR's tokio dev-dep split (utils) and
+          # the cfg(not(wasm32)) gates on the retry (utils) and data_input (models)
+          # test modules exist to keep green. `cargo build` only covers the lib, so
+          # without this a regression to those gates stays invisible until someone
+          # runs the wasm tests by hand.
+          cargo test -p cognee-utils -p cognee-models --target wasm32-unknown-unknown --no-run
+          # chunking under BOTH feature configs: the shared wasm_smoke module has a
+          # #[cfg(feature = "tiktoken")] arm, and the no-feature build of
+          # tests/wasm.rs is otherwise only ever exercised by the live Node step
+          # below (which depends on the wasm-bindgen-cli install). A renamed
+          # DocumentChunk field or a changed chunk_text signature breaks here.
+          # Always spell chunking's wasm feature set explicitly with
+          # --no-default-features [--features tiktoken] — identical to the build
+          # step and check_all.sh — so the checks can't diverge if `default` grows.
+          cargo test -p cognee-chunking --no-default-features --target wasm32-unknown-unknown --no-run
+          cargo test -p cognee-chunking --no-default-features --features tiktoken --target wasm32-unknown-unknown --no-run
 
       # wasm-bindgen-test-runner must match the resolved wasm-bindgen crate
       # exactly or it refuses to run; read the version from the just-generated lock.
@@ -274,10 +289,10 @@ jobs:
           echo "Installing wasm-bindgen-cli $WB_VER"
           cargo install wasm-bindgen-cli --version "$WB_VER" --locked
 
-      - name: Run Node smoke tests (default + tiktoken)
+      - name: Run Node smoke tests (no-features + tiktoken)
         run: |
-          cargo test -p cognee-chunking --target wasm32-unknown-unknown --test wasm
-          cargo test -p cognee-chunking --features tiktoken --target wasm32-unknown-unknown --test wasm
+          cargo test -p cognee-chunking --no-default-features --target wasm32-unknown-unknown --test wasm
+          cargo test -p cognee-chunking --no-default-features --features tiktoken --target wasm32-unknown-unknown --test wasm
 
   # ── Stage 2: Build and run tests (depends on lint) ────────────────────
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,63 @@ jobs:
       - name: Check (MSRV)
         run: cargo +1.91.0 check --all-targets
 
+  # ── wasm32 Config-1 lane: logic crates compile + run on wasm32 ────────
+  # The wasm smoke-test files are #![cfg(target_arch = "wasm32")], so the native
+  # lint/check lanes compile them to empty crates and never type-check them.
+  # This lane builds the logic crates for wasm32-unknown-unknown, type-checks
+  # every wasm test target (so a DocumentChunk-field or chunk_text-signature
+  # drift fails CI), and runs the Node smoke test. The headless-browser runner
+  # stays manual — it needs a WebDriver + browser; see docs/spike-wasm-config1.md.
+  # No protoc/cmake/lbug here: the three logic crates pull none of them.
+  wasm:
+    name: wasm32 (Config-1 logic crates)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust (stable) + wasm32 target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install Node (for the wasm-bindgen test runner)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Cache cargo/target (wasm)
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm-v1
+
+      # Build first so Cargo.lock exists (it is gitignored) before we pin the
+      # runner to the resolved wasm-bindgen version below.
+      - name: Build logic crates (wasm32)
+        run: |
+          cargo build -p cognee-models -p cognee-utils --target wasm32-unknown-unknown
+          cargo build -p cognee-chunking --no-default-features --features tiktoken --target wasm32-unknown-unknown
+
+      # Drift guard: type-check every wasm test target (wasm.rs, wasm_browser.rs
+      # and the shared wasm_smoke module). --no-run needs no runner, so it works
+      # before wasm-bindgen-cli is installed. A renamed DocumentChunk field or a
+      # changed chunk_text signature breaks here instead of slipping through.
+      - name: Type-check wasm test targets (drift guard)
+        run: cargo test -p cognee-chunking --features tiktoken --target wasm32-unknown-unknown --no-run
+
+      # wasm-bindgen-test-runner must match the resolved wasm-bindgen crate
+      # exactly or it refuses to run; read the version from the just-generated lock.
+      - name: Install wasm-bindgen-test-runner (matching the locked version)
+        run: |
+          WB_VER=$(sed -n '/^name = "wasm-bindgen"$/{n;s/^version = "\(.*\)"$/\1/p}' Cargo.lock)
+          echo "Installing wasm-bindgen-cli $WB_VER"
+          cargo install wasm-bindgen-cli --version "$WB_VER" --locked
+
+      - name: Run Node smoke tests (default + tiktoken)
+        run: |
+          cargo test -p cognee-chunking --target wasm32-unknown-unknown --test wasm
+          cargo test -p cognee-chunking --features tiktoken --target wasm32-unknown-unknown --test wasm
+
   # ── Stage 2: Build and run tests (depends on lint) ────────────────────
   test:
     name: Test (stable)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ dirs = "6"
 dotenv = "0.15"
 env_logger = "0.11"
 futures = "0.3"
+futures-timer = { version = "3", features = ["wasm-bindgen"] }
 futures-util = "0.3"
 hex = "0.4"
 hmac = "0.12"
@@ -128,7 +129,12 @@ tracing-appender = "0.2"
 tracing-opentelemetry = { version = "=0.32", default-features = false, features = ["tracing-log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 url = "2.5"
-uuid = { version = "1.21", features = ["v4", "v5", "serde"] }
+# `js` makes uuid's v4 randomness work on wasm32-unknown (routing through
+# wasm-bindgen/js-sys). It is a no-op on native targets — uuid gates its
+# wasm-bindgen/js-sys deps to wasm internally — so enabling it workspace-wide
+# leaves native builds unchanged while every crate's uuid works on wasm.
+# See docs/spike-wasm-config1.md.
+uuid = { version = "1.21", features = ["v4", "v5", "serde", "js"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
 # Project rule made enforceable: "no unwrap()/expect() in non-test code"

--- a/crates/chunking/Cargo.toml
+++ b/crates/chunking/Cargo.toml
@@ -17,22 +17,36 @@ workspace = true
 [dependencies]
 async-trait.workspace = true
 cognee-models = { path = "../models", version = "0.1.1" }
-cognee-storage = { path = "../storage", version = "0.1.1" }
 cognee-utils = { path = "../utils", version = "0.1.1" }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
 uuid.workspace = true
 tokenizers = { workspace = true, optional = true }
 tiktoken-rs = { workspace = true, optional = true }
+
+# The storage-backed `cognify_pipeline` module (and the tokio it needs) is the
+# only part of chunking that touches the filesystem-coupled cognee-storage crate.
+# It is cfg'd out on wasm32 (see lib.rs), so neither dep is pulled there. The
+# pure chunking primitives (chunk_text, TokenCounter, …) stay wasm-clean.
+# See docs/spike-wasm-config1.md.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cognee-storage = { path = "../storage", version = "0.1.1" }
+tokio.workspace = true
 
 [features]
 default      = []
 hf-tokenizer = ["dep:tokenizers", "tokenizers/http"]
 tiktoken     = ["dep:tiktoken-rs"]
 
-[dev-dependencies]
+# Native test deps: the inline unit tests use MockStorage + a multi-thread tokio.
+# Both are filesystem/native-only, so they are gated off wasm — the wasm test
+# target (tests/wasm.rs) needs neither.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 cognee-storage = { path = "../storage", features = ["testing"] }
 tokio.workspace = true
+
+# wasm smoke test (tests/wasm.rs) runs under wasm-bindgen-test-runner.
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/crates/chunking/src/lib.rs
+++ b/crates/chunking/src/lib.rs
@@ -13,6 +13,9 @@ pub mod chunk_by_paragraph;
 pub mod chunk_by_row;
 pub mod chunk_by_sentence;
 pub mod chunk_by_word;
+// cognify_pipeline pulls in cognee-storage (filesystem-coupled) + tokio; excluded
+// on wasm32, where only the pure chunking primitives are available.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod cognify_pipeline;
 pub mod config;
 pub mod cut_type;
@@ -24,6 +27,7 @@ pub mod token_counter;
 pub(crate) mod test_inputs;
 
 pub use chunk_by_row::chunk_by_row;
+#[cfg(not(target_arch = "wasm32"))]
 pub use cognify_pipeline::ExtractTextChunksPipeline;
 pub use config::TokenCounterKind;
 pub use cut_type::CutType;

--- a/crates/chunking/src/lib.rs
+++ b/crates/chunking/src/lib.rs
@@ -4,7 +4,9 @@
 //! token-bounded chunks. Zero-copy where possible (chunks borrow `&str` slices
 //! via byte-offset tracking).
 //!
-//! - [`text_chunker`] / [`cognify_pipeline`] — the chunking entry points
+//! - [`text_chunker`] / `cognify_pipeline` — the chunking entry points (the
+//!   latter is a plain code span, not an intra-doc link: it is gated off wasm32,
+//!   where the link would be unresolved on a `--target wasm32` doc build)
 //! - [`token_counter`] — the [`token_counter::TokenCounter`] trait and its
 //!   `WordCounter` / `HuggingFaceTokenCounter` / `TikTokenCounter` impls,
 //!   selected by [`config`] (`TokenCounterKind::from_env`)

--- a/crates/chunking/tests/wasm.rs
+++ b/crates/chunking/tests/wasm.rs
@@ -1,8 +1,10 @@
-//! WebAssembly smoke test for the Config-1 spike.
+//! WebAssembly smoke test for the Config-1 spike — **Node** runner.
 //!
 //! Proves the pure chunking primitives (`chunk_text` + a `TokenCounter`)
 //! actually **run** inside a wasm host — not merely that they compile. This
 //! closes the last Config-1 acceptance item (see `docs/spike-wasm-config1.md`).
+//! The same assertions also run in a real headless browser via
+//! `wasm_browser.rs`; both share the bodies in `wasm_smoke/mod.rs`.
 //!
 //! The whole file is gated to `wasm32`; on native targets it compiles to an
 //! empty crate, so it never interferes with the normal test suite.
@@ -25,44 +27,22 @@
 
 #![cfg(target_arch = "wasm32")]
 
-use cognee_chunking::{NAMESPACE_OID, TokenCounter, WordCounter, chunk_text};
+mod wasm_smoke;
+
 use wasm_bindgen_test::wasm_bindgen_test;
 
 #[wasm_bindgen_test]
 fn word_counter_runs_in_wasm() {
-    assert_eq!(WordCounter.count_tokens("hello wasm world"), 3);
-    assert_eq!(WordCounter.count_tokens(""), 0);
+    wasm_smoke::word_counter();
 }
 
 #[wasm_bindgen_test]
 fn chunk_text_runs_in_wasm() {
-    let counter = WordCounter;
-    // NAMESPACE_OID is a valid Uuid; reuse it as the document id so the test
-    // needs no direct uuid dependency.
-    let doc = NAMESPACE_OID;
-    let text = "First paragraph of the spike.\n\n\
-                Second paragraph has a few more words than the first one does.";
-
-    let chunks = chunk_text(doc, text, 8, &counter);
-
-    assert!(!chunks.is_empty(), "expected at least one chunk");
-    for (i, c) in chunks.iter().enumerate() {
-        assert_eq!(c.chunk_index, i, "chunks must be indexed sequentially from 0");
-        assert!(!c.text.is_empty(), "chunk text should be non-empty");
-        assert!(c.chunk_size > 0, "chunk size should be counted");
-        assert_eq!(c.document_id, doc, "chunk should carry its document id");
-    }
+    wasm_smoke::chunk_text_smoke();
 }
 
 #[cfg(feature = "tiktoken")]
 #[wasm_bindgen_test]
 fn tiktoken_counter_runs_in_wasm() {
-    use cognee_chunking::TikTokenCounter;
-
-    // The cl100k_base BPE tables are bundled in the binary (pure Rust) — this
-    // exercises that they load and encode under wasm with no filesystem/network.
-    let counter = TikTokenCounter::cl100k_base().expect("cl100k_base BPE loads in wasm");
-    let n = counter.count_tokens("Hello, world!");
-    assert!((3..=6).contains(&n), "expected 3-6 cl100k tokens, got {n}");
-    assert_eq!(counter.count_tokens(""), 0);
+    wasm_smoke::tiktoken_counter();
 }

--- a/crates/chunking/tests/wasm.rs
+++ b/crates/chunking/tests/wasm.rs
@@ -1,0 +1,68 @@
+//! WebAssembly smoke test for the Config-1 spike.
+//!
+//! Proves the pure chunking primitives (`chunk_text` + a `TokenCounter`)
+//! actually **run** inside a wasm host — not merely that they compile. This
+//! closes the last Config-1 acceptance item (see `docs/spike-wasm-config1.md`).
+//!
+//! The whole file is gated to `wasm32`; on native targets it compiles to an
+//! empty crate, so it never interferes with the normal test suite.
+//!
+//! Run it (on a host without Windows Smart App Control — e.g. WSL/Linux):
+//!
+//! ```bash
+//! # one-time: provides the `wasm-bindgen-test-runner` used by .cargo/config.toml
+//! cargo install wasm-bindgen-cli
+//! # needs Node.js on PATH (the runner executes the wasm under node by default)
+//!
+//! cargo test -p cognee-chunking --target wasm32-unknown-unknown --test wasm
+//! cargo test -p cognee-chunking --features tiktoken \
+//!     --target wasm32-unknown-unknown --test wasm
+//! ```
+//!
+//! `--test wasm` builds only this integration test (not the crate's inline
+//! `#[test]` unit tests, which use the native libtest harness and don't run
+//! under the wasm-bindgen runner).
+
+#![cfg(target_arch = "wasm32")]
+
+use cognee_chunking::{NAMESPACE_OID, TokenCounter, WordCounter, chunk_text};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[wasm_bindgen_test]
+fn word_counter_runs_in_wasm() {
+    assert_eq!(WordCounter.count_tokens("hello wasm world"), 3);
+    assert_eq!(WordCounter.count_tokens(""), 0);
+}
+
+#[wasm_bindgen_test]
+fn chunk_text_runs_in_wasm() {
+    let counter = WordCounter;
+    // NAMESPACE_OID is a valid Uuid; reuse it as the document id so the test
+    // needs no direct uuid dependency.
+    let doc = NAMESPACE_OID;
+    let text = "First paragraph of the spike.\n\n\
+                Second paragraph has a few more words than the first one does.";
+
+    let chunks = chunk_text(doc, text, 8, &counter);
+
+    assert!(!chunks.is_empty(), "expected at least one chunk");
+    for (i, c) in chunks.iter().enumerate() {
+        assert_eq!(c.chunk_index, i, "chunks must be indexed sequentially from 0");
+        assert!(!c.text.is_empty(), "chunk text should be non-empty");
+        assert!(c.chunk_size > 0, "chunk size should be counted");
+        assert_eq!(c.document_id, doc, "chunk should carry its document id");
+    }
+}
+
+#[cfg(feature = "tiktoken")]
+#[wasm_bindgen_test]
+fn tiktoken_counter_runs_in_wasm() {
+    use cognee_chunking::TikTokenCounter;
+
+    // The cl100k_base BPE tables are bundled in the binary (pure Rust) — this
+    // exercises that they load and encode under wasm with no filesystem/network.
+    let counter = TikTokenCounter::cl100k_base().expect("cl100k_base BPE loads in wasm");
+    let n = counter.count_tokens("Hello, world!");
+    assert!((3..=6).contains(&n), "expected 3-6 cl100k tokens, got {n}");
+    assert_eq!(counter.count_tokens(""), 0);
+}

--- a/crates/chunking/tests/wasm_browser.rs
+++ b/crates/chunking/tests/wasm_browser.rs
@@ -1,0 +1,50 @@
+//! WebAssembly smoke test for the Config-1 spike — **headless browser** runner.
+//!
+//! Identical assertions to `wasm.rs` (shared via `wasm_smoke/mod.rs`), but
+//! `wasm_bindgen_test_configure!(run_in_browser)` makes the test runner drive a
+//! real browser through a WebDriver instead of executing under Node. This proves
+//! the wasm artifact runs on the *actual* target the repo owner asked for —
+//! `wasm32-unknown-unknown` + JS glue in the browser — not just under Node.
+//!
+//! The whole file is gated to `wasm32`; on native targets it compiles to an
+//! empty crate.
+//!
+//! Run it (WSL/Linux) with a browser + matching WebDriver available. With
+//! Chrome for Testing unpacked under `~/.cft`:
+//!
+//! ```bash
+//! export CHROMEDRIVER="$HOME/.cft/chromedriver-linux64/chromedriver"
+//! export CHROME="$HOME/.cft/chrome-linux64/chrome"   # binary the driver launches
+//! # the runner launches the browser headless by default (set NO_HEADLESS=1 to see it)
+//!
+//! cargo test -p cognee-chunking --target wasm32-unknown-unknown --test wasm_browser
+//! cargo test -p cognee-chunking --features tiktoken \
+//!     --target wasm32-unknown-unknown --test wasm_browser
+//! ```
+//!
+//! Geckodriver/Firefox works too (`GECKODRIVER` env var) — any WebDriver the
+//! `wasm-bindgen-test-runner` recognizes.
+
+#![cfg(target_arch = "wasm32")]
+
+mod wasm_smoke;
+
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn word_counter_runs_in_browser() {
+    wasm_smoke::word_counter();
+}
+
+#[wasm_bindgen_test]
+fn chunk_text_runs_in_browser() {
+    wasm_smoke::chunk_text_smoke();
+}
+
+#[cfg(feature = "tiktoken")]
+#[wasm_bindgen_test]
+fn tiktoken_counter_runs_in_browser() {
+    wasm_smoke::tiktoken_counter();
+}

--- a/crates/chunking/tests/wasm_smoke/mod.rs
+++ b/crates/chunking/tests/wasm_smoke/mod.rs
@@ -1,0 +1,53 @@
+//! Shared smoke-test bodies for the Config-1 wasm spike.
+//!
+//! These plain functions hold the actual assertions; they are wrapped with
+//! `#[wasm_bindgen_test]` by both runners:
+//!
+//! * `wasm.rs`         — executes them under **Node** (the default runner).
+//! * `wasm_browser.rs` — executes them in a **headless browser** (via
+//!   `wasm_bindgen_test_configure!(run_in_browser)` + a WebDriver).
+//!
+//! Keeping the bodies here means the two harnesses can never drift apart. This
+//! file lives in a `tests/` subdirectory, so cargo does not treat it as its own
+//! test target — it is only compiled when `mod`-included by a wasm test file.
+
+use cognee_chunking::{NAMESPACE_OID, TokenCounter, WordCounter, chunk_text};
+
+pub fn word_counter() {
+    assert_eq!(WordCounter.count_tokens("hello wasm world"), 3);
+    assert_eq!(WordCounter.count_tokens(""), 0);
+}
+
+pub fn chunk_text_smoke() {
+    let counter = WordCounter;
+    // NAMESPACE_OID is a valid Uuid; reuse it as the document id so the test
+    // needs no direct uuid dependency.
+    let doc = NAMESPACE_OID;
+    let text = "First paragraph of the spike.\n\n\
+                Second paragraph has a few more words than the first one does.";
+
+    let chunks = chunk_text(doc, text, 8, &counter);
+
+    assert!(!chunks.is_empty(), "expected at least one chunk");
+    for (i, c) in chunks.iter().enumerate() {
+        assert_eq!(
+            c.chunk_index, i,
+            "chunks must be indexed sequentially from 0"
+        );
+        assert!(!c.text.is_empty(), "chunk text should be non-empty");
+        assert!(c.chunk_size > 0, "chunk size should be counted");
+        assert_eq!(c.document_id, doc, "chunk should carry its document id");
+    }
+}
+
+#[cfg(feature = "tiktoken")]
+pub fn tiktoken_counter() {
+    use cognee_chunking::TikTokenCounter;
+
+    // The cl100k_base BPE tables are bundled in the binary (pure Rust) — this
+    // exercises that they load and encode under wasm with no filesystem/network.
+    let counter = TikTokenCounter::cl100k_base().expect("cl100k_base BPE loads in wasm");
+    let n = counter.count_tokens("Hello, world!");
+    assert!((3..=6).contains(&n), "expected 3-6 cl100k tokens, got {n}");
+    assert_eq!(counter.count_tokens(""), 0);
+}

--- a/crates/models/Cargo.toml
+++ b/crates/models/Cargo.toml
@@ -20,4 +20,18 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
+
+# tokio: the workspace dep carries rt-multi-thread + fs, which fail to compile on
+# wasm32-unknown-unknown (the runtime has no OS threads or filesystem). Workspace
+# inheritance can only add features, not drop them, so wasm gets a direct tokio
+# spec limited to the wasm-supported set. See docs/spike-wasm-config1.md.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1", default-features = false, features = ["sync", "macros", "io-util", "rt", "time"] }
+# chrono's `Utc::now()` (used by DataPoint::new) calls the system clock, which
+# traps as `unreachable` on wasm32. The `wasmbind` feature routes it through
+# `js_sys::Date` instead. The feature is additive, so the base `chrono.workspace`
+# dep just gains it via unification on wasm. See docs/spike-wasm-config1.md.
+chrono = { workspace = true, features = ["wasmbind"] }

--- a/crates/models/Cargo.toml
+++ b/crates/models/Cargo.toml
@@ -21,15 +21,15 @@ serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
 
-# tokio: the workspace dep carries rt-multi-thread + fs, which fail to compile on
-# wasm32-unknown-unknown (the runtime has no OS threads or filesystem). Workspace
-# inheritance can only add features, not drop them, so wasm gets a direct tokio
-# spec limited to the wasm-supported set. See docs/spike-wasm-config1.md.
+# tokio is only used here for local-filesystem streaming (data_input.rs), which is
+# cfg'd out on wasm32 — so wasm needs no tokio at all. Gate the dep to non-wasm:
+# the workspace tokio carries rt-multi-thread + fs, neither of which compiles on
+# wasm32-unknown-unknown, and a plain (ungated) dep would try to build them there.
+# See docs/spike-wasm-config1.md.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tokio = { version = "1", default-features = false, features = ["sync", "macros", "io-util", "rt", "time"] }
 # chrono's `Utc::now()` (used by DataPoint::new) calls the system clock, which
 # traps as `unreachable` on wasm32. The `wasmbind` feature routes it through
 # `js_sys::Date` instead. The feature is additive, so the base `chrono.workspace`

--- a/crates/models/src/data_input.rs
+++ b/crates/models/src/data_input.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 use std::future::Future;
+// Local-filesystem streaming is unavailable on wasm32 (no OS filesystem); the
+// FilePath arm below is cfg'd out there, so these imports are too.
+#[cfg(not(target_arch = "wasm32"))]
 use tokio::fs::File;
+#[cfg(not(target_arch = "wasm32"))]
 use tokio::io::AsyncReadExt;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -47,17 +51,30 @@ impl DataInput {
                 callback(text.as_bytes()).await?;
             }
             Self::FilePath(path) => {
-                let clean_path = path.strip_prefix("file://").unwrap_or(path);
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    let clean_path = path.strip_prefix("file://").unwrap_or(path);
 
-                let mut file = File::open(clean_path).await.map_err(E::from)?;
-                let mut buffer = vec![0u8; BUFFER_SIZE];
+                    let mut file = File::open(clean_path).await.map_err(E::from)?;
+                    let mut buffer = vec![0u8; BUFFER_SIZE];
 
-                loop {
-                    let bytes_read = file.read(&mut buffer).await.map_err(E::from)?;
-                    if bytes_read == 0 {
-                        break;
+                    loop {
+                        let bytes_read = file.read(&mut buffer).await.map_err(E::from)?;
+                        if bytes_read == 0 {
+                            break;
+                        }
+                        callback(&buffer[..bytes_read]).await?;
                     }
-                    callback(&buffer[..bytes_read]).await?;
+                }
+                // wasm32 has no local filesystem; callers must resolve a FilePath to
+                // Text/Binary before streaming (mirrors the Url/S3Path arms).
+                #[cfg(target_arch = "wasm32")]
+                {
+                    let _ = path;
+                    return Err(E::from(std::io::Error::new(
+                        std::io::ErrorKind::Unsupported,
+                        "Local file paths are not supported on wasm32; resolve inputs to Text or Binary before streaming.",
+                    )));
                 }
             }
             Self::Url(_url) => {

--- a/crates/models/src/data_input.rs
+++ b/crates/models/src/data_input.rs
@@ -213,6 +213,11 @@ mod tests {
         assert_eq!(item.classify(), "text");
     }
 
+    // tokio is a non-wasm-only dependency here (see Cargo.toml), so this async
+    // test is gated off wasm to keep `cargo test --target wasm32` compiling. The
+    // sibling sync #[test]s above stay compiled on wasm as a lightweight API
+    // drift check; this one runs on native, where process_by_chunks is async.
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn test_url_process_by_chunks_error_message() {
         let input = DataInput::Url("https://example.com".to_string());

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -21,33 +21,33 @@ tracing.workspace = true
 # Random (for jitter)
 rand.workspace = true
 
-# UUID generation
+# Cross-platform async timer for retry backoff (retry.rs). Works on both native
+# and wasm32: its `wasm-bindgen` feature routes through setTimeout on wasm and is
+# a no-op on native (which uses a timer thread). This is why retry needs no tokio
+# and no in-code cfg — tokio's timer would never fire on wasm32-unknown.
+futures-timer.workspace = true
+
+# UUID generation. The `js` wasm randomness source is enabled on the workspace
+# uuid dep (a no-op on native), so v4 works on wasm with no per-crate override.
 uuid = { workspace = true, features = ["v4", "v5"] }
 
 # Secret redaction (cognee_utils::redact)
 regex = { workspace = true }
 
-# tokio: see crates/models/Cargo.toml — the workspace dep's rt-multi-thread + fs
-# features don't compile on wasm32, and inheritance can't drop them, so wasm gets
-# a direct tokio spec limited to the wasm-supported feature set.
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio.workspace = true
-
-# WebAssembly (browser) spike — Config 1. On wasm32-unknown-unknown the default
-# getrandom backends are unavailable, so route both versions in our tree through
-# the JS crypto API. These are feature-only shims (the crates are already pulled
-# transitively — getrandom 0.2 via rand 0.8, getrandom 0.4 via uuid); declaring
-# them here lets Cargo's feature unification turn the JS backends on. getrandom
-# 0.4 additionally needs the getrandom_backend="wasm_js" cfg, set in
-# .cargo/config.toml. See docs/spike-wasm-config1.md.
+# WebAssembly (browser) spike — Config 1. The only getrandom in our wasm tree is
+# 0.2, pulled transitively by rand 0.8 (the jitter in retry.rs). On wasm32 it has
+# no default backend, so the `js` feature routes it through the browser crypto
+# API. This is a feature-only shim: rand already pulls getrandom 0.2; declaring
+# it here just lets Cargo's feature unification turn the JS backend on.
+# (uuid does NOT use getrandom on wasm32-unknown, and tokio is no longer a library
+# dependency at all — retry uses futures-timer — so no other wasm shim is needed.
+# See docs/spike-wasm-config1.md.)
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-getrandom_v04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
-# uuid 1.23 refuses to build on wasm32 without an explicit randomness source.
-# `js` routes v4 generation through the browser crypto API; feature unification
-# applies this to every crate sharing this uuid in the wasm build.
-uuid = { workspace = true, features = ["v4", "v5", "js"] }
-tokio = { version = "1", default-features = false, features = ["sync", "macros", "io-util", "rt", "time"] }
 
-[dev-dependencies]
+# tokio is only used by the #[tokio::test] async tests, which run on the native
+# libtest harness (not wasm-bindgen-test). Gate the dev-dep — and the retry test
+# module that needs it (see retry.rs) — off wasm so `cargo test --target wasm32`
+# compiles, mirroring how crates/chunking/Cargo.toml splits its dev-deps.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -15,9 +15,6 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-# Async runtime
-tokio.workspace = true
-
 # Structured logging/tracing
 tracing.workspace = true
 
@@ -29,6 +26,28 @@ uuid = { workspace = true, features = ["v4", "v5"] }
 
 # Secret redaction (cognee_utils::redact)
 regex = { workspace = true }
+
+# tokio: see crates/models/Cargo.toml — the workspace dep's rt-multi-thread + fs
+# features don't compile on wasm32, and inheritance can't drop them, so wasm gets
+# a direct tokio spec limited to the wasm-supported feature set.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio.workspace = true
+
+# WebAssembly (browser) spike — Config 1. On wasm32-unknown-unknown the default
+# getrandom backends are unavailable, so route both versions in our tree through
+# the JS crypto API. These are feature-only shims (the crates are already pulled
+# transitively — getrandom 0.2 via rand 0.8, getrandom 0.4 via uuid); declaring
+# them here lets Cargo's feature unification turn the JS backends on. getrandom
+# 0.4 additionally needs the getrandom_backend="wasm_js" cfg, set in
+# .cargo/config.toml. See docs/spike-wasm-config1.md.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+getrandom_v04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+# uuid 1.23 refuses to build on wasm32 without an explicit randomness source.
+# `js` routes v4 generation through the browser crypto API; feature unification
+# applies this to every crate sharing this uuid in the wasm build.
+uuid = { workspace = true, features = ["v4", "v5", "js"] }
+tokio = { version = "1", default-features = false, features = ["sync", "macros", "io-util", "rt", "time"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/utils/src/retry.rs
+++ b/crates/utils/src/retry.rs
@@ -179,7 +179,11 @@ where
                             delay
                         );
 
-                        tokio::time::sleep(delay).await;
+                        // futures-timer's Delay is runtime-agnostic and works on
+                        // both native and wasm32 (its wasm-bindgen feature routes
+                        // through setTimeout). tokio::time would not fire on
+                        // wasm32-unknown — no clock, no thread parking.
+                        futures_timer::Delay::new(delay).await;
                         attempt += 1;
                     }
                 }
@@ -188,7 +192,11 @@ where
     }
 }
 
-#[cfg(test)]
+// These are #[tokio::test] async tests on the native libtest harness; tokio is a
+// native-only dev-dependency, so the module is gated off wasm (matching how the
+// dev-deps are target-split in Cargo.toml). This keeps `cargo test --target
+// wasm32` compiling — the tests run on native, where retry actually executes.
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use std::sync::Arc;

--- a/docs/spike-wasm-config1.md
+++ b/docs/spike-wasm-config1.md
@@ -17,8 +17,8 @@ The following crates now compile to `wasm32-unknown-unknown`:
 
 | Crate | wasm32 | Notes |
 |---|---|---|
-| `cognee-models` | ✅ | local-filesystem streaming arm cfg'd out |
-| `cognee-utils` | ✅ | getrandom + uuid + tokio shims |
+| `cognee-models` | ✅ | local-filesystem streaming arm cfg'd out; no tokio on wasm |
+| `cognee-utils` | ✅ | getrandom 0.2 `js`; uuid `js` (workspace); `futures-timer` for retry (no tokio) |
 | `cognee-chunking` (`--features tiktoken`) | ✅ | storage-coupled `cognify_pipeline` cfg'd out |
 | `cognee-storage` | ❌ (excluded) | fundamentally filesystem-coupled — see Config 2 |
 
@@ -56,7 +56,14 @@ cargo build -p cognee-chunking \
 Every wall was in a **transitive dependency or a single filesystem code path** —
 none in the core logic. Each was fixed minimally and target-gated.
 
-### Wall 1 — `getrandom` has no default wasm backend
+> **Note on Walls 1–3.** The spike's first pass over-shimmed the dependency
+> layer — an extra getrandom 0.4 crate, a rustflag read by nobody, and reduced
+> per-crate tokio specs. PR review (checked against the actual manifests and
+> `cargo tree --target wasm32-unknown-unknown`) pruned these. The walls below are
+> written as **resolved**, with a "Review correction" note where the first
+> approach was wrong.
+
+### Wall 1 — `getrandom` (via `rand`) has no default wasm backend
 
 ```
 error: the wasm*-unknown-unknown targets are not supported by default, you may
@@ -64,34 +71,27 @@ error: the wasm*-unknown-unknown targets are not supported by default, you may
   --> getrandom-0.2.17/src/lib.rs
 ```
 
-`getrandom` appears in **two** major versions, both via `cognee-utils`:
+`cognee-utils` pulls `getrandom 0.2.17` transitively through the retry jitter:
+`rand 0.8.6` → `rand_core 0.6.4` → `getrandom 0.2.17`. On wasm it has no default
+entropy source.
 
-- `getrandom 0.2.17` ← `rand_core 0.6.4` ← `rand 0.8.6` ← `cognee-utils`
-- `getrandom 0.4.3`  ← `uuid 1.23.4` ← `cognee-utils`
-
-The two versions use different opt-in mechanisms:
-
-- **0.2** — enable the `js` cargo feature.
-- **0.4** (post-0.3 backend system) — enable the `wasm_js` cargo feature **and**
-  set `--cfg getrandom_backend="wasm_js"` in `RUSTFLAGS`.
-
-**Fix** (`crates/utils/Cargo.toml`, wasm32 target block + `.cargo/config.toml`):
+**Fix** (`crates/utils/Cargo.toml`, wasm32 target block) — enable getrandom 0.2's
+`js` feature (browser crypto API). A feature-only shim: `rand` already pulls the
+crate; this just turns the backend on.
 
 ```toml
-# crates/utils/Cargo.toml
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-getrandom_v04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 ```
 
-```toml
-# .cargo/config.toml
-[target.wasm32-unknown-unknown]
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
-```
-
-These are feature-only shims: both crates are already in the tree transitively,
-so declaring them just lets Cargo's feature unification turn on the JS backends.
+> **Review correction.** The first pass also added a getrandom **0.4** shim
+> (`getrandom_v04`) plus `--cfg getrandom_backend="wasm_js"` in
+> `.cargo/config.toml`, assuming `uuid` pulled getrandom 0.4 on wasm. It does
+> not: uuid 1.23 gates its `getrandom`/`rand` deps to **non-wasm** targets and
+> uses `wasm-bindgen`/`js-sys` on wasm32 (Wall 2). `cargo tree --target
+> wasm32-unknown-unknown` shows no getrandom 0.4 in the graph, and the rustflag
+> was read by nobody. Both were removed — getrandom 0.2 + `js` is the only
+> randomness shim actually needed.
 
 ### Wall 2 — `uuid` refuses to build on wasm without a randomness source
 
@@ -101,39 +101,62 @@ error: to use `uuid` on `wasm32-unknown-unknown`, specify a source of
   --> uuid-1.23.4/src/rng.rs
 ```
 
-**Fix** — enable uuid's `js` feature on wasm (same target block):
+uuid 1.23's `js` feature pulls `wasm-bindgen` + `js-sys` (both target-gated to
+wasm inside uuid) and routes `Uuid::new_v4()` through the browser crypto API —
+no getrandom involved on wasm.
+
+**Fix** — enable `js` on the **workspace** uuid dependency, not per-crate:
 
 ```toml
-uuid = { workspace = true, features = ["v4", "v5", "js"] }
+# Cargo.toml (workspace)
+uuid = { version = "1.21", features = ["v4", "v5", "serde", "js"] }
 ```
 
-### Wall 3 — `tokio` rejects `rt-multi-thread` / `fs` on wasm
+`js` is a no-op on native (the wasm-bindgen/js-sys deps don't exist there), so
+enabling it workspace-wide leaves native builds byte-identical while every
+crate's uuid works on wasm. This also fixes a latent gap: `cognee-models` calls
+`Uuid::new_v4()` but does not depend on `cognee-utils`, so a per-crate `js` in
+utils only reached models by feature-unification leak when both were compiled
+together — a standalone `cargo build -p cognee-models --target wasm32` would have
+missed it.
+
+### Wall 3 — `tokio`'s `rt-multi-thread` / `fs` don't compile on wasm
 
 ```
 error: Only features sync,macros,io-util,rt,time are supported on wasm.
   --> tokio-1.52.3/src/lib.rs
 ```
 
-The workspace tokio (`Cargo.toml`) carries
-`["rt-multi-thread", "macros", "sync", "time", "fs", "io-util"]`. **Workspace
-dependency inheritance can only *add* features, never drop them**, so a wasm
-crate cannot inherit the workspace tokio and subtract `rt-multi-thread`/`fs`.
+The workspace tokio carries `rt-multi-thread` + `fs`, and workspace inheritance
+can only *add* features, never drop them — so a wasm crate can't inherit it. The
+resolution is not a reduced-feature tokio but **no tokio on wasm at all**:
 
-**Fix** — split the tokio dependency by target in each logic crate: non-wasm
-inherits the workspace tokio unchanged; wasm gets a direct, reduced spec.
+- **`cognee-models`** — its only tokio use is local-file streaming in the
+  `FilePath` arm, already cfg'd off wasm (Wall 4). tokio is gated to non-wasm; the
+  wasm build pulls none.
+- **`cognee-utils`** — its only non-test tokio use was `tokio::time::sleep` in
+  `retry.rs`. tokio's timer doesn't actually fire on wasm32 (no clock, no thread
+  parking), so it is replaced with `futures_timer::Delay` — a runtime-agnostic
+  timer whose `wasm-bindgen` feature is a native no-op. tokio becomes a
+  native-only **dev-dependency** (the `#[tokio::test]` module is gated off wasm).
+- **`cognee-chunking`** — only uses tokio in its storage-coupled pipeline, gated
+  off wasm (Wall 5).
 
 ```toml
+# crates/models/Cargo.toml — tokio is non-wasm-only
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio.workspace = true
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-tokio = { version = "1", default-features = false,
-          features = ["sync", "macros", "io-util", "rt", "time"] }
+# crates/utils/Cargo.toml — retry uses a cross-platform timer; no lib tokio
+[dependencies]
+futures-timer.workspace = true
 ```
 
-Applied to `crates/models/Cargo.toml` and `crates/utils/Cargo.toml`.
-(`cognee-chunking` only uses tokio in its storage-coupled pipeline, so on wasm it
-drops tokio entirely — see Wall 5.)
+> **Review correction.** The first pass instead gave each crate a reduced wasm
+> tokio spec (`["sync","macros","io-util","rt","time"]`). Most features were
+> unused and tokio's timer is inert on wasm anyway, so the blocks were removed in
+> favour of `futures-timer` + native-only tokio — fewer cfgs, and retry's backoff
+> now actually works on wasm.
 
 ### Wall 4 — `cognee-models` streams local files via `tokio::fs`
 
@@ -228,17 +251,25 @@ Config 1 (achieved) and Config 2.
 ## Files changed
 
 ```
-.cargo/config.toml                    wasm32 rustflags (getrandom_backend) + wasm test runner
-crates/models/Cargo.toml              tokio target split + chrono `wasmbind` on wasm (Wall 6)
-crates/models/src/data_input.rs       cfg-gate FilePath fs streaming off wasm
-crates/utils/Cargo.toml               getrandom/uuid/tokio wasm shims + tokio split
+Cargo.toml                            workspace: uuid `js` (no-op on native); add futures-timer
+.cargo/config.toml                    wasm test runner (getrandom_backend rustflag removed in review)
+crates/models/Cargo.toml              tokio gated non-wasm-only; chrono `wasmbind` on wasm (Wall 6)
+crates/models/src/data_input.rs       cfg-gate FilePath fs streaming + async test off wasm
+crates/utils/Cargo.toml               getrandom 0.2 `js`; futures-timer; tokio dev-dep split off wasm
+crates/utils/src/retry.rs             tokio::time::sleep -> futures_timer::Delay; test module off wasm
 crates/chunking/Cargo.toml            gate cognee-storage + tokio off wasm; wasm test dev-dep
 crates/chunking/src/lib.rs            gate cognify_pipeline off wasm
-crates/chunking/tests/wasm.rs         NEW — wasm smoke test, Node runner
-crates/chunking/tests/wasm_browser.rs NEW — same assertions, headless-browser runner
-crates/chunking/tests/wasm_smoke/mod.rs NEW — shared assertion bodies for both runners
+crates/chunking/tests/wasm.rs         wasm smoke test, Node runner
+crates/chunking/tests/wasm_browser.rs same assertions, headless-browser runner
+crates/chunking/tests/wasm_smoke/mod.rs shared assertion bodies for both runners
+.github/workflows/ci.yml              NEW `wasm` job: build + --no-run drift guard + Node run
+scripts/check_all.sh                  build-only wasm drift guard (no runner)
 docs/spike-wasm-config1.md            this report
 ```
+
+> Committed in two steps then revised: `8fa4dde` (build+run), `4f1bff0` (browser
+> runner), and a review-response round (dependency pruning + wasm CI). See the
+> "Review correction" notes in Walls 1–3.
 
 ## Acceptance: running in a wasm host (Node + headless browser)
 
@@ -286,6 +317,28 @@ cargo test -p cognee-chunking --features tiktoken \
 > - The Node runner has worked on Node 18 and 20; Node 20+ is recommended (an
 >   earlier wasm-bindgen/Node-18 combination crashed V8 on the externref glue).
 
+### CI coverage (drift guard)
+
+Because the wasm test files are `#![cfg(target_arch = "wasm32")]`, the native
+lanes compile them to empty crates and never type-check them — a renamed
+`DocumentChunk` field or a changed `chunk_text` signature would stay green on
+native CI and only surface on a manual wasm run. Two guards close this:
+
+- **`ci.yml` `wasm` job** — builds the logic crates for
+  `wasm32-unknown-unknown`, then type-checks the wasm **test** build of every
+  crate whose wasm test layer this work gates (`cargo test … --no-run`, no runner
+  needed): `cognee-utils` + `cognee-models` (so the tokio dev-dep split and the
+  `cfg(not(wasm32))` gates on the retry/data_input test modules can't silently
+  regress — `cargo build` only covers the lib), and `cognee-chunking` under
+  **both** the default and `--features tiktoken` configs (the shared `wasm_smoke`
+  module has a `#[cfg(feature = "tiktoken")]` arm, and the default build of
+  `tests/wasm.rs` is otherwise only exercised by the live Node step). It then
+  installs a version-matched `wasm-bindgen-cli` (read from the gitignored
+  Cargo.lock) and runs the **Node** smoke tests. The headless-browser runner
+  stays manual (needs a WebDriver).
+- **`scripts/check_all.sh`** — the same build-only `--no-run` drift guards
+  locally, with no Node/wasm-bindgen-cli requirement.
+
 ## Config 2 — what's left (sized for its own issue)
 
 To run the **full** pipeline (`add → cognify → search`) in-browser, the two
@@ -299,10 +352,12 @@ genuine blockers from the audit remain, plus the storage finding above:
 3. **wasm-clean storage** — an in-memory `StorageTrait` backend **and**
    decoupling `StorageWriter` from `tokio::fs::File` (e.g. an enum/`Box<dyn>`
    writer, or a `Vec<u8>` buffer on wasm), so `cognify_pipeline` can run on wasm.
-4. **Runtime shims already proven viable here** — single-thread tokio rt
-   (`rt` + `time`, no `rt-multi-thread`/`fs`), `getrandom` JS backend, uuid `js`.
-   Still needed: `reqwest` Fetch/`wasm-bindgen` transport for the
-   OpenAI-compatible embedding + remote-HTTP backends.
+4. **Runtime shims already proven viable here** — `getrandom 0.2` `js` backend,
+   uuid `js` (workspace), `futures-timer` for delays (tokio's timer is inert on
+   wasm). Still needed: `reqwest` Fetch/`wasm-bindgen` transport for the
+   OpenAI-compatible embedding + remote-HTTP backends, and — if any async code on
+   the wasm path needs an executor — a wasm-compatible runtime
+   (e.g. `wasm-bindgen-futures`) rather than tokio's `rt`.
 5. **Not blockers** (already pure Rust / HTTP): `BruteForceVectorDB`,
    `OpenAICompatibleEmbeddingEngine`, `TikTokenCounter` / `WordCounter`.
 

--- a/docs/spike-wasm-config1.md
+++ b/docs/spike-wasm-config1.md
@@ -84,6 +84,13 @@ crate; this just turns the backend on.
 getrandom = { version = "0.2", features = ["js"] }
 ```
 
+This is the **only** randomness shim needed. `uuid` does *not* pull getrandom on
+wasm32-unknown — it sources its own wasm randomness through its `js` feature,
+enabled once on the **workspace** `uuid` dependency (Wall 2). There is no
+getrandom 0.4 dependency and no `getrandom_backend` rustflag (`.cargo/config.toml`
+carries only `runner = "wasm-bindgen-test-runner"`); the plain `cargo build` path
+needs neither.
+
 > **Review correction.** The first pass also added a getrandom **0.4** shim
 > (`getrandom_v04`) plus `--cfg getrandom_backend="wasm_js"` in
 > `.cargo/config.toml`, assuming `uuid` pulled getrandom 0.4 on wasm. It does

--- a/docs/spike-wasm-config1.md
+++ b/docs/spike-wasm-config1.md
@@ -1,0 +1,323 @@
+# Spike: compiling cognee-rs to WebAssembly — Config 1 (logic-only)
+
+**Status:** Config 1 **achieved** — the logic-only crate set builds *and runs* on
+`wasm32-unknown-unknown`, verified under both Node and a real headless browser.
+**Scope:** prove the logic-only crate set cross-compiles to wasm, actually
+executes there, and record the exact wall hit at each step. This is a feasibility
+spike, not a production WASM SDK. Config 2 (full in-browser pipeline with
+in-memory graph + relational backends) remains future work, sized at the end.
+
+**Target chosen:** `wasm32-unknown-unknown` + JS glue (via `wasm-bindgen`) — the
+repo owner's *preferred* outcome (browser-capable), not the `wasm32-wasip1`
+fallback. See the decision note at the end.
+
+## TL;DR
+
+The following crates now compile to `wasm32-unknown-unknown`:
+
+| Crate | wasm32 | Notes |
+|---|---|---|
+| `cognee-models` | ✅ | local-filesystem streaming arm cfg'd out |
+| `cognee-utils` | ✅ | getrandom + uuid + tokio shims |
+| `cognee-chunking` (`--features tiktoken`) | ✅ | storage-coupled `cognify_pipeline` cfg'd out |
+| `cognee-storage` | ❌ (excluded) | fundamentally filesystem-coupled — see Config 2 |
+
+Native builds of all four crates remain green (verified with `cargo check` on the
+host target); every wasm-specific change is behind `cfg(target_arch = "wasm32")`
+(or its negation) and leaves the native code path byte-identical.
+
+A `wasm-bindgen-test` smoke test then **runs** the chunking primitives + token
+counting inside an actual wasm host — under Node *and* headless Chrome — closing
+the last acceptance item (see [Acceptance](#acceptance-running-in-a-wasm-host-node--headless-browser)).
+
+### Reproduce
+
+```bash
+# one-time: the wasm target
+rustup target add wasm32-unknown-unknown
+
+# logic crates
+cargo build -p cognee-models -p cognee-utils \
+    --target wasm32-unknown-unknown
+
+# + chunking primitives (tiktoken is pure Rust; do NOT use hf-tokenizer on wasm)
+cargo build -p cognee-chunking \
+    --no-default-features --features tiktoken \
+    --target wasm32-unknown-unknown
+```
+
+> Toolchain note: this repo pins its toolchain via `rust-toolchain.toml`, so a
+> plain `cargo …` already selects it. (On a Windows host whose `~/.cargo/bin`
+> `cargo.exe` proxy is a broken 0-byte shim, either run from a Linux/WSL checkout
+> or drive cargo via `rustup run <toolchain> cargo …`.)
+
+## The walls, in the order they were hit
+
+Every wall was in a **transitive dependency or a single filesystem code path** —
+none in the core logic. Each was fixed minimally and target-gated.
+
+### Wall 1 — `getrandom` has no default wasm backend
+
+```
+error: the wasm*-unknown-unknown targets are not supported by default, you may
+       need to enable the "js" feature.
+  --> getrandom-0.2.17/src/lib.rs
+```
+
+`getrandom` appears in **two** major versions, both via `cognee-utils`:
+
+- `getrandom 0.2.17` ← `rand_core 0.6.4` ← `rand 0.8.6` ← `cognee-utils`
+- `getrandom 0.4.3`  ← `uuid 1.23.4` ← `cognee-utils`
+
+The two versions use different opt-in mechanisms:
+
+- **0.2** — enable the `js` cargo feature.
+- **0.4** (post-0.3 backend system) — enable the `wasm_js` cargo feature **and**
+  set `--cfg getrandom_backend="wasm_js"` in `RUSTFLAGS`.
+
+**Fix** (`crates/utils/Cargo.toml`, wasm32 target block + `.cargo/config.toml`):
+
+```toml
+# crates/utils/Cargo.toml
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+getrandom_v04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+```
+
+```toml
+# .cargo/config.toml
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+```
+
+These are feature-only shims: both crates are already in the tree transitively,
+so declaring them just lets Cargo's feature unification turn on the JS backends.
+
+### Wall 2 — `uuid` refuses to build on wasm without a randomness source
+
+```
+error: to use `uuid` on `wasm32-unknown-unknown`, specify a source of
+       randomness using one of the `js`, `rng-getrandom`, or `rng-rand` features
+  --> uuid-1.23.4/src/rng.rs
+```
+
+**Fix** — enable uuid's `js` feature on wasm (same target block):
+
+```toml
+uuid = { workspace = true, features = ["v4", "v5", "js"] }
+```
+
+### Wall 3 — `tokio` rejects `rt-multi-thread` / `fs` on wasm
+
+```
+error: Only features sync,macros,io-util,rt,time are supported on wasm.
+  --> tokio-1.52.3/src/lib.rs
+```
+
+The workspace tokio (`Cargo.toml`) carries
+`["rt-multi-thread", "macros", "sync", "time", "fs", "io-util"]`. **Workspace
+dependency inheritance can only *add* features, never drop them**, so a wasm
+crate cannot inherit the workspace tokio and subtract `rt-multi-thread`/`fs`.
+
+**Fix** — split the tokio dependency by target in each logic crate: non-wasm
+inherits the workspace tokio unchanged; wasm gets a direct, reduced spec.
+
+```toml
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1", default-features = false,
+          features = ["sync", "macros", "io-util", "rt", "time"] }
+```
+
+Applied to `crates/models/Cargo.toml` and `crates/utils/Cargo.toml`.
+(`cognee-chunking` only uses tokio in its storage-coupled pipeline, so on wasm it
+drops tokio entirely — see Wall 5.)
+
+### Wall 4 — `cognee-models` streams local files via `tokio::fs`
+
+The first **source-level** wall (the earlier static audit had marked the logic
+crates as fs-free; this one was missed):
+
+```
+error[E0432]: unresolved import `tokio::fs`
+  --> crates/models/src/data_input.rs:3
+```
+
+`DataInput::process_by_chunks` reads `DataInput::FilePath` from the local
+filesystem. wasm32 has no filesystem.
+
+**Fix** — cfg-gate the `FilePath` arm (and its `tokio::fs`/`AsyncReadExt`
+imports) off wasm; on wasm it returns `io::ErrorKind::Unsupported`, exactly
+mirroring how the existing `Url` and `S3Path` arms already defer resolution.
+Callers must resolve a path to `Text`/`Binary` before streaming. The native code
+path is unchanged.
+
+### Wall 5 — `cognee-chunking` → `cognee-storage` is filesystem-coupled
+
+`cognee-chunking` depends on `cognee-storage`, but **only** through
+`cognify_pipeline::ExtractTextChunksPipeline`, which holds an
+`Arc<dyn StorageTrait>`. The core chunking primitives (`chunk_text`, the
+`TokenCounter` trait, `TikTokenCounter`, `WordCounter`, the word/sentence/
+paragraph/row chunkers) have **zero** storage dependency.
+
+`cognee-storage` cannot currently compile on wasm — and not just `LocalStorage`:
+
+- `storage_trait.rs` exposes `StorageWriter { file: tokio::fs::File }` and
+  `get_full_path(..) -> PathBuf` in the public trait surface.
+- `local_storage.rs` is entirely `tokio::fs`.
+- even `MockStorage` uses `tempfile::NamedTempFile` + `tokio::fs::File::from_std`.
+
+So the trait itself — not just the default backend — is filesystem-shaped.
+
+**Fix for Config 1** — cfg-gate `cognify_pipeline` (and therefore the
+`cognee-storage` + `tokio` deps) off wasm in `cognee-chunking`. wasm keeps the
+pure chunking primitives, which is exactly the Config-1 / acceptance target:
+
+```toml
+# crates/chunking/Cargo.toml
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cognee-storage = { path = "../storage", version = "0.1.1" }
+tokio.workspace = true
+```
+
+```rust
+// crates/chunking/src/lib.rs
+#[cfg(not(target_arch = "wasm32"))]
+pub mod cognify_pipeline;
+#[cfg(not(target_arch = "wasm32"))]
+pub use cognify_pipeline::ExtractTextChunksPipeline;
+```
+
+### Wall 6 — `chrono::Utc::now()` traps at runtime (invisible to the compiler)
+
+The only wall **the build could not catch**. After all six crates compiled, the
+smoke test still aborted the moment it touched real logic:
+
+```
+test chunk_text_runs_in_wasm ... FAILED
+  RuntimeError: unreachable executed
+```
+
+`chunk_text` → `DocumentChunk::new` → `DataPoint::new` calls `chrono::Utc::now()`,
+which reads the system clock. On `wasm32-unknown-unknown` chrono has no clock
+source and the call lowers to an `unreachable` instruction that traps at runtime.
+A compile-only check (or `cargo build`) sails right past this — it is purely a
+**runtime** wall, which is exactly why the acceptance step *runs* the code rather
+than only building it.
+
+**Fix** — enable chrono's `wasmbind` feature on wasm, which routes `Utc::now()`
+through `js_sys::Date`. The feature is additive, so the base `chrono.workspace`
+dep simply gains it via feature unification on wasm only:
+
+```toml
+# crates/models/Cargo.toml — wasm32 target block
+chrono = { workspace = true, features = ["wasmbind"] }
+```
+
+## Correction to the prior dependency audit
+
+The pre-spike audit listed `cognee-storage` as a "light" Config-1 crate
+(`async-trait/tokio/uuid`). In practice **storage is fundamentally
+filesystem-coupled at the trait level**, and is the first crate that needs real
+new code (an in-memory backend + a writer abstraction that isn't `tokio::fs::File`)
+rather than a feature/cfg tweak. This makes it the natural boundary between
+Config 1 (achieved) and Config 2.
+
+## Files changed
+
+```
+.cargo/config.toml                    wasm32 rustflags (getrandom_backend) + wasm test runner
+crates/models/Cargo.toml              tokio target split + chrono `wasmbind` on wasm (Wall 6)
+crates/models/src/data_input.rs       cfg-gate FilePath fs streaming off wasm
+crates/utils/Cargo.toml               getrandom/uuid/tokio wasm shims + tokio split
+crates/chunking/Cargo.toml            gate cognee-storage + tokio off wasm; wasm test dev-dep
+crates/chunking/src/lib.rs            gate cognify_pipeline off wasm
+crates/chunking/tests/wasm.rs         NEW — wasm smoke test, Node runner
+crates/chunking/tests/wasm_browser.rs NEW — same assertions, headless-browser runner
+crates/chunking/tests/wasm_smoke/mod.rs NEW — shared assertion bodies for both runners
+docs/spike-wasm-config1.md            this report
+```
+
+## Acceptance: running in a wasm host (Node + headless browser)
+
+The crates build *and run*. The acceptance smoke test exercises the pure logic
+path end-to-end inside a wasm host — `WordCounter`, `chunk_text` (which drives
+`DataPoint::new` → the Wall-6 `Utc::now()`), and (under `--features tiktoken`)
+`TikTokenCounter` cl100k BPE encoding. The assertion bodies live in
+`tests/wasm_smoke/mod.rs` and are shared by two runners so they can't drift:
+
+| Runner | Config | Default features | `--features tiktoken` |
+|---|---|---|---|
+| **Node** (`tests/wasm.rs`) | default | ✅ 2 passed | ✅ 3 passed |
+| **Headless Chrome** (`tests/wasm_browser.rs`, `run_in_browser`) | real browser | ✅ 2 passed | ✅ 3 passed |
+
+The browser runner is what proves the *owner's target* — the wasm artifact and
+its `wasm-bindgen` JS glue executing in a real browser, not merely under Node.
+
+### Reproduce the tests
+
+```bash
+# one-time host tooling
+cargo install wasm-bindgen-cli          # must match the locked wasm-bindgen version
+# Node on PATH for the Node runner.
+
+# Node runner (default + tiktoken)
+cargo test -p cognee-chunking --target wasm32-unknown-unknown --test wasm
+cargo test -p cognee-chunking --features tiktoken \
+    --target wasm32-unknown-unknown --test wasm
+
+# Headless-browser runner — needs a WebDriver + matching browser. With
+# Chrome for Testing unpacked locally and `google-chrome` on PATH:
+export CHROMEDRIVER=/path/to/chromedriver
+cargo test -p cognee-chunking --target wasm32-unknown-unknown --test wasm_browser
+cargo test -p cognee-chunking --features tiktoken \
+    --target wasm32-unknown-unknown --test wasm_browser
+```
+
+> Environment notes (from the spike host):
+> - `wasm-bindgen-cli` must match the locked `wasm-bindgen` version (0.2.126
+>   here); a mismatch fails the runner.
+> - Chrome runs headless via the matched **Chrome for Testing** + `chromedriver`
+>   pair; `CHROMEDRIVER` points the runner at the driver, which discovers the
+>   browser through a `google-chrome` symlink on `PATH`. Under WSL the browser
+>   needs `--no-sandbox` (the runner's default headless args already include it).
+> - The Node runner has worked on Node 18 and 20; Node 20+ is recommended (an
+>   earlier wasm-bindgen/Node-18 combination crashed V8 on the externref glue).
+
+## Config 2 — what's left (sized for its own issue)
+
+To run the **full** pipeline (`add → cognify → search`) in-browser, the two
+genuine blockers from the audit remain, plus the storage finding above:
+
+1. **In-memory relational store** — a pure-`HashMap` implementation of
+   `IngestDb` / `SearchHistoryDb` / `DeleteDb`, replacing the SeaORM/SQLite (C)
+   and Postgres (network) backends. Largest new piece.
+2. **In-memory graph** — a pure-Rust `GraphDBTrait` impl (harden/promote
+   `MockGraphDB`), replacing Ladybug (C++) and PgGraph (network).
+3. **wasm-clean storage** — an in-memory `StorageTrait` backend **and**
+   decoupling `StorageWriter` from `tokio::fs::File` (e.g. an enum/`Box<dyn>`
+   writer, or a `Vec<u8>` buffer on wasm), so `cognify_pipeline` can run on wasm.
+4. **Runtime shims already proven viable here** — single-thread tokio rt
+   (`rt` + `time`, no `rt-multi-thread`/`fs`), `getrandom` JS backend, uuid `js`.
+   Still needed: `reqwest` Fetch/`wasm-bindgen` transport for the
+   OpenAI-compatible embedding + remote-HTTP backends.
+5. **Not blockers** (already pure Rust / HTTP): `BruteForceVectorDB`,
+   `OpenAICompatibleEmbeddingEngine`, `TikTokenCounter` / `WordCounter`.
+
+A `wasm` feature set on `cognee-lib` (mirroring the existing `android-default`
+set, dropping onnx/pgvector/pggraph/postgres/pdfium/server/gRPC-telemetry and
+keeping brute-force vector + tiktoken + HTTP embedding) is the umbrella-crate
+entry point for Config 2, with cfg-guards on the native-only deps mirroring the
+existing `cfg(not(target_os = "android"))` guard in `crates/vector/Cargo.toml`.
+
+## Decision: `wasm32-unknown-unknown` vs `wasm32-wasip1`
+
+This spike targeted **`wasm32-unknown-unknown`** (browser / `wasm-bindgen`),
+which is the harder, more portable target and the one the SDK use-cases want.
+`wasm32-wasip1` (WASI) does **not** rescue the heavy backends: the C++ deps
+(`lbug`/Ladybug, `ort`, `arrow`) build through `cxx` + `cmake` and don't target
+wasm at all, and even where C (`libsqlite3-sys`) could theoretically build with
+`wasi-sdk`, the graph backend still can't. So the in-memory backends are required
+regardless of which wasm target is chosen; `unknown-unknown` is the right default.

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -43,15 +43,21 @@ echo "=== Rust: wasm32 Config-1 (logic crates + wasm test drift guard) ==="
 echo "================================================================"
 # The wasm smoke-test files are #![cfg(target_arch = "wasm32")], so the native
 # `cargo check --all-targets` above compiles them to empty crates and never
-# type-checks them. Build the logic crates for the real target and type-check
-# every wasm test (incl. the shared wasm_smoke module) so a DocumentChunk-field
-# or chunk_text-signature drift is caught here. Build-only: running the tests
-# needs Node + wasm-bindgen-cli (see ci.yml's wasm job and
+# type-checks them. Type-check the wasm *test* build of every crate whose wasm
+# test layer this repo gates: utils/models (the tokio dev-dep split + the
+# cfg(not(wasm32)) gates on their retry/data_input test modules) and chunking's
+# smoke tests (DocumentChunk/chunk_text drift, incl. the shared wasm_smoke
+# module). Run chunking under both feature configs so the default build of
+# tests/wasm.rs is covered, not just the tiktoken one. Build-only (--no-run):
+# running the tests needs Node + wasm-bindgen-cli (see ci.yml's wasm job and
 # docs/spike-wasm-config1.md). The target install is a no-op once present.
 rustup target add wasm32-unknown-unknown >/dev/null 2>&1 || true
-cargo build -p cognee-models -p cognee-utils --target wasm32-unknown-unknown
-cargo test -p cognee-chunking --no-default-features --features tiktoken \
-    --target wasm32-unknown-unknown --no-run
+cargo test -p cognee-utils -p cognee-models --target wasm32-unknown-unknown --no-run
+# Spell chunking's wasm feature set explicitly (--no-default-features
+# [--features tiktoken]) — identical to ci.yml's wasm job — so local and CI
+# checks compile the same set even if cognee-chunking's `default` ever grows.
+cargo test -p cognee-chunking --no-default-features --target wasm32-unknown-unknown --no-run
+cargo test -p cognee-chunking --no-default-features --features tiktoken --target wasm32-unknown-unknown --no-run
 
 echo ""
 echo "================================================================"

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -39,6 +39,22 @@ cargo check -p cognee-lib --no-default-features
 
 echo ""
 echo "================================================================"
+echo "=== Rust: wasm32 Config-1 (logic crates + wasm test drift guard) ==="
+echo "================================================================"
+# The wasm smoke-test files are #![cfg(target_arch = "wasm32")], so the native
+# `cargo check --all-targets` above compiles them to empty crates and never
+# type-checks them. Build the logic crates for the real target and type-check
+# every wasm test (incl. the shared wasm_smoke module) so a DocumentChunk-field
+# or chunk_text-signature drift is caught here. Build-only: running the tests
+# needs Node + wasm-bindgen-cli (see ci.yml's wasm job and
+# docs/spike-wasm-config1.md). The target install is a no-op once present.
+rustup target add wasm32-unknown-unknown >/dev/null 2>&1 || true
+cargo build -p cognee-models -p cognee-utils --target wasm32-unknown-unknown
+cargo test -p cognee-chunking --no-default-features --features tiktoken \
+    --target wasm32-unknown-unknown --no-run
+
+echo ""
+echo "================================================================"
 echo "=== Rust: Test (telemetry crate noop fallback) ==="
 echo "================================================================"
 # Mirrors the no-default-features test lane in .github/workflows/ci.yml.


### PR DESCRIPTION
Addresses #16 (mirrored as topoteretes/cognee#3513 )
 
@GraDKh — this lands on your **preferred** target, not the fallback: it builds **and runs** on `wasm32-unknown-unknown` with JS glue (via `wasm-bindgen`), verified in a **real headless browser** — no WASI needed.
 
## 1. The Problem
 
WebAssembly (`wasm32-unknown-unknown` + JS, for the browser) is a target edge runtime for cognee-rs, but the workspace was never built for wasm and several foundational assumptions break there:
 
- **Randomness** — wasm has no OS RNG; `getrandom` (two major versions, via `rand 0.8` and `uuid`) fails to link without an explicit JS backend.
- **Async runtime** — `tokio`'s `rt-multi-thread`/`fs` features don't compile on wasm.
- **Filesystem** — code streaming local files via `tokio::fs` has no wasm equivalent.
- **Time** — `chrono::Utc::now()` traps as `unreachable` at *runtime* (invisible to the compiler).
- **Storage coupling** — `cognee-storage` is filesystem-shaped at the *trait* level.
- **Verification gap** — building isn't running; and running under Node isn't the same as running in a real browser, which is what the owner actually wants.
## 2. The Scope
 
**Config 1 = logic-only feasibility, on the owner's *preferred* target.** Prove the pure-logic crates (`cognee-utils`, `cognee-models`, `cognee-chunking`) **compile and run** on `wasm32-unknown-unknown` with JS glue (`wasm-bindgen`) — verified in a real headless browser, not just Node — using the smallest target-gated changes and **zero native-build impact**.
 
**Out of scope (Config 2, not done):** wasm-clean `cognee-storage` (decouple `StorageWriter` from `tokio::fs::File`), an in-memory relational store (`IngestDb`/`SearchHistoryDb`/`DeleteDb` over `HashMap`), an in-memory `GraphDBTrait`, a `reqwest` Fetch transport, and a `wasm` feature on `cognee-lib` mirroring the existing android-default pattern. `cognee-storage` is **excluded** from wasm here, not made wasm-clean.
 
## 3. The Solution — 6 walls, fixed minimally and target-gated
 
| # | Wall | Fix |
|---|------|-----|
| 1 | `getrandom` (two versions) | `js` feature (0.2 via `rand`) + `wasm_js` feature & `--cfg getrandom_backend="wasm_js"` (0.4 via `uuid`) |
| 2 | `uuid` needs wasm randomness | `uuid` `js` feature on wasm |
| 3 | `tokio` rejects `rt-multi-thread`/`fs`; workspace inheritance can't drop features | per-crate target split: native = workspace tokio, wasm = `["sync","macros","io-util","rt","time"]` |
| 4 | `cognee-models` streams local files via `tokio::fs` | cfg-gate the `FilePath` arm off wasm (returns `Unsupported`, mirroring `Url`/`S3Path`) |
| 5 | `cognee-chunking` → `cognee-storage` fs-coupled at trait level | cfg-gate `cognify_pipeline` + storage/tokio deps off wasm; pure primitives stay |
| 6 | Runtime trap: `chrono::Utc::now()` → `unreachable` | `chrono` `wasmbind` feature on wasm (routes through `js_sys::Date`) |
 
**Verification (the new increment):** added a `wasm-bindgen-test` smoke test that *runs* the chunking primitives + token counting in a wasm host. The assertion bodies are shared (`wasm_smoke/mod.rs`) by two runners — **Node** (`wasm.rs`) and **headless Chrome** (`wasm_browser.rs` via `wasm_bindgen_test_configure!(run_in_browser)`) — so they can't drift. The browser runner proves the owner's exact target: the wasm artifact + its JS glue executing in a real browser.
 
Every change is `cfg(target_arch = "wasm32")`-gated, so the native build is untouched by construction.
 
## 4. Files
 
### In the first commit (`8fa4dde`, 7 files, already committed)
 
- `.cargo/config.toml` — wasm32 rustflags (`getrandom_backend`) + wasm test runner
- `crates/models/Cargo.toml` — tokio target split + chrono `wasmbind` on wasm (Wall 6)
- `crates/models/src/data_input.rs` — cfg-gate `FilePath` fs streaming off wasm
- `crates/utils/Cargo.toml` — getrandom/uuid/tokio wasm shims + tokio split
- `crates/chunking/Cargo.toml` — gate `cognee-storage` + tokio off wasm; wasm test dev-dep
- `crates/chunking/src/lib.rs` — gate `cognify_pipeline` off wasm
- `crates/chunking/tests/wasm.rs` — original Node smoke test
### This commit
 
**Modified:**
- `crates/chunking/tests/wasm.rs` — refactored to delegate to the shared module
**Added:**
- `crates/chunking/tests/wasm_browser.rs` — headless-browser runner (`run_in_browser`)
- `crates/chunking/tests/wasm_smoke/mod.rs` — shared assertion bodies for both runners
- `docs/spike-wasm-config1.md` — full spike report (walls 1–6, acceptance, Config-2 sizing) — *was never committed in `8fa4dde`; lands here*
## 5. Environment
 
- **Host:** WSL Ubuntu 24.04, x86_64. Rust toolchain pinned via `rust-toolchain.toml` (plain `cargo` selects it).
- **Build:** `wasm32-unknown-unknown` target (`rustup target add wasm32-unknown-unknown`).
- **Test (both runners):** `wasm-bindgen-cli` **0.2.126** — must match the locked `wasm-bindgen`.
- **Node runner:** Node on PATH (ran on 18 and 20; **20+ recommended** — an earlier wasm-bindgen/Node-18 combo crashed V8 on the externref glue).
- **Browser runner:** **Chrome for Testing 150.0.7871.24** + matching **chromedriver 150**, run headless; `CHROMEDRIVER` env points at the driver, `google-chrome` symlinked onto PATH for discovery; under WSL Chrome needs `--no-sandbox` (the runner's default headless args include it).
## 6. Test Results — all green
 
| Check | Result |
|-------|--------|
| wasm32 build (models, utils, chunking `--features tiktoken`) | ✅ |
| Native `cargo check` (all 4 crates) + `-p cognee-chunking --all-targets` | ✅ clean |
| `cargo fmt --check` | ✅ clean |
| Node runner — default / tiktoken | ✅ 2 passed / ✅ 3 passed |
| Headless Chrome runner — default / tiktoken | ✅ 2 passed / ✅ 3 passed |
 
### Reproduce locally
 
```bash
# build
cargo build -p cognee-models -p cognee-utils --target wasm32-unknown-unknown
cargo build -p cognee-chunking --no-default-features --features tiktoken \
    --target wasm32-unknown-unknown
 
# Node runner (needs wasm-bindgen-cli matching the locked version + Node 20+)
cargo test -p cognee-chunking --target wasm32-unknown-unknown --test wasm
cargo test -p cognee-chunking --features tiktoken \
    --target wasm32-unknown-unknown --test wasm
 
# Headless-browser runner (needs a WebDriver + browser; runs headless by default)
export CHROMEDRIVER=/path/to/chromedriver        # google-chrome on PATH
cargo test -p cognee-chunking --target wasm32-unknown-unknown --test wasm_browser
cargo test -p cognee-chunking --features tiktoken \
    --target wasm32-unknown-unknown --test wasm_browser
```
 
## Notes for reviewers
 
The browser test needs a WebDriver + browser present (Chrome for Testing + chromedriver in this spike). It's not wired into CI here — happy to add a setup step, or mark it `#[ignore]`-by-default, whichever you'd prefer.
 
cc @GraDKh — this is Config 1, now with browser verification included.
 
