### PR TITLE
refactor(llm): extract shared OpenAI-compatible adapter builder

### DIFF
--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -12,7 +12,9 @@ use cognee_database::{
 use cognee_delete::DeleteService;
 use cognee_embedding::{EmbeddingConfig, EmbeddingEngine, EmbeddingProvider};
 use cognee_graph::{GraphDBTrait, LadybugAdapter};
-use cognee_llm::{Llm, OpenAIAdapter, OpenAIResponsesClient, ResponsesClient, Transcriber};
+use cognee_llm::{
+    Llm, OpenAIResponsesClient, ResponsesClient, Transcriber, build_openai_compatible_adapter,
+};
 use cognee_ontology::{OntologyManager, OntologyResolver};
 use cognee_search::{
     SeaOrmSessionStore, SearchBuilder, SearchOrchestrator, SessionManager, SessionStore,
@@ -262,23 +264,19 @@ fn wire_llm(cfg: &HttpServerConfig) -> Option<Arc<dyn Llm>> {
         return None;
     }
 
-    let api_key = cfg.llm_api_key.expose_secret().to_string();
+    let api_key = cfg.llm_api_key.expose_secret();
     if api_key.is_empty() {
         tracing::warn!("LLM API key missing; llm not wired");
         return None;
     }
 
-    let endpoint = if cfg.llm_endpoint.trim().is_empty() {
-        None
-    } else {
-        Some(cfg.llm_endpoint.clone())
-    };
-
-    match OpenAIAdapter::new(cfg.llm_model.clone(), api_key, endpoint).map(|adapter| {
-        adapter
-            .with_structured_output_retries(cfg.llm_max_retries.max(1))
-            .with_network_retries(cfg.llm_max_retries.max(1))
-    }) {
+    match build_openai_compatible_adapter(
+        &cfg.llm_provider,
+        &cfg.llm_model,
+        api_key,
+        &cfg.llm_endpoint,
+        cfg.llm_max_retries,
+    ) {
         Ok(adapter) => Some(Arc::new(adapter) as Arc<dyn Llm>),
         Err(err) => {
             tracing::warn!("llm wiring failed, wiring as None: {err}");
@@ -292,22 +290,18 @@ fn wire_transcriber(cfg: &HttpServerConfig) -> Option<Arc<dyn Transcriber>> {
         return None;
     }
 
-    let api_key = cfg.llm_api_key.expose_secret().to_string();
+    let api_key = cfg.llm_api_key.expose_secret();
     if api_key.is_empty() {
         return None;
     }
 
-    let endpoint = if cfg.llm_endpoint.trim().is_empty() {
-        None
-    } else {
-        Some(cfg.llm_endpoint.clone())
-    };
-
-    match OpenAIAdapter::new(cfg.llm_model.clone(), api_key, endpoint).map(|adapter| {
-        adapter
-            .with_structured_output_retries(cfg.llm_max_retries.max(1))
-            .with_network_retries(cfg.llm_max_retries.max(1))
-    }) {
+    match build_openai_compatible_adapter(
+        &cfg.llm_provider,
+        &cfg.llm_model,
+        api_key,
+        &cfg.llm_endpoint,
+        cfg.llm_max_retries,
+    ) {
         Ok(adapter) => Some(Arc::new(adapter) as Arc<dyn Transcriber>),
         Err(err) => {
             tracing::warn!("transcriber wiring failed, wiring as None: {err}");

--- a/crates/lib/src/component_manager.rs
+++ b/crates/lib/src/component_manager.rs
@@ -13,7 +13,7 @@ use cognee_graph::GraphDBTrait;
 use cognee_graph::LadybugAdapter;
 #[cfg(feature = "pggraph")]
 use cognee_graph::PgGraphAdapter;
-use cognee_llm::{Llm, OpenAIAdapter, Transcriber};
+use cognee_llm::{Llm, Transcriber, build_openai_compatible_adapter};
 use cognee_storage::{LocalStorage, StorageTrait};
 #[cfg(feature = "pgvector")]
 use cognee_vector::PgVectorAdapter;
@@ -597,24 +597,14 @@ impl ComponentManager {
         // Build the real adapter exactly as before.
         let adapter: Arc<dyn Llm> = match provider.as_str() {
             "openai" => {
-                if llm_api_key.is_empty() {
-                    return Err(ComponentError::Config(
-                        "llm_api_key must be configured".to_string(),
-                    ));
-                }
-
-                let endpoint = if llm_endpoint.is_empty() {
-                    None
-                } else {
-                    Some(llm_endpoint)
-                };
-
-                let retries = llm_max_retries.max(1);
-
-                let adapter = OpenAIAdapter::new(llm_model, llm_api_key, endpoint)
-                    .map_err(|e| ComponentError::Llm(format!("initialization failed: {e}")))?
-                    .with_structured_output_retries(retries)
-                    .with_network_retries(retries);
+                let adapter = build_openai_compatible_adapter(
+                    "openai",
+                    &llm_model,
+                    &llm_api_key,
+                    &llm_endpoint,
+                    llm_max_retries,
+                )
+                .map_err(|e| ComponentError::Llm(e.to_string()))?;
 
                 Arc::new(adapter)
             }
@@ -670,24 +660,14 @@ impl ComponentManager {
 
         match provider.as_str() {
             "openai" => {
-                if llm_api_key.is_empty() {
-                    return Err(ComponentError::Config(
-                        "llm_api_key must be configured".to_string(),
-                    ));
-                }
-
-                let endpoint = if llm_endpoint.is_empty() {
-                    None
-                } else {
-                    Some(llm_endpoint)
-                };
-
-                let retries = llm_max_retries.max(1);
-
-                let adapter = OpenAIAdapter::new(llm_model, llm_api_key, endpoint)
-                    .map_err(|e| ComponentError::Llm(format!("initialization failed: {e}")))?
-                    .with_structured_output_retries(retries)
-                    .with_network_retries(retries);
+                let adapter = build_openai_compatible_adapter(
+                    "openai",
+                    &llm_model,
+                    &llm_api_key,
+                    &llm_endpoint,
+                    llm_max_retries,
+                )
+                .map_err(|e| ComponentError::Llm(e.to_string()))?;
 
                 Ok(Some(Arc::new(adapter) as Arc<dyn Transcriber>))
             }

--- a/crates/llm/src/factory.rs
+++ b/crates/llm/src/factory.rs
@@ -1,0 +1,102 @@
+//! Shared construction of OpenAI-compatible LLM adapters.
+//!
+//! The embedded component manager (`cognee-lib`) and the standalone HTTP server
+//! (`cognee-http-server`) both wire the LLM the same way: an [`OpenAIAdapter`]
+//! built from the configured model / key / endpoint, with structured-output and
+//! network retries applied. Centralising that here keeps the two wiring paths in
+//! sync (see issue #17). Provider routing beyond `openai` is layered on top of
+//! this function in a follow-up; today it covers the OpenAI / OpenAI-compatible
+//! path that both call sites already used.
+
+use crate::{LlmError, LlmResult, OpenAIAdapter};
+
+/// Build an [`OpenAIAdapter`] for an OpenAI-compatible `provider`.
+///
+/// `endpoint` is the raw configured value; an empty or whitespace-only string is
+/// treated as "unset" so the adapter falls back to its provider default.
+/// `max_retries` is floored at 1 and applied to both the structured-output and
+/// network retry loops, matching the previous inline wiring.
+///
+/// Returns [`LlmError::ConfigError`] when a required API key is missing or the
+/// provider is unsupported, so each caller can decide whether to hard-fail
+/// (component manager) or skip and wire `None` (HTTP server).
+pub fn build_openai_compatible_adapter(
+    provider: &str,
+    model: &str,
+    api_key: &str,
+    endpoint: &str,
+    max_retries: u32,
+) -> LlmResult<OpenAIAdapter> {
+    let retries = max_retries.max(1);
+
+    match provider.to_ascii_lowercase().as_str() {
+        "openai" => {
+            if api_key.is_empty() {
+                return Err(LlmError::ConfigError(
+                    "llm_api_key must be configured".to_string(),
+                ));
+            }
+
+            let adapter = OpenAIAdapter::new(
+                model.to_string(),
+                api_key.to_string(),
+                endpoint_or_default(endpoint),
+            )?
+            .with_structured_output_retries(retries)
+            .with_network_retries(retries);
+            Ok(adapter)
+        }
+        other => Err(LlmError::ConfigError(format!(
+            "Unsupported llm_provider '{other}'. Supported: openai."
+        ))),
+    }
+}
+
+/// Treat an empty / whitespace endpoint as "unset" so the adapter uses its
+/// provider default base URL.
+fn endpoint_or_default(endpoint: &str) -> Option<String> {
+    if endpoint.trim().is_empty() {
+        None
+    } else {
+        Some(endpoint.to_string())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+    use crate::Llm;
+
+    #[test]
+    fn builds_openai_adapter_and_strips_provider_prefix() {
+        let adapter =
+            build_openai_compatible_adapter("openai", "openai/gpt-4o-mini", "sk-test", "", 3)
+                .expect("adapter should build");
+        // OpenAIAdapter strips the leading `openai/` litellm-style prefix.
+        assert_eq!(adapter.model(), "gpt-4o-mini");
+    }
+
+    #[test]
+    fn openai_requires_api_key() {
+        let result = build_openai_compatible_adapter("openai", "gpt-4o-mini", "", "", 3);
+        assert!(matches!(result, Err(LlmError::ConfigError(_))));
+    }
+
+    #[test]
+    fn provider_matching_is_case_insensitive() {
+        let adapter = build_openai_compatible_adapter("OpenAI", "gpt-4o-mini", "sk-test", "", 1)
+            .expect("adapter should build");
+        assert_eq!(adapter.model(), "gpt-4o-mini");
+    }
+
+    #[test]
+    fn unsupported_provider_errors() {
+        let result = build_openai_compatible_adapter("acme", "model", "key", "", 3);
+        assert!(matches!(result, Err(LlmError::ConfigError(_))));
+    }
+}

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -54,6 +54,7 @@ pub mod adapters;
 pub mod config;
 pub mod dynamic_model;
 pub mod error;
+pub mod factory;
 pub mod llm_trait;
 #[cfg(feature = "mock")]
 pub mod mock;
@@ -67,6 +68,7 @@ pub use adapters::OpenAIAdapter;
 pub use config::{LlmConfig, LlmProvider};
 pub use dynamic_model::{DynamicGraphModel, GraphModelError, graph_schema_to_graph_model};
 pub use error::{LlmError, LlmResult};
+pub use factory::build_openai_compatible_adapter;
 pub use llm_trait::{Llm, LlmExt};
 pub use responses_client::{OpenAIResponsesClient, ResponsesClient, ResponsesRequest};
 pub use schema::{


### PR DESCRIPTION
## Summary

Groundwork for the LLM-adapter parity work in #17 (Tier 1). Both wiring paths that build the LLM adapter - the embedded `ComponentManager` (`cognee-lib`) and the standalone HTTP server (`cognee-http-server`) - duplicated the same
construction logic: API-key validation, empty-endpoint → provider-default fallback, and structured-output / network retry wrapping.

As called out on the issue, extracting this into a single shared function is a prerequisite for adding compatible-endpoint provider routing (ollama / mistral / gemini / custom) without re-duplicating it across both sites.

This PR does **only** that extraction. It is a pure refactor with no behavioural change.

## Changes

- Add `cognee_llm::build_openai_compatible_adapter(provider, model, api_key, endpoint, max_retries)`   in a new `crates/llm/src/factory.rs`, exported from the crate root.
- Route both `ComponentManager::init_llm_adapter` and `init_transcriber` (cognee-lib)   through it.
- Route both `wire_llm` and `wire_transcriber` (cognee-http-server) through it.
- Supports the `openai` / OpenAI-compatible path only - the same set both call sites   already handled. Additional providers are layered on top in the Tier 1 follow-up.

## Behaviour

No change. The OpenAI path is equivalent (same key check, same empty-endpoint default, same retry counts). The HTTP server still wires `None` for non-`openai` providers via its existing guard.

## Testing

- `cargo test -p cognee-llm --lib factory`  - 4 new unit tests: builds adapter, strips litellm-style `openai/` model prefix, case-insensitive provider match, missing-key error, unknown-provider error. All pass.
- `cargo fmt --all -- --check`  -  clean.
- `cargo check --all-targets` and `cargo clippy --all-targets -- -D warnings`  - clean.
- `cargo check -p cognee-lib --no-default-features` — clean.

## Scope

Part of #17 ,  **does not close it.** This is the shared-function extraction only. Tier 1 provider routing, Tier 2 (native Anthropic), and Tier 3 (Azure / Bedrock) follow in separate PRs.