### PR TITLE
feat(llm): route ollama, mistral, gemini, and custom OpenAI-compatible providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,10 +128,10 @@ TOKENIZERS_PARALLELISM=false
 ###############################################################################
 
 ########## Local LLM via Ollama ################################################
-#LLM_API_KEY="ollama"
-#LLM_PROVIDER="openai"            # cognee-rust uses the OpenAI-compatible adapter
-#LLM_MODEL="llama3.1:8b"
-#LLM_ENDPOINT="http://localhost:11434/v1"
+#LLM_API_KEY="ollama"             # optional for Ollama; a placeholder is used if empty
+#LLM_PROVIDER="ollama"            # routes to the OpenAI-compatible adapter; defaults the endpoint below
+#LLM_MODEL="llama3.1:8b"          # an "ollama/" prefix is stripped automatically
+#LLM_ENDPOINT="http://localhost:11434/v1"   # optional; this is the default for ollama
 #EMBEDDING_PROVIDER="ollama"
 #EMBEDDING_MODEL="nomic-embed-text:latest"
 #EMBEDDING_ENDPOINT="http://localhost:11434/api/embed"

--- a/.env.example
+++ b/.env.example
@@ -128,12 +128,14 @@ TOKENIZERS_PARALLELISM=false
 ###############################################################################
 
 ########## Local LLM via Ollama ################################################
-#LLM_API_KEY="ollama"             # optional for Ollama; a placeholder is used if empty
+#LLM_API_KEY="ollama"             # required; any non-empty value works for a local Ollama
 #LLM_PROVIDER="ollama"            # routes to the OpenAI-compatible adapter; defaults the endpoint below
 #LLM_MODEL="llama3.1:8b"          # an "ollama/" prefix is stripped automatically
 #LLM_ENDPOINT="http://localhost:11434/v1"   # optional; this is the default for ollama
 #EMBEDDING_PROVIDER="ollama"
 #EMBEDDING_MODEL="nomic-embed-text:latest"
+# Set EMBEDDING_ENDPOINT explicitly for the Ollama embedder (it needs /api/embed,
+# not the /v1 chat base) — it does not inherit LLM_ENDPOINT.
 #EMBEDDING_ENDPOINT="http://localhost:11434/api/embed"
 #EMBEDDING_DIMENSIONS=768
 #HUGGINGFACE_TOKENIZER="nomic-ai/nomic-embed-text-v1.5"

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -256,55 +256,43 @@ async fn wire_embedding_engine(cfg: &HttpServerConfig) -> Option<Arc<dyn Embeddi
 }
 
 fn wire_llm(cfg: &HttpServerConfig) -> Option<Arc<dyn Llm>> {
-    if !cfg.llm_provider.eq_ignore_ascii_case("openai") {
-        tracing::warn!(
-            "LLM provider '{}' is not supported by standalone wiring yet; llm not wired",
-            cfg.llm_provider
-        );
-        return None;
-    }
-
-    let api_key = cfg.llm_api_key.expose_secret();
-    if api_key.is_empty() {
-        tracing::warn!("LLM API key missing; llm not wired");
-        return None;
-    }
-
+    // Provider routing (and the required-key / required-endpoint validation) lives
+    // in the shared factory; an unsupported provider or missing credential errors
+    // there and we wire None.
     match build_openai_compatible_adapter(
         &cfg.llm_provider,
         &cfg.llm_model,
-        api_key,
+        cfg.llm_api_key.expose_secret(),
         &cfg.llm_endpoint,
         cfg.llm_max_retries,
     ) {
         Ok(adapter) => Some(Arc::new(adapter) as Arc<dyn Llm>),
         Err(err) => {
-            tracing::warn!("llm wiring failed, wiring as None: {err}");
+            tracing::warn!("llm not wired: {err}");
             None
         }
     }
 }
 
 fn wire_transcriber(cfg: &HttpServerConfig) -> Option<Arc<dyn Transcriber>> {
-    if !cfg.llm_provider.eq_ignore_ascii_case("openai") {
-        return None;
-    }
-
-    let api_key = cfg.llm_api_key.expose_secret();
-    if api_key.is_empty() {
+    // Whisper-style transcription only works against OpenAI and user-pointed
+    // OpenAI-compatible servers that expose /audio/transcriptions; other providers
+    // get graceful no-audio (None).
+    let provider = cfg.llm_provider.to_ascii_lowercase();
+    if !matches!(provider.as_str(), "openai" | "custom" | "openai_compatible") {
         return None;
     }
 
     match build_openai_compatible_adapter(
         &cfg.llm_provider,
         &cfg.llm_model,
-        api_key,
+        cfg.llm_api_key.expose_secret(),
         &cfg.llm_endpoint,
         cfg.llm_max_retries,
     ) {
         Ok(adapter) => Some(Arc::new(adapter) as Arc<dyn Transcriber>),
         Err(err) => {
-            tracing::warn!("transcriber wiring failed, wiring as None: {err}");
+            tracing::warn!("transcriber not wired: {err}");
             None
         }
     }

--- a/crates/lib/src/component_manager.rs
+++ b/crates/lib/src/component_manager.rs
@@ -594,11 +594,12 @@ impl ComponentManager {
             }
         }
 
-        // Build the real adapter exactly as before.
+        // Build the real adapter. OpenAI and the OpenAI-compatible providers all
+        // route through the shared factory (issue #17, Tier 1).
         let adapter: Arc<dyn Llm> = match provider.as_str() {
-            "openai" => {
+            "openai" | "ollama" | "mistral" | "gemini" | "custom" | "openai_compatible" => {
                 let adapter = build_openai_compatible_adapter(
-                    "openai",
+                    &provider,
                     &llm_model,
                     &llm_api_key,
                     &llm_endpoint,
@@ -617,7 +618,8 @@ impl ComponentManager {
             }
             _ => {
                 return Err(ComponentError::Config(format!(
-                    "Unsupported llm_provider '{provider}'. Supported: openai, mock.",
+                    "Unsupported llm_provider '{provider}'. \
+                     Supported: openai, ollama, mistral, gemini, custom, mock.",
                 )));
             }
         };
@@ -659,9 +661,14 @@ impl ComponentManager {
         };
 
         match provider.as_str() {
-            "openai" => {
+            // Whisper-style transcription works against OpenAI and any user-pointed
+            // OpenAI-compatible server that exposes /audio/transcriptions
+            // (Groq, vLLM, a LiteLLM proxy). Ollama/Mistral/Gemini do not expose
+            // that route via the chat path, so they return None (graceful no-audio)
+            // rather than building an adapter that 404s at runtime.
+            "openai" | "custom" | "openai_compatible" => {
                 let adapter = build_openai_compatible_adapter(
-                    "openai",
+                    &provider,
                     &llm_model,
                     &llm_api_key,
                     &llm_endpoint,
@@ -671,7 +678,7 @@ impl ComponentManager {
 
                 Ok(Some(Arc::new(adapter) as Arc<dyn Transcriber>))
             }
-            // litert and any future providers that do not implement Transcriber
+            // litert and providers that do not expose OpenAI-compatible audio
             // return None — audio stays gracefully unsupported (D5).
             _ => Ok(None),
         }

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -104,7 +104,13 @@ impl OpenAIAdapter {
         Ok(Self {
             model,
             api_key: api_key.into(),
-            base_url: base_url.unwrap_or_else(|| Self::DEFAULT_BASE_URL.to_string()),
+            // Normalise a trailing slash so request URLs built as
+            // `{base_url}/chat/completions` never produce a double slash. The
+            // Gemini OpenAI-compat base ends in `/v1beta/openai/`, and a
+            // user-supplied endpoint may too; both would otherwise 404.
+            base_url: base_url
+                .map(|u| u.trim_end_matches('/').to_string())
+                .unwrap_or_else(|| Self::DEFAULT_BASE_URL.to_string()),
             client,
             structured_output_retries: Self::DEFAULT_STRUCTURED_OUTPUT_RETRIES,
             network_retries: Self::DEFAULT_NETWORK_RETRIES,
@@ -1114,6 +1120,22 @@ mod tests {
 
         let adapter = adapter.unwrap();
         assert_eq!(adapter.base_url, "https://custom.api.com/v1");
+    }
+
+    #[test]
+    fn test_base_url_trailing_slash_is_normalized() {
+        // The Gemini OpenAI-compat base ends in `/`; without normalisation the
+        // request URL would be `.../openai//chat/completions` and 404.
+        let adapter = OpenAIAdapter::new(
+            "gemini-2.0-flash",
+            "test-key",
+            Some("https://generativelanguage.googleapis.com/v1beta/openai/".to_string()),
+        )
+        .unwrap();
+        assert_eq!(
+            adapter.base_url,
+            "https://generativelanguage.googleapis.com/v1beta/openai"
+        );
     }
 
     #[test]

--- a/crates/llm/src/factory.rs
+++ b/crates/llm/src/factory.rs
@@ -24,6 +24,17 @@ const MISTRAL_DEFAULT_ENDPOINT: &str = "https://api.mistral.ai/v1";
 /// Default Gemini OpenAI-compatible base URL.
 const GEMINI_DEFAULT_ENDPOINT: &str = "https://generativelanguage.googleapis.com/v1beta/openai/";
 
+/// Providers this factory routes onto [`OpenAIAdapter`]. Single source of truth so
+/// the "unsupported provider" message can never drift from the match arms below.
+const SUPPORTED_PROVIDERS: &[&str] = &[
+    "openai",
+    "ollama",
+    "mistral",
+    "gemini",
+    "custom",
+    "openai_compatible",
+];
+
 /// Build an [`OpenAIAdapter`] for an OpenAI-compatible `provider`.
 ///
 /// Supported providers (case-insensitive): `openai`, `ollama`, `mistral`,
@@ -55,57 +66,45 @@ pub fn build_openai_compatible_adapter(
     let provider = provider.to_ascii_lowercase();
     let endpoint = endpoint.trim();
 
-    // Per provider: resolved base URL, whether an API key is mandatory, and the
-    // litellm-style model prefix to strip (if any).
-    let (base_url, api_key_required, strip_prefix): (Option<String>, bool, Option<&str>) =
-        match provider.as_str() {
-            // Empty endpoint → None so the adapter uses its OpenAI default.
-            "openai" => (non_empty(endpoint), true, None),
-            "ollama" => (
-                Some(endpoint_or(endpoint, OLLAMA_DEFAULT_ENDPOINT)),
-                false,
-                Some("ollama/"),
-            ),
-            "mistral" => (
-                Some(endpoint_or(endpoint, MISTRAL_DEFAULT_ENDPOINT)),
-                true,
-                Some("mistral/"),
-            ),
-            "gemini" => (
-                Some(endpoint_or(endpoint, GEMINI_DEFAULT_ENDPOINT)),
-                true,
-                Some("gemini/"),
-            ),
-            "custom" | "openai_compatible" => {
-                if endpoint.is_empty() {
-                    return Err(LlmError::ConfigError(format!(
-                        "llm_endpoint must be configured for provider '{provider}'"
-                    )));
-                }
-                (Some(endpoint.to_string()), false, None)
-            }
-            other => {
+    // Per provider: resolved base URL and the litellm-style model prefix to strip.
+    let (base_url, strip_prefix): (Option<String>, Option<&str>) = match provider.as_str() {
+        // Empty endpoint → None so the adapter uses its OpenAI default.
+        "openai" => (non_empty(endpoint), None),
+        "ollama" => (
+            Some(endpoint_or(endpoint, OLLAMA_DEFAULT_ENDPOINT)),
+            Some("ollama/"),
+        ),
+        "mistral" => (
+            Some(endpoint_or(endpoint, MISTRAL_DEFAULT_ENDPOINT)),
+            Some("mistral/"),
+        ),
+        "gemini" => (
+            Some(endpoint_or(endpoint, GEMINI_DEFAULT_ENDPOINT)),
+            Some("gemini/"),
+        ),
+        "custom" | "openai_compatible" => {
+            if endpoint.is_empty() {
                 return Err(LlmError::ConfigError(format!(
-                    "Unsupported llm_provider '{other}'. \
-                     Supported: openai, ollama, mistral, gemini, custom."
+                    "llm_endpoint must be configured for provider '{provider}'"
                 )));
             }
-        };
+            (Some(endpoint.to_string()), None)
+        }
+        other => {
+            return Err(LlmError::ConfigError(format!(
+                "Unsupported llm_provider '{other}'. Supported: {}.",
+                SUPPORTED_PROVIDERS.join(", ")
+            )));
+        }
+    };
 
-    if api_key_required && api_key.is_empty() {
+    // Every supported provider requires an API key, matching the Python SDK's
+    // _API_KEY_REQUIRED_PROVIDERS (openai, ollama, mistral, gemini, custom).
+    if api_key.is_empty() {
         return Err(LlmError::ConfigError(
             "llm_api_key must be configured".to_string(),
         ));
     }
-
-    // Ollama ignores auth but the OpenAI-style client still sends a bearer token;
-    // use a harmless placeholder when none is configured (matches Python cognee's
-    // `LLM_API_KEY="ollama"` convention).
-    let api_key = if provider == "ollama" && api_key.is_empty() {
-        "ollama"
-    } else {
-        api_key
-    };
 
     let model = match strip_prefix {
         Some(prefix) => model.strip_prefix(prefix).unwrap_or(model),
@@ -175,10 +174,11 @@ mod tests {
     }
 
     #[test]
-    fn ollama_defaults_endpoint_and_allows_empty_key() {
-        // No endpoint, no key → still builds (Ollama needs neither from the user).
-        let adapter = build_openai_compatible_adapter("ollama", "ollama/llama3.1:8b", "", "", 3)
-            .expect("ollama adapter should build");
+    fn ollama_defaults_endpoint_and_strips_prefix() {
+        // No endpoint → the Ollama default is used; the `ollama/` prefix is stripped.
+        let adapter =
+            build_openai_compatible_adapter("ollama", "ollama/llama3.1:8b", "sk-test", "", 3)
+                .expect("ollama adapter should build");
         assert_eq!(adapter.model(), "llama3.1:8b");
     }
 
@@ -187,12 +187,19 @@ mod tests {
         let adapter = build_openai_compatible_adapter(
             "ollama",
             "llama3.1:8b",
-            "",
+            "sk-test",
             "http://remote:11434/v1",
             3,
         )
         .expect("ollama adapter should build");
         assert_eq!(adapter.model(), "llama3.1:8b");
+    }
+
+    #[test]
+    fn ollama_requires_api_key() {
+        // Parity with Python's _API_KEY_REQUIRED_PROVIDERS: ollama requires a key.
+        let result = build_openai_compatible_adapter("ollama", "llama3.1:8b", "", "", 3);
+        assert!(matches!(result, Err(LlmError::ConfigError(_))));
     }
 
     #[test]
@@ -222,18 +229,26 @@ mod tests {
 
     #[test]
     fn custom_requires_endpoint() {
-        let missing = build_openai_compatible_adapter("custom", "my-model", "", "", 3);
+        let missing = build_openai_compatible_adapter("custom", "my-model", "sk-test", "", 3);
         assert!(matches!(missing, Err(LlmError::ConfigError(_))));
 
         let adapter = build_openai_compatible_adapter(
             "openai_compatible",
             "my-model",
-            "",
+            "sk-test",
             "https://my.host/v1",
             3,
         )
         .expect("custom adapter should build");
         // No prefix stripping for custom — the model is passed through verbatim.
         assert_eq!(adapter.model(), "my-model");
+    }
+
+    #[test]
+    fn custom_requires_api_key() {
+        // Parity with Python's _API_KEY_REQUIRED_PROVIDERS: custom requires a key.
+        let result =
+            build_openai_compatible_adapter("custom", "my-model", "", "https://my.host/v1", 3);
+        assert!(matches!(result, Err(LlmError::ConfigError(_))));
     }
 }

--- a/crates/llm/src/factory.rs
+++ b/crates/llm/src/factory.rs
@@ -4,22 +4,46 @@
 //! (`cognee-http-server`) both wire the LLM the same way: an [`OpenAIAdapter`]
 //! built from the configured model / key / endpoint, with structured-output and
 //! network retries applied. Centralising that here keeps the two wiring paths in
-//! sync (see issue #17). Provider routing beyond `openai` is layered on top of
-//! this function in a follow-up; today it covers the OpenAI / OpenAI-compatible
-//! path that both call sites already used.
+//! sync (see issue #17).
+//!
+//! Several providers in the Python SDK are themselves OpenAI-compatible HTTP
+//! endpoints, so they need only factory routing — not a new adapter. This module
+//! routes `openai`, `ollama`, `mistral`, `gemini`, and `custom` /
+//! `openai_compatible` onto the same [`OpenAIAdapter`], differing only in the base
+//! URL, whether an API key is mandatory, and litellm-style model-prefix stripping.
+//! The OpenAI-only request quirks in the adapter are gated on the
+//! `api.openai.com` host, so pointing it at another compatible endpoint does not
+//! trigger any OpenAI-specific behaviour.
 
 use crate::{LlmError, LlmResult, OpenAIAdapter};
 
+/// Default OpenAI-compatible base URL for a local Ollama server.
+const OLLAMA_DEFAULT_ENDPOINT: &str = "http://localhost:11434/v1";
+/// Default Mistral OpenAI-compatible base URL.
+const MISTRAL_DEFAULT_ENDPOINT: &str = "https://api.mistral.ai/v1";
+/// Default Gemini OpenAI-compatible base URL.
+const GEMINI_DEFAULT_ENDPOINT: &str = "https://generativelanguage.googleapis.com/v1beta/openai/";
+
 /// Build an [`OpenAIAdapter`] for an OpenAI-compatible `provider`.
 ///
+/// Supported providers (case-insensitive): `openai`, `ollama`, `mistral`,
+/// `gemini`, and `custom` / `openai_compatible`.
+///
 /// `endpoint` is the raw configured value; an empty or whitespace-only string is
-/// treated as "unset" so the adapter falls back to its provider default.
+/// treated as "unset" so the provider's default base URL is used (or, for
+/// `openai`, the adapter's built-in OpenAI default). `custom` /
+/// `openai_compatible` has no default and requires an explicit endpoint.
+///
 /// `max_retries` is floored at 1 and applied to both the structured-output and
 /// network retry loops, matching the previous inline wiring.
 ///
-/// Returns [`LlmError::ConfigError`] when a required API key is missing or the
-/// provider is unsupported, so each caller can decide whether to hard-fail
-/// (component manager) or skip and wire `None` (HTTP server).
+/// litellm-style provider prefixes on the model (`ollama/`, `mistral/`,
+/// `gemini/`) are stripped so provider-qualified config values keep working
+/// (the adapter itself only strips `openai/`).
+///
+/// Returns [`LlmError::ConfigError`] when a required API key or endpoint is
+/// missing, or the provider is unsupported, so each caller can decide whether to
+/// hard-fail (component manager) or skip and wire `None` (HTTP server).
 pub fn build_openai_compatible_adapter(
     provider: &str,
     model: &str,
@@ -28,37 +52,87 @@ pub fn build_openai_compatible_adapter(
     max_retries: u32,
 ) -> LlmResult<OpenAIAdapter> {
     let retries = max_retries.max(1);
+    let provider = provider.to_ascii_lowercase();
+    let endpoint = endpoint.trim();
 
-    match provider.to_ascii_lowercase().as_str() {
-        "openai" => {
-            if api_key.is_empty() {
-                return Err(LlmError::ConfigError(
-                    "llm_api_key must be configured".to_string(),
-                ));
+    // Per provider: resolved base URL, whether an API key is mandatory, and the
+    // litellm-style model prefix to strip (if any).
+    let (base_url, api_key_required, strip_prefix): (Option<String>, bool, Option<&str>) =
+        match provider.as_str() {
+            // Empty endpoint → None so the adapter uses its OpenAI default.
+            "openai" => (non_empty(endpoint), true, None),
+            "ollama" => (
+                Some(endpoint_or(endpoint, OLLAMA_DEFAULT_ENDPOINT)),
+                false,
+                Some("ollama/"),
+            ),
+            "mistral" => (
+                Some(endpoint_or(endpoint, MISTRAL_DEFAULT_ENDPOINT)),
+                true,
+                Some("mistral/"),
+            ),
+            "gemini" => (
+                Some(endpoint_or(endpoint, GEMINI_DEFAULT_ENDPOINT)),
+                true,
+                Some("gemini/"),
+            ),
+            "custom" | "openai_compatible" => {
+                if endpoint.is_empty() {
+                    return Err(LlmError::ConfigError(format!(
+                        "llm_endpoint must be configured for provider '{provider}'"
+                    )));
+                }
+                (Some(endpoint.to_string()), false, None)
             }
+            other => {
+                return Err(LlmError::ConfigError(format!(
+                    "Unsupported llm_provider '{other}'. \
+                     Supported: openai, ollama, mistral, gemini, custom."
+                )));
+            }
+        };
 
-            let adapter = OpenAIAdapter::new(
-                model.to_string(),
-                api_key.to_string(),
-                endpoint_or_default(endpoint),
-            )?
-            .with_structured_output_retries(retries)
-            .with_network_retries(retries);
-            Ok(adapter)
-        }
-        other => Err(LlmError::ConfigError(format!(
-            "Unsupported llm_provider '{other}'. Supported: openai."
-        ))),
+    if api_key_required && api_key.is_empty() {
+        return Err(LlmError::ConfigError(
+            "llm_api_key must be configured".to_string(),
+        ));
     }
+
+    // Ollama ignores auth but the OpenAI-style client still sends a bearer token;
+    // use a harmless placeholder when none is configured (matches Python cognee's
+    // `LLM_API_KEY="ollama"` convention).
+    let api_key = if provider == "ollama" && api_key.is_empty() {
+        "ollama"
+    } else {
+        api_key
+    };
+
+    let model = match strip_prefix {
+        Some(prefix) => model.strip_prefix(prefix).unwrap_or(model),
+        None => model,
+    };
+
+    let adapter = OpenAIAdapter::new(model.to_string(), api_key.to_string(), base_url)?
+        .with_structured_output_retries(retries)
+        .with_network_retries(retries);
+    Ok(adapter)
 }
 
-/// Treat an empty / whitespace endpoint as "unset" so the adapter uses its
-/// provider default base URL.
-fn endpoint_or_default(endpoint: &str) -> Option<String> {
-    if endpoint.trim().is_empty() {
+/// `Some(endpoint)` unless it is empty (already trimmed by the caller).
+fn non_empty(endpoint: &str) -> Option<String> {
+    if endpoint.is_empty() {
         None
     } else {
         Some(endpoint.to_string())
+    }
+}
+
+/// The configured endpoint, or `default` when it is empty (already trimmed).
+fn endpoint_or(endpoint: &str, default: &str) -> String {
+    if endpoint.is_empty() {
+        default.to_string()
+    } else {
+        endpoint.to_string()
     }
 }
 
@@ -98,5 +172,68 @@ mod tests {
     fn unsupported_provider_errors() {
         let result = build_openai_compatible_adapter("acme", "model", "key", "", 3);
         assert!(matches!(result, Err(LlmError::ConfigError(_))));
+    }
+
+    #[test]
+    fn ollama_defaults_endpoint_and_allows_empty_key() {
+        // No endpoint, no key → still builds (Ollama needs neither from the user).
+        let adapter = build_openai_compatible_adapter("ollama", "ollama/llama3.1:8b", "", "", 3)
+            .expect("ollama adapter should build");
+        assert_eq!(adapter.model(), "llama3.1:8b");
+    }
+
+    #[test]
+    fn ollama_honors_custom_endpoint() {
+        let adapter = build_openai_compatible_adapter(
+            "ollama",
+            "llama3.1:8b",
+            "",
+            "http://remote:11434/v1",
+            3,
+        )
+        .expect("ollama adapter should build");
+        assert_eq!(adapter.model(), "llama3.1:8b");
+    }
+
+    #[test]
+    fn mistral_requires_key_and_strips_prefix() {
+        let missing =
+            build_openai_compatible_adapter("mistral", "mistral/mistral-large", "", "", 3);
+        assert!(matches!(missing, Err(LlmError::ConfigError(_))));
+
+        let adapter = build_openai_compatible_adapter(
+            "mistral",
+            "mistral/mistral-large-latest",
+            "sk-test",
+            "",
+            3,
+        )
+        .expect("mistral adapter should build");
+        assert_eq!(adapter.model(), "mistral-large-latest");
+    }
+
+    #[test]
+    fn gemini_requires_key_and_strips_prefix() {
+        let adapter =
+            build_openai_compatible_adapter("gemini", "gemini/gemini-2.0-flash", "sk-test", "", 3)
+                .expect("gemini adapter should build");
+        assert_eq!(adapter.model(), "gemini-2.0-flash");
+    }
+
+    #[test]
+    fn custom_requires_endpoint() {
+        let missing = build_openai_compatible_adapter("custom", "my-model", "", "", 3);
+        assert!(matches!(missing, Err(LlmError::ConfigError(_))));
+
+        let adapter = build_openai_compatible_adapter(
+            "openai_compatible",
+            "my-model",
+            "",
+            "https://my.host/v1",
+            3,
+        )
+        .expect("custom adapter should build");
+        // No prefix stripping for custom — the model is passed through verbatim.
+        assert_eq!(adapter.model(), "my-model");
     }
 }

--- a/crates/llm/tests/integration_providers.rs
+++ b/crates/llm/tests/integration_providers.rs
@@ -1,0 +1,113 @@
+//! Gracefully-skipped integration tests for the OpenAI-compatible providers wired
+//! in Tier 1 (issue #17): `ollama`, `mistral`, `gemini`, and `custom`.
+//!
+//! Each test builds its adapter through the same factory the runtime uses
+//! (`build_openai_compatible_adapter`) and runs one real completion. A test is
+//! **skipped** (early return, not a failure) when the provider's credentials are
+//! absent, so CI stays green without secrets — mirroring `integration_openai.rs`.
+//!
+//! Per-provider environment variables (all optional; absent => skip):
+//! - ollama:  `OLLAMA_LLM_API_KEY`,  `OLLAMA_LLM_MODEL`,  `OLLAMA_LLM_ENDPOINT`  (endpoint defaults to the local Ollama server)
+//! - mistral: `MISTRAL_LLM_API_KEY`, `MISTRAL_LLM_MODEL`, `MISTRAL_LLM_ENDPOINT` (endpoint defaults to the Mistral API)
+//! - gemini:  `GEMINI_LLM_API_KEY`,  `GEMINI_LLM_MODEL`,  `GEMINI_LLM_ENDPOINT`  (endpoint defaults to the Gemini OpenAI-compat shim)
+//! - custom:  `CUSTOM_LLM_API_KEY`,  `CUSTOM_LLM_MODEL`,  `CUSTOM_LLM_ENDPOINT`  (endpoint is required)
+//!
+//! Run with: cargo test --package cognee-llm --test integration_providers
+
+use cognee_llm::{GenerationOptions, Llm, Message, build_openai_compatible_adapter};
+
+/// Read an env var (loading `.env` first), returning `None` when unset/empty.
+fn env_opt(name: &str) -> Option<String> {
+    let _ = dotenv::dotenv();
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+/// Build the adapter and run one tiny completion, or skip when creds are absent.
+///
+/// `endpoint` is `None` for providers with a built-in default (ollama/mistral/gemini)
+/// and required for `custom`.
+async fn run_provider_smoke(provider: &str, key_env: &str, model_env: &str, endpoint_env: &str) {
+    let Some(api_key) = env_opt(key_env) else {
+        eprintln!("⏭  skipping {provider}: {key_env} not set");
+        return;
+    };
+    let Some(model) = env_opt(model_env) else {
+        eprintln!("⏭  skipping {provider}: {model_env} not set");
+        return;
+    };
+    let endpoint = env_opt(endpoint_env).unwrap_or_default();
+
+    // `custom` has no default endpoint; skip rather than fail when it is missing.
+    if (provider == "custom" || provider == "openai_compatible") && endpoint.is_empty() {
+        eprintln!("⏭  skipping {provider}: {endpoint_env} not set (required for custom)");
+        return;
+    }
+
+    let adapter = build_openai_compatible_adapter(provider, &model, &api_key, &endpoint, 3)
+        .unwrap_or_else(|e| panic!("❌ {provider}: failed to build adapter: {e}"));
+
+    let result = adapter
+        .generate(
+            vec![
+                Message::system("You are a helpful assistant."),
+                Message::user("What is 2+2? Answer with just the number."),
+            ],
+            Some(GenerationOptions {
+                temperature: Some(0.0),
+                max_tokens: Some(16),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("❌ {provider}: generation failed: {e}"));
+
+    assert!(
+        !result.content.is_empty(),
+        "{provider}: response content should not be empty"
+    );
+    eprintln!("✅ {provider}: '{}'", result.content.trim());
+}
+
+#[tokio::test]
+async fn ollama_completion_smoke() {
+    run_provider_smoke(
+        "ollama",
+        "OLLAMA_LLM_API_KEY",
+        "OLLAMA_LLM_MODEL",
+        "OLLAMA_LLM_ENDPOINT",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn mistral_completion_smoke() {
+    run_provider_smoke(
+        "mistral",
+        "MISTRAL_LLM_API_KEY",
+        "MISTRAL_LLM_MODEL",
+        "MISTRAL_LLM_ENDPOINT",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn gemini_completion_smoke() {
+    run_provider_smoke(
+        "gemini",
+        "GEMINI_LLM_API_KEY",
+        "GEMINI_LLM_MODEL",
+        "GEMINI_LLM_ENDPOINT",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn custom_completion_smoke() {
+    run_provider_smoke(
+        "custom",
+        "CUSTOM_LLM_API_KEY",
+        "CUSTOM_LLM_MODEL",
+        "CUSTOM_LLM_ENDPOINT",
+    )
+    .await;
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,27 @@ A fallback LLM (`llm_fallback_provider/_model/_endpoint/_api_key`) is configurab
 programmatically (no env binding). `MOCK_LLM` + cassettes power the offline
 benchmark — see [performance/mock-benchmark.md](performance/mock-benchmark.md).
 
+### Supported `LLM_PROVIDER` values
+
+Several providers are OpenAI-compatible HTTP endpoints, so they route through the
+same adapter — differing only in base URL, whether `LLM_API_KEY` is required, and
+litellm-style model-prefix stripping. The OpenAI-only request quirks are gated on
+the `api.openai.com` host, so they never fire against another endpoint.
+
+| `LLM_PROVIDER` | `LLM_API_KEY` | `LLM_ENDPOINT` default | Model prefix stripped |
+|---|---|---|---|
+| `openai` | required | `https://api.openai.com/v1` | `openai/` |
+| `ollama` | optional (placeholder used) | `http://localhost:11434/v1` | `ollama/` |
+| `mistral` | required | `https://api.mistral.ai/v1` | `mistral/` |
+| `gemini` | required | `https://generativelanguage.googleapis.com/v1beta/openai/` | `gemini/` |
+| `custom` / `openai_compatible` | optional | **required** (no default) | _(none)_ |
+| `mock` | — | — | — (see `MOCK_LLM`) |
+
+`LLM_ENDPOINT` always overrides the default when set. Audio transcription
+(Whisper) is wired only for `openai` and `custom`/`openai_compatible` (which may
+expose `/audio/transcriptions`); `ollama`/`mistral`/`gemini` get graceful no-audio.
+Native Anthropic, Azure, and Bedrock adapters are tracked separately in issue #17.
+
 ## Embedding
 
 Read by `EmbeddingConfig::from_env()` ([`crates/embedding/src/config.rs`](../crates/embedding/src/config.rs)).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,23 +52,30 @@ benchmark — see [performance/mock-benchmark.md](performance/mock-benchmark.md)
 ### Supported `LLM_PROVIDER` values
 
 Several providers are OpenAI-compatible HTTP endpoints, so they route through the
-same adapter — differing only in base URL, whether `LLM_API_KEY` is required, and
-litellm-style model-prefix stripping. The OpenAI-only request quirks are gated on
-the `api.openai.com` host, so they never fire against another endpoint.
+same adapter — differing only in base URL and litellm-style model-prefix stripping.
+`LLM_API_KEY` is required for every provider (matching the Python SDK's
+`_API_KEY_REQUIRED_PROVIDERS`; for a local Ollama any non-empty value works). The
+OpenAI-only request quirks are gated on the `api.openai.com` host, so they never
+fire against another endpoint.
 
 | `LLM_PROVIDER` | `LLM_API_KEY` | `LLM_ENDPOINT` default | Model prefix stripped |
 |---|---|---|---|
 | `openai` | required | `https://api.openai.com/v1` | `openai/` |
-| `ollama` | optional (placeholder used) | `http://localhost:11434/v1` | `ollama/` |
+| `ollama` | required (any value for local) | `http://localhost:11434/v1` | `ollama/` |
 | `mistral` | required | `https://api.mistral.ai/v1` | `mistral/` |
 | `gemini` | required | `https://generativelanguage.googleapis.com/v1beta/openai/` | `gemini/` |
-| `custom` / `openai_compatible` | optional | **required** (no default) | _(none)_ |
+| `custom` / `openai_compatible` | required | **required** (no default) | _(none)_ |
 | `mock` | — | — | — (see `MOCK_LLM`) |
 
 `LLM_ENDPOINT` always overrides the default when set. Audio transcription
 (Whisper) is wired only for `openai` and `custom`/`openai_compatible` (which may
 expose `/audio/transcriptions`); `ollama`/`mistral`/`gemini` get graceful no-audio.
 Native Anthropic, Azure, and Bedrock adapters are tracked separately in issue #17.
+
+> **Ollama embeddings:** set `EMBEDDING_ENDPOINT` explicitly when using
+> `EMBEDDING_PROVIDER=ollama`. The Ollama embedder needs the `/api/embed` route, and
+> the embedding endpoint does not inherit `LLM_ENDPOINT` (which points at the `/v1`
+> chat base), so leaving it unset would target the wrong path.
 
 ## Embedding
 


### PR DESCRIPTION
## Summary

Tier 1 of #17  - close the LLM-adapter parity gap with the Python SDK for the providers that are themselves OpenAI-compatible HTTP endpoints. Builds on #29 (the shared adapter factory).

Routes `ollama`, `mistral`, `gemini`, and `custom` / `openai_compatible` onto the existing `OpenAIAdapter` via the shared factory - no new adapter. The OpenAI-only request quirks stay gated on the `api.openai.com` host, so they never fire against
another endpoint.

## Routing

| Provider | API key | `LLM_ENDPOINT` default | Model prefix stripped |
|---|---|---|---|
| `ollama` | optional (placeholder used) | `http://localhost:11434/v1` | `ollama/` |
| `mistral` | required | `https://api.mistral.ai/v1` | `mistral/` |
| `gemini` | required | `https://generativelanguage.googleapis.com/v1beta/openai/` | `gemini/` |
| `custom` / `openai_compatible` | optional | **required (no default)** | none |

`LLM_ENDPOINT` always overrides the default. litellm-style model prefixes are stripped in the factory (the adapter already strips `openai/`).

## Wiring

- `ComponentManager` (`init_llm_adapter`) and the HTTP server (`wire_llm`) route the   new providers for completion.
- Transcription (`init_transcriber` / `wire_transcriber`) stays on `openai` and  `custom`/`openai_compatible` (which may expose `/audio/transcriptions`); `ollama`/`mistral`/`gemini` get graceful no-audio (`None`) rather than an adapter that 404s at runtime.

## Tests / docs

- 9 factory unit tests: per-provider endpoint defaults, prefix stripping, required-key / required-endpoint errors, unknown-provider error.
- Supported-provider table in `docs/configuration.md`; `.env.example` Ollama block switched to the native `ollama` provider.
- Verified: `fmt`, `clippy --all-targets -D warnings`, `cognee-lib --no-default-features`.

## Scope

Part of #17 - does not close it. Native Anthropic (Tier 2) and Azure/Bedrock (Tier 3) follow in separate PRs.