### PR TITLE
ci(ts-prebuild): build darwin-arm64 on macos-15 (Xcode 16.4)

### DIFF
--- a/.github/workflows/ts-prebuild.yml
+++ b/.github/workflows/ts-prebuild.yml
@@ -36,6 +36,9 @@ jobs:
   # ── Build per-platform .node artifacts ───────────────────────────────
   build-platform:
     name: Build ${{ matrix.platform }}
+    # Cap each leg so a stuck build (e.g. a hung native compile) fails fast
+    # instead of running to the 6h/24h default and burning runner time.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -70,9 +73,12 @@ jobs:
             rust-target: x86_64-apple-darwin
             cross: false
 
-          # macOS arm64 (Apple Silicon)
+          # macOS arm64 (Apple Silicon). Use macos-15 (default Xcode 16.4):
+          # the older macos-14 default (Xcode 15.4) ships a libc++ whose
+          # std::construct_at trips a C++20 aggregate-init bug while compiling
+          # lbug's bundled C++ (needs Clang 16+ / P0960 support).
           - platform: darwin-arm64
-            runner: macos-14
+            runner: macos-15
             rust-target: aarch64-apple-darwin
             cross: false
 


### PR DESCRIPTION
## Problem

The `darwin-arm64` prebuild leg already targets a native Apple Silicon runner, but it **fails in ~29 min** compiling the bundled C++ dep `lbug v0.14.1`:

```
.../Xcode_15.4.app/.../c++/v1/__memory/allocator_traits.h:304:9:
error: no matching function for call to 'construct_at'
failed to run custom build command for `lbug v0.14.1` (exit status 101)
```

This is the known libc++ **C++20 aggregate-init / `construct_at`** failure. The `macos-14` image **defaults to Xcode 15.4** (Apple clang 15), which lacks the Clang 16+ / P0960 support `lbug` needs — which is why the artifact has been built locally on a newer-Xcode laptop instead of in CI.

## Fix

- Switch the `darwin-arm64` leg from `macos-14` → **`macos-15`** (default **Xcode 16.4**). Still a native Apple Silicon runner, so no cross-compile. `macos-15` standard runners are free on this public repo.
- Add `timeout-minutes: 90` to `build-platform` so a stuck leg fails fast instead of running to the default (the `darwin-x64` leg recently ran the full 24h).

## Notes

- The `darwin-x64` (`macos-13`, Intel) leg hanging for 24h is a **separate** issue, not addressed here. The new `timeout-minutes` cap at least stops it from burning a full day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)