### PR TITLE
Perf: Optimize embeddings generation & engines

### DIFF
--- a/crates/cli/src/config_store.rs
+++ b/crates/cli/src/config_store.rs
@@ -141,6 +141,7 @@ pub fn known_keys() -> Vec<&'static str> {
         "embedding_dimensions",
         "embedding_max_sequence_length",
         "embedding_batch_size",
+        "embedding_onnx_batch_size",
         "embedding_provider",
         "embedding_endpoint",
         "embedding_api_key",
@@ -312,6 +313,10 @@ pub fn as_flat_map(settings: &Settings) -> BTreeMap<&'static str, Value> {
             Value::from(settings.embedding_batch_size),
         ),
         (
+            "embedding_onnx_batch_size",
+            Value::from(settings.embedding_onnx_batch_size),
+        ),
+        (
             "embedding_provider",
             Value::String(settings.embedding_provider.clone()),
         ),
@@ -388,6 +393,7 @@ pub fn set_value(settings: &mut Settings, key: &str, value: Value) -> Result<(),
             settings.embedding_max_sequence_length = expect_u32(key, value)?
         }
         "embedding_batch_size" => settings.embedding_batch_size = expect_u32(key, value)?,
+        "embedding_onnx_batch_size" => settings.embedding_onnx_batch_size = expect_u32(key, value)?,
         "embedding_provider" => settings.embedding_provider = expect_string(key, value)?,
         "embedding_endpoint" => settings.embedding_endpoint = expect_string(key, value)?,
         "embedding_api_key" => settings.embedding_api_key = expect_string(key, value)?,
@@ -475,6 +481,9 @@ pub fn unset_key(settings: &mut Settings, key: &str) -> Result<(), CliError> {
             settings.embedding_max_sequence_length = defaults.embedding_max_sequence_length
         }
         "embedding_batch_size" => settings.embedding_batch_size = defaults.embedding_batch_size,
+        "embedding_onnx_batch_size" => {
+            settings.embedding_onnx_batch_size = defaults.embedding_onnx_batch_size
+        }
         "embedding_provider" => settings.embedding_provider = defaults.embedding_provider,
         "embedding_endpoint" => settings.embedding_endpoint = defaults.embedding_endpoint,
         "embedding_api_key" => settings.embedding_api_key = defaults.embedding_api_key,

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -2652,6 +2652,7 @@ async fn reuse_or_embed(
     ids: &[Uuid],
     texts: &[&str],
 ) -> Result<Vec<Vec<f32>>, CognifyError> {
+    debug_assert_eq!(ids.len(), texts.len(), "ids and texts must be parallel");
     let missing_texts: Vec<&str> = ids
         .iter()
         .zip(texts)

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -1098,6 +1098,7 @@ pub async fn add_data_points(
         embedding_engine,
         vector_db,
         config,
+        &embeddings,
     )
     .await?;
 
@@ -2642,6 +2643,42 @@ async fn generate_embeddings(
     Ok(embeddings)
 }
 
+/// Return one vector per `texts[i]`, reusing `precomputed[ids[i]]` when present
+/// and embedding only the texts whose id is missing. `ids` and `texts` must be
+/// parallel slices.
+async fn reuse_or_embed(
+    engine: &Arc<dyn EmbeddingEngine>,
+    precomputed: &std::collections::HashMap<Uuid, Vec<f32>>,
+    ids: &[Uuid],
+    texts: &[&str],
+) -> Result<Vec<Vec<f32>>, CognifyError> {
+    let missing_texts: Vec<&str> = ids
+        .iter()
+        .zip(texts)
+        .filter(|(id, _)| !precomputed.contains_key(*id))
+        .map(|(_, text)| *text)
+        .collect();
+
+    let fresh = if missing_texts.is_empty() {
+        Vec::new()
+    } else {
+        engine
+            .embed(&missing_texts)
+            .await
+            .map_err(|e| CognifyError::EmbeddingError(e.to_string()))?
+    };
+
+    let mut fresh = fresh.into_iter();
+    ids.iter()
+        .map(|id| match precomputed.get(id) {
+            Some(vector) => Ok(vector.clone()),
+            None => fresh
+                .next()
+                .ok_or_else(|| CognifyError::EmbeddingError("missing fresh embedding".into())),
+        })
+        .collect()
+}
+
 /// Index data points in vector database.
 #[allow(clippy::too_many_arguments)]
 async fn index_data_points(
@@ -2657,9 +2694,18 @@ async fn index_data_points(
     engine: Arc<dyn EmbeddingEngine>,
     vector_db: Arc<dyn VectorDB>,
     config: &CognifyConfig,
+    precomputed_embeddings: &[Embedding],
 ) -> Result<IndexedFieldsStats, CognifyError> {
     let mut stats = IndexedFieldsStats::default();
     let dimension = engine.dimension();
+
+    // Vectors already produced by `generate_embeddings`, keyed by data point id,
+    // so the chunk/entity/summary collections below reuse them rather than
+    // re-embedding the same text.
+    let precomputed: std::collections::HashMap<Uuid, Vec<f32>> = precomputed_embeddings
+        .iter()
+        .map(|e| (e.data_point_id, e.vector.clone()))
+        .collect();
 
     // 1. Index DocumentChunk.text field
     if !chunks.is_empty() {
@@ -2674,11 +2720,9 @@ async fn index_data_points(
                 .map_err(|e| CognifyError::VectorDBError(e.to_string()))?;
         }
 
+        let ids: Vec<Uuid> = chunks.iter().map(|c| c.base.id).collect();
         let texts: Vec<_> = chunks.iter().map(|c| c.text.as_str()).collect();
-        let vectors = engine
-            .embed(&texts)
-            .await
-            .map_err(|e| CognifyError::EmbeddingError(e.to_string()))?;
+        let vectors = reuse_or_embed(&engine, &precomputed, &ids, &texts).await?;
 
         let points: Vec<VectorPoint> = chunks
             .iter()
@@ -2731,11 +2775,9 @@ async fn index_data_points(
                 .map_err(|e| CognifyError::VectorDBError(e.to_string()))?;
         }
 
+        let ids: Vec<Uuid> = entities.iter().map(|e| e.entity.base.id).collect();
         let names: Vec<_> = entities.iter().map(|e| e.entity.name.as_str()).collect();
-        let vectors = engine
-            .embed(&names)
-            .await
-            .map_err(|e| CognifyError::EmbeddingError(e.to_string()))?;
+        let vectors = reuse_or_embed(&engine, &precomputed, &ids, &names).await?;
 
         let points: Vec<VectorPoint> = entities
             .iter()
@@ -2850,11 +2892,9 @@ async fn index_data_points(
                 .map_err(|e| CognifyError::VectorDBError(e.to_string()))?;
         }
 
+        let ids: Vec<Uuid> = summaries.iter().map(|s| s.base.id).collect();
         let texts: Vec<_> = summaries.iter().map(|s| s.text.as_str()).collect();
-        let vectors = engine
-            .embed(&texts)
-            .await
-            .map_err(|e| CognifyError::EmbeddingError(e.to_string()))?;
+        let vectors = reuse_or_embed(&engine, &precomputed, &ids, &texts).await?;
 
         let points: Vec<VectorPoint> = summaries
             .iter()
@@ -4017,6 +4057,191 @@ mod tests {
             "paragraph_end".to_string(),
             doc_id,
         )
+    }
+
+    fn test_entity(name: &str, entity_type_id: Uuid) -> GraphNodePair {
+        let mut entity_base = DataPoint::new("Entity", None);
+        entity_base.id = Uuid::new_v4();
+        let entity = cognee_models::Entity {
+            base: entity_base,
+            name: name.to_string(),
+            is_a: None,
+            description: format!("description of {name}"),
+        };
+
+        let mut type_base = DataPoint::new("EntityType", None);
+        type_base.id = entity_type_id;
+        let entity_type = cognee_models::EntityType {
+            base: type_base,
+            name: "Generic".to_string(),
+            description: "Generic type".to_string(),
+        };
+
+        GraphNodePair {
+            entity,
+            entity_type,
+        }
+    }
+
+    // index_data_points reuses the vectors produced by generate_embeddings, so
+    // chunks/entities/summaries are embedded once. Only the entity-type name is
+    // embedded inside index_data_points, for 6 embedded texts in total.
+    #[tokio::test]
+    async fn embedding_reuse_avoids_double_pass() {
+        use cognee_embedding::MockEmbeddingEngine;
+        use cognee_vector::MockVectorDB;
+
+        let engine = Arc::new(MockEmbeddingEngine::new(8));
+        let engine_dyn: Arc<dyn EmbeddingEngine> = engine.clone();
+        let vector: Arc<dyn VectorDB> = Arc::new(MockVectorDB::new());
+
+        let doc_id = Uuid::new_v4();
+        let chunks = vec![
+            test_chunk(Uuid::new_v4(), doc_id, "first chunk text"),
+            test_chunk(Uuid::new_v4(), doc_id, "second chunk text"),
+        ];
+
+        // Both entities share one EntityType id, so dedup embeds a single type.
+        let shared_type_id = Uuid::new_v4();
+        let entities = vec![
+            test_entity("Alice", shared_type_id),
+            test_entity("Bob", shared_type_id),
+        ];
+
+        let summaries = vec![TextSummary::new(
+            chunks[0].base.id,
+            "a summary".to_string(),
+            None,
+            "mock-model".to_string(),
+        )];
+
+        let dataset_id = Uuid::new_v4();
+        let config = CognifyConfig::default(); // embed_triplets = false
+
+        // 2 chunks + 2 entities + 1 summary = 5 texts.
+        let embeddings = generate_embeddings(&chunks, &entities, &summaries, engine_dyn.clone())
+            .await
+            .unwrap();
+        assert_eq!(embeddings.len(), 5);
+        assert_eq!(engine.embedded_text_count(), 5);
+
+        index_data_points(
+            &chunks,
+            &entities,
+            &summaries,
+            &[],
+            &[],
+            &[],
+            dataset_id,
+            None,
+            None,
+            engine_dyn,
+            vector,
+            &config,
+            &embeddings,
+        )
+        .await
+        .unwrap();
+
+        // 5 from generate_embeddings + 1 entity-type (not precomputed) = 6.
+        assert_eq!(engine.embedded_text_count(), 6);
+    }
+
+    // Prints a before/after embedding-work comparison for a realistic fixture.
+    // The "before" run passes an empty precomputed slice, which reproduces the
+    // pre-fix double pass (index_data_points re-embeds everything); the "after"
+    // run passes the precomputed vectors so chunks/entities/summaries are
+    // embedded once. Run with:
+    //   cargo test -p cognee-cognify --lib report_embedding_reuse_savings -- --nocapture
+    #[tokio::test]
+    async fn report_embedding_reuse_savings() {
+        use cognee_embedding::MockEmbeddingEngine;
+        use cognee_vector::MockVectorDB;
+
+        let doc_id = Uuid::new_v4();
+        let chunks: Vec<DocumentChunk> = (0..24)
+            .map(|i| test_chunk(Uuid::new_v4(), doc_id, &format!("chunk text number {i}")))
+            .collect();
+        let type_ids: Vec<Uuid> = (0..4).map(|_| Uuid::new_v4()).collect();
+        let entities: Vec<GraphNodePair> = (0..16)
+            .map(|i| test_entity(&format!("Entity {i}"), type_ids[i % 4]))
+            .collect();
+        let summaries: Vec<TextSummary> = (0..10)
+            .map(|i| {
+                TextSummary::new(
+                    Uuid::new_v4(),
+                    format!("summary number {i}"),
+                    None,
+                    "mock-model".to_string(),
+                )
+            })
+            .collect();
+
+        let overlap = chunks.len() + entities.len() + summaries.len();
+        let dataset_id = Uuid::new_v4();
+        let config = CognifyConfig::default();
+
+        // Runs generate_embeddings + index_data_points on one counting engine
+        // and returns (embed calls, texts embedded). `reuse = false` passes an
+        // empty precomputed slice to reproduce the pre-fix behavior.
+        async fn measure(
+            reuse: bool,
+            chunks: &[DocumentChunk],
+            entities: &[GraphNodePair],
+            summaries: &[TextSummary],
+            dataset_id: Uuid,
+            config: &CognifyConfig,
+        ) -> (usize, usize) {
+            let engine = Arc::new(MockEmbeddingEngine::new(8));
+            let engine_dyn: Arc<dyn EmbeddingEngine> = engine.clone();
+            let vector: Arc<dyn VectorDB> = Arc::new(MockVectorDB::new());
+
+            let embeddings = generate_embeddings(chunks, entities, summaries, engine_dyn.clone())
+                .await
+                .unwrap();
+            let precomputed: &[Embedding] = if reuse { &embeddings } else { &[] };
+            index_data_points(
+                chunks,
+                entities,
+                summaries,
+                &[],
+                &[],
+                &[],
+                dataset_id,
+                None,
+                None,
+                engine_dyn,
+                vector,
+                config,
+                precomputed,
+            )
+            .await
+            .unwrap();
+            (engine.call_count(), engine.embedded_text_count())
+        }
+
+        let (before_calls, before_texts) =
+            measure(false, &chunks, &entities, &summaries, dataset_id, &config).await;
+        let (after_calls, after_texts) =
+            measure(true, &chunks, &entities, &summaries, dataset_id, &config).await;
+
+        println!(
+            "\n  Embedding work per cognify ({} chunks / {} entities / {} summaries):",
+            chunks.len(),
+            entities.len(),
+            summaries.len()
+        );
+        println!("    BEFORE (double pass): {before_calls} embed() calls, {before_texts} texts");
+        println!("    AFTER  (reuse)      : {after_calls} embed() calls, {after_texts} texts");
+        println!(
+            "    Saved: {} texts ({:.0}% fewer)\n",
+            before_texts - after_texts,
+            100.0 * (before_texts - after_texts) as f64 / before_texts as f64,
+        );
+
+        // The fix removes exactly one redundant embedding of every
+        // chunk/entity/summary text.
+        assert_eq!(before_texts - after_texts, overlap);
     }
 
     fn url_metadata(url: &str, final_url: &str, title: &str) -> String {

--- a/crates/embedding/Cargo.toml
+++ b/crates/embedding/Cargo.toml
@@ -51,6 +51,7 @@ tokenizers  = { workspace = true, optional = true }
 [dev-dependencies]
 serial_test = { workspace = true }
 tempfile = { workspace = true }
+mockito = "1"
 
 # The integration test exercises the ONNX engine (config::OnnxEmbeddingConfig,
 # onnx::OnnxEmbeddingEngine), which only exist under the `onnx` feature. Gate it

--- a/crates/embedding/src/config.rs
+++ b/crates/embedding/src/config.rs
@@ -150,6 +150,7 @@ impl OnnxEmbeddingConfig {
 /// - `EMBEDDING_API_VERSION` — API version string
 /// - `EMBEDDING_MAX_COMPLETION_TOKENS` — maximum tokens (default: 8191)
 /// - `EMBEDDING_BATCH_SIZE` — texts per embedding request (default: 36)
+/// - `EMBEDDING_ONNX_BATCH_SIZE` — ONNX inference batch size (default: 32; `onnx` feature only)
 /// - `HUGGINGFACE_TOKENIZER` — HuggingFace tokenizer identifier
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingConfig {
@@ -431,6 +432,14 @@ impl EmbeddingConfig {
             config.batch_size = n;
         }
 
+        #[cfg(feature = "onnx")]
+        if let Ok(val) = std::env::var("EMBEDDING_ONNX_BATCH_SIZE")
+            && let Ok(n) = val.trim().parse::<usize>()
+            && n > 0
+        {
+            config.onnx.batch_size = n;
+        }
+
         // HUGGINGFACE_TOKENIZER
         if let Ok(val) = std::env::var("HUGGINGFACE_TOKENIZER") {
             let val = val.trim().to_string();
@@ -629,6 +638,17 @@ mod tests {
         unsafe { std::env::remove_var("EMBEDDING_API_KEY") };
         unsafe { std::env::remove_var("LLM_API_KEY") };
         assert_eq!(config.api_key, Some("embed-key".to_string()));
+    }
+
+    #[test]
+    #[cfg(feature = "onnx")]
+    #[serial]
+    fn from_env_onnx_batch_size_override() {
+        // SAFETY: see test_from_env_mock_embedding_true
+        unsafe { std::env::set_var("EMBEDDING_ONNX_BATCH_SIZE", "8") };
+        let config = EmbeddingConfig::from_env();
+        unsafe { std::env::remove_var("EMBEDDING_ONNX_BATCH_SIZE") };
+        assert_eq!(config.onnx.batch_size, 8);
     }
 
     #[test]

--- a/crates/embedding/src/config.rs
+++ b/crates/embedding/src/config.rs
@@ -149,7 +149,7 @@ impl OnnxEmbeddingConfig {
 /// - `EMBEDDING_API_KEY` — API key (fallback: `LLM_API_KEY`)
 /// - `EMBEDDING_API_VERSION` — API version string
 /// - `EMBEDDING_MAX_COMPLETION_TOKENS` — maximum tokens (default: 8191)
-/// - `EMBEDDING_BATCH_SIZE` — texts per batch (default: 36)
+/// - `EMBEDDING_BATCH_SIZE` — texts per embedding request (default: 36)
 /// - `HUGGINGFACE_TOKENIZER` — HuggingFace tokenizer identifier
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingConfig {
@@ -176,6 +176,12 @@ pub struct EmbeddingConfig {
     pub max_completion_tokens: usize,
 
     /// Number of texts to send in a single embedding request (default: 36).
+    ///
+    /// Matches the Python SDK and stays within the small client-batch limits of
+    /// the self-hosted servers this adapter targets (e.g. TEI defaults to 32).
+    /// Raise it via `EMBEDDING_BATCH_SIZE` for providers that accept larger
+    /// batches. For the OpenAI-compatible engine, up to `MAX_CONCURRENT_BATCHES`
+    /// sub-batches are also dispatched concurrently.
     pub batch_size: usize,
 
     /// If true, use mock embeddings regardless of `provider`.

--- a/crates/embedding/src/mock.rs
+++ b/crates/embedding/src/mock.rs
@@ -41,6 +41,8 @@ pub struct MockEmbeddingEngine {
     failure_after: Arc<Mutex<Option<usize>>>,
     /// Number of `embed` invocations observed.
     call_count: Arc<Mutex<usize>>,
+    /// Total number of texts passed across all `embed` invocations.
+    text_count: Arc<Mutex<usize>>,
 }
 
 impl MockEmbeddingEngine {
@@ -54,6 +56,7 @@ impl MockEmbeddingEngine {
             mode: MockVectorMode::Zero,
             failure_after: Arc::new(Mutex::new(None)),
             call_count: Arc::new(Mutex::new(0)),
+            text_count: Arc::new(Mutex::new(0)),
         }
     }
 
@@ -67,6 +70,7 @@ impl MockEmbeddingEngine {
             mode: MockVectorMode::Zero,
             failure_after: Arc::new(Mutex::new(None)),
             call_count: Arc::new(Mutex::new(0)),
+            text_count: Arc::new(Mutex::new(0)),
         }
     }
 
@@ -79,6 +83,7 @@ impl MockEmbeddingEngine {
             mode: MockVectorMode::Deterministic,
             failure_after: Arc::new(Mutex::new(None)),
             call_count: Arc::new(Mutex::new(0)),
+            text_count: Arc::new(Mutex::new(0)),
         }
     }
 
@@ -126,6 +131,16 @@ impl MockEmbeddingEngine {
         let mut slot = self.failure_after.lock().unwrap(); // lock poison is unrecoverable
         *slot = Some(n);
     }
+
+    /// Number of `embed` invocations observed so far (one per batched call).
+    pub fn call_count(&self) -> usize {
+        *self.call_count.lock().unwrap() // lock poison is unrecoverable
+    }
+
+    /// Total number of texts embedded across all `embed` invocations.
+    pub fn embedded_text_count(&self) -> usize {
+        *self.text_count.lock().unwrap() // lock poison is unrecoverable
+    }
 }
 
 #[async_trait]
@@ -137,6 +152,10 @@ impl EmbeddingEngine for MockEmbeddingEngine {
             *count += 1;
             *count
         };
+        {
+            let mut texts_seen = self.text_count.lock().unwrap(); // lock poison is unrecoverable
+            *texts_seen += texts.len();
+        }
         let failure_threshold = {
             let slot = self.failure_after.lock().unwrap(); // lock poison is unrecoverable
             *slot

--- a/crates/embedding/src/ollama.rs
+++ b/crates/embedding/src/ollama.rs
@@ -38,6 +38,20 @@ struct OllamaBatchEmbedRequest<'a> {
     dimensions: Option<usize>,
 }
 
+/// Outcome of a failed batched (`array input`) request.
+///
+/// Only [`BatchError::ArrayUnsupported`] triggers the per-text fallback in
+/// [`OllamaEmbeddingEngine::embed_all`]; a [`BatchError::Fatal`] (real HTTP or
+/// parse error such as 404 model-not-found) propagates instead of fanning out
+/// `1 + N` doomed requests.
+enum BatchError {
+    /// The server likely ignores/does not support array `input`: it returned a
+    /// count that does not match the inputs or an unrecognised response shape.
+    ArrayUnsupported,
+    /// A genuine error that per-text requests would hit too.
+    Fatal(EmbeddingError),
+}
+
 // ─── Engine ───────────────────────────────────────────────────────────────────
 
 /// Embedding engine that calls the Ollama `/api/embed` HTTP endpoint.
@@ -191,12 +205,7 @@ impl OllamaEmbeddingEngine {
     }
 
     /// Call the endpoint once with an array `input` (no retry).
-    ///
-    /// Returns [`EmbeddingError::ApiError`] if the server returns a number of
-    /// embeddings that does not match the number of inputs — which is also how
-    /// servers that ignore array `input` surface, letting [`embed_all`] fall
-    /// back to one request per text.
-    async fn embed_batch_once(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
+    async fn embed_batch_once(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, BatchError> {
         let truncated: Vec<&str> = texts.iter().map(|t| self.truncate_text(t)).collect();
 
         let request_body = OllamaBatchEmbedRequest {
@@ -215,7 +224,9 @@ impl OllamaEmbeddingEngine {
             .json(&request_body)
             .send()
             .await
-            .map_err(|e| EmbeddingError::HttpError(format!("Request failed: {e}")))?;
+            .map_err(|e| {
+                BatchError::Fatal(EmbeddingError::HttpError(format!("Request failed: {e}")))
+            })?;
 
         let status = response.status();
         if !status.is_success() {
@@ -223,65 +234,69 @@ impl OllamaEmbeddingEngine {
                 .text()
                 .await
                 .unwrap_or_else(|_| "<failed to read body>".to_string());
-            return Err(if status.as_u16() == 429 || status.is_server_error() {
-                EmbeddingError::HttpError(format!("HTTP {status}: {body}"))
-            } else {
-                EmbeddingError::ApiError(format!("HTTP {status}: {body}"))
-            });
+            return Err(BatchError::Fatal(
+                if status.as_u16() == 429 || status.is_server_error() {
+                    EmbeddingError::HttpError(format!("HTTP {status}: {body}"))
+                } else {
+                    EmbeddingError::ApiError(format!("HTTP {status}: {body}"))
+                },
+            ));
         }
 
-        let value: Value = response
-            .json()
-            .await
-            .map_err(|e| EmbeddingError::ApiError(format!("Failed to parse response: {e}")))?;
+        let value: Value = response.json().await.map_err(|e| {
+            BatchError::Fatal(EmbeddingError::ApiError(format!(
+                "Failed to parse response: {e}"
+            )))
+        })?;
 
-        let embeddings = extract_all_embeddings_from_value(&value)?;
+        // An unrecognised shape or a count that doesn't match the inputs means the
+        // server ignored/rejected array `input`; treat it as "array unsupported"
+        // so the caller can fall back to per-text requests.
+        let embeddings =
+            extract_all_embeddings_from_value(&value).map_err(|_| BatchError::ArrayUnsupported)?;
         if embeddings.len() != texts.len() {
-            return Err(EmbeddingError::ApiError(format!(
-                "Expected {} embeddings for batch, got {}",
-                texts.len(),
-                embeddings.len()
-            )));
+            return Err(BatchError::ArrayUnsupported);
         }
         Ok(embeddings)
     }
 
     /// Batch variant of [`embed_single_with_retry`], retrying transient errors.
-    async fn embed_batch_with_retry(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
+    async fn embed_batch_with_retry(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, BatchError> {
         let max_duration = std::time::Duration::from_secs(128);
         let start = std::time::Instant::now();
         let mut wait_secs = 8u64;
         loop {
             match self.embed_batch_once(texts).await {
                 Ok(v) => return Ok(v),
-                Err(e)
-                    if matches!(e, EmbeddingError::HttpError(_))
-                        && start.elapsed() < max_duration =>
-                {
-                    let jitter = rand::random::<u64>() % wait_secs;
-                    tokio::time::sleep(std::time::Duration::from_secs(wait_secs + jitter)).await;
-                    wait_secs = (wait_secs * 2).min(128);
+                Err(err) => {
+                    let transient = matches!(&err, BatchError::Fatal(EmbeddingError::HttpError(_)));
+                    if transient && start.elapsed() < max_duration {
+                        let jitter = rand::random::<u64>() % wait_secs;
+                        tokio::time::sleep(std::time::Duration::from_secs(wait_secs + jitter))
+                            .await;
+                        wait_secs = (wait_secs * 2).min(128);
+                    } else {
+                        return Err(err);
+                    }
                 }
-                Err(e) => return Err(e),
             }
         }
     }
 
     /// Embed all texts, sub-batched by `batch_size` using array `input`.
     ///
-    /// If a batch fails with a non-transient [`EmbeddingError::ApiError`] (e.g.
-    /// an older Ollama that does not accept array `input`), that batch falls
-    /// back to the legacy path of one concurrent request per text, so behavior
-    /// is preserved on every server version.
+    /// Only falls back to one request per text when the server signals it does
+    /// not support array `input` ([`BatchError::ArrayUnsupported`]); genuine
+    /// errors propagate rather than fanning out `1 + N` doomed requests.
     async fn embed_all(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
         let sanitized = sanitize_embedding_inputs(texts);
         let sanitized_refs: Vec<&str> = sanitized.iter().map(|s| s.as_ref()).collect();
 
         let mut embeddings: Vec<Vec<f32>> = Vec::with_capacity(texts.len());
-        for batch in sanitized_refs.chunks(self.batch_size) {
+        for batch in sanitized_refs.chunks(self.batch_size.max(1)) {
             match self.embed_batch_with_retry(batch).await {
                 Ok(batch_embeddings) => embeddings.extend(batch_embeddings),
-                Err(EmbeddingError::ApiError(_)) => {
+                Err(BatchError::ArrayUnsupported) => {
                     let futures: Vec<_> = batch
                         .iter()
                         .map(|&text| self.embed_single_with_retry(text))
@@ -290,7 +305,7 @@ impl OllamaEmbeddingEngine {
                         embeddings.push(result?);
                     }
                 }
-                Err(e) => return Err(e),
+                Err(BatchError::Fatal(e)) => return Err(e),
             }
         }
 
@@ -676,12 +691,14 @@ mod tests {
     #[tokio::test]
     async fn embed_falls_back_to_per_text_when_array_rejected() {
         let mut server = mockito::Server::new_async().await;
-        // Array request rejected with a non-retryable 4xx (older Ollama).
+        // Legacy server ignores the array and returns a single embedding →
+        // count mismatch → treated as "array unsupported" → per-text fallback.
         let batch = server
             .mock("POST", "/api/embed")
             .match_body(mockito::Matcher::Regex(r#""input":\["#.to_string()))
-            .with_status(400)
-            .with_body("array input not supported")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"embedding":[9.9,9.9]}"#)
             .create_async()
             .await;
         // Per-text requests succeed; distinct vectors verify ordering is kept.
@@ -707,5 +724,60 @@ mod tests {
         batch.assert_async().await;
         single_a.assert_async().await;
         single_b.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn embed_does_not_panic_on_zero_batch_size() {
+        let mut server = mockito::Server::new_async().await;
+        // Each element becomes its own single-item batch (chunks(1)).
+        let batch = server
+            .mock("POST", "/api/embed")
+            .match_body(mockito::Matcher::Regex(r#""input":\["#.to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"embeddings":[[1.0,0.0]]}"#)
+            .expect(2)
+            .create_async()
+            .await;
+
+        let config = EmbeddingConfig {
+            batch_size: 0,
+            ..config_for(&server.url())
+        };
+        let engine = OllamaEmbeddingEngine::new(&config).unwrap();
+        let out = engine.embed(&["alpha", "beta"]).await.unwrap();
+
+        assert_eq!(out.len(), 2);
+        batch.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn embed_propagates_http_error_without_falling_back() {
+        let mut server = mockito::Server::new_async().await;
+        // A genuine 404 (e.g. model not found) must propagate, not fan out.
+        let batch = server
+            .mock("POST", "/api/embed")
+            .match_body(mockito::Matcher::Regex(r#""input":\["#.to_string()))
+            .with_status(404)
+            .with_body("model not found")
+            .expect(1)
+            .create_async()
+            .await;
+        // Per-text (string input) requests must never be issued.
+        let per_text = server
+            .mock("POST", "/api/embed")
+            .match_body(mockito::Matcher::Regex(r#""input":"[a-z]"#.to_string()))
+            .with_status(200)
+            .with_body(r#"{"embedding":[0.0,0.0]}"#)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let engine = OllamaEmbeddingEngine::new(&config_for(&server.url())).unwrap();
+        let result = engine.embed(&["alpha", "beta"]).await;
+
+        assert!(result.is_err());
+        batch.assert_async().await;
+        per_text.assert_async().await;
     }
 }

--- a/crates/embedding/src/ollama.rs
+++ b/crates/embedding/src/ollama.rs
@@ -1,7 +1,9 @@
 //! Ollama embedding engine.
 //!
-//! Calls the Ollama `/api/embed` endpoint for each input text concurrently.
-//! Supports all three response shapes that Ollama can return:
+//! Calls the Ollama `/api/embed` endpoint with a batched array `input`,
+//! sub-batched by `batch_size`, falling back to one concurrent request per text
+//! on servers that do not accept array input. Supports all three response
+//! shapes that Ollama can return:
 //! - `{"embeddings": [[...]]}` — standard Ollama `/api/embed`
 //! - `{"embedding": [...]}` — legacy Ollama `/api/embeddings`
 //! - `{"data": [{"embedding": [...]}]}` — OpenAI-compatible fallback shape
@@ -26,11 +28,23 @@ struct OllamaEmbedRequest<'a> {
     dimensions: Option<usize>,
 }
 
+/// Batched request body: recent Ollama `/api/embed` accepts an array `input`
+/// and returns one embedding per element under the `embeddings` key.
+#[derive(Serialize)]
+struct OllamaBatchEmbedRequest<'a> {
+    model: &'a str,
+    input: Vec<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dimensions: Option<usize>,
+}
+
 // ─── Engine ───────────────────────────────────────────────────────────────────
 
 /// Embedding engine that calls the Ollama `/api/embed` HTTP endpoint.
 ///
-/// Sends one request per input text concurrently using `futures::future::join_all`.
+/// Sends a batched array `input` per request, sub-batched by `batch_size`, and
+/// falls back to one concurrent request per text (via
+/// `futures::future::join_all`) for servers that do not accept array input.
 /// Transient HTTP errors (network failures, 429, 5xx) are retried with
 /// exponential back-off starting at 8 s (doubling to 128 s) for up to 128 s total.
 ///
@@ -176,23 +190,113 @@ impl OllamaEmbeddingEngine {
         }
     }
 
-    /// Embed all texts concurrently, one request per text.
+    /// Call the endpoint once with an array `input` (no retry).
+    ///
+    /// Returns [`EmbeddingError::ApiError`] if the server returns a number of
+    /// embeddings that does not match the number of inputs — which is also how
+    /// servers that ignore array `input` surface, letting [`embed_all`] fall
+    /// back to one request per text.
+    async fn embed_batch_once(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
+        let truncated: Vec<&str> = texts.iter().map(|t| self.truncate_text(t)).collect();
+
+        let request_body = OllamaBatchEmbedRequest {
+            model: &self.model,
+            input: truncated,
+            dimensions: if self.dimensions > 0 {
+                Some(self.dimensions)
+            } else {
+                None
+            },
+        };
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| EmbeddingError::HttpError(format!("Request failed: {e}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<failed to read body>".to_string());
+            return Err(if status.as_u16() == 429 || status.is_server_error() {
+                EmbeddingError::HttpError(format!("HTTP {status}: {body}"))
+            } else {
+                EmbeddingError::ApiError(format!("HTTP {status}: {body}"))
+            });
+        }
+
+        let value: Value = response
+            .json()
+            .await
+            .map_err(|e| EmbeddingError::ApiError(format!("Failed to parse response: {e}")))?;
+
+        let embeddings = extract_all_embeddings_from_value(&value)?;
+        if embeddings.len() != texts.len() {
+            return Err(EmbeddingError::ApiError(format!(
+                "Expected {} embeddings for batch, got {}",
+                texts.len(),
+                embeddings.len()
+            )));
+        }
+        Ok(embeddings)
+    }
+
+    /// Batch variant of [`embed_single_with_retry`], retrying transient errors.
+    async fn embed_batch_with_retry(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
+        let max_duration = std::time::Duration::from_secs(128);
+        let start = std::time::Instant::now();
+        let mut wait_secs = 8u64;
+        loop {
+            match self.embed_batch_once(texts).await {
+                Ok(v) => return Ok(v),
+                Err(e)
+                    if matches!(e, EmbeddingError::HttpError(_))
+                        && start.elapsed() < max_duration =>
+                {
+                    let jitter = rand::random::<u64>() % wait_secs;
+                    tokio::time::sleep(std::time::Duration::from_secs(wait_secs + jitter)).await;
+                    wait_secs = (wait_secs * 2).min(128);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Embed all texts, sub-batched by `batch_size` using array `input`.
+    ///
+    /// If a batch fails with a non-transient [`EmbeddingError::ApiError`] (e.g.
+    /// an older Ollama that does not accept array `input`), that batch falls
+    /// back to the legacy path of one concurrent request per text, so behavior
+    /// is preserved on every server version.
     async fn embed_all(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
         let sanitized = sanitize_embedding_inputs(texts);
         let sanitized_refs: Vec<&str> = sanitized.iter().map(|s| s.as_ref()).collect();
 
-        let futures: Vec<_> = sanitized_refs
-            .iter()
-            .map(|&text| self.embed_single_with_retry(text))
-            .collect();
-
-        let results = future::join_all(futures).await;
-
-        let embeddings: EmbeddingResult<Vec<Vec<f32>>> = results.into_iter().collect();
+        let mut embeddings: Vec<Vec<f32>> = Vec::with_capacity(texts.len());
+        for batch in sanitized_refs.chunks(self.batch_size) {
+            match self.embed_batch_with_retry(batch).await {
+                Ok(batch_embeddings) => embeddings.extend(batch_embeddings),
+                Err(EmbeddingError::ApiError(_)) => {
+                    let futures: Vec<_> = batch
+                        .iter()
+                        .map(|&text| self.embed_single_with_retry(text))
+                        .collect();
+                    for result in future::join_all(futures).await {
+                        embeddings.push(result?);
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
 
         Ok(handle_embedding_response(
             texts,
-            embeddings?,
+            embeddings,
             self.dimensions,
         ))
     }
@@ -264,6 +368,39 @@ fn extract_embedding_from_value(value: &Value) -> EmbeddingResult<Vec<f32>> {
         return Err(EmbeddingError::ApiError(
             "Response 'data' array is empty or missing 'embedding' field".to_string(),
         ));
+    }
+
+    Err(EmbeddingError::ApiError(format!(
+        "Unrecognised response shape; expected 'embeddings', 'embedding', or 'data' key. Got: {value}"
+    )))
+}
+
+/// Extract every embedding from a batched response (array `input`).
+///
+/// Handles the same shapes as [`extract_embedding_from_value`] but returns all
+/// embeddings rather than just the first:
+/// - `{"embeddings": [[...], [...]]}` — standard `/api/embed`
+/// - `{"data": [{"embedding": [...]}, ...]}` — OpenAI-compatible
+/// - `{"embedding": [...]}` — single embedding, returned as a one-element vec
+fn extract_all_embeddings_from_value(value: &Value) -> EmbeddingResult<Vec<Vec<f32>>> {
+    if let Some(embeddings) = value.get("embeddings").and_then(|v| v.as_array()) {
+        return embeddings.iter().map(parse_f32_array).collect();
+    }
+
+    if let Some(data) = value.get("data").and_then(|v| v.as_array()) {
+        return data
+            .iter()
+            .map(|item| {
+                item.get("embedding").ok_or_else(|| {
+                    EmbeddingError::ApiError("Response 'data' item missing 'embedding'".to_string())
+                })
+            })
+            .map(|embedding| embedding.and_then(parse_f32_array))
+            .collect();
+    }
+
+    if let Some(embedding) = value.get("embedding") {
+        return Ok(vec![parse_f32_array(embedding)?]);
     }
 
     Err(EmbeddingError::ApiError(format!(
@@ -464,5 +601,111 @@ mod tests {
         let result = extract_embedding_from_value(&json);
         assert!(result.is_err());
         assert!(matches!(result, Err(EmbeddingError::ApiError(_))));
+    }
+
+    // ── Batched response parsing (array input) ───────────────────────────────
+
+    #[test]
+    fn test_parse_all_embeddings_shape1() {
+        let json = serde_json::json!({
+            "embeddings": [[0.1_f64, 0.2_f64], [0.3_f64, 0.4_f64]]
+        });
+        let result = extract_all_embeddings_from_value(&json).expect("should parse batch");
+        assert_eq!(result.len(), 2);
+        assert!((result[0][0] - 0.1_f32).abs() < 1e-6);
+        assert!((result[1][1] - 0.4_f32).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_parse_all_embeddings_data_shape() {
+        let json = serde_json::json!({
+            "data": [{"embedding": [0.1_f64]}, {"embedding": [0.2_f64]}]
+        });
+        let result = extract_all_embeddings_from_value(&json).expect("should parse batch");
+        assert_eq!(result.len(), 2);
+        assert!((result[0][0] - 0.1_f32).abs() < 1e-6);
+        assert!((result[1][0] - 0.2_f32).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_parse_all_embeddings_single_shape() {
+        let json = serde_json::json!({ "embedding": [0.5_f64, 0.6_f64] });
+        let result = extract_all_embeddings_from_value(&json).expect("should parse single");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].len(), 2);
+    }
+
+    #[test]
+    fn test_parse_all_embeddings_unrecognised() {
+        let json = serde_json::json!({ "nope": 1 });
+        assert!(matches!(
+            extract_all_embeddings_from_value(&json),
+            Err(EmbeddingError::ApiError(_))
+        ));
+    }
+
+    // ── End-to-end batching / fallback (mock HTTP server) ────────────────────
+
+    fn config_for(server_url: &str) -> EmbeddingConfig {
+        EmbeddingConfig {
+            dimensions: 2,
+            endpoint: Some(format!("{server_url}/api/embed")),
+            ..make_config()
+        }
+    }
+
+    #[tokio::test]
+    async fn embed_batches_array_input() {
+        let mut server = mockito::Server::new_async().await;
+        let batch = server
+            .mock("POST", "/api/embed")
+            .match_body(mockito::Matcher::Regex(r#""input":\["#.to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"embeddings":[[1.0,0.0],[0.0,1.0]]}"#)
+            .create_async()
+            .await;
+
+        let engine = OllamaEmbeddingEngine::new(&config_for(&server.url())).unwrap();
+        let out = engine.embed(&["alpha", "beta"]).await.unwrap();
+
+        assert_eq!(out, vec![vec![1.0, 0.0], vec![0.0, 1.0]]);
+        batch.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn embed_falls_back_to_per_text_when_array_rejected() {
+        let mut server = mockito::Server::new_async().await;
+        // Array request rejected with a non-retryable 4xx (older Ollama).
+        let batch = server
+            .mock("POST", "/api/embed")
+            .match_body(mockito::Matcher::Regex(r#""input":\["#.to_string()))
+            .with_status(400)
+            .with_body("array input not supported")
+            .create_async()
+            .await;
+        // Per-text requests succeed; distinct vectors verify ordering is kept.
+        let single_a = server
+            .mock("POST", "/api/embed")
+            .match_body(mockito::Matcher::Regex(r#""input":"alpha""#.to_string()))
+            .with_status(200)
+            .with_body(r#"{"embedding":[1.0,0.0]}"#)
+            .create_async()
+            .await;
+        let single_b = server
+            .mock("POST", "/api/embed")
+            .match_body(mockito::Matcher::Regex(r#""input":"beta""#.to_string()))
+            .with_status(200)
+            .with_body(r#"{"embedding":[0.0,1.0]}"#)
+            .create_async()
+            .await;
+
+        let engine = OllamaEmbeddingEngine::new(&config_for(&server.url())).unwrap();
+        let out = engine.embed(&["alpha", "beta"]).await.unwrap();
+
+        assert_eq!(out, vec![vec![1.0, 0.0], vec![0.0, 1.0]]);
+        batch.assert_async().await;
+        single_a.assert_async().await;
+        single_b.assert_async().await;
     }
 }

--- a/crates/embedding/src/openai_compatible.rs
+++ b/crates/embedding/src/openai_compatible.rs
@@ -4,7 +4,7 @@
 //! `/v1/embeddings` endpoint (vLLM, llama.cpp, TEI, LocalAI, etc.).
 
 use async_trait::async_trait;
-use futures::stream::{self, StreamExt};
+use futures::stream::{self, StreamExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
 
 use crate::config::EmbeddingConfig;
@@ -196,23 +196,24 @@ impl EmbeddingEngine for OpenAICompatibleEmbeddingEngine {
         }
 
         // Dispatch sub-batches concurrently (bounded by MAX_CONCURRENT_BATCHES).
-        // `buffered` preserves input order, so the flattened result still lines
-        // up one-to-one with `texts`.
+        // `try_collect` over `buffer_unordered` aborts on the first failure —
+        // cancelling in-flight retries instead of waiting them out — and the
+        // batch index restores input order afterwards.
         let batch_futures: Vec<_> = texts
-            .chunks(self.batch_size)
-            .map(|batch| self.embed_batch_with_retry(batch))
+            .chunks(self.batch_size.max(1))
+            .enumerate()
+            .map(|(index, batch)| async move {
+                self.embed_batch_with_retry(batch).await.map(|v| (index, v))
+            })
             .collect();
-        let batch_results: Vec<EmbeddingResult<Vec<Vec<f32>>>> = stream::iter(batch_futures)
-            .buffered(MAX_CONCURRENT_BATCHES)
-            .collect()
-            .await;
 
-        let mut results: Vec<Vec<f32>> = Vec::with_capacity(texts.len());
-        for batch in batch_results {
-            results.extend(batch?);
-        }
+        let mut indexed: Vec<(usize, Vec<Vec<f32>>)> = stream::iter(batch_futures)
+            .buffer_unordered(MAX_CONCURRENT_BATCHES)
+            .try_collect()
+            .await?;
 
-        Ok(results)
+        indexed.sort_by_key(|(index, _)| *index);
+        Ok(indexed.into_iter().flat_map(|(_, batch)| batch).collect())
     }
 
     fn dimension(&self) -> usize {

--- a/crates/embedding/src/openai_compatible.rs
+++ b/crates/embedding/src/openai_compatible.rs
@@ -4,12 +4,18 @@
 //! `/v1/embeddings` endpoint (vLLM, llama.cpp, TEI, LocalAI, etc.).
 
 use async_trait::async_trait;
+use futures::stream::{self, StreamExt};
 use serde::{Deserialize, Serialize};
 
 use crate::config::EmbeddingConfig;
 use crate::engine::EmbeddingEngine;
 use crate::error::{EmbeddingError, EmbeddingResult};
 use crate::utils::{handle_embedding_response, sanitize_embedding_inputs};
+
+/// Maximum number of sub-batch HTTP requests issued concurrently from a single
+/// `embed` call. Bounds in-flight work against provider rate limits while still
+/// overlapping network latency across sub-batches.
+const MAX_CONCURRENT_BATCHES: usize = 8;
 
 // ─── Response types ───────────────────────────────────────────────────────────
 
@@ -189,11 +195,21 @@ impl EmbeddingEngine for OpenAICompatibleEmbeddingEngine {
             return Ok(Vec::new());
         }
 
-        let mut results: Vec<Vec<f32>> = Vec::with_capacity(texts.len());
+        // Dispatch sub-batches concurrently (bounded by MAX_CONCURRENT_BATCHES).
+        // `buffered` preserves input order, so the flattened result still lines
+        // up one-to-one with `texts`.
+        let batch_futures: Vec<_> = texts
+            .chunks(self.batch_size)
+            .map(|batch| self.embed_batch_with_retry(batch))
+            .collect();
+        let batch_results: Vec<EmbeddingResult<Vec<Vec<f32>>>> = stream::iter(batch_futures)
+            .buffered(MAX_CONCURRENT_BATCHES)
+            .collect()
+            .await;
 
-        for batch in texts.chunks(self.batch_size) {
-            let batch_results = self.embed_batch_with_retry(batch).await?;
-            results.extend(batch_results);
+        let mut results: Vec<Vec<f32>> = Vec::with_capacity(texts.len());
+        for batch in batch_results {
+            results.extend(batch?);
         }
 
         Ok(results)

--- a/crates/lib/src/component_manager.rs
+++ b/crates/lib/src/component_manager.rs
@@ -506,7 +506,11 @@ impl ComponentManager {
                     model_name: settings.embedding_model_name.clone(),
                     dimensions: settings.embedding_dimensions as usize,
                     max_sequence_length: settings.embedding_max_sequence_length as usize,
-                    batch_size: settings.embedding_batch_size as usize,
+                    // ONNX inference batch is the leading tensor dimension, not an
+                    // HTTP request size, so it keeps its own (memory-tuned) default
+                    // rather than inheriting embedding_batch_size, which can OOM on
+                    // constrained edge/Android devices.
+                    batch_size: cognee_embedding::OnnxEmbeddingConfig::default().batch_size,
                 },
                 huggingface_tokenizer: None,
             }

--- a/crates/lib/src/component_manager.rs
+++ b/crates/lib/src/component_manager.rs
@@ -506,11 +506,7 @@ impl ComponentManager {
                     model_name: settings.embedding_model_name.clone(),
                     dimensions: settings.embedding_dimensions as usize,
                     max_sequence_length: settings.embedding_max_sequence_length as usize,
-                    // ONNX inference batch is the leading tensor dimension, not an
-                    // HTTP request size, so it keeps its own (memory-tuned) default
-                    // rather than inheriting embedding_batch_size, which can OOM on
-                    // constrained edge/Android devices.
-                    batch_size: cognee_embedding::OnnxEmbeddingConfig::default().batch_size,
+                    batch_size: settings.embedding_onnx_batch_size as usize,
                 },
                 huggingface_tokenizer: None,
             }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -738,7 +738,7 @@ impl Default for Settings {
             // cognee_embedding::known_model_dimensions.
             embedding_dimensions,
             embedding_max_sequence_length: 512,
-            embedding_batch_size: 32,
+            embedding_batch_size: 36,
             embedding_endpoint: String::new(),
             embedding_api_key: String::new(),
             embedding_api_version: String::new(),

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -114,6 +114,10 @@ pub struct Settings {
     pub embedding_dimensions: u32,
     pub embedding_max_sequence_length: u32,
     pub embedding_batch_size: u32,
+    /// ONNX inference batch size (the leading tensor dimension), independent of
+    /// `embedding_batch_size` which sizes HTTP requests. Maps to
+    /// `EMBEDDING_ONNX_BATCH_SIZE`; only the ONNX/Fastembed provider reads it.
+    pub embedding_onnx_batch_size: u32,
     /// Embedding API endpoint URL (e.g. `https://api.openai.com/v1/embeddings`).
     /// Maps to `EMBEDDING_ENDPOINT` env var.
     pub embedding_endpoint: String,
@@ -392,6 +396,11 @@ impl Settings {
             && let Ok(n) = v.parse::<u32>()
         {
             self.embedding_batch_size = n;
+        }
+        if let Some(v) = str_var("EMBEDDING_ONNX_BATCH_SIZE")
+            && let Ok(n) = v.parse::<u32>()
+        {
+            self.embedding_onnx_batch_size = n;
         }
         if let Some(v) = str_var("EMBEDDING_MAX_SEQUENCE_LENGTH")
             && let Ok(n) = v.parse::<u32>()
@@ -739,6 +748,7 @@ impl Default for Settings {
             embedding_dimensions,
             embedding_max_sequence_length: 512,
             embedding_batch_size: 36,
+            embedding_onnx_batch_size: 32,
             embedding_endpoint: String::new(),
             embedding_api_key: String::new(),
             embedding_api_version: String::new(),
@@ -1825,6 +1835,23 @@ mod tests {
         // resolver / strategy should stay at defaults when not set
         assert_eq!(s.ontology_resolver, "rdflib");
         assert_eq!(s.ontology_matching_strategy, "fuzzy");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn overlay_onnx_batch_size_is_independent_of_request_batch() {
+        // SAFETY: test is serial — no other thread reads/writes env concurrently.
+        unsafe { std::env::set_var("EMBEDDING_ONNX_BATCH_SIZE", "8") };
+        let mut s = Settings::default();
+        s.overlay_from_env();
+        unsafe { std::env::remove_var("EMBEDDING_ONNX_BATCH_SIZE") };
+
+        assert_eq!(s.embedding_onnx_batch_size, 8);
+        // The HTTP request batch is untouched by the ONNX override.
+        assert_eq!(
+            s.embedding_batch_size,
+            Settings::default().embedding_batch_size
+        );
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,7 @@ Read by `EmbeddingConfig::from_env()` ([`crates/embedding/src/config.rs`](../cra
 | `EMBEDDING_TOKENIZER_PATH` / `COGNEE_E2E_TOKENIZER_PATH` | `embedding_tokenizer_path` | `./target/models/bge-small-tokenizer.json` |
 | `EMBEDDING_MAX_SEQUENCE_LENGTH` | `embedding_max_sequence_length` | `512` |
 | `EMBEDDING_BATCH_SIZE` | `embedding_batch_size` | `36` (texts per embedding request; raise for providers that allow larger batches. The OpenAI-compatible engine also dispatches up to 8 sub-batches concurrently) |
+| `EMBEDDING_ONNX_BATCH_SIZE` | `embedding_onnx_batch_size` | `32` (ONNX inference batch size; independent of `EMBEDDING_BATCH_SIZE`. Lower it under memory pressure on edge devices) |
 | `MOCK_EMBEDDING` | _(provider override)_ | `false` (also accepts `deterministic`) |
 
 Provider values: `onnx`, `fastembed`, `openai`, `openai_compatible`, `ollama`, `mock`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,7 +64,7 @@ Read by `EmbeddingConfig::from_env()` ([`crates/embedding/src/config.rs`](../cra
 | `EMBEDDING_MODEL_PATH` / `COGNEE_E2E_EMBED_MODEL_PATH` | `embedding_model_path` | `./target/models/BGE-Small-v1.5-model_quantized.onnx` |
 | `EMBEDDING_TOKENIZER_PATH` / `COGNEE_E2E_TOKENIZER_PATH` | `embedding_tokenizer_path` | `./target/models/bge-small-tokenizer.json` |
 | `EMBEDDING_MAX_SEQUENCE_LENGTH` | `embedding_max_sequence_length` | `512` |
-| `EMBEDDING_BATCH_SIZE` | `embedding_batch_size` | `32` |
+| `EMBEDDING_BATCH_SIZE` | `embedding_batch_size` | `36` (texts per embedding request; raise for providers that allow larger batches. The OpenAI-compatible engine also dispatches up to 8 sub-batches concurrently) |
 | `MOCK_EMBEDDING` | _(provider override)_ | `false` (also accepts `deterministic`) |
 
 Provider values: `onnx`, `fastembed`, `openai`, `openai_compatible`, `ollama`, `mock`.


### PR DESCRIPTION
Closes #20.

Every cognify run was embedding the same chunks, entities and summaries twice: once
in generate_embeddings (only used for a count) and again in index_data_points before
writing to the vector database. This doubles embedding requests and latency on remote
APIs and doubles CPU on local ONNX.

What changed:

* generate_embeddings now runs once and index_data_points reuses those vectors. It
  only embeds what generate_embeddings never produced (entity types, triplets, edge
  types), with a fallback so nothing goes unembedded. Reported counts and existing
  assertions are unchanged.
* Ollama now sends a batched array input instead of one request per text, and falls
  back to the old per text path on older servers that reject arrays. Both the batch
  path and the fallback are covered by mock server tests.
* The OpenAI compatible engine now sends its sub batches concurrently with a bounded
  cap instead of one after another. The request batch default stays at 36 (Python's
  value); raise it with EMBEDDING_BATCH_SIZE for providers that allow larger batches.
* The ONNX inference batch is decoupled from the request batch and keeps its own
  default of 32, so raising EMBEDDING_BATCH_SIZE no longer changes tensor sizes on
  constrained edge devices.

A small test prints the saving on a fixed input:

  cargo test -p cognee-cognify --lib report_embedding_reuse_savings -- --nocapture

  Embedding work per cognify (24 chunks / 16 entities / 10 summaries):
    BEFORE (double pass): 7 embed() calls, 104 texts
    AFTER  (reuse)      : 4 embed() calls, 54 texts
    Saved: 50 texts (48% fewer)

Verified locally with cargo check on the workspace, clippy with warnings denied, fmt,
and the embedding and cognify unit tests. Provider backed integration tests and the
cross SDK parity suite are left to CI. No changes to IDs, schema, content hashing or
vector collection names, so Python parity is unaffected.
