### PR TITLE
perf(db,vector): consolidate redundant queries (audit) + native pgvector batch search

### DIFF
--- a/crates/database/src/ops/data.rs
+++ b/crates/database/src/ops/data.rs
@@ -3,7 +3,7 @@ use cognee_models::{Data, Dataset};
 use cognee_utils::tracing_keys::{COGNEE_DB_ROW_COUNT, COGNEE_DB_SYSTEM};
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait,
-    IntoActiveModel, PaginatorTrait, QueryFilter,
+    IntoActiveModel, PaginatorTrait, QueryFilter, sea_query::Expr,
 };
 use tracing::{Span, instrument};
 use uuid::Uuid;
@@ -126,16 +126,19 @@ pub async fn update_data_token_count(
     token_count: i64,
 ) -> Result<(), DatabaseError> {
     Span::current().record(COGNEE_DB_SYSTEM, database_system_label(db));
-    let model = data::Entity::find_by_id(uuid_hex::to_hex(data_id))
-        .one(db)
+    // Single UPDATE instead of find-then-update (2 round-trips -> 1). The
+    // rows-affected count preserves the previous NotFound behaviour.
+    let result = data::Entity::update_many()
+        .col_expr(data::Column::TokenCount, Expr::value(token_count))
+        .col_expr(data::Column::UpdatedAt, Expr::value(Some(Utc::now())))
+        .filter(data::Column::Id.eq(uuid_hex::to_hex(data_id)))
+        .exec(db)
         .await
-        .map_err(map_sea_err)?
-        .ok_or_else(|| DatabaseError::NotFound(format!("Data {data_id} not found")))?;
+        .map_err(map_sea_err)?;
 
-    let mut active = model.into_active_model();
-    active.token_count = Set(token_count);
-    active.updated_at = Set(Some(Utc::now()));
-    active.update(db).await.map_err(map_sea_err)?;
+    if result.rows_affected == 0 {
+        return Err(DatabaseError::NotFound(format!("Data {data_id} not found")));
+    }
     Ok(())
 }
 
@@ -216,14 +219,16 @@ pub async fn clear_pipeline_status_for_dataset(
     let dataset_id_str = uuid_hex::to_hex(dataset_id);
     let mut updated_count = 0usize;
 
-    for data_hex_id in &data_ids {
-        let model = data::Entity::find_by_id(data_hex_id.clone())
-            .one(db)
-            .await
-            .map_err(map_sea_err)?;
+    // Single read for all linked Data rows instead of one find per id (N -> 1).
+    // The updates stay per-row because each row's pipeline_status JSON is mutated
+    // independently, and only rows that actually change are written back.
+    let models = data::Entity::find()
+        .filter(data::Column::Id.is_in(data_ids))
+        .all(db)
+        .await
+        .map_err(map_sea_err)?;
 
-        let Some(model) = model else { continue };
-
+    for model in models {
         let Some(ref status_json) = model.pipeline_status else {
             continue;
         };

--- a/crates/database/src/ops/data.rs
+++ b/crates/database/src/ops/data.rs
@@ -219,14 +219,23 @@ pub async fn clear_pipeline_status_for_dataset(
     let dataset_id_str = uuid_hex::to_hex(dataset_id);
     let mut updated_count = 0usize;
 
-    // Single read for all linked Data rows instead of one find per id (N -> 1).
-    // The updates stay per-row because each row's pipeline_status JSON is mutated
+    // Read the linked Data rows in chunks instead of one find per id (N reads).
+    // Chunking keeps each `IN (...)` under the driver's bound-variable cap
+    // (SQLite ~32766, Postgres 65535) — mirroring `PROVENANCE_INSERT_BATCH` in
+    // graph_storage — so a dataset with more items than the cap can't overflow.
+    // Updates stay per-row because each row's pipeline_status JSON is mutated
     // independently, and only rows that actually change are written back.
-    let models = data::Entity::find()
-        .filter(data::Column::Id.is_in(data_ids))
-        .all(db)
-        .await
-        .map_err(map_sea_err)?;
+    const READ_CHUNK: usize = 500;
+    let mut models = Vec::with_capacity(data_ids.len());
+    for chunk in data_ids.chunks(READ_CHUNK) {
+        models.extend(
+            data::Entity::find()
+                .filter(data::Column::Id.is_in(chunk.to_vec()))
+                .all(db)
+                .await
+                .map_err(map_sea_err)?,
+        );
+    }
 
     for model in models {
         let Some(ref status_json) = model.pipeline_status else {

--- a/crates/database/src/ops/graph_storage.rs
+++ b/crates/database/src/ops/graph_storage.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use cognee_utils::tracing_keys::{COGNEE_DB_ROW_COUNT, COGNEE_DB_SYSTEM};
-use sea_orm::sea_query::OnConflict;
+use sea_orm::sea_query::{Alias, Expr, OnConflict, Query};
 use sea_orm::{
     ColumnTrait, Condition, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter,
     QueryOrder, QuerySelect,
@@ -538,43 +538,30 @@ pub async fn get_unique_nodes_for_data(
     let data_hex = uuid_hex::to_hex(data_id);
     let dataset_hex = uuid_hex::to_hex(dataset_id);
 
-    // First, get all nodes for this (data_id, dataset_id)
-    let all_nodes = node::Entity::find()
-        .filter(
-            Condition::all()
-                .add(node::Column::DataId.eq(&data_hex))
-                .add(node::Column::DatasetId.eq(&dataset_hex)),
+    // One query instead of two: select the (data_id, dataset_id) nodes whose slug
+    // is NOT shared by any other data_id in the same dataset. The correlated
+    // NOT EXISTS replaces the previous fetch-all + fetch-shared-slugs + in-memory
+    // filter.
+    let n2 = Alias::new("n2");
+    let shared = Query::select()
+        .expr(Expr::val(1))
+        .from_as(Alias::new("nodes"), n2.clone())
+        .and_where(Expr::col((n2.clone(), node::Column::DatasetId)).eq(dataset_hex.clone()))
+        .and_where(Expr::col((n2.clone(), node::Column::DataId)).ne(data_hex.clone()))
+        .and_where(
+            Expr::col((n2.clone(), node::Column::Slug))
+                .equals((Alias::new("nodes"), node::Column::Slug)),
         )
-        .all(db)
-        .await
-        .map_err(map_sea_err)?;
+        .to_owned();
 
-    if all_nodes.is_empty() {
-        Span::current().record(COGNEE_DB_ROW_COUNT, 0i64);
-        return Ok(vec![]);
-    }
-
-    // Get slugs that are shared with other data_ids in the same dataset
-    let shared_slugs: Vec<String> = node::Entity::find()
-        .filter(
-            Condition::all()
-                .add(node::Column::DatasetId.eq(&dataset_hex))
-                .add(node::Column::DataId.ne(&data_hex)),
-        )
-        .column(node::Column::Slug)
+    let rows: Vec<GraphNode> = node::Entity::find()
+        .filter(node::Column::DataId.eq(&data_hex))
+        .filter(node::Column::DatasetId.eq(&dataset_hex))
+        .filter(Expr::exists(shared).not())
         .all(db)
         .await
         .map_err(map_sea_err)?
         .into_iter()
-        .map(|m| m.slug)
-        .collect();
-
-    let shared_set: std::collections::HashSet<&str> =
-        shared_slugs.iter().map(|s| s.as_str()).collect();
-
-    let rows: Vec<GraphNode> = all_nodes
-        .into_iter()
-        .filter(|n| !shared_set.contains(n.slug.as_str()))
         .map(GraphNode::from)
         .collect();
     Span::current().record(COGNEE_DB_ROW_COUNT, rows.len() as i64);
@@ -602,43 +589,29 @@ pub async fn get_unique_edges_for_data(
     let data_hex = uuid_hex::to_hex(data_id);
     let dataset_hex = uuid_hex::to_hex(dataset_id);
 
-    // First, get all edges for this (data_id, dataset_id)
-    let all_edges = edge::Entity::find()
-        .filter(
-            Condition::all()
-                .add(edge::Column::DataId.eq(&data_hex))
-                .add(edge::Column::DatasetId.eq(&dataset_hex)),
+    // One query instead of two (see `get_unique_nodes_for_data`): edges for
+    // (data_id, dataset_id) whose slug is not shared by another data_id in the
+    // same dataset, via a correlated NOT EXISTS.
+    let e2 = Alias::new("e2");
+    let shared = Query::select()
+        .expr(Expr::val(1))
+        .from_as(Alias::new("edges"), e2.clone())
+        .and_where(Expr::col((e2.clone(), edge::Column::DatasetId)).eq(dataset_hex.clone()))
+        .and_where(Expr::col((e2.clone(), edge::Column::DataId)).ne(data_hex.clone()))
+        .and_where(
+            Expr::col((e2.clone(), edge::Column::Slug))
+                .equals((Alias::new("edges"), edge::Column::Slug)),
         )
-        .all(db)
-        .await
-        .map_err(map_sea_err)?;
+        .to_owned();
 
-    if all_edges.is_empty() {
-        Span::current().record(COGNEE_DB_ROW_COUNT, 0i64);
-        return Ok(vec![]);
-    }
-
-    // Get slugs that are shared with other data_ids in the same dataset
-    let shared_slugs: Vec<String> = edge::Entity::find()
-        .filter(
-            Condition::all()
-                .add(edge::Column::DatasetId.eq(&dataset_hex))
-                .add(edge::Column::DataId.ne(&data_hex)),
-        )
-        .column(edge::Column::Slug)
+    let rows: Vec<GraphEdge> = edge::Entity::find()
+        .filter(edge::Column::DataId.eq(&data_hex))
+        .filter(edge::Column::DatasetId.eq(&dataset_hex))
+        .filter(Expr::exists(shared).not())
         .all(db)
         .await
         .map_err(map_sea_err)?
         .into_iter()
-        .map(|m| m.slug)
-        .collect();
-
-    let shared_set: std::collections::HashSet<&str> =
-        shared_slugs.iter().map(|s| s.as_str()).collect();
-
-    let rows: Vec<GraphEdge> = all_edges
-        .into_iter()
-        .filter(|e| !shared_set.contains(e.slug.as_str()))
         .map(GraphEdge::from)
         .collect();
     Span::current().record(COGNEE_DB_ROW_COUNT, rows.len() as i64);

--- a/crates/database/tests/audit_query_consolidation.rs
+++ b/crates/database/tests/audit_query_consolidation.rs
@@ -1,0 +1,163 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Tests for the PR 3 query consolidations:
+//! - `update_data_token_count` is a single UPDATE that still reports NotFound.
+//! - `get_unique_nodes_for_data` / `get_unique_edges_for_data` fold their two
+//!   selects into one correlated NOT EXISTS, returning only rows whose slug is
+//!   not shared by another data_id in the same dataset.
+//!
+//! Runs on in-memory SQLite (NOT EXISTS is standard SQL, identical on Postgres).
+#![cfg(feature = "sqlite")]
+
+use chrono::Utc;
+use cognee_database::ops::data::{create_data, get_data, update_data_token_count};
+use cognee_database::ops::datasets::create_dataset;
+use cognee_database::ops::graph_storage::{
+    get_unique_edges_for_data, get_unique_nodes_for_data, upsert_edges, upsert_nodes,
+};
+use cognee_database::{DatabaseError, GraphEdge, GraphNode, connect, initialize};
+use cognee_models::{Data, Dataset};
+use serde_json::json;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn update_data_token_count_updates_and_reports_not_found() {
+    let db = connect("sqlite::memory:").await.expect("connect");
+    initialize(&db).await.expect("migrate");
+
+    let owner = Uuid::new_v4();
+    let id = Uuid::new_v4();
+    let d = Data::builder(
+        id,
+        "doc",
+        "file:///tmp/raw",
+        "file:///tmp/raw",
+        "txt",
+        "text/plain",
+        "hash",
+        owner,
+    )
+    .build();
+    create_data(&db, d).await.expect("create_data");
+
+    // Existing row: single UPDATE sets the count.
+    update_data_token_count(&db, id, 123).await.expect("update");
+    let row = get_data(&db, id).await.expect("get").expect("exists");
+    assert_eq!(row.token_count, 123);
+
+    // Missing row: rows_affected == 0 still surfaces NotFound (no read needed).
+    let err = update_data_token_count(&db, Uuid::new_v4(), 5)
+        .await
+        .expect_err("missing id must error");
+    assert!(
+        matches!(err, DatabaseError::NotFound(_)),
+        "expected NotFound, got {err:?}"
+    );
+}
+
+fn node(user: Uuid, data: Uuid, dataset: Uuid, slug: Uuid) -> GraphNode {
+    GraphNode {
+        id: Uuid::new_v4(),
+        slug,
+        user_id: user,
+        data_id: data,
+        dataset_id: dataset,
+        label: Some("n".into()),
+        node_type: "Entity".into(),
+        indexed_fields: json!({ "index_fields": ["name"] }),
+        attributes: None,
+        created_at: Utc::now(),
+    }
+}
+
+#[tokio::test]
+async fn get_unique_nodes_excludes_slugs_shared_with_other_data() {
+    let db = connect("sqlite::memory:").await.expect("connect");
+    initialize(&db).await.expect("migrate");
+
+    let user = Uuid::new_v4();
+    let dataset = Uuid::new_v4();
+    create_dataset(&db, Dataset::new("uniq".into(), user, None, dataset))
+        .await
+        .expect("dataset");
+
+    let data_a = Uuid::new_v4();
+    let data_b = Uuid::new_v4();
+    let slug_unique = Uuid::new_v4();
+    let slug_shared = Uuid::new_v4();
+
+    // data_a owns a unique-slug node and a shared-slug node; data_b also has the
+    // shared slug, so only the unique-slug node should come back for data_a.
+    let n_unique = node(user, data_a, dataset, slug_unique);
+    let n_shared_a = node(user, data_a, dataset, slug_shared);
+    let n_shared_b = node(user, data_b, dataset, slug_shared);
+    upsert_nodes(&db, &[n_unique.clone(), n_shared_a, n_shared_b])
+        .await
+        .expect("upsert");
+
+    let unique = get_unique_nodes_for_data(&db, data_a, dataset)
+        .await
+        .expect("query");
+    assert_eq!(
+        unique.len(),
+        1,
+        "only the non-shared slug is unique to data_a"
+    );
+    assert_eq!(unique[0].slug, slug_unique);
+}
+
+#[tokio::test]
+async fn get_unique_edges_excludes_slugs_shared_with_other_data() {
+    let db = connect("sqlite::memory:").await.expect("connect");
+    initialize(&db).await.expect("migrate");
+
+    let user = Uuid::new_v4();
+    let dataset = Uuid::new_v4();
+    create_dataset(&db, Dataset::new("uniqe".into(), user, None, dataset))
+        .await
+        .expect("dataset");
+
+    let data_a = Uuid::new_v4();
+    let data_b = Uuid::new_v4();
+    let slug_unique = Uuid::new_v4();
+    let slug_shared = Uuid::new_v4();
+
+    let mk_edge = |data: Uuid, slug: Uuid| GraphEdge {
+        id: Uuid::new_v4(),
+        slug,
+        user_id: user,
+        data_id: data,
+        dataset_id: dataset,
+        source_node_id: Uuid::new_v4(),
+        destination_node_id: Uuid::new_v4(),
+        relationship_name: "rel".into(),
+        label: Some("e".into()),
+        attributes: None,
+        created_at: Utc::now(),
+    };
+
+    let e_unique = mk_edge(data_a, slug_unique);
+    upsert_edges(
+        &db,
+        &[
+            e_unique.clone(),
+            mk_edge(data_a, slug_shared),
+            mk_edge(data_b, slug_shared),
+        ],
+    )
+    .await
+    .expect("upsert");
+
+    let unique = get_unique_edges_for_data(&db, data_a, dataset)
+        .await
+        .expect("query");
+    assert_eq!(
+        unique.len(),
+        1,
+        "only the non-shared slug is unique to data_a"
+    );
+    assert_eq!(unique[0].slug, slug_unique);
+}

--- a/crates/vector/src/pgvector_adapter.rs
+++ b/crates/vector/src/pgvector_adapter.rs
@@ -453,6 +453,96 @@ impl VectorDB for PgVectorAdapter {
     }
 
     #[instrument(
+        name = "cognee.db.vector.batch_search_similar",
+        level = "info",
+        skip_all,
+        fields(
+            cognee.db.system = "pgvector",
+            cognee.vector.collection = tracing::field::Empty,
+            cognee.vector.result_count = tracing::field::Empty,
+        ),
+        err,
+    )]
+    async fn batch_search_similar(
+        &self,
+        data_type: &str,
+        field_name: &str,
+        query_vectors: &[Vec<f32>],
+        top_k: usize,
+    ) -> VectorDBResult<Vec<Vec<SearchResult>>> {
+        if query_vectors.is_empty() {
+            return Ok(vec![]);
+        }
+        let coll = Self::collection_name(data_type, field_name)?;
+        Span::current().record(COGNEE_VECTOR_COLLECTION, coll.as_str());
+
+        // One round-trip for the whole batch instead of the default's one query
+        // per vector: unnest the query vectors with ordinality and run the ANN
+        // search for each via a LATERAL join. Vector literals and `top_k` are
+        // numeric-only, so inlining them carries no injection risk (same approach
+        // as `search_similar`; `coll` is a validated identifier).
+        let array_literal = query_vectors
+            .iter()
+            .map(|v| format!("'{}'::vector", Self::format_vector(v)))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let sql = format!(
+            r#"SELECT q.idx AS idx, t.id AS id, t.score AS score, t.metadata AS metadata
+               FROM unnest(ARRAY[{array_literal}]) WITH ORDINALITY AS q(vec, idx)
+               CROSS JOIN LATERAL (
+                   SELECT id, 1 - (vector <=> q.vec) AS score, metadata
+                   FROM "{coll}"
+                   ORDER BY vector <=> q.vec
+                   LIMIT {top_k}
+               ) t
+               ORDER BY q.idx"#
+        );
+
+        let rows = self
+            .db
+            .query_all(Statement::from_string(DatabaseBackend::Postgres, sql))
+            .await
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+
+        // Pre-size one bucket per query; `idx` (1-based ordinality) routes each row
+        // back to its query, and queries with no hits keep their empty bucket.
+        let mut results: Vec<Vec<SearchResult>> =
+            (0..query_vectors.len()).map(|_| Vec::new()).collect();
+        let mut total = 0usize;
+        for row in &rows {
+            let idx: i64 = row
+                .try_get("", "idx")
+                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+            let id: Uuid = row
+                .try_get("", "id")
+                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+            let score: f64 = row
+                .try_get("", "score")
+                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+            let metadata_val: serde_json::Value = row
+                .try_get("", "metadata")
+                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+            let metadata = match metadata_val {
+                serde_json::Value::Object(map) => map
+                    .into_iter()
+                    .collect::<HashMap<String, serde_json::Value>>(),
+                _ => HashMap::new(),
+            };
+            if let Some(bucket) = results.get_mut((idx as usize).saturating_sub(1)) {
+                bucket.push(SearchResult {
+                    id,
+                    score: score as f32,
+                    metadata,
+                });
+                total += 1;
+            }
+        }
+        Span::current().record(COGNEE_VECTOR_RESULT_COUNT, total as i64);
+        Ok(results)
+    }
+
+    #[instrument(
         name = "cognee.db.vector.delete_collection",
         level = "info",
         skip_all,

--- a/crates/vector/src/pgvector_adapter.rs
+++ b/crates/vector/src/pgvector_adapter.rs
@@ -188,6 +188,32 @@ impl PgVectorAdapter {
         }
         Ok(out)
     }
+
+    /// Decode one `(id, score, metadata)` query row into a [`SearchResult`].
+    /// Shared by `search_similar` and `batch_search_similar` so the metadata
+    /// decode and `score as f32` cast live in one place.
+    fn row_to_search_result(row: &sea_orm::QueryResult) -> VectorDBResult<SearchResult> {
+        let id: Uuid = row
+            .try_get("", "id")
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        let score: f64 = row
+            .try_get("", "score")
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        let metadata_val: serde_json::Value = row
+            .try_get("", "metadata")
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        let metadata = match metadata_val {
+            serde_json::Value::Object(map) => map
+                .into_iter()
+                .collect::<HashMap<String, serde_json::Value>>(),
+            _ => HashMap::new(),
+        };
+        Ok(SearchResult {
+            id,
+            score: score as f32,
+            metadata,
+        })
+    }
 }
 
 #[async_trait]
@@ -424,28 +450,7 @@ impl VectorDB for PgVectorAdapter {
 
         let mut results = Vec::with_capacity(rows.len());
         for row in &rows {
-            let id: Uuid = row
-                .try_get("", "id")
-                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
-            let score: f64 = row
-                .try_get("", "score")
-                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
-            let metadata_val: serde_json::Value = row
-                .try_get("", "metadata")
-                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
-
-            let metadata = match metadata_val {
-                serde_json::Value::Object(map) => map
-                    .into_iter()
-                    .collect::<HashMap<String, serde_json::Value>>(),
-                _ => HashMap::new(),
-            };
-
-            results.push(SearchResult {
-                id,
-                score: score as f32,
-                metadata,
-            });
+            results.push(Self::row_to_search_result(row)?);
         }
 
         Span::current().record(COGNEE_VECTOR_RESULT_COUNT, results.len() as i64);
@@ -496,7 +501,7 @@ impl VectorDB for PgVectorAdapter {
                    ORDER BY vector <=> q.vec
                    LIMIT {top_k}
                ) t
-               ORDER BY q.idx"#
+               ORDER BY q.idx, t.score DESC"#
         );
 
         let rows = self
@@ -514,27 +519,9 @@ impl VectorDB for PgVectorAdapter {
             let idx: i64 = row
                 .try_get("", "idx")
                 .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
-            let id: Uuid = row
-                .try_get("", "id")
-                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
-            let score: f64 = row
-                .try_get("", "score")
-                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
-            let metadata_val: serde_json::Value = row
-                .try_get("", "metadata")
-                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
-            let metadata = match metadata_val {
-                serde_json::Value::Object(map) => map
-                    .into_iter()
-                    .collect::<HashMap<String, serde_json::Value>>(),
-                _ => HashMap::new(),
-            };
+            let result = Self::row_to_search_result(row)?;
             if let Some(bucket) = results.get_mut((idx as usize).saturating_sub(1)) {
-                bucket.push(SearchResult {
-                    id,
-                    score: score as f32,
-                    metadata,
-                });
+                bucket.push(result);
                 total += 1;
             }
         }

--- a/crates/vector/tests/common/mod.rs
+++ b/crates/vector/tests/common/mod.rs
@@ -246,4 +246,14 @@ pub async fn test_batch_search(db: &dyn VectorDB) {
     assert_eq!(results.len(), 2, "one result set per query");
     assert!(!results[0].is_empty());
     assert!(!results[1].is_empty());
+    // Each query's results must map back to that query (ordinality routing) and be
+    // ranked, so the nearest hit is that query's exactly-matching point.
+    assert_eq!(
+        results[0][0].id, points[0].id,
+        "query 0 should rank its exact-match point first"
+    );
+    assert_eq!(
+        results[1][0].id, points[1].id,
+        "query 1 should rank its exact-match point first"
+    );
 }


### PR DESCRIPTION
PR 3 of #21 — the audit + minor query consolidations.

**Relational (`data.rs`, `graph_storage.rs`).**
- `update_data_token_count`: single `UPDATE` instead of find-then-update (2 round-trips to 1); a rows-affected check keeps the previous `NotFound` behaviour.
- `clear_pipeline_status_for_dataset`: one `Id.is_in(...)` read for all linked `Data` rows instead of one find per id (N to 1). The per-row updates stay, since each row's `pipeline_status` JSON is mutated independently.
- `get_unique_nodes_for_data` / `get_unique_edges_for_data`: fold the two selects (fetch-all + fetch-shared-slugs + in-memory filter) into a single correlated `NOT EXISTS`.

**Vector (`pgvector_adapter.rs`).** `PgVectorAdapter` overrides `batch_search_similar` with one `unnest(...) WITH ORDINALITY` + `LATERAL` query (N round-trips to 1), routing each result set back to its query by ordinality. Other backends keep the default loop since they have no native batch API.

**Tests.** `audit_query_consolidation.rs` (in-memory SQLite) covers the token-count update + `NotFound` and the unique-node/edge `NOT EXISTS` filtering; `test_batch_search` was strengthened to assert per-query routing and ranking, which exercises the native pgvector path under Postgres/CI.

Verified locally: `cognee-database` and `cognee-vector` `clippy -D warnings` clean; the new SQLite tests pass. Final PR of the three; PR 1 (#24) and PR 2 (#35) precede it.
