### PR TITLE
feat(llm): Azure OpenAI support (Tier 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,11 +141,11 @@ TOKENIZERS_PARALLELISM=false
 #HUGGINGFACE_TOKENIZER="nomic-ai/nomic-embed-text-v1.5"
 
 ########## Azure OpenAI (API key auth) ########################################
-#LLM_PROVIDER="openai"
-#LLM_MODEL="gpt-4o-mini"
-#LLM_ENDPOINT="https://YOUR-RESOURCE.openai.azure.com"
+#LLM_PROVIDER="azure"             # api-key auth + ?api-version= query on the OpenAI path
+#LLM_MODEL="gpt-4o-mini"          # deployment name (ignored by Azure; the deployment is in the URL)
+#LLM_ENDPOINT="https://YOUR-RESOURCE.openai.azure.com/openai/deployments/gpt-4o-mini"  # deployment URL, required
 #LLM_API_KEY="your-azure-api-key"
-#LLM_API_VERSION="2024-12-01-preview"
+#LLM_API_VERSION="2024-12-01-preview"   # required for azure
 #LLM_MAX_TOKENS=16384
 #EMBEDDING_MODEL="text-embedding-3-large"
 #EMBEDDING_ENDPOINT="https://YOUR-RESOURCE.openai.azure.com/openai/deployments/text-embedding-3-large"

--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -139,6 +139,7 @@ mod tests {
                 max_retries: 3,
                 max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
                 llm_args: serde_json::Map::new(),
+                api_version: String::new(),
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),

--- a/crates/components/src/builtins/llm.rs
+++ b/crates/components/src/builtins/llm.rs
@@ -132,6 +132,63 @@ impl LlmFactory for AnthropicLlmFactory {
     }
 }
 
+/// Provider id served by [`AzureLlmFactory`].
+pub const AZURE_PROVIDER: &str = "azure";
+
+/// Built-in factory for Azure OpenAI. Azure is wire-compatible with the OpenAI
+/// chat API but authenticates with an `api-key` header and appends an
+/// `?api-version=<v>` query, and the deployment is encoded in the endpoint URL
+/// (issue #17, Tier 3). It builds the shared `OpenAIAdapter` against the explicit
+/// deployment endpoint, then switches to the Azure auth/URL conventions with
+/// `with_api_version`.
+pub struct AzureLlmFactory;
+
+#[async_trait]
+impl LlmFactory for AzureLlmFactory {
+    fn provider(&self) -> &str {
+        AZURE_PROVIDER
+    }
+
+    async fn build(&self, ctx: &BackendBuildContext) -> Result<Arc<dyn Llm>, ComponentError> {
+        if ctx.llm.endpoint.trim().is_empty() {
+            return Err(ComponentError::Config(
+                "azure provider requires LLM_ENDPOINT (the deployment URL: \
+                 https://<resource>.openai.azure.com/openai/deployments/<deployment>)"
+                    .to_string(),
+            ));
+        }
+        let api_version = ctx.llm.api_version.trim();
+        if api_version.is_empty() {
+            return Err(ComponentError::Config(
+                "azure provider requires LLM_API_VERSION (e.g. 2024-12-01-preview)".to_string(),
+            ));
+        }
+        // Azure's endpoint is the deployment URL, so build it as a "custom"
+        // explicit-endpoint OpenAI adapter (which enforces endpoint + key), then
+        // switch to api-key auth and the api-version query.
+        let adapter = build_openai_compatible_adapter(
+            "custom",
+            &ctx.llm.model,
+            &ctx.llm.api_key,
+            &ctx.llm.endpoint,
+            ctx.llm.max_retries,
+        )
+        .map_err(|e| ComponentError::Llm(e.to_string()))?
+        .with_api_version(api_version)
+        .with_extra_args(ctx.llm.llm_args.clone());
+        Ok(Arc::new(adapter))
+    }
+
+    async fn build_transcriber(
+        &self,
+        _ctx: &BackendBuildContext,
+    ) -> Result<Option<Arc<dyn Transcriber>>, ComponentError> {
+        // Azure Whisper deployments exist but need their own deployment URL and
+        // api-version; not wired here, so audio degrades gracefully to None.
+        Ok(None)
+    }
+}
+
 // ── Cross-cutting mock / record helpers ───────────────────────────────────
 //
 // These are applied uniformly by `ComponentRegistry::build_llm` regardless of

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -121,6 +121,9 @@ pub struct LlmInputs {
     /// Applied by the OpenAI-compatible factory via
     /// `OpenAIAdapter::with_extra_args`. See that field's docs for semantics.
     pub llm_args: serde_json::Map<String, serde_json::Value>,
+    /// Azure `api-version` (empty = unset). Only consumed by the azure provider,
+    /// which requires it alongside a deployment `endpoint`.
+    pub api_version: String,
     /// Replaces the provider adapter with a cassette replay mock.
     pub mock: bool,
     /// Cassette path for the replay mock (consumed only under `mock-llm`).

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -92,6 +92,8 @@ impl ComponentRegistry {
         }
         // Native Anthropic Messages API adapter (not OpenAI-compatible).
         reg.register_llm(Arc::new(llm::AnthropicLlmFactory));
+        // Azure OpenAI: OpenAI-compatible wire, but api-key auth + api-version.
+        reg.register_llm(Arc::new(llm::AzureLlmFactory));
 
         reg
     }
@@ -409,6 +411,7 @@ mod tests {
                 max_retries: 3,
                 max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
                 llm_args: serde_json::Map::new(),
+                api_version: String::new(),
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -198,6 +198,10 @@ pub struct HttpServerConfig {
     /// Env: `LLM_ENDPOINT` (fallback `OPENAI_URL`).
     pub llm_endpoint: String,
 
+    /// LLM API version (Azure OpenAI only).
+    /// Env: `LLM_API_VERSION`.
+    pub llm_api_version: String,
+
     /// LLM retry count for both structured-output and network retries.
     /// Env: `LLM_MAX_RETRIES`.
     pub llm_max_retries: u32,
@@ -351,6 +355,7 @@ impl Default for HttpServerConfig {
             llm_model: "gpt-4o-mini".to_string(),
             llm_api_key: SecretString::new(String::new().into()),
             llm_endpoint: String::new(),
+            llm_api_version: String::new(),
             llm_max_retries: 3,
             llm_max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
             session_store_backend: "seaorm".to_string(),
@@ -539,6 +544,9 @@ impl HttpServerConfig {
         if let Some(v) = first_non_empty_env(&["LLM_ENDPOINT", "OPENAI_URL"]) {
             cfg.llm_endpoint = v;
         }
+        if let Ok(v) = std::env::var("LLM_API_VERSION") {
+            cfg.llm_api_version = v;
+        }
         if let Ok(v) = std::env::var("LLM_MAX_RETRIES") {
             cfg.llm_max_retries = v
                 .parse::<u32>()
@@ -688,6 +696,7 @@ impl HttpServerConfig {
                 // The CLI/ComponentManager path wires `LLM_ARGS` via
                 // `cognee::Settings`.
                 llm_args: serde_json::Map::new(),
+                api_version: self.llm_api_version.clone(),
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -279,6 +279,30 @@ fn wire_responses_client(cfg: &HttpServerConfig) -> Option<Arc<dyn ResponsesClie
         return None;
     }
 
+    // The OpenAI Responses client speaks the OpenAI /responses convention
+    // (Authorization: Bearer, no api-version). Allowlist the providers that use
+    // that convention *and* can serve a /responses route: openai (empty means the
+    // openai default), plus the Bearer-auth OpenAI-compatible gateways — LiteLLM
+    // proxy and vLLM (>=0.9) expose an OpenAI-style /responses route and are
+    // typically configured as `custom` / `openai_compatible`. Excluded because
+    // they would 401/404 on every POST /api/v1/responses: Azure (api-key +
+    // api-version), Anthropic (no /responses route), and the ollama / mistral /
+    // gemini gateways (no /responses route). The feature is already opt-in via
+    // `responses_client_enabled` (config.rs), so a `custom` gateway that does not
+    // implement the route only 404s when its operator explicitly enables and
+    // calls it — add/cognify/search are unaffected either way.
+    let provider = cfg.llm_provider.to_ascii_lowercase();
+    if !matches!(
+        provider.as_str(),
+        "openai" | "" | "custom" | "openai_compatible"
+    ) {
+        tracing::info!(
+            "responses client not wired for provider '{provider}' \
+             (its gateway does not serve the OpenAI /responses route)"
+        );
+        return None;
+    }
+
     let api_key = cfg.llm_api_key.expose_secret().to_string();
     if api_key.is_empty() {
         tracing::warn!("responses client enabled but llm api key is missing; wiring as None");
@@ -407,5 +431,42 @@ mod tests {
             msg.contains("postgres connection string") && msg.contains("VECTOR_DB_PROVIDER"),
             "expected actionable pgvector error, got: {msg}"
         );
+    }
+
+    #[test]
+    fn wire_responses_client_allowlist_covers_bearer_compatible_gateways() {
+        use secrecy::SecretString;
+
+        let cfg_for = |provider: &str| HttpServerConfig {
+            llm_provider: provider.to_string(),
+            llm_api_key: SecretString::new("sk-test".to_string().into()),
+            responses_client_enabled: true,
+            ..Default::default()
+        };
+
+        // openai plus the Bearer-auth OpenAI-compatible gateways (LiteLLM / vLLM,
+        // configured as custom / openai_compatible) can serve the /responses route.
+        for provider in ["openai", "", "custom", "openai_compatible"] {
+            assert!(
+                wire_responses_client(&cfg_for(provider)).is_some(),
+                "provider '{provider}' should wire a responses client"
+            );
+        }
+
+        // api-key auth (azure) or no /responses route (anthropic / ollama /
+        // mistral / gemini) stay excluded.
+        for provider in ["azure", "anthropic", "ollama", "mistral", "gemini"] {
+            assert!(
+                wire_responses_client(&cfg_for(provider)).is_none(),
+                "provider '{provider}' must not wire a responses client"
+            );
+        }
+
+        // The opt-in flag still gates an allowlisted provider.
+        let disabled = HttpServerConfig {
+            responses_client_enabled: false,
+            ..cfg_for("openai")
+        };
+        assert!(wire_responses_client(&disabled).is_none());
     }
 }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -847,6 +847,7 @@ impl Settings {
                 max_retries: self.llm_max_retries,
                 max_completion_tokens: self.llm_max_completion_tokens,
                 llm_args: self.llm_args.clone(),
+                api_version: self.llm_api_version.clone(),
                 mock: self.llm_mock,
                 cassette: self.llm_cassette.clone(),
                 record_path: self.llm_record_path.clone(),

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -49,6 +49,10 @@ pub struct OpenAIAdapter {
     model: String,
     api_key: String,
     base_url: String,
+    /// When `Some`, the adapter targets Azure OpenAI: requests authenticate with
+    /// the `api-key` header (not `Authorization: Bearer`) and carry an
+    /// `?api-version=<v>` query parameter. `None` is the standard OpenAI path.
+    api_version: Option<String>,
     client: Client,
     structured_output_retries: usize,
     /// Number of times to retry the HTTP request on transient network/server errors.
@@ -100,6 +104,79 @@ pub struct OpenAIAdapter {
     /// matching the historical [`GenerationOptions::default`] cap so an adapter
     /// built without config behaves exactly as before.
     default_max_tokens: Option<u32>,
+    /// Whether this adapter's `(model, base_url)` pair is an OpenAI reasoning
+    /// model that needs the reasoning parameter shape. Computed once at
+    /// construction (both inputs are fixed there) so the per-request build path
+    /// does not re-parse `base_url` on every `is_reasoning_model()` call. See
+    /// [`compute_reasoning_model`].
+    reasoning_model: bool,
+}
+
+/// Whether `model` is an OpenAI reasoning family (`gpt-5*`, `o1*`, `o3*`, `o4*`)
+/// served from a host that requires the reasoning parameter shape.
+///
+/// Detection is name-based and host-agnostic for remote hosts, so it fires on
+/// both official OpenAI and Azure deployments (`*.openai.azure.com`) of these
+/// models, which both require the reasoning parameter shape. (A host gate on
+/// `api.openai.com` used to leave Azure o-series/gpt-5 deployments sending
+/// `max_tokens`+`temperature`, which Azure 400s on every call.) It is suppressed
+/// only for a local host (see [`is_local_base_url`]) — loopback, or Ollama's
+/// default port on a private-network address — which keeps accepting the legacy
+/// parameters even when a served model name collides with a reasoning prefix.
+///
+/// A self-hosted gateway on a private network but a non-Ollama port (e.g. a LAN
+/// vLLM at `http://192.168.1.5:8000`) is treated as remote and gets the
+/// reasoning shape; such a host is often a proxy to real OpenAI, where that
+/// shape is correct. A deployment that needs the opposite can point the model at
+/// a loopback bind or use Ollama's port.
+fn compute_reasoning_model(model: &str, base_url: &str) -> bool {
+    let m = model.to_lowercase();
+    let is_reasoning_name =
+        m.starts_with("gpt-5") || m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4");
+    is_reasoning_name && !is_local_base_url(base_url)
+}
+
+/// Heuristic for a local / non-OpenAI-compatible host that does not accept the
+/// reasoning-model parameter shape.
+///
+/// Matches on the parsed host authority, not a substring scan of the whole URL,
+/// so a genuinely remote endpoint whose URL merely contains `localhost` as a
+/// subdomain (`o3.localhost.example.com`) or `127.0.0.1` in a path/query is not
+/// misclassified as local. Local means either:
+/// - a loopback host (`localhost`, `127.0.0.0/8`, `::1`), any port; or
+/// - Ollama's default port `11434` on a private-network host (loopback or an
+///   RFC-1918 / link-local address). The port shortcut is gated on a private
+///   host so a genuinely remote endpoint that merely listens on `11434`
+///   (`https://gateway.example.com:11434`) is not classified local and still
+///   gets the reasoning shape for a real o-series/gpt-5 model.
+fn is_local_base_url(base_url: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(base_url) else {
+        // An unparseable base_url can't be classified as local; treat it as
+        // remote so a reasoning model still gets the correct parameter shape.
+        return false;
+    };
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    // url keeps brackets on IPv6 literals; strip them so `[::1]` parses as `::1`.
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    let Ok(ip) = host.parse::<std::net::IpAddr>() else {
+        // A named remote host (not the `localhost` label) is not local.
+        return false;
+    };
+    if ip.is_loopback() {
+        return true;
+    }
+    let is_private = match ip {
+        std::net::IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+        // Unique-local (`fc00::/7`) detection is not stable on IpAddr; loopback
+        // (handled above) covers the realistic local-IPv6 case.
+        std::net::IpAddr::V6(_) => false,
+    };
+    is_private && url.port() == Some(11434)
 }
 
 impl OpenAIAdapter {
@@ -150,22 +227,30 @@ impl OpenAIAdapter {
         // that legitimately contain a slash (e.g. Baseten's `openai/gpt-oss-120b`).
         let model: String = model.into();
 
+        // Normalise a trailing slash so request URLs built as
+        // `{base_url}/chat/completions` never produce a double slash. The
+        // Gemini OpenAI-compat base ends in `/v1beta/openai/`, and a
+        // user-supplied endpoint may too; both would otherwise 404.
+        let base_url = base_url
+            .map(|u| u.trim_end_matches('/').to_string())
+            .unwrap_or_else(|| Self::DEFAULT_BASE_URL.to_string());
+
+        // Both `model` and `base_url` are fixed for the adapter's lifetime, so
+        // classify once here instead of re-parsing `base_url` on every request.
+        let reasoning_model = compute_reasoning_model(&model, &base_url);
+
         Ok(Self {
             model,
             api_key: api_key.into(),
-            // Normalise a trailing slash so request URLs built as
-            // `{base_url}/chat/completions` never produce a double slash. The
-            // Gemini OpenAI-compat base ends in `/v1beta/openai/`, and a
-            // user-supplied endpoint may too; both would otherwise 404.
-            base_url: base_url
-                .map(|u| u.trim_end_matches('/').to_string())
-                .unwrap_or_else(|| Self::DEFAULT_BASE_URL.to_string()),
+            base_url,
+            api_version: None,
             client,
             structured_output_retries: Self::DEFAULT_STRUCTURED_OUTPUT_RETRIES,
             network_retries: Self::DEFAULT_NETWORK_RETRIES,
             transcription_model,
             extra_args: serde_json::Map::new(),
             default_max_tokens: Some(Self::DEFAULT_MAX_COMPLETION_TOKENS),
+            reasoning_model,
         })
     }
 
@@ -269,6 +354,59 @@ impl OpenAIAdapter {
         format!("Bearer {}", self.api_key)
     }
 
+    /// Enable Azure OpenAI mode by setting the API version. An empty/whitespace
+    /// value is treated as unset (stays on the standard OpenAI path). In Azure
+    /// mode the `base_url` is expected to be the deployment endpoint
+    /// (`https://<resource>.openai.azure.com/openai/deployments/<deployment>`),
+    /// so `{base_url}/chat/completions?api-version=<v>` is the Azure request URL.
+    pub fn with_api_version(mut self, api_version: impl Into<String>) -> Self {
+        let v = api_version.into();
+        let trimmed = v.trim();
+        // Store trimmed: `endpoint_url` interpolates this raw, so trailing
+        // whitespace would percent-encode to `?api-version=...%20` and Azure
+        // 400s every request. (Matches the embedding path's api-version handling.)
+        self.api_version = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+        self
+    }
+
+    /// Build a request URL for `path`, appending `api-version=<v>` in Azure mode.
+    ///
+    /// The api-version is added through `Url::query_pairs_mut`, so the query
+    /// separator is chosen correctly even if `base_url` already carries a query
+    /// (no malformed double-`?`) and the value is percent-encoded rather than
+    /// interpolated raw. If `base_url` does not parse as a URL we fall back to a
+    /// manual append that still picks `?` vs `&` from the existing query, so the
+    /// api-version is never silently dropped (Azure 400s without it).
+    fn endpoint_url(&self, path: &str) -> String {
+        let base = format!("{}/{path}", self.base_url);
+        match &self.api_version {
+            Some(v) => match reqwest::Url::parse(&base) {
+                Ok(mut url) => {
+                    url.query_pairs_mut().append_pair("api-version", v);
+                    url.into()
+                }
+                Err(_) => {
+                    let sep = if base.contains('?') { '&' } else { '?' };
+                    format!("{base}{sep}api-version={v}")
+                }
+            },
+            None => base,
+        }
+    }
+
+    /// Apply the provider's auth header: `api-key` for Azure, `Authorization:
+    /// Bearer` for standard OpenAI / OpenAI-compatible endpoints.
+    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.api_version {
+            Some(_) => req.header("api-key", &self.api_key),
+            None => req.header("Authorization", self.auth_header()),
+        }
+    }
+
     /// Whether to request non-thinking mode for local Qwen OpenAI-compatible endpoints.
     fn should_disable_thinking(&self) -> bool {
         self.model.to_lowercase().starts_with("qwen") && !self.base_url.contains("api.openai.com")
@@ -278,15 +416,10 @@ impl OpenAIAdapter {
     /// that reject `temperature`/`top_p`/`frequency_penalty`/`presence_penalty`
     /// overrides and require `max_completion_tokens` in place of `max_tokens`.
     ///
-    /// Gated on the official `api.openai.com` base URL so custom OpenAI-compatible
-    /// proxies (Ollama, vLLM, …) keep accepting legacy parameters even when the
-    /// configured model name happens to match a reasoning-family prefix.
+    /// Returns the value classified once at construction (see
+    /// [`compute_reasoning_model`]); no per-call URL parsing.
     fn is_reasoning_model(&self) -> bool {
-        if !self.base_url.contains("api.openai.com") {
-            return false;
-        }
-        let m = self.model.to_lowercase();
-        m.starts_with("gpt-5") || m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4")
+        self.reasoning_model
     }
 
     /// Insert `max_tokens` (or `max_completion_tokens` on reasoning models) into a
@@ -337,7 +470,7 @@ impl OpenAIAdapter {
         ),
     )]
     async fn send_chat_request(&self, request_body: Value) -> LlmResult<OpenAIResponse> {
-        let url = format!("{}/chat/completions", self.base_url);
+        let url = self.endpoint_url("chat/completions");
         tracing::Span::current().record("url", url.as_str());
         let debug_enabled = std::env::var("COGNEE_DEBUG_LLM_REQUEST")
             .map(|v| cognee_utils::parse_env_bool(&v))
@@ -366,9 +499,7 @@ impl OpenAIAdapter {
             }
 
             let response = match self
-                .client
-                .post(&url)
-                .header("Authorization", self.auth_header())
+                .apply_auth(self.client.post(&url))
                 .header("Content-Type", "application/json")
                 .json(&request_body)
                 .send()
@@ -1232,7 +1363,7 @@ impl OpenAIAdapter {
         &self,
         form: reqwest::multipart::Form,
     ) -> LlmResult<WhisperResponse> {
-        let url = format!("{}/audio/transcriptions", self.base_url);
+        let url = self.endpoint_url("audio/transcriptions");
         tracing::Span::current().record("url", url.as_str());
 
         // We cannot clone a multipart Form, so the first attempt uses the
@@ -1252,9 +1383,7 @@ impl OpenAIAdapter {
         // the form on each attempt.
 
         let response = self
-            .client
-            .post(&url)
-            .header("Authorization", self.auth_header())
+            .apply_auth(self.client.post(&url))
             .multipart(form)
             .send()
             .await
@@ -1566,6 +1695,76 @@ mod tests {
     }
 
     #[test]
+    fn openai_mode_has_no_api_version_and_bearer_url() {
+        let adapter = OpenAIAdapter::new("gpt-4o-mini", "sk-test", None).unwrap();
+        assert!(adapter.api_version.is_none());
+        // No api-version query on the standard OpenAI path.
+        assert_eq!(
+            adapter.endpoint_url("chat/completions"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn with_api_version_enables_azure_mode_and_query() {
+        let adapter = OpenAIAdapter::new(
+            "gpt-4o-mini",
+            "sk-test",
+            Some("https://res.openai.azure.com/openai/deployments/gpt-4o-mini".to_string()),
+        )
+        .unwrap()
+        .with_api_version("2024-12-01-preview");
+        assert_eq!(adapter.api_version.as_deref(), Some("2024-12-01-preview"));
+        assert_eq!(
+            adapter.endpoint_url("chat/completions"),
+            "https://res.openai.azure.com/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-12-01-preview"
+        );
+    }
+
+    #[test]
+    fn endpoint_url_hardens_against_double_query_and_encodes_api_version() {
+        // base_url already carrying a query must not yield a malformed double-`?`;
+        // the api-version is appended with `&`.
+        let with_query = OpenAIAdapter::new(
+            "gpt-4o-mini",
+            "sk-test",
+            Some("https://res.openai.azure.com/openai/deployments/gpt-4o-mini?foo=bar".to_string()),
+        )
+        .unwrap()
+        .with_api_version("2024-12-01-preview");
+        let url = with_query.endpoint_url("chat/completions");
+        assert_eq!(url.matches('?').count(), 1, "exactly one '?': {url}");
+        assert!(url.contains("foo=bar"), "existing query preserved: {url}");
+        assert!(
+            url.contains("api-version=2024-12-01-preview"),
+            "api-version appended: {url}"
+        );
+
+        // A value with a reserved character is percent-encoded, not interpolated raw.
+        let odd = OpenAIAdapter::new(
+            "gpt-4o-mini",
+            "sk-test",
+            Some("https://res.openai.azure.com/openai/deployments/gpt-4o-mini".to_string()),
+        )
+        .unwrap()
+        .with_api_version("2024 preview&x=1");
+        let url = odd.endpoint_url("chat/completions");
+        assert!(
+            !url.contains("api-version=2024 preview&x=1"),
+            "raw value must not appear unencoded: {url}"
+        );
+        assert!(url.contains("api-version="), "api-version present: {url}");
+    }
+
+    #[test]
+    fn with_api_version_empty_stays_openai_mode() {
+        let adapter = OpenAIAdapter::new("gpt-4o-mini", "sk-test", None)
+            .unwrap()
+            .with_api_version("   ");
+        assert!(adapter.api_version.is_none());
+    }
+
+    #[test]
     fn test_is_reasoning_model_matches_openai_families() {
         let cases = [
             ("gpt-5", true),
@@ -1604,6 +1803,89 @@ mod tests {
         )
         .unwrap();
         assert!(!adapter.is_reasoning_model());
+    }
+
+    #[test]
+    fn is_reasoning_model_detected_on_azure_and_remote_gateways() {
+        // The bug this fixes: a host gate on api.openai.com left Azure o-series /
+        // gpt-5 deployments sending max_tokens + temperature, which Azure 400s on
+        // every call. Detection is now name-based, so the Azure deployment matches.
+        let azure = OpenAIAdapter::new(
+            "o3-mini",
+            "sk-test",
+            Some("https://my-resource.openai.azure.com/openai/deployments/o3".to_string()),
+        )
+        .unwrap()
+        .with_api_version("2024-12-01-preview");
+        assert!(azure.is_reasoning_model());
+
+        // A remote (non-local) OpenAI-compatible gateway serving a reasoning
+        // model is detected too, since detection is host-agnostic.
+        let gateway = OpenAIAdapter::new(
+            "gpt-5",
+            "sk-test",
+            Some("https://gateway.example.com/v1".to_string()),
+        )
+        .unwrap();
+        assert!(gateway.is_reasoning_model());
+
+        // Regression: the old substring scan misclassified a genuinely remote
+        // host as local when the URL merely contained a loopback token. A
+        // `localhost` subdomain label must NOT suppress detection.
+        let subdomain = OpenAIAdapter::new(
+            "o3-mini",
+            "sk-test",
+            Some("https://o3.localhost.example.com/v1".to_string()),
+        )
+        .unwrap();
+        assert!(subdomain.is_reasoning_model());
+        // `127.0.0.1` appearing only in a path must NOT suppress detection.
+        let path_ip = OpenAIAdapter::new(
+            "gpt-5",
+            "sk-test",
+            Some("https://gateway.example.com/proxy/127.0.0.1/v1".to_string()),
+        )
+        .unwrap();
+        assert!(path_ip.is_reasoning_model());
+        // An actual loopback host is still suppressed (local runtimes reject the shape).
+        let loopback = OpenAIAdapter::new(
+            "o3-mini",
+            "sk-test",
+            Some("http://127.0.0.1:8080/v1".to_string()),
+        )
+        .unwrap();
+        assert!(!loopback.is_reasoning_model());
+
+        // A genuinely remote endpoint that merely listens on Ollama's default
+        // port 11434 is NOT local: a real reasoning model there still gets the
+        // reasoning shape. (The port shortcut is gated on a private host.)
+        let remote_11434 = OpenAIAdapter::new(
+            "gpt-5",
+            "sk-test",
+            Some("https://gateway.example.com:11434/v1".to_string()),
+        )
+        .unwrap();
+        assert!(remote_11434.is_reasoning_model());
+
+        // Ollama on a private-network host (RFC-1918 + port 11434) is local, so
+        // a name-colliding model is suppressed.
+        let lan_ollama = OpenAIAdapter::new(
+            "o3-mini",
+            "sk-test",
+            Some("http://192.168.1.5:11434/v1".to_string()),
+        )
+        .unwrap();
+        assert!(!lan_ollama.is_reasoning_model());
+
+        // A private-network host on a non-Ollama port is treated as remote (often
+        // a proxy to real OpenAI), so the reasoning shape applies.
+        let lan_gateway = OpenAIAdapter::new(
+            "gpt-5",
+            "sk-test",
+            Some("http://192.168.1.5:8000/v1".to_string()),
+        )
+        .unwrap();
+        assert!(lan_gateway.is_reasoning_model());
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,8 +82,16 @@ alias each other) so a stray `OPENAI_URL` cannot misroute Anthropic traffic —
 matching the Python SDK, which passes no base URL. To route Anthropic traffic
 through a proxy / gateway / Bedrock-compatible endpoint, set the dedicated
 `ANTHROPIC_BASE_URL` (alias `ANTHROPIC_API_BASE`); it overrides the default only
-on the Anthropic path and other providers ignore it. Native Azure and Bedrock
-adapters are tracked separately in issue #17.
+on the Anthropic path and other providers ignore it.
+
+`azure` reuses the OpenAI request path with Azure's auth and URL conventions: it
+authenticates with the `api-key` header and appends an `?api-version=<v>` query.
+Set `LLM_PROVIDER=azure`, `LLM_API_KEY`, `LLM_API_VERSION` (e.g.
+`2024-12-01-preview`), and `LLM_ENDPOINT` to the **deployment** URL
+(`https://<resource>.openai.azure.com/openai/deployments/<deployment>`); the model
+in the request body is ignored by Azure since the deployment is in the URL.
+
+Native Bedrock adapters are tracked separately in issue #17.
 
 > **Ollama embeddings:** set `EMBEDDING_ENDPOINT` explicitly when using
 > `EMBEDDING_PROVIDER=ollama`. The Ollama embedder needs the `/api/embed` route, and


### PR DESCRIPTION
## Summary

Tier 3 of #17 -  add Azure OpenAI support. Azure is wire-compatible with the OpenAI chat API, so it is implemented as a thin variant of the existing request path rather than a new adapter. Builds on #30 (Tier 1) and the Tier 2 Anthropic PR.

Azure differs from OpenAI in two ways, both handled on `OpenAIAdapter` behind an optional `api_version`:

- Auth: the `api-key` header instead of `Authorization: Bearer`.
- URL: an `?api-version=<v>` query parameter on every request; the deployment is  encoded in the endpoint URL (`{base}/openai/deployments/{deployment}`), so  `{base_url}/chat/completions?api-version=<v>` is the Azure request URL.

The Azure path is fully gated on `api_version` being set, so the standard OpenAI / OpenAI-compatible path is byte-for-byte unchanged when it is unset. The OpenAI-only request quirks already key off the `api.openai.com` host, so they never fire on Azure.

## Changes

- `OpenAIAdapter`: optional `api_version` field + `with_api_version(..)`; `endpoint_url`  appends the api-version query in Azure mode; `apply_auth` selects `api-key` vs  `Authorization: Bearer`. Empty/whitespace api-version is treated as unset.
- Wire `azure` into `ComponentManager::init_llm_adapter` and the HTTP server's  `wire_llm`. Both require `LLM_API_KEY`, `LLM_ENDPOINT` (the deployment URL), and  `LLM_API_VERSION`.
- Add `llm_api_version` to the HTTP server config (env `LLM_API_VERSION`).
- Docs: `docs/configuration.md` describes the Azure conventions; the `.env.example`  Azure block now uses `LLM_PROVIDER=azure` with the deployment URL.

## Behaviour

No change to existing providers. OpenAI and the Tier 1 OpenAI-compatible providers keep Bearer auth and no api-version query (api_version stays `None`). Azure is the only path that sends `api-key` + `?api-version=`.

## Tests

- New unit tests: the api-version query is appended and `api-key` auth is selected in  Azure mode; the standard OpenAI path keeps Bearer auth and no query; an empty  api-version stays on the OpenAI path.
- The full `cognee-llm` lib suite (78 tests) passes, confirming the shared-adapter  refactor does not regress the OpenAI path.
- Verified: `fmt`, `clippy --all-targets -D warnings` (cognee-llm / cognee-lib /  cognee-http-server).

## Scope

Part of #17 - does not close it. Bedrock (the larger Tier 3 item: SigV4 signing, per-region/model payloads) is deferred per the issue unless there is concrete demand. Stacked on #30 and the Tier 2 PR; until those merge this PR's diff includes their commits, after which GitHub drops the overlap.