### PR TITLE
ci(ts-prebuild): fix the win32-x64-msvc prebuild (MSVC env + launcher + CRT)

### DIFF
--- a/.github/workflows/ts-prebuild.yml
+++ b/.github/workflows/ts-prebuild.yml
@@ -126,6 +126,19 @@ jobs:
         with:
           arch: x64
 
+      # .cargo/config.toml routes the bundled CMake C/C++ build through
+      # scripts/ccache-launcher.sh, a POSIX sh script. Ninja can't CreateProcess
+      # a .sh on Windows (`%1 is not a valid Win32 application`). Clear the
+      # launcher here so CMake invokes cl.exe directly — a set env var overrides
+      # the non-forced [env] in config.toml, and ccache isn't installed on the
+      # Windows runner anyway (the ccache-action step is skipped there).
+      - name: Disable POSIX ccache launcher (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "CMAKE_C_COMPILER_LAUNCHER=" >> "$GITHUB_ENV"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=" >> "$GITHUB_ENV"
+
       - name: ccache (lbug bundled C++, restore-only)
         if: runner.os != 'Windows'
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/ts-prebuild.yml
+++ b/.github/workflows/ts-prebuild.yml
@@ -126,18 +126,29 @@ jobs:
         with:
           arch: x64
 
-      # .cargo/config.toml routes the bundled CMake C/C++ build through
-      # scripts/ccache-launcher.sh, a POSIX sh script. Ninja can't CreateProcess
-      # a .sh on Windows (`%1 is not a valid Win32 application`). Clear the
-      # launcher here so CMake invokes cl.exe directly — a set env var overrides
-      # the non-forced [env] in config.toml, and ccache isn't installed on the
-      # Windows runner anyway (the ccache-action step is skipped there).
-      - name: Disable POSIX ccache launcher (Windows)
+      # Two Windows-only build-env fixes:
+      #
+      # 1. .cargo/config.toml routes the bundled CMake C/C++ build through
+      #    scripts/ccache-launcher.sh, a POSIX sh script. Ninja can't
+      #    CreateProcess a .sh on Windows (`%1 is not a valid Win32
+      #    application`). Clear the launcher so CMake invokes cl.exe directly —
+      #    a set env var overrides the non-forced [env] in config.toml, and
+      #    ccache isn't installed on the Windows runner anyway.
+      #
+      # 2. CRT mismatch: lbug compiles its C++ with /MD (dynamic CRT, matching
+      #    Rust's msvc default), but esaxx-rs hardcodes `.static_crt(true)` ->
+      #    /MT, so linking the addon fails with LNK2038/LNK1319. Force /MD for
+      #    cc-built C++ deps via target-scoped CXXFLAGS/CFLAGS (cc appends env
+      #    flags last, so /MD wins over esaxx's /MT at cl.exe). Target-scoped so
+      #    host build-script compiles are untouched.
+      - name: Configure Windows C/C++ build env
         if: runner.os == 'Windows'
         shell: bash
         run: |
           echo "CMAKE_C_COMPILER_LAUNCHER=" >> "$GITHUB_ENV"
           echo "CMAKE_CXX_COMPILER_LAUNCHER=" >> "$GITHUB_ENV"
+          echo "CFLAGS_x86_64_pc_windows_msvc=/MD" >> "$GITHUB_ENV"
+          echo "CXXFLAGS_x86_64_pc_windows_msvc=/MD" >> "$GITHUB_ENV"
 
       - name: ccache (lbug bundled C++, restore-only)
         if: runner.os != 'Windows'

--- a/.github/workflows/ts-prebuild.yml
+++ b/.github/workflows/ts-prebuild.yml
@@ -114,6 +114,18 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install cmake protoc --no-progress
 
+      # lbug (a Kùzu fork) forces the CMake "Ninja" generator, and Ninja+MSVC
+      # does NOT search for the compiler — cl.exe/link.exe must already be on
+      # PATH via the MSVC developer environment. Without it the build fails with
+      # `ninja: CreateProcess: %1 is not a valid Win32 application`. This is the
+      # GitHub-hosted equivalent of the `vcvars64.bat` call Kùzu's own Windows
+      # CI uses; it exports the MSVC env to all subsequent steps.
+      - name: Set up MSVC developer environment (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: ccache (lbug bundled C++, restore-only)
         if: runner.os != 'Windows'
         uses: hendrikmuhs/ccache-action@v1.2


### PR DESCRIPTION
## Summary

Gets the `win32-x64-msvc` prebuild leg building green for the first time. Verified end-to-end on a dispatched run: **win32 now succeeds and uploads an 87 MB `.node`** (all four platforms green).

## Investigation

`lbug` (the bundled C++ graph engine) is a private fork of **[Kùzu](https://github.com/kuzudb/kuzu)**; Kùzu's own Rust `build.rs` forces the CMake **Ninja** generator and its Windows CI activates MSVC via `vcvars64.bat`. Following those recipes uncovered three stacked failures, each fixed here:

1. **No MSVC environment** → `ninja: CreateProcess: %1 is not a valid Win32 application` (CMake couldn't find `cl.exe`). Added `ilammy/msvc-dev-cmd@v1` — the GitHub-hosted equivalent of Kùzu's `vcvars64.bat`.
2. **POSIX ccache launcher on Windows** → `.cargo/config.toml` wires `CMAKE_*_COMPILER_LAUNCHER=scripts/ccache-launcher.sh`; Ninja can't `CreateProcess` a `.sh`. Cleared the launcher env on Windows (documented Windows caveat in `docs/build/lbug-rebuilds.md`; ccache isn't installed there anyway).
3. **CRT mismatch** → `LNK2038/LNK1319`: `esaxx-rs` hardcodes `.static_crt(true)` (`/MT`) while `lbug` uses `/MD` (Rust's msvc default). Forced `/MD` for cc-built C/C++ deps via target-scoped `CXXFLAGS`/`CFLAGS` so it wins over esaxx's `/MT` at `cl.exe`.

## Changes (all Windows-only, in `ts-prebuild.yml`)

- Add `ilammy/msvc-dev-cmd@v1` (x64) before the build.
- New "Configure Windows C/C++ build env" step: clear the `.sh` compiler launcher and set target-scoped `/MD`.

No changes affect the other platforms. `@cognee/neon-win32-x64-msvc` was never published; with this, it can be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)