### PR TITLE
perf(cognify): bound summarization concurrency and add retry jitter

### DIFF
--- a/crates/cognify/src/config.rs
+++ b/crates/cognify/src/config.rs
@@ -72,11 +72,6 @@ pub struct CognifyConfig {
     /// Default: true (matches Python)
     pub enable_summarization: bool,
 
-    /// Batch size for summarization (parallel summary generation).
-    /// Python default: No explicit batching (processes all chunks in parallel)
-    /// Rust: Prevents spawning too many tasks
-    pub summarization_batch_size: usize,
-
     /// Whether to generate and index triplet embeddings.
     /// Triplets are formatted as "source › relationship › target"
     /// Python config: CognifyConfig.triplet_embedding (default: False)
@@ -219,7 +214,6 @@ impl Default for CognifyConfig {
             custom_extraction_prompt: None,
 
             enable_summarization: true,
-            summarization_batch_size: 50,
 
             embed_triplets: false,
             embedding_batch_size: 100,
@@ -283,12 +277,6 @@ impl CognifyConfig {
     /// Enable or disable summarization.
     pub fn with_summarization(mut self, enable: bool) -> Self {
         self.enable_summarization = enable;
-        self
-    }
-
-    /// Set summarization batch size.
-    pub fn with_summarization_batch_size(mut self, batch_size: usize) -> Self {
-        self.summarization_batch_size = batch_size;
         self
     }
 
@@ -461,12 +449,6 @@ impl CognifyConfig {
             ));
         }
 
-        if self.summarization_batch_size == 0 {
-            return Err(ConfigError::InvalidParameter(
-                "summarization_batch_size must be greater than 0".to_string(),
-            ));
-        }
-
         if self.data_per_batch == 0 {
             return Err(ConfigError::InvalidParameter(
                 "data_per_batch must be greater than 0".to_string(),
@@ -593,7 +575,6 @@ mod tests {
 
         // Summarization defaults
         assert!(config.enable_summarization);
-        assert_eq!(config.summarization_batch_size, 50);
 
         // Embedding defaults
         assert!(!config.embed_triplets);
@@ -698,12 +679,6 @@ mod tests {
             ..Default::default()
         };
         assert!(config2.validate().is_err());
-
-        let config3 = CognifyConfig {
-            summarization_batch_size: 0,
-            ..Default::default()
-        };
-        assert!(config3.validate().is_err());
     }
 
     /// Local ONNX/BGE default: the model's 512-token sequence limit binds →

--- a/crates/cognify/src/summarization/extractor.rs
+++ b/crates/cognify/src/summarization/extractor.rs
@@ -33,6 +33,41 @@ fn default_summary_options() -> GenerationOptions {
 /// drift guard.
 const DEFAULT_SUMMARY_PROMPT: &str = include_str!("prompts/summarize_content.txt");
 
+/// Summarize a single chunk of text. Shared by [`SummaryExtractor::extract_summary`]
+/// and the bounded [`SummaryExtractor::summarize_chunks`] pipeline so neither has
+/// to fabricate a throwaway extractor per call.
+async fn summarize_one(
+    llm: &Arc<dyn Llm>,
+    summary_schema: &Option<serde_json::Value>,
+    text: &str,
+    custom_prompt: Option<&str>,
+) -> Result<SummarizedContent, CognifyError> {
+    let system_prompt = custom_prompt.unwrap_or(DEFAULT_SUMMARY_PROMPT);
+    let options = Some(default_summary_options());
+
+    match summary_schema {
+        None => llm
+            .create_structured_output(text, system_prompt, options)
+            .await
+            .map_err(|e| CognifyError::LlmError(e.to_string())),
+        Some(schema) => {
+            let raw: serde_json::Value = llm
+                .create_structured_output_raw(text, system_prompt, schema, options)
+                .await
+                .map_err(|e| CognifyError::LlmError(e.to_string()))?;
+            let summary = raw.get("summary").and_then(|v| v.as_str()).ok_or_else(|| {
+                CognifyError::LlmError(
+                    "summary_schema output missing string `summary` field".to_string(),
+                )
+            })?;
+            Ok(SummarizedContent {
+                summary: summary.to_string(),
+                description: String::new(),
+            })
+        }
+    }
+}
+
 /// Summary extractor for text chunks.
 ///
 /// Uses an LLM (via the Llm trait) to generate hierarchical summaries from text chunks.
@@ -108,35 +143,7 @@ impl SummaryExtractor {
         text: &str,
         custom_prompt: Option<&str>,
     ) -> Result<SummarizedContent, CognifyError> {
-        let system_prompt = custom_prompt.unwrap_or(DEFAULT_SUMMARY_PROMPT);
-        let options = Some(default_summary_options());
-
-        match &self.summary_schema {
-            None => {
-                let summarized: SummarizedContent = self
-                    .llm
-                    .create_structured_output(text, system_prompt, options)
-                    .await
-                    .map_err(|e| CognifyError::LlmError(e.to_string()))?;
-                Ok(summarized)
-            }
-            Some(schema) => {
-                let raw: serde_json::Value = self
-                    .llm
-                    .create_structured_output_raw(text, system_prompt, schema, options)
-                    .await
-                    .map_err(|e| CognifyError::LlmError(e.to_string()))?;
-                let summary = raw.get("summary").and_then(|v| v.as_str()).ok_or_else(|| {
-                    CognifyError::LlmError(
-                        "summary_schema output missing string `summary` field".to_string(),
-                    )
-                })?;
-                Ok(SummarizedContent {
-                    summary: summary.to_string(),
-                    description: String::new(),
-                })
-            }
-        }
+        summarize_one(&self.llm, &self.summary_schema, text, custom_prompt).await
     }
 
     /// Summarize multiple text chunks in parallel.
@@ -187,12 +194,8 @@ impl SummaryExtractor {
                 let model_name = model_name.clone();
                 let prompt = custom_prompt.clone();
                 async move {
-                    let extractor = SummaryExtractor {
-                        llm,
-                        summary_schema,
-                        max_parallel: 1,
-                    };
-                    let summarized = extractor.extract_summary(&text, prompt.as_deref()).await?;
+                    let summarized =
+                        summarize_one(&llm, &summary_schema, &text, prompt.as_deref()).await?;
                     let summary =
                         TextSummary::from_summarized_content(chunk_id, summarized, model_name);
                     Ok::<(usize, TextSummary), CognifyError>((index, summary))

--- a/crates/cognify/src/summarization/extractor.rs
+++ b/crates/cognify/src/summarization/extractor.rs
@@ -58,14 +58,23 @@ pub struct SummaryExtractor {
     /// When `Some`, the dynamic schema path is taken instead of the typed
     /// `SummarizedContent` path (Python `summarization_model` parity).
     summary_schema: Option<serde_json::Value>,
+    /// Maximum number of concurrent summarization LLM calls. Bounds in-flight
+    /// requests on large documents (see issue #19).
+    max_parallel: usize,
 }
 
 impl SummaryExtractor {
+    /// Default cap on concurrent summarization LLM calls. Matches the graph
+    /// extractor's default `max_parallel_extractions` so both stages share the
+    /// same in-flight ceiling.
+    pub const DEFAULT_MAX_PARALLEL: usize = 20;
+
     /// Create a new summary extractor using the built-in `SummarizedContent` schema.
     pub fn new(llm: Arc<dyn Llm>) -> Self {
         Self {
             llm,
             summary_schema: None,
+            max_parallel: Self::DEFAULT_MAX_PARALLEL,
         }
     }
 
@@ -78,7 +87,15 @@ impl SummaryExtractor {
         Self {
             llm,
             summary_schema: schema,
+            max_parallel: Self::DEFAULT_MAX_PARALLEL,
         }
+    }
+
+    /// Set the maximum number of concurrent summarization LLM calls. Values
+    /// below 1 are coerced to 1.
+    pub fn with_max_parallel(mut self, max_parallel: usize) -> Self {
+        self.max_parallel = max_parallel.max(1);
+        self
     }
 
     /// Extract a summary from text.
@@ -142,45 +159,51 @@ impl SummaryExtractor {
             return Ok(vec![]);
         }
 
-        let mut tasks = Vec::new();
+        use futures::stream::{self, StreamExt, TryStreamExt};
 
-        for chunk in chunks {
-            let llm_clone = Arc::clone(&self.llm);
-            let schema_clone = self.summary_schema.clone();
-            let prompt_clone = custom_prompt.clone();
-            let text = chunk.text.clone();
-
-            let task = tokio::spawn(async move {
-                let extractor = SummaryExtractor {
-                    llm: llm_clone,
-                    summary_schema: schema_clone,
-                };
-                extractor
-                    .extract_summary(&text, prompt_clone.as_deref())
-                    .await
-            });
-
-            tasks.push(task);
-        }
-
-        let results = futures::future::join_all(tasks).await;
-
-        // Get model name from LLM
         let model_name = self.llm.model().to_string();
 
-        let mut summaries = Vec::new();
-        for (chunk_index, result) in results.into_iter().enumerate() {
-            let chunk = &chunks[chunk_index];
-            let summarized =
-                result.map_err(|e| CognifyError::LlmError(format!("Task join error: {e}")))??;
+        // Pre-extract owned per-chunk inputs (index, text, chunk id) so the
+        // stream yields owned items. Mapping a stream over borrowed `&chunk`
+        // references trips a higher-ranked-lifetime inference bug when the
+        // surrounding future is boxed; owning the items avoids it.
+        let inputs: Vec<(usize, String, uuid::Uuid)> = chunks
+            .iter()
+            .enumerate()
+            .map(|(index, chunk)| (index, chunk.text.clone(), chunk.base.id))
+            .collect();
 
-            let text_summary =
-                TextSummary::from_summarized_content(chunk.base.id, summarized, model_name.clone());
+        // Bounded-concurrency pipeline: at most `max_parallel` summarization
+        // calls are in flight at once. This replaces the previous unbounded
+        // per-chunk `tokio::spawn`, which opened one request per chunk on a large
+        // document — a rate-limit and memory risk (issue #19). `buffer_unordered`
+        // keeps the global cap while pipelining across chunks; results arrive out
+        // of order, so each future carries its chunk index and we re-sort to
+        // preserve the input order the callers expect.
+        let mut indexed: Vec<(usize, TextSummary)> = stream::iter(inputs)
+            .map(|(index, text, chunk_id)| {
+                let llm = Arc::clone(&self.llm);
+                let summary_schema = self.summary_schema.clone();
+                let model_name = model_name.clone();
+                let prompt = custom_prompt.clone();
+                async move {
+                    let extractor = SummaryExtractor {
+                        llm,
+                        summary_schema,
+                        max_parallel: 1,
+                    };
+                    let summarized = extractor.extract_summary(&text, prompt.as_deref()).await?;
+                    let summary =
+                        TextSummary::from_summarized_content(chunk_id, summarized, model_name);
+                    Ok::<(usize, TextSummary), CognifyError>((index, summary))
+                }
+            })
+            .buffer_unordered(self.max_parallel)
+            .try_collect()
+            .await?;
 
-            summaries.push(text_summary);
-        }
-
-        Ok(summaries)
+        indexed.sort_by_key(|(index, _)| *index);
+        Ok(indexed.into_iter().map(|(_, summary)| summary).collect())
     }
 
     /// Get a reference to the underlying LLM.
@@ -210,6 +233,87 @@ mod tests {
     fn test_default_prompt_not_empty() {
         assert!(!DEFAULT_SUMMARY_PROMPT.is_empty());
         assert!(DEFAULT_SUMMARY_PROMPT.contains("Summarize the chunk for retrieval"));
+    }
+
+    #[tokio::test]
+    async fn summarize_chunks_bounds_concurrency_and_preserves_order() {
+        use cognee_llm::{GenerationResponse, LlmResult, Message};
+        use serde_json::{Value, json};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use uuid::Uuid;
+
+        /// Mock LLM that records the peak number of concurrent in-flight calls.
+        struct ConcurrencyTracker {
+            in_flight: AtomicUsize,
+            max_seen: AtomicUsize,
+            calls: AtomicUsize,
+        }
+
+        #[async_trait::async_trait]
+        impl Llm for ConcurrencyTracker {
+            async fn generate(
+                &self,
+                _messages: Vec<Message>,
+                _options: Option<GenerationOptions>,
+            ) -> LlmResult<GenerationResponse> {
+                unreachable!("summarization uses structured output, not generate")
+            }
+
+            async fn create_structured_output_with_messages_raw(
+                &self,
+                _messages: Vec<Message>,
+                _json_schema: &Value,
+                _options: Option<GenerationOptions>,
+            ) -> LlmResult<Value> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                let current = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                self.max_seen.fetch_max(current, Ordering::SeqCst);
+                // Hold the "request" open so overlapping calls are observable.
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                self.in_flight.fetch_sub(1, Ordering::SeqCst);
+                Ok(json!({ "summary": "s", "description": "d" }))
+            }
+
+            fn model(&self) -> &str {
+                "mock-tracker"
+            }
+        }
+
+        let tracker = Arc::new(ConcurrencyTracker {
+            in_flight: AtomicUsize::new(0),
+            max_seen: AtomicUsize::new(0),
+            calls: AtomicUsize::new(0),
+        });
+        let llm: Arc<dyn Llm> = tracker.clone();
+
+        let doc_id = Uuid::new_v4();
+        let chunks: Vec<DocumentChunk> = (0..10)
+            .map(|i| {
+                DocumentChunk::new(
+                    Uuid::new_v4(),
+                    format!("chunk text {i}"),
+                    3,
+                    i,
+                    "paragraph_end".to_string(),
+                    doc_id,
+                )
+            })
+            .collect();
+        let expected: Vec<Option<Uuid>> = chunks.iter().map(|c| Some(c.base.id)).collect();
+
+        let extractor = SummaryExtractor::new(llm).with_max_parallel(3);
+        let summaries = extractor.summarize_chunks(&chunks, None).await.unwrap();
+
+        // Every chunk produced one summary, in the original input order.
+        assert_eq!(summaries.len(), 10);
+        assert_eq!(tracker.calls.load(Ordering::SeqCst), 10);
+        let got: Vec<Option<Uuid>> = summaries.iter().map(|s| s.made_from).collect();
+        assert_eq!(got, expected, "summaries must preserve input chunk order");
+
+        // Concurrency was real (overlapping) but never exceeded the cap of 3.
+        let peak = tracker.max_seen.load(Ordering::SeqCst);
+        assert!(peak >= 2, "expected overlapping calls, peak was {peak}");
+        assert!(peak <= 3, "concurrency cap exceeded: peak {peak} > 3");
     }
 
     #[test]

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -882,7 +882,8 @@ pub async fn summarize_text(
 
     let summaries = if config.enable_summarization && !non_dlt_chunks.is_empty() {
         let summary_extractor =
-            SummaryExtractor::new_with_schema(llm, config.summary_schema.clone());
+            SummaryExtractor::new_with_schema(llm, config.summary_schema.clone())
+                .with_max_parallel(config.max_parallel_extractions);
         let mut all_summaries = Vec::new();
 
         for batch in non_dlt_chunks.chunks(config.summarization_batch_size) {

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -884,12 +884,14 @@ pub async fn summarize_text(
         let summary_extractor =
             SummaryExtractor::new_with_schema(llm, config.summary_schema.clone())
                 .with_max_parallel(config.max_parallel_extractions);
-        let mut all_summaries = Vec::new();
 
-        for batch in non_dlt_chunks.chunks(config.summarization_batch_size) {
-            let batch_summaries = summary_extractor.summarize_chunks(batch, None).await?;
-            all_summaries.extend(batch_summaries);
-        }
+        // Stream every chunk through one bounded pipeline. `summarize_chunks`
+        // already caps in-flight requests at `max_parallel_extractions` internally
+        // (issue #19), so an outer batch loop would only insert a sequential
+        // barrier between batches without lowering peak concurrency.
+        let all_summaries = summary_extractor
+            .summarize_chunks(&non_dlt_chunks, None)
+            .await?;
 
         info!("Generated {} summaries", all_summaries.len());
         all_summaries

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -40,6 +40,9 @@ thiserror.workspace = true
 # HTTP client (for API-based implementations)
 reqwest = { workspace = true, features = ["multipart"] }
 
+# Jitter for retry backoff
+rand = { workspace = true }
+
 tracing.workspace = true
 
 # Shared tracing-key constants

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -216,15 +216,15 @@ impl OpenAIAdapter {
         for attempt in 0..=self.network_retries {
             debug!(attempt, "LLM API attempt");
             if attempt > 0 {
-                let delay_ms = (1_000u64 * 2u64.saturating_pow(attempt as u32 - 1)).min(30_000);
+                let delay = crate::retry::retry_backoff(attempt as u32);
                 warn!(
                     attempt,
                     network_retries = self.network_retries,
-                    delay_ms,
+                    delay_ms = delay.as_millis() as u64,
                     error = %last_error,
                     "LLM request failed, retrying",
                 );
-                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                tokio::time::sleep(delay).await;
             }
 
             let response = match self
@@ -972,15 +972,15 @@ impl Transcriber for OpenAIAdapter {
         for attempt in 0..=self.network_retries {
             debug!(attempt, "Transcription API attempt");
             if attempt > 0 {
-                let delay_ms = (1_000u64 * 2u64.saturating_pow(attempt as u32 - 1)).min(30_000);
+                let delay = crate::retry::retry_backoff(attempt as u32);
                 warn!(
                     attempt,
                     network_retries = self.network_retries,
-                    delay_ms,
+                    delay_ms = delay.as_millis() as u64,
                     error = %last_error,
                     "Transcription request failed, retrying",
                 );
-                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                tokio::time::sleep(delay).await;
             }
 
             let form =

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -60,6 +60,7 @@ pub mod llm_trait;
 pub mod mock;
 pub mod prompts;
 pub mod responses_client;
+mod retry;
 pub mod schema;
 pub mod transcriber;
 pub mod types;

--- a/crates/llm/src/responses_client.rs
+++ b/crates/llm/src/responses_client.rs
@@ -212,14 +212,14 @@ impl OpenAIResponsesClient {
         for attempt in 0..=self.network_retries {
             debug!(attempt, "Responses API attempt");
             if attempt > 0 {
-                let delay_ms = (1_000u64 * 2u64.saturating_pow(attempt as u32 - 1)).min(30_000);
+                let delay = crate::retry::retry_backoff(attempt as u32);
                 warn!(
                     attempt,
-                    delay_ms,
+                    delay_ms = delay.as_millis() as u64,
                     error = %last_error,
                     "Responses API request failed, retrying",
                 );
-                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                tokio::time::sleep(delay).await;
             }
 
             let mut builder = self

--- a/crates/llm/src/retry.rs
+++ b/crates/llm/src/retry.rs
@@ -1,0 +1,75 @@
+//! Shared retry backoff with jitter for transient LLM API failures.
+//!
+//! The adapters retry transient network / HTTP 429 / 5xx failures with
+//! exponential backoff. A purely deterministic schedule (1s, 2s, 4s, …) means a
+//! batch of requests that all hit a rate limit at the same instant also retry at
+//! the same instants — a thundering herd that keeps tripping the limit. Adding
+//! jitter spreads those retries out. See issue #19.
+
+use std::time::Duration;
+
+/// Capped exponential backoff base for a 1-indexed `attempt`: 1s, 2s, 4s, …
+/// capped at 30s.
+fn base_backoff_ms(attempt: u32) -> u64 {
+    // Saturating arithmetic so a very large `attempt` can't overflow before the
+    // `.min(30_000)` cap clamps it.
+    1_000u64
+        .saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1)))
+        .min(30_000)
+}
+
+/// Exponential backoff with **equal jitter** for retry `attempt` (1-indexed).
+///
+/// Returns a duration in `[base/2, base]`, where `base` is the capped
+/// exponential backoff. Keeping at least half the backoff preserves the growing
+/// delay, while the random half spreads simultaneous retries to avoid a
+/// thundering herd (e.g. a batch that all hit HTTP 429 at once).
+pub(crate) fn retry_backoff(attempt: u32) -> Duration {
+    let base = base_backoff_ms(attempt);
+    let half = base / 2;
+    let jitter = if half == 0 {
+        0
+    } else {
+        rand::random::<u64>() % (half + 1)
+    };
+    Duration::from_millis(half + jitter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_stays_within_equal_jitter_bounds() {
+        for attempt in 1..=8u32 {
+            let base = base_backoff_ms(attempt);
+            for _ in 0..200 {
+                let ms = retry_backoff(attempt).as_millis() as u64;
+                assert!(ms >= base / 2, "attempt {attempt}: {ms} < {}", base / 2);
+                assert!(ms <= base, "attempt {attempt}: {ms} > {base}");
+            }
+        }
+    }
+
+    #[test]
+    fn backoff_grows_then_caps_at_30s() {
+        // The base doubles each attempt and caps at 30s, so the jittered value
+        // never exceeds 30s.
+        assert_eq!(base_backoff_ms(1), 1_000);
+        assert_eq!(base_backoff_ms(2), 2_000);
+        assert_eq!(base_backoff_ms(6), 30_000); // 32s would exceed the cap
+        for _ in 0..200 {
+            assert!(retry_backoff(100).as_millis() as u64 <= 30_000);
+        }
+    }
+
+    #[test]
+    fn backoff_is_randomized() {
+        // Over many samples at a fixed attempt we should see more than one value
+        // (otherwise jitter is not being applied).
+        let distinct: std::collections::HashSet<u64> = (0..50)
+            .map(|_| retry_backoff(4).as_millis() as u64)
+            .collect();
+        assert!(distinct.len() > 1, "expected jittered (varied) delays");
+    }
+}

--- a/crates/llm/src/retry.rs
+++ b/crates/llm/src/retry.rs
@@ -5,17 +5,24 @@
 //! batch of requests that all hit a rate limit at the same instant also retry at
 //! the same instants — a thundering herd that keeps tripping the limit. Adding
 //! jitter spreads those retries out. See issue #19.
+//!
+//! The capped-exponential base is computed by [`cognee_utils::retry::RetryConfig`]
+//! so the backoff math has a single source of truth shared with the rest of the
+//! workspace; this module only layers **equal jitter** on top.
 
 use std::time::Duration;
 
-/// Capped exponential backoff base for a 1-indexed `attempt`: 1s, 2s, 4s, …
-/// capped at 30s.
+use cognee_utils::retry::RetryConfig;
+
+/// Capped exponential base (1s, 2s, 4s, … capped at 30s) for a 1-indexed
+/// `attempt`, delegated to the shared `cognee_utils` implementation.
 fn base_backoff_ms(attempt: u32) -> u64 {
-    // Saturating arithmetic so a very large `attempt` can't overflow before the
-    // `.min(30_000)` cap clamps it.
-    1_000u64
-        .saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1)))
-        .min(30_000)
+    // `RetryConfig::calculate_delay` is 0-indexed and, with no jitter factor,
+    // returns `initial_delay_ms * multiplier^attempt` capped at `max_delay_ms`.
+    // 1000ms initial, 2x multiplier, 30s cap matches the previous local math.
+    RetryConfig::new(0, 1_000, 30_000)
+        .calculate_delay(attempt.saturating_sub(1))
+        .as_millis() as u64
 }
 
 /// Exponential backoff with **equal jitter** for retry `attempt` (1-indexed).
@@ -24,7 +31,14 @@ fn base_backoff_ms(attempt: u32) -> u64 {
 /// exponential backoff. Keeping at least half the backoff preserves the growing
 /// delay, while the random half spreads simultaneous retries to avoid a
 /// thundering herd (e.g. a batch that all hit HTTP 429 at once).
+///
+/// `attempt` is 1-indexed (the first retry is attempt 1); callers guard on
+/// `attempt > 0`.
 pub(crate) fn retry_backoff(attempt: u32) -> Duration {
+    debug_assert!(
+        attempt >= 1,
+        "retry_backoff expects a 1-indexed attempt >= 1"
+    );
     let base = base_backoff_ms(attempt);
     let half = base / 2;
     let jitter = if half == 0 {
@@ -52,12 +66,17 @@ mod tests {
     }
 
     #[test]
-    fn backoff_grows_then_caps_at_30s() {
-        // The base doubles each attempt and caps at 30s, so the jittered value
-        // never exceeds 30s.
+    fn base_matches_capped_exponential_schedule() {
+        // Delegated to cognee_utils but must still produce the 1s/2s/4s… schedule
+        // capped at 30s.
         assert_eq!(base_backoff_ms(1), 1_000);
         assert_eq!(base_backoff_ms(2), 2_000);
+        assert_eq!(base_backoff_ms(3), 4_000);
         assert_eq!(base_backoff_ms(6), 30_000); // 32s would exceed the cap
+    }
+
+    #[test]
+    fn backoff_never_exceeds_30s_cap() {
         for _ in 0..200 {
             assert!(retry_backoff(100).as_millis() as u64 <= 30_000);
         }

--- a/crates/utils/src/retry.rs
+++ b/crates/utils/src/retry.rs
@@ -59,8 +59,12 @@ impl RetryConfig {
         self
     }
 
-    /// Calculate the delay for a given attempt number.
-    fn calculate_delay(&self, attempt: u32) -> Duration {
+    /// Calculate the delay for a given attempt number (0-indexed).
+    ///
+    /// Public so other crates can reuse this single capped-exponential-backoff
+    /// implementation rather than re-deriving the math (see `cognee-llm`'s
+    /// `retry_backoff`).
+    pub fn calculate_delay(&self, attempt: u32) -> Duration {
         let base_delay =
             self.initial_delay_ms as f64 * self.backoff_multiplier.powi(attempt as i32);
 


### PR DESCRIPTION
## Summary

First, measurable slice of #19. This PR lands the two LLM-call optimizations that improve correctness/robustness on their own and do not depend on a wall-clock benchmark to justify:

1. **Bound summarization concurrency.** Summarization spawned one `tokio::spawn` per chunk with no ceiling, so a large document could open one in-flight LLM request per chunk , a rate-limit and memory risk, and unlike graph extraction
   which is already bounded. `summarize_chunks` now runs a bounded  `buffer_unordered(max_parallel)` pipeline (default 20, matching the graph extractor's `max_parallel_extractions`), wired from `CognifyConfig`. Output order and fail-on-first-error semantics are preserved.

2. **Retry jitter.** The adapter's network backoff was deterministic (1s, 2s, 4s …), so a batch of requests that all hit HTTP 429 at the same instant also retried in lockstep, a thundering herd that keeps tripping the limit. Backoff now uses equal jitter in `[base/2, base]` via a shared `retry_backoff` helper.

Both changes are correctness/robustness wins: they reduce the chance of *causing* rate-limit stalls, which is the real-life bottleneck #19 calls out.

## What is intentionally not in this PR

The larger latency items in #19 , removing inter-batch barriers for graph extraction (`buffer_unordered` over all chunks), multi-chunk-per-request batching, and prompt caching , are worth doing but only land credibly *with measurements*. The maintainer has rightly noted that neither an instant `ReplayLlm` benchmark nor a low-sample live-API run represents the real-life high-load case where rate limits are the bottleneck. I propose to land those behind a deterministic load harness (see the issue comment) so each change ships with before/after numbers under a rate-limited regime, rather than guesses.

## Tests

- `retry_backoff` unit tests: stays within the equal-jitter bounds for every attempt, caps at 30s, and is actually randomized. (Also fixed a latent multiply overflow at very large attempt counts, found by the cap test.)
- `summarize_chunks` concurrency test: a mock LLM records peak in-flight calls; with 10 chunks and a cap of 3 the peak never exceeds 3, all 10 are summarized, and the output preserves input order.
- `fmt`, `clippy --all-targets -D warnings`.

## Relation to the LLM-adapter PRs (#30, #40, #41)

This continues the LLM-layer work from the #17 tiers: provider routing (#30), the native Anthropic adapter (#40), and Azure (#41). The retry jitter lands in the same `OpenAIAdapter` request loop those PRs hardened, and the prompt-caching follow-up
maps directly onto the native Anthropic adapter from #40 (Anthropic prompt caching is set on the `system`/tools blocks the adapter already builds). So the LLM-call optimization in #19 is a natural continuation of that adapter work, by the same
author who owns those code paths.

## Scope

Part of #19 (the LLM slice of the #22 external-API performance umbrella). Does not close it: the measured pipelining/batching/caching follow-ups remain.