### PR TITLE
fix(e2e): boot the cross-SDK Rust http-server with the mock vector backend

### DIFF
--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -184,6 +184,21 @@ async fn wire_vector_db(cfg: &HttpServerConfig) -> Result<Arc<dyn VectorDB>, Ser
                      VECTOR_DB_PROVIDER=pgvector"
                 )));
             }
+            // Guard against the incoherent default (VECTOR_DB_PROVIDER unset →
+            // pgvector, VECTOR_DB_URL unset → derived from SYSTEM_ROOT_DIRECTORY,
+            // i.e. a filesystem path). Without this, pgvector reports a cryptic
+            // "connection string '…/vectors' cannot be parsed". Point the
+            // operator at the actual misconfiguration instead.
+            if !(url.starts_with("postgres://") || url.starts_with("postgresql://")) {
+                return Err(ServerError::Other(anyhow!(
+                    "VECTOR_DB_PROVIDER=pgvector requires a postgres connection \
+                     string in VECTOR_DB_URL (postgres://… or postgresql://…), but \
+                     got '{url}'. If you did not intend to use pgvector, set \
+                     VECTOR_DB_PROVIDER explicitly (e.g. 'mock' in a dev-mock \
+                     build); the default derives this value from \
+                     SYSTEM_ROOT_DIRECTORY, which is not a valid Postgres URL."
+                )));
+            }
             let adapter = PgVectorAdapter::new(url, cfg.embedding_dimensions as usize)
                 .await
                 .map_err(|e| ServerError::Other(anyhow!("pgvector adapter init: {e}")))?;
@@ -439,5 +454,27 @@ mod tests {
             Err(err) => err.to_string(),
         };
         assert!(msg.contains("database connect failed"));
+    }
+
+    #[tokio::test]
+    async fn wire_vector_db_pgvector_rejects_non_postgres_url() {
+        // The incoherent default (VECTOR_DB_PROVIDER unset → pgvector, plus a
+        // VECTOR_DB_URL derived from SYSTEM_ROOT_DIRECTORY → a filesystem path)
+        // must fail with an actionable message, not the cryptic connection-
+        // string parse error the pgvector driver would otherwise emit.
+        let cfg = HttpServerConfig {
+            vector_provider: "pgvector".to_string(),
+            vector_db_url: "/srv/.cognee_system/vectors".to_string(),
+            ..Default::default()
+        };
+
+        let msg = match wire_vector_db(&cfg).await {
+            Ok(_) => String::new(),
+            Err(err) => err.to_string(),
+        };
+        assert!(
+            msg.contains("postgres connection string") && msg.contains("VECTOR_DB_PROVIDER"),
+            "expected actionable pgvector error, got: {msg}"
+        );
     }
 }

--- a/e2e-cross-sdk/Dockerfile
+++ b/e2e-cross-sdk/Dockerfile
@@ -63,12 +63,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release --package cognee-cli \
     && cp target/release/cognee-cli /usr/local/bin/cognee-cli-rust
 
-# Build the HTTP server binary in release mode (feature-gated `bin`)
+# Build the HTTP server binary in release mode.
+# `dev-mock` enables the in-memory `VECTOR_DB_PROVIDER=mock` wiring: the harness
+# is single-node with no Postgres, so the server uses the mock vector store
+# (mirroring Python cognee's `brute-force` default). Without it the only vector
+# option is pgvector, which the server cannot connect to and fails to start.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/build/cognee-rust/target \
     --mount=type=cache,target=/ccache \
-    cargo build --release --package cognee-http-server --features bin \
+    cargo build --release --package cognee-http-server --features bin,dev-mock \
     && cp target/release/cognee-http-server /usr/local/bin/cognee-http-server
 
 # Build the harness-only telemetry emit binary used by the cross-SDK

--- a/e2e-cross-sdk/bin/start_servers.sh
+++ b/e2e-cross-sdk/bin/start_servers.sh
@@ -108,11 +108,27 @@ echo "[start_servers] Starting Python uvicorn on :8000..."
 PY_PID=$!
 
 # ── Start Rust HTTP server on :8001 ──────────────────────────────────────────
+# The Rust server gets its OWN roots under $RS_WORKSPACE (/rs) — otherwise it
+# inherits the Python SYSTEM_ROOT_DIRECTORY (/py/...) exported above and both
+# servers would share one workspace, defeating the isolation the harness relies
+# on. VECTOR_DB_PROVIDER=mock selects the in-memory vector store (the binary is
+# built with --features dev-mock): the harness has no Postgres, and the OSS
+# server's only other option is pgvector. Without this the server derives the
+# pgvector connection string from SYSTEM_ROOT_DIRECTORY (a filesystem path),
+# fails to parse it, and never reaches /health. Mirrors Python's brute-force
+# default vector backend for this single-node parity run.
+mkdir -p "$RS_WORKSPACE/.cognee_system/databases" \
+         "$RS_WORKSPACE/.data_storage" \
+         "$RS_WORKSPACE/.cognee_cache"
 echo "[start_servers] Starting Rust cognee-http-server on :8001..."
 (cd "$RS_WORKSPACE" && \
  HTTP_API_HOST=127.0.0.1 \
  HTTP_API_PORT=8001 \
  ENV=test \
+ SYSTEM_ROOT_DIRECTORY="$RS_WORKSPACE/.cognee_system" \
+ DATA_ROOT_DIRECTORY="$RS_WORKSPACE/.data_storage" \
+ CACHE_ROOT_DIRECTORY="$RS_WORKSPACE/.cognee_cache" \
+ VECTOR_DB_PROVIDER=mock \
  exec cognee-http-server) &
 RS_PID=$!
 

--- a/e2e-cross-sdk/harness/test_http_recall.py
+++ b/e2e-cross-sdk/harness/test_http_recall.py
@@ -41,9 +41,16 @@ _RECALL_CASES = [
 ]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def recalled_seeded(authed_clients, unique_dataset_name):
-    """Seed + cognify on both servers once per module."""
+    """Seed + cognify on both servers before a recall case.
+
+    Function-scoped (not module): it depends on the function-scoped
+    ``authed_clients`` / ``unique_dataset_name`` fixtures, and a module-scoped
+    fixture may not depend on function-scoped ones (pytest ScopeMismatch). Each
+    parametrized case seeds the same text into its own fresh dataset on *both*
+    servers, so py/rs stay in lockstep and the parity assertion holds.
+    """
     for side, client in authed_clients.items():
         r = seed_dataset_with_text(client, name=unique_dataset_name, text=_SEED_TEXT)
         ds_id = r.get("dataset_id") or r.get("id")

--- a/e2e-cross-sdk/harness/test_http_v2_recall.py
+++ b/e2e-cross-sdk/harness/test_http_v2_recall.py
@@ -51,9 +51,14 @@ _SEED_TEXT = (
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def recall_v2_seeded(authed_clients, unique_dataset_name):
-    """Seed + cognify on both servers once per module."""
+    """Seed + cognify on both servers before a recall case.
+
+    Function-scoped: a module-scoped fixture may not depend on the
+    function-scoped ``authed_clients`` / ``unique_dataset_name`` (pytest
+    ScopeMismatch). Both servers are seeded identically per case, so parity holds.
+    """
     for _side, client in authed_clients.items():
         r = seed_dataset_with_text(client, name=unique_dataset_name, text=_SEED_TEXT)
         ds_id = r.get("dataset_id") or r.get("id")


### PR DESCRIPTION
## Problem

The Rust `cognee-http-server` never started in the **http-parity** harness, so the workflow always failed:

```
Error: failed to wire default backend handles
  0: server error: pgvector adapter init: Storage error: PGVector connect failed:
     Connection Error: The connection string '/py/.cognee_system/vectors' cannot be parsed.
```

`start_servers.sh` globally exports `SYSTEM_ROOT_DIRECTORY=/py/.cognee_system` (for the Python server), and the Rust server launch set no `VECTOR_DB_PROVIDER`. It therefore fell into the default `vector_provider=pgvector` + `vector_db_url=<SYSTEM_ROOT>/vectors` (a **filesystem path**). pgvector can't parse a path → wiring failed → `/health` never came up → run failed. The harness has **no Postgres**, so pgvector was never viable there.

## Fix

**Harness**
- `start_servers.sh`: give the Rust server its **own** roots under `$RS_WORKSPACE` (`/rs`) instead of inheriting Python's `/py` root, and set `VECTOR_DB_PROVIDER=mock` — the in-memory store, mirroring Python cognee's `brute-force` default for this single-node parity run.
- `Dockerfile`: build with `--features bin,dev-mock` so the `mock` provider is compiled in (OSS builds otherwise expose only `pgvector`).

**Latent config bug**
- `wire_vector_db` now rejects a non-postgres `VECTOR_DB_URL` under `pgvector` with an actionable error instead of the driver's cryptic parse failure. New unit test added.

## Verification
- Local: server boots with `VECTOR_DB_PROVIDER=mock`, `/health` → `{"status":"ready","health":"healthy"}`; the pgvector-with-path default now emits the clear error.
- `wire_vector_db_pgvector_rejects_non_postgres_url` unit test passes; fmt clean.
- End-to-end http-parity runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)