### PR TITLE
fix(ts): enable html-loader in Neon binding for URL ingestion

### DIFF
--- a/ts/cognee-ts-neon/Cargo.toml
+++ b/ts/cognee-ts-neon/Cargo.toml
@@ -28,6 +28,12 @@ default = [
     "tiktoken",
     "sqlite",
     "testing",
+    # URL / HTML ingestion — parity with the CLI and HTTP server, which enable
+    # this by default. Without it `remember`/`add` with a `url` input fail at
+    # runtime with `IngestionError::UrlIngestionUnavailable`. reqwest (rustls)
+    # is already linked via cognee-llm/cognee-embedding, so this only adds the
+    # scraper/robots parsing deps — no new native/TLS dependency.
+    "html-loader",
     # Product-analytics emission ON by default — Python-SDK parity. The
     # cognee-lib `send_telemetry` call sites are otherwise compiled out
     # because cognee-lib is pulled with `default-features = false`.
@@ -45,6 +51,9 @@ hf-tokenizer  = ["cognee-lib/hf-tokenizer",  "cognee-bindings-common/hf-tokenize
 tiktoken      = ["cognee-lib/tiktoken",      "cognee-bindings-common/tiktoken"]
 sqlite        = ["cognee-lib/sqlite",        "cognee-bindings-common/sqlite"]
 testing       = ["cognee-lib/testing",       "cognee-bindings-common/testing"]
+# URL/HTML ingestion. Only cognee-lib gates this (ingestion/cognify); the
+# bindings-common facade always accepts `url` inputs, so nothing to forward there.
+html-loader   = ["cognee-lib/html-loader"]
 
 [dependencies]
 # Shared SDK facade (HandleState, CogneeServices, SdkError, wire helpers).


### PR DESCRIPTION
## Problem

Calling `remember({ type: 'url' })` / `add` with a `url` input on the `cognee` npm package throws:

> URL ingestion requires the `html-loader` feature to be enabled

## Root cause

The Neon binding pulls `cognee-lib` with `default-features = false` and re-declares its own default feature list, which **omitted `html-loader`**. As a result the prebuilt npm binary compiled the `#[cfg(not(feature = "html-loader"))]` branch in the ingestion pipeline (`crates/ingestion/src/pipeline.rs:639-642`), which returns `IngestionError::UrlIngestionUnavailable`.

The CLI (`crates/cli/Cargo.toml`) and HTTP server (`crates/http-server/Cargo.toml`) both enable `html-loader` by default for Python-SDK parity — the Neon binding now matches.

## Fix

`ts/cognee-ts-neon/Cargo.toml`:
- Add `"html-loader"` to the `default` feature list.
- Add the forwarding declaration `html-loader = ["cognee-lib/html-loader"]`.

`reqwest` (rustls-tls) is already linked via `cognee-llm`/`cognee-embedding`, so this only pulls in the scraper/robots parsing deps — **no new native or TLS dependency, and no cross-compile impact**.

## Verification

- `cargo check` / debug build of the Neon crate succeed with `html-loader` enabled.
- Full jest suite green after rebuilding the `.node`: **204 passed, 0 failed**, 13 skipped (credential-gated).

## Note

The prebuilt platform binaries (`ts-prebuild.yml`) must be **rebuilt and republished** for npm users to pick up URL ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)