### PR TITLE
chore: release v0.1.3

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -33,6 +33,16 @@ env:
 jobs:
   dry-run:
     name: cargo publish --dry-run (every publishable crate)
+    # Skip on release/* PRs: they bump every internal `cognee-* = "^X.Y.Z"` dep
+    # requirement to a version that is not on crates.io yet, so a per-crate
+    # `cargo publish --dry-run` cannot resolve those deps against the index
+    # (candidate versions found which didn't match). Only the ordered real
+    # publish in release-publish.yml — leaves first — can satisfy them. Packaging
+    # (readme/license/excluded files) is already validated on every non-release
+    # PR at the published baseline, so nothing is lost by skipping here.
+    if: >-
+      github.event_name != 'pull_request' ||
+      !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,32 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Consolidate redundant queries (audit) + native pgvector batch search (#36)
+- Optimize embeddings generation and engines (#34)
+- Consolidate redundant queries and add native pgvector batch search (#36)
 - Eliminate two N+1 query loops (has_edges, update_last_accessed) (#24)
-- Extract shared OpenAI-compatible adapter builder (#29)
 
 ### Fixed
 
-- Enable html-loader feature in Neon binding for URL ingestion (#50)
+- Enable the HTML loader in the Neon (Node.js) binding for URL ingestion (#50)
 - Fail loudly when NATURAL_LANGUAGE search is unsupported by the backend (#51)
-- Boot the cross-SDK Rust http-server with the mock vector backend (#48)
-- Drop readme.workspace so crates use the default local README
-- Four reported v0.1.1 bugs + cross-dataset dedup (#11)
-
-### Other
-
-- Label-driven two-phase release (crates.io + npm + C-API) (#53)
-- Optimize embeddings generation & engines (#34)
-- Split secret-free community checks from the keyed test suite (#32)
-- Fix cache-budget eviction (python shares debug cache) + logging flake (#44)
-- Config 1 logic-only crates run on wasm32 (browser-verified) (#25)
-- Run workspace tests in parallel under nextest (#31)
-- Fix the win32-x64-msvc prebuild (MSVC env + launcher + CRT) (#42)
-- Drop the darwin-x64 (Intel macOS) prebuild leg (#37)
-- Build darwin-arm64 on macos-15 (Xcode 16.4) (#33)
-- Drop unsupported linux-musl platform packages (#28)
-- Bump cognee-ts and platform packages to 0.1.2 (#13)
-- Cross-compile linux-arm64-gnu prebuilt (#12)
+- Fix reported TypeScript SDK bugs and cross-dataset deduplication (#11)
 
 
 ## [0.1.1](https://github.com/topoteretes/cognee-rs/compare/cognee-models-v0.1.0...cognee-models-v0.1.1) - 2026-06-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/topoteretes/cognee-rs/compare/v0.1.0...v0.1.3) - 2026-07-02
+
+### Added
+
+- Route ollama, mistral, gemini, and custom OpenAI-compatible providers (#30)
+
+### Changed
+
+- Consolidate redundant queries (audit) + native pgvector batch search (#36)
+- Eliminate two N+1 query loops (has_edges, update_last_accessed) (#24)
+- Extract shared OpenAI-compatible adapter builder (#29)
+
+### Fixed
+
+- Enable html-loader feature in Neon binding for URL ingestion (#50)
+- Fail loudly when NATURAL_LANGUAGE search is unsupported by the backend (#51)
+- Boot the cross-SDK Rust http-server with the mock vector backend (#48)
+- Drop readme.workspace so crates use the default local README
+- Four reported v0.1.1 bugs + cross-dataset dedup (#11)
+
+### Other
+
+- Label-driven two-phase release (crates.io + npm + C-API) (#53)
+- Optimize embeddings generation & engines (#34)
+- Split secret-free community checks from the keyed test suite (#32)
+- Fix cache-budget eviction (python shares debug cache) + logging flake (#44)
+- Config 1 logic-only crates run on wasm32 (browser-verified) (#25)
+- Run workspace tests in parallel under nextest (#31)
+- Fix the win32-x64-msvc prebuild (MSVC env + launcher + CRT) (#42)
+- Drop the darwin-x64 (Intel macOS) prebuild leg (#37)
+- Build darwin-arm64 on macos-15 (Xcode 16.4) (#33)
+- Drop unsupported linux-musl platform packages (#28)
+- Bump cognee-ts and platform packages to 0.1.2 (#13)
+- Cross-compile linux-arm64-gnu prebuilt (#12)
+
+
 ## [0.1.1](https://github.com/topoteretes/cognee-rs/compare/cognee-models-v0.1.0...cognee-models-v0.1.1) - 2026-06-26
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 authors = ["Topoteretes <support@cognee.ai>"]

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.1.0"
+version = "0.1.3"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
 authors = ["Topoteretes <support@cognee.ai>"]

--- a/crates/bindings-common/Cargo.toml
+++ b/crates/bindings-common/Cargo.toml
@@ -44,7 +44,7 @@ sqlite        = ["cognee-lib/sqlite"]
 testing       = ["cognee-lib/testing"]
 
 [dependencies]
-cognee-lib = { path = "../lib", version = "0.1.1", default-features = false }
+cognee-lib = { path = "../lib", version = "0.1.3", default-features = false }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/chunking/Cargo.toml
+++ b/crates/chunking/Cargo.toml
@@ -16,8 +16,8 @@ workspace = true
 
 [dependencies]
 async-trait.workspace = true
-cognee-models = { path = "../models", version = "0.1.1" }
-cognee-utils = { path = "../utils", version = "0.1.1" }
+cognee-models = { path = "../models", version = "0.1.3" }
+cognee-utils = { path = "../utils", version = "0.1.3" }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
@@ -32,7 +32,7 @@ tiktoken-rs = { workspace = true, optional = true }
 # pure chunking primitives (chunk_text, TokenCounter, …) stay wasm-clean.
 # See docs/spike-wasm-config1.md.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cognee-storage = { path = "../storage", version = "0.1.1" }
+cognee-storage = { path = "../storage", version = "0.1.3" }
 tokio.workspace = true
 
 [features]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -86,8 +86,8 @@ android-default = ["cognee-lib/android-default"]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
-cognee-lib = { path = "../lib", version = "0.1.1" }
-cognee-logging = { path = "../logging", version = "0.1.1" }
+cognee-lib = { path = "../lib", version = "0.1.3" }
+cognee-logging = { path = "../logging", version = "0.1.3" }
 dirs.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cognify/Cargo.toml
+++ b/crates/cognify/Cargo.toml
@@ -21,19 +21,19 @@ image-loader = ["cognee-ingestion/image-loader"]
 audio-loader = ["cognee-ingestion/audio-loader"]
 
 [dependencies]
-cognee-models = { path = "../models", version = "0.1.1" }
-cognee-storage = { path = "../storage", version = "0.1.1" }
-cognee-chunking = { path = "../chunking", version = "0.1.1" }
-cognee-core = { path = "../core", version = "0.1.1" }
-cognee-ingestion = { path = "../ingestion", version = "0.1.1" }
-cognee-llm = { path = "../llm", version = "0.1.1" }
-cognee-graph = { path = "../graph", version = "0.1.1" }
-cognee-utils = { path = "../utils", version = "0.1.1" }
-cognee-embedding = { path = "../embedding", version = "0.1.1" }
-cognee-vector = { path = "../vector", version = "0.1.1" }
-cognee-ontology = { path = "../ontology", version = "0.1.1" }
-cognee-database = { path = "../database", version = "0.1.1" }
-cognee-session = { path = "../session", version = "0.1.1" }
+cognee-models = { path = "../models", version = "0.1.3" }
+cognee-storage = { path = "../storage", version = "0.1.3" }
+cognee-chunking = { path = "../chunking", version = "0.1.3" }
+cognee-core = { path = "../core", version = "0.1.3" }
+cognee-ingestion = { path = "../ingestion", version = "0.1.3" }
+cognee-llm = { path = "../llm", version = "0.1.3" }
+cognee-graph = { path = "../graph", version = "0.1.3" }
+cognee-utils = { path = "../utils", version = "0.1.3" }
+cognee-embedding = { path = "../embedding", version = "0.1.3" }
+cognee-vector = { path = "../vector", version = "0.1.3" }
+cognee-ontology = { path = "../ontology", version = "0.1.3" }
+cognee-database = { path = "../database", version = "0.1.3" }
+cognee-session = { path = "../session", version = "0.1.3" }
 
 chrono.workspace = true
 uuid = { workspace = true, features = ["v4"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,11 +19,11 @@ telemetry = ["cognee-telemetry/telemetry"]
 pipeline-run-registry = []
 
 [dependencies]
-cognee-database = { path = "../database", version = "0.1.1" }
-cognee-graph = { path = "../graph", version = "0.1.1" }
-cognee-models = { path = "../models", version = "0.1.1" }
-cognee-telemetry = { path = "../telemetry", version = "0.1.1" }
-cognee-vector = { path = "../vector", version = "0.1.1" }
+cognee-database = { path = "../database", version = "0.1.3" }
+cognee-graph = { path = "../graph", version = "0.1.3" }
+cognee-models = { path = "../models", version = "0.1.3" }
+cognee-telemetry = { path = "../telemetry", version = "0.1.3" }
+cognee-vector = { path = "../vector", version = "0.1.3" }
 
 async-trait.workspace = true
 chrono.workspace = true

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -19,8 +19,8 @@ sqlite   = ["sea-orm/sqlx-sqlite"]
 postgres = ["sea-orm/sqlx-postgres"]
 
 [dependencies]
-cognee-models     = { path = "../models", version = "0.1.1" }
-cognee-utils      = { path = "../utils", version = "0.1.1" }
+cognee-models     = { path = "../models", version = "0.1.3" }
+cognee-utils      = { path = "../utils", version = "0.1.3" }
 async-trait.workspace = true
 chrono.workspace  = true
 include_dir = "0.7"

--- a/crates/delete/Cargo.toml
+++ b/crates/delete/Cargo.toml
@@ -15,13 +15,13 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-cognee-core = { path = "../core", version = "0.1.1", features = ["pipeline-run-registry"] }
-cognee-database = { path = "../database", version = "0.1.1" }
-cognee-graph = { path = "../graph", version = "0.1.1" }
-cognee-models = { path = "../models", version = "0.1.1" }
-cognee-session = { path = "../session", version = "0.1.1" }
-cognee-storage = { path = "../storage", version = "0.1.1" }
-cognee-vector = { path = "../vector", version = "0.1.1" }
+cognee-core = { path = "../core", version = "0.1.3", features = ["pipeline-run-registry"] }
+cognee-database = { path = "../database", version = "0.1.3" }
+cognee-graph = { path = "../graph", version = "0.1.3" }
+cognee-models = { path = "../models", version = "0.1.3" }
+cognee-session = { path = "../session", version = "0.1.3" }
+cognee-storage = { path = "../storage", version = "0.1.3" }
+cognee-vector = { path = "../vector", version = "0.1.3" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/embedding/Cargo.toml
+++ b/crates/embedding/Cargo.toml
@@ -35,7 +35,7 @@ ort-tensorrt = ["ort/tensorrt"]
 
 [dependencies]
 async-trait = { workspace = true }
-cognee-utils = { path = "../utils", version = "0.1.1" }
+cognee-utils = { path = "../utils", version = "0.1.3" }
 futures     = { workspace = true }
 tokio       = { workspace = true }
 serde       = { workspace = true }

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -45,8 +45,8 @@ sea-orm-migration = { version = "1.1", features = [
 ], optional = true }
 
 # Internal dependencies
-cognee-models = { path = "../models", version = "0.1.1" }
-cognee-utils = { path = "../utils", version = "0.1.1" }
+cognee-models = { path = "../models", version = "0.1.3" }
+cognee-utils = { path = "../utils", version = "0.1.3" }
 
 [features]
 ladybug = ["dep:lbug"]

--- a/crates/http-server/Cargo.toml
+++ b/crates/http-server/Cargo.toml
@@ -95,29 +95,29 @@ hyper = { version = "1", features = ["server", "http1", "http2"] }
 # NOTE: cognee-lib is intentionally NOT a direct dep here — adding it would
 # create a cycle when cognee-lib's `server` feature pulls in cognee-http-server.
 # Concrete cognee-lib types are wired via AppState in P1+.
-cognee-models = { path = "../models", version = "0.1.1" }
-cognee-observability = { path = "../observability", version = "0.1.1", optional = true }
+cognee-models = { path = "../models", version = "0.1.3" }
+cognee-observability = { path = "../observability", version = "0.1.3", optional = true }
 # Product-analytics client. Gated by the `telemetry` feature so a
 # `--no-default-features` build drops the dep entirely; the `emit` helper
 # in `telemetry.rs` compiles to a noop when absent.
-cognee-telemetry = { path = "../telemetry", version = "0.1.1", optional = true, features = ["telemetry"] }
-cognee-core = { path = "../core", version = "0.1.1", features = ["pipeline-run-registry"] }
-cognee-database = { path = "../database", version = "0.1.1", features = ["sqlite"] }
+cognee-telemetry = { path = "../telemetry", version = "0.1.3", optional = true, features = ["telemetry"] }
+cognee-core = { path = "../core", version = "0.1.3", features = ["pipeline-run-registry"] }
+cognee-database = { path = "../database", version = "0.1.3", features = ["sqlite"] }
 sea-orm = { version = "1", default-features = false, features = ["runtime-tokio-rustls", "with-chrono", "with-uuid", "with-json"] }
-cognee-storage = { path = "../storage", version = "0.1.1" }
-cognee-ingestion = { path = "../ingestion", version = "0.1.1" }
-cognee-cognify = { path = "../cognify", version = "0.1.1" }
-cognee-embedding = { path = "../embedding", version = "0.1.1", features = ["onnx"] }
-cognee-delete = { path = "../delete", version = "0.1.1" }
-cognee-ontology = { path = "../ontology", version = "0.1.1" }
-cognee-search = { path = "../search", version = "0.1.1" }
-cognee-session = { path = "../session", version = "0.1.1" }
-cognee-llm = { path = "../llm", version = "0.1.1" }
-cognee-graph = { path = "../graph", version = "0.1.1", features = ["ladybug"] }
-cognee-vector = { path = "../vector", version = "0.1.1", features = ["pgvector"] }
-cognee-logging = { path = "../logging", version = "0.1.1" }
-cognee-visualization = { path = "../visualization", version = "0.1.1" }
-cognee-utils = { path = "../utils", version = "0.1.1" }
+cognee-storage = { path = "../storage", version = "0.1.3" }
+cognee-ingestion = { path = "../ingestion", version = "0.1.3" }
+cognee-cognify = { path = "../cognify", version = "0.1.3" }
+cognee-embedding = { path = "../embedding", version = "0.1.3", features = ["onnx"] }
+cognee-delete = { path = "../delete", version = "0.1.3" }
+cognee-ontology = { path = "../ontology", version = "0.1.3" }
+cognee-search = { path = "../search", version = "0.1.3" }
+cognee-session = { path = "../session", version = "0.1.3" }
+cognee-llm = { path = "../llm", version = "0.1.3" }
+cognee-graph = { path = "../graph", version = "0.1.3", features = ["ladybug"] }
+cognee-vector = { path = "../vector", version = "0.1.3", features = ["pgvector"] }
+cognee-logging = { path = "../logging", version = "0.1.3" }
+cognee-visualization = { path = "../visualization", version = "0.1.3" }
+cognee-utils = { path = "../utils", version = "0.1.3" }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }

--- a/crates/ingestion/Cargo.toml
+++ b/crates/ingestion/Cargo.toml
@@ -18,13 +18,13 @@ workspace = true
 async-trait.workspace = true
 # `pipeline.rs` uses `DbPipelineWatcher` unconditionally, so it needs the
 # `pipeline-run-registry` module which `cognee-core` gates behind this feature.
-cognee-core = { path = "../core", version = "0.1.1", features = ["pipeline-run-registry"] }
-cognee-database = { path = "../database", version = "0.1.1" }
-cognee-graph = { path = "../graph", version = "0.1.1" }
-cognee-models = { path = "../models", version = "0.1.1" }
-cognee-storage = { path = "../storage", version = "0.1.1" }
-cognee-vector = { path = "../vector", version = "0.1.1" }
-cognee-utils = { path = "../utils", version = "0.1.1" }
+cognee-core = { path = "../core", version = "0.1.3", features = ["pipeline-run-registry"] }
+cognee-database = { path = "../database", version = "0.1.3" }
+cognee-graph = { path = "../graph", version = "0.1.3" }
+cognee-models = { path = "../models", version = "0.1.3" }
+cognee-storage = { path = "../storage", version = "0.1.3" }
+cognee-vector = { path = "../vector", version = "0.1.3" }
+cognee-utils = { path = "../utils", version = "0.1.3" }
 md-5.workspace = true
 sha2.workspace = true
 uuid.workspace = true
@@ -51,7 +51,7 @@ calamine = { workspace = true, optional = true }
 mail-parser = { workspace = true, optional = true }
 quick-xml = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
-cognee-llm = { path = "../llm", version = "0.1.1", optional = true }
+cognee-llm = { path = "../llm", version = "0.1.3", optional = true }
 
 [features]
 default = []

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -142,26 +142,26 @@ testing = [
 ]
 
 [dependencies]
-cognee-chunking = { path = "../chunking", version = "0.1.1" }
-cognee-utils = { path = "../utils", version = "0.1.1" }
-cognee-http-server = { path = "../http-server", version = "0.1.0", optional = true }
-cognee-cognify = { path = "../cognify", version = "0.1.1" }
-cognee-core = { path = "../core", version = "0.1.1", features = ["pipeline-run-registry"] }
-cognee-delete = { path = "../delete", version = "0.1.1" }
-cognee-database = { path = "../database", version = "0.1.1" }
-cognee-embedding = { path = "../embedding", version = "0.1.1" }
-cognee-graph = { path = "../graph", version = "0.1.1" }
-cognee-ingestion = { path = "../ingestion", version = "0.1.1" }
-cognee-llm = { path = "../llm", version = "0.1.1" }
-cognee-models = { path = "../models", version = "0.1.1" }
-cognee-observability = { path = "../observability", version = "0.1.1", optional = true }
-cognee-ontology = { path = "../ontology", version = "0.1.1" }
-cognee-search = { path = "../search", version = "0.1.1" }
-cognee-session = { path = "../session", version = "0.1.1" }
-cognee-storage = { path = "../storage", version = "0.1.1" }
-cognee-telemetry = { path = "../telemetry", version = "0.1.1" }
-cognee-vector = { path = "../vector", version = "0.1.1" }
-cognee-visualization = { path = "../visualization", version = "0.1.1", optional = true }
+cognee-chunking = { path = "../chunking", version = "0.1.3" }
+cognee-utils = { path = "../utils", version = "0.1.3" }
+cognee-http-server = { path = "../http-server", version = "0.1.3", optional = true }
+cognee-cognify = { path = "../cognify", version = "0.1.3" }
+cognee-core = { path = "../core", version = "0.1.3", features = ["pipeline-run-registry"] }
+cognee-delete = { path = "../delete", version = "0.1.3" }
+cognee-database = { path = "../database", version = "0.1.3" }
+cognee-embedding = { path = "../embedding", version = "0.1.3" }
+cognee-graph = { path = "../graph", version = "0.1.3" }
+cognee-ingestion = { path = "../ingestion", version = "0.1.3" }
+cognee-llm = { path = "../llm", version = "0.1.3" }
+cognee-models = { path = "../models", version = "0.1.3" }
+cognee-observability = { path = "../observability", version = "0.1.3", optional = true }
+cognee-ontology = { path = "../ontology", version = "0.1.3" }
+cognee-search = { path = "../search", version = "0.1.3" }
+cognee-session = { path = "../session", version = "0.1.3" }
+cognee-storage = { path = "../storage", version = "0.1.3" }
+cognee-telemetry = { path = "../telemetry", version = "0.1.3" }
+cognee-vector = { path = "../vector", version = "0.1.3" }
+cognee-visualization = { path = "../visualization", version = "0.1.3", optional = true }
 async-trait.workspace = true
 chrono.workspace = true
 dotenv.workspace = true

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -43,7 +43,7 @@ reqwest = { workspace = true, features = ["multipart"] }
 tracing.workspace = true
 
 # Shared tracing-key constants
-cognee-utils = { path = "../utils", version = "0.1.1" }
+cognee-utils = { path = "../utils", version = "0.1.3" }
 
 # Content hashing (cassette mock, feature-gated)
 sha2 = { workspace = true, optional = true }

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -28,7 +28,7 @@ telemetry = [
 ]
 
 [dependencies]
-cognee-utils = { path = "../utils", version = "0.1.1" }
+cognee-utils = { path = "../utils", version = "0.1.3" }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/ontology/Cargo.toml
+++ b/crates/ontology/Cargo.toml
@@ -15,7 +15,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-cognee-models = { path = "../models", version = "0.1.1" }
+cognee-models = { path = "../models", version = "0.1.3" }
 
 uuid = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -19,14 +19,14 @@ default = []
 telemetry = ["cognee-telemetry/telemetry"]
 
 [dependencies]
-cognee-embedding = { path = "../embedding", version = "0.1.1" }
-cognee-database = { path = "../database", version = "0.1.1" }
-cognee-graph = { path = "../graph", version = "0.1.1" }
-cognee-llm = { path = "../llm", version = "0.1.1" }
-cognee-session = { path = "../session", version = "0.1.1", features = ["sea-orm-store"] }
-cognee-telemetry = { path = "../telemetry", version = "0.1.1" }
-cognee-utils = { path = "../utils", version = "0.1.1" }
-cognee-vector = { path = "../vector", version = "0.1.1" }
+cognee-embedding = { path = "../embedding", version = "0.1.3" }
+cognee-database = { path = "../database", version = "0.1.3" }
+cognee-graph = { path = "../graph", version = "0.1.3" }
+cognee-llm = { path = "../llm", version = "0.1.3" }
+cognee-session = { path = "../session", version = "0.1.3", features = ["sea-orm-store"] }
+cognee-telemetry = { path = "../telemetry", version = "0.1.3" }
+cognee-utils = { path = "../utils", version = "0.1.3" }
+cognee-vector = { path = "../vector", version = "0.1.3" }
 
 async-trait.workspace = true
 indexmap = "2"

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -24,8 +24,8 @@ sea-orm-store = ["dep:sea-orm", "dep:sea-orm-migration"]
 telemetry = ["cognee-telemetry/telemetry"]
 
 [dependencies]
-cognee-llm = { path = "../llm", version = "0.1.1" }
-cognee-telemetry = { path = "../telemetry", version = "0.1.1" }
+cognee-llm = { path = "../llm", version = "0.1.3" }
+cognee-telemetry = { path = "../telemetry", version = "0.1.3" }
 async-trait.workspace = true
 chrono.workspace = true
 thiserror.workspace = true

--- a/crates/vector/Cargo.toml
+++ b/crates/vector/Cargo.toml
@@ -44,7 +44,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Telemetry constants
-cognee-utils = { path = "../utils", version = "0.1.1" }
+cognee-utils = { path = "../utils", version = "0.1.3" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/visualization/Cargo.toml
+++ b/crates/visualization/Cargo.toml
@@ -15,7 +15,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-cognee-graph = { path = "../graph", version = "0.1.1" }
+cognee-graph = { path = "../graph", version = "0.1.3" }
 dirs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/ts/cognee-ts-neon/Cargo.toml
+++ b/ts/cognee-ts-neon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognee-ts-neon"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/cognee-ts",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Node.js bindings for the cognee AI-memory SDK",
   "license": "MIT OR Apache-2.0",
   "publishConfig": {
@@ -44,10 +44,10 @@
     "dotenv": "^16.6.1"
   },
   "optionalDependencies": {
-    "@cognee/neon-darwin-arm64": "0.1.2",
-    "@cognee/neon-linux-arm64-gnu": "0.1.2",
-    "@cognee/neon-linux-x64-gnu": "0.1.2",
-    "@cognee/neon-win32-x64-msvc": "0.1.2"
+    "@cognee/neon-darwin-arm64": "0.1.3",
+    "@cognee/neon-linux-arm64-gnu": "0.1.3",
+    "@cognee/neon-linux-x64-gnu": "0.1.3",
+    "@cognee/neon-win32-x64-msvc": "0.1.3"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",

--- a/ts/platform-packages/darwin-arm64/package.json
+++ b/ts/platform-packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-darwin-arm64",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Prebuilt cognee native addon for darwin-arm64 (aarch64-apple-darwin)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/linux-arm64-gnu/package.json
+++ b/ts/platform-packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-linux-arm64-gnu",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Prebuilt cognee native addon for linux-arm64-gnu (aarch64-unknown-linux-gnu)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/linux-x64-gnu/package.json
+++ b/ts/platform-packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-linux-x64-gnu",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Prebuilt cognee native addon for linux-x64-gnu (x86_64-unknown-linux-gnu)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/win32-x64-msvc/package.json
+++ b/ts/platform-packages/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-win32-x64-msvc",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Prebuilt cognee native addon for win32-x64-msvc (x86_64-pc-windows-msvc)",
   "main": "index.js",
   "os": [


### PR DESCRIPTION
Automated release PR for **v0.1.3**, opened from issue #54.

Merging this PR publishes to crates.io, npm, and the C-API GitHub Release.
Review the `CHANGELOG.md` diff below and the green PR checks first.

## Changelog

## [0.1.3](https://github.com/topoteretes/cognee-rs/compare/v0.1.0...v0.1.3) - 2026-07-02

### Added

- Route ollama, mistral, gemini, and custom OpenAI-compatible providers (#30)

### Changed

- Consolidate redundant queries (audit) + native pgvector batch search (#36)
- Eliminate two N+1 query loops (has_edges, update_last_accessed) (#24)
- Extract shared OpenAI-compatible adapter builder (#29)

### Fixed

- Enable html-loader feature in Neon binding for URL ingestion (#50)
- Fail loudly when NATURAL_LANGUAGE search is unsupported by the backend (#51)
- Boot the cross-SDK Rust http-server with the mock vector backend (#48)
- Drop readme.workspace so crates use the default local README
- Four reported v0.1.1 bugs + cross-dataset dedup (#11)

### Other

- Label-driven two-phase release (crates.io + npm + C-API) (#53)
- Optimize embeddings generation & engines (#34)
- Split secret-free community checks from the keyed test suite (#32)
- Fix cache-budget eviction (python shares debug cache) + logging flake (#44)
- Config 1 logic-only crates run on wasm32 (browser-verified) (#25)
- Run workspace tests in parallel under nextest (#31)
- Fix the win32-x64-msvc prebuild (MSVC env + launcher + CRT) (#42)
- Drop the darwin-x64 (Intel macOS) prebuild leg (#37)
- Build darwin-arm64 on macos-15 (Xcode 16.4) (#33)
- Drop unsupported linux-musl platform packages (#28)
- Bump cognee-ts and platform packages to 0.1.2 (#13)
- Cross-compile linux-arm64-gnu prebuilt (#12)
