### PR TITLE
refactor: extract cognee-components + pluggable adapter registry

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -8,6 +8,12 @@ name: publish-dry-run
 #
 # Sourcing the crate list from scripts/split/publish-order.sh (T10c) keeps the
 # CI gate and the local sweep in lock-step.
+#
+# New-crate handling: a crate that depends on a brand-new sibling not yet on
+# crates.io cannot be dry-run-published until that sibling's first real publish
+# (cargo resolves deps against the index even in --dry-run). The dry-run step
+# downgrades exactly that case to a SKIP so introducing a new workspace crate
+# does not red the gate; every other packaging error still fails.
 on:
   push:
     branches: [main, master, oss-split]
@@ -83,21 +89,46 @@ jobs:
       - name: Dry-run publish each crate in topological order
         run: |
           set -euo pipefail
+          # Workspace member names, used to tell a "new crate not yet on the
+          # index" failure apart from a genuine packaging/dependency error.
+          ws_members="$(cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
+            | python3 -c 'import json,sys; print("\n".join(p["name"] for p in json.load(sys.stdin)["packages"]))')"
+          is_ws_member() { printf '%s\n' "$ws_members" | grep -qxF "$1"; }
+
           : > /tmp/dry-run.log
           fails=0
+          skips=0
           while IFS= read -r c; do
             [ -z "$c" ] && continue
             printf '── %-32s ' "$c"
+            crate_log="$(mktemp)"
             if cargo publish --dry-run --no-verify --allow-dirty -p "$c" \
-                  >> /tmp/dry-run.log 2>&1; then
+                  > "$crate_log" 2>&1; then
               echo OK
             else
-              echo FAIL
-              fails=$((fails + 1))
+              # `cargo publish` resolves deps against the crates.io index even in
+              # --dry-run, so a crate that depends on a brand-new sibling (one not
+              # yet published) cannot dry-run until that sibling's first real
+              # publish — which release-publish.yml does leaves-first. Downgrade
+              # exactly that case ("no matching package named `<workspace crate>`
+              # found") to a SKIP; every other failure (missing readme/license,
+              # excluded files, version-bump mistakes, a genuinely missing
+              # external dep) is still a hard failure.
+              missing="$(grep -oE 'no matching package named `[^`]+` found' "$crate_log" \
+                | head -1 | sed -E 's/^no matching package named `([^`]+)` found$/\1/' || true)"
+              if [ -n "$missing" ] && is_ws_member "$missing"; then
+                echo "SKIP (depends on not-yet-published workspace crate '$missing')"
+                skips=$((skips + 1))
+              else
+                echo FAIL
+                fails=$((fails + 1))
+              fi
             fi
+            cat "$crate_log" >> /tmp/dry-run.log
+            rm -f "$crate_log"
           done < <(scripts/split/publish-order.sh)
           echo
-          echo "=== summary: ${fails} failure(s) ==="
+          echo "=== summary: ${fails} failure(s), ${skips} skip(s) ==="
           if [ "$fails" -gt 0 ]; then
             echo "=== full log ==="
             cat /tmp/dry-run.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/chunking",
     "crates/cognify",
     "crates/core",
+    "crates/components",
     "crates/lib",
     "crates/logging",
     "crates/cli",

--- a/crates/bindings-common/src/handle.rs
+++ b/crates/bindings-common/src/handle.rs
@@ -17,6 +17,7 @@ use tokio::sync::Mutex as TokioMutex;
 use uuid::Uuid;
 
 use cognee_lib::ComponentManager;
+use cognee_lib::ComponentRegistry;
 use cognee_lib::config::{ConfigManager, Settings};
 use cognee_lib::database::DatabaseConnection;
 use cognee_lib::models::User;
@@ -74,7 +75,22 @@ impl HandleState {
     ///
     /// For env-only construction use [`HandleState::from_env`].
     pub fn from_settings(settings: Settings) -> Self {
-        let cm = Arc::new(ComponentManager::new(ConfigManager::new(settings)));
+        Self::from_settings_with_registry(settings, ComponentRegistry::with_builtins())
+    }
+
+    /// Construct from `Settings` with an explicit component registry.
+    ///
+    /// This is the injection seam for external adapters: a closed cloud build
+    /// registers its qdrant / litert factories on a `ComponentRegistry` and
+    /// passes it here so a configured `vector_provider="qdrant"` (etc.)
+    /// resolves through the same construction path the py/ts/c SDKs use. With
+    /// the OSS built-in registry this is byte-for-byte equivalent to
+    /// [`from_settings`](Self::from_settings).
+    pub fn from_settings_with_registry(settings: Settings, registry: ComponentRegistry) -> Self {
+        let cm = Arc::new(ComponentManager::with_registry(
+            ConfigManager::new(settings),
+            registry,
+        ));
         HandleState {
             cm,
             services: TokioMutex::new(None),

--- a/crates/components/Cargo.toml
+++ b/crates/components/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "cognee-components"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Cognee — shared pipeline-component construction: adapter factories + a pluggable registry."
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+# Standalone builds register the common OSS provider set. Downstream crates
+# (cognee-lib, cognee-http-server) depend with `default-features = false` and
+# forward exactly the features they want, so `--no-default-features` builds
+# stay precise.
+default = ["onnx", "ladybug", "pgvector", "pggraph", "mock-llm"]
+
+onnx         = ["cognee-embedding/onnx"]
+onnx-dynamic = ["onnx", "cognee-embedding/onnx-dynamic"]
+ort-cuda     = ["cognee-embedding/ort-cuda"]
+ort-tensorrt = ["cognee-embedding/ort-tensorrt"]
+ladybug      = ["cognee-graph/ladybug"]
+pgvector     = ["cognee-vector/pgvector", "dep:url"]
+pggraph      = ["cognee-graph/postgres", "dep:url"]
+# Record/replay cassette-based mock LLM (MOCK_LLM / COGNEE_RECORD_LLM).
+mock-llm     = ["cognee-llm/mock"]
+# Enables the in-memory `mock` vector provider in `with_builtins()`.
+testing      = ["cognee-vector/testing"]
+
+[dependencies]
+cognee-database = { path = "../database", version = "0.1.3" }
+cognee-embedding = { path = "../embedding", version = "0.1.3" }
+cognee-graph = { path = "../graph", version = "0.1.3" }
+cognee-llm = { path = "../llm", version = "0.1.3" }
+cognee-storage = { path = "../storage", version = "0.1.3" }
+cognee-vector = { path = "../vector", version = "0.1.3" }
+async-trait.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+url = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tempfile = { workspace = true }
+cognee-vector = { path = "../vector", features = ["testing"] }
+cognee-database = { path = "../database", features = ["sqlite"] }

--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -30,12 +30,18 @@ fn sqlite_fs_path(url: &str) -> Option<String> {
         return None;
     }
     let after = url.trim_start_matches("sqlite:");
+    // Collapse any run of leading slashes on the absolute forms to a single
+    // one, so an extra slash (e.g. `sqlite:////abs`) can't yield a
+    // double-leading-slash path that some platforms read as a UNC/network path.
     let path = if let Some(rest) = after.strip_prefix("//localhost/") {
-        format!("/{rest}")
-    } else if let Some(rest) = after.strip_prefix("///") {
-        format!("/{rest}")
+        format!("/{}", rest.trim_start_matches('/'))
     } else if let Some(rest) = after.strip_prefix("//") {
-        rest.to_string()
+        // `//<rest>`: absolute when `rest` starts with `/` (i.e. `sqlite:///…`),
+        // otherwise a relative path (`sqlite://data/…`).
+        match rest.strip_prefix('/') {
+            Some(abs) => format!("/{}", abs.trim_start_matches('/')),
+            None => rest.to_string(),
+        }
     } else {
         after.to_string()
     };
@@ -152,6 +158,9 @@ mod tests {
             sqlite_fs_path("sqlite://localhost/abs/db"),
             Some("/abs/db".into())
         );
+        // Extra leading slashes collapse to one (no double-leading-slash /
+        // accidental UNC path).
+        assert_eq!(sqlite_fs_path("sqlite:////abs/db"), Some("/abs/db".into()));
         // Query strings are stripped.
         assert_eq!(
             sqlite_fs_path("sqlite://data/db?mode=rwc"),

--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -9,69 +9,66 @@ use cognee_database::{DatabaseConnection, connect, initialize};
 use crate::context::BackendBuildContext;
 use crate::error::ComponentError;
 
+/// Extract the on-disk filesystem path from a SQLite URL, or `None` for
+/// non-file URLs (`postgres://…`, in-memory `sqlite::memory:`).
+///
+/// SQLite has no meaningful remote "host", so any `//<authority>` is treated as
+/// part of the path — matching the HTTP server's historical
+/// `strip_prefix("sqlite://")`, which is why a two-slash *relative* form like
+/// `sqlite://data/cognee.db` must still yield `data/cognee.db` (not be skipped
+/// as a host form). Shapes handled:
+///
+///   `sqlite:./rel/db`            → `./rel/db`        (1-slash relative)
+///   `sqlite:/abs/db`             → `/abs/db`         (1-slash absolute)
+///   `sqlite://rel/db`            → `rel/db`          (2-slash relative)
+///   `sqlite:///abs/db`           → `/abs/db`         (3-slash absolute)
+///   `sqlite://localhost/abs/db`  → `/abs/db`         (host form)
+///
+/// Any `?query` (e.g. `?mode=rwc`) is stripped.
+fn sqlite_fs_path(url: &str) -> Option<String> {
+    if !url.starts_with("sqlite:") || url.contains(":memory:") {
+        return None;
+    }
+    let after = url.trim_start_matches("sqlite:");
+    let path = if let Some(rest) = after.strip_prefix("//localhost/") {
+        format!("/{rest}")
+    } else if let Some(rest) = after.strip_prefix("///") {
+        format!("/{rest}")
+    } else if let Some(rest) = after.strip_prefix("//") {
+        rest.to_string()
+    } else {
+        after.to_string()
+    };
+    let path = path.split('?').next().unwrap_or(&path).to_string();
+    if path.is_empty() { None } else { Some(path) }
+}
+
 /// Connect to and initialize the relational database from the resolved URL.
 ///
-/// For SQLite file-backed databases, the parent directory is created first:
-/// sea-orm's `?mode=rwc` creates the *file* but not missing ancestor
-/// directories, so a settings override that redirects the DB to a new path
-/// (e.g. per-test isolation) would otherwise fail with "unable to open
-/// database file".
-///
-/// URL shapes handled:
-///   `sqlite:./rel/path/db`       (relative, 1-slash)
-///   `sqlite:///abs/path/db`      (absolute, 3-slash)
-///   `sqlite://localhost/abs/db`  (host form)
-/// All others (postgres, in-memory `sqlite::memory:`) are left alone.
+/// For SQLite file-backed databases, the parent directory is created first
+/// (non-fatal): sea-orm's `?mode=rwc` creates the *file* but not missing
+/// ancestor directories, so a settings override that redirects the DB to a new
+/// path (e.g. per-test isolation) would otherwise fail with "unable to open
+/// database file". File creation itself is left to the driver via `?mode=rwc`
+/// (callers that want auto-create put `mode=rwc` in the URL); this function
+/// never creates the DB file, so a mistyped path still fails loudly at connect
+/// instead of silently producing an empty database at the wrong location.
 pub async fn build_database(
     ctx: &BackendBuildContext,
 ) -> Result<Arc<DatabaseConnection>, ComponentError> {
     let url = &ctx.relational_db_url;
 
-    if url.starts_with("sqlite:") && !url.contains(":memory:") {
-        // Strip the sqlite: scheme and any leading host ("//localhost") or
-        // extra slashes to get the raw filesystem path (before '?').
-        let after_scheme = url.trim_start_matches("sqlite:");
-        let path_part = if after_scheme.starts_with("//localhost/") {
-            Some(&after_scheme["//localhost".len()..])
-        } else if after_scheme.starts_with("///") {
-            // sqlite:///abs/path — empty authority, absolute path.
-            Some(&after_scheme[2..])
-        } else if after_scheme.starts_with("//") {
-            // sqlite://somehost/... — genuine host form; leave entirely to the
-            // driver instead of attempting create_dir_all("//somehost").
-            None
-        } else {
-            Some(after_scheme)
-        };
-        // Drop query string (e.g. ?mode=rwc).
-        if let Some(path_part) = path_part {
-            let path_no_query = path_part.split('?').next().unwrap_or(path_part);
-            let db_path = Path::new(path_no_query);
-            if let Some(parent) = db_path.parent()
-                && !parent.as_os_str().is_empty()
-            {
-                // Non-fatal: an unusual-but-driver-valid URL must still reach
-                // sea-orm and surface the driver's own error.
-                if let Err(e) = std::fs::create_dir_all(parent) {
-                    tracing::warn!(
-                        "could not create SQLite parent directory '{}': {e}",
-                        parent.display()
-                    );
-                }
-            }
-            // Create the DB file when missing. `cognee-lib`'s default URL carries
-            // `?mode=rwc` (the driver would create it), but the HTTP server's
-            // `sqlite://{path}` form has no such query, so without this an
-            // absolute path to a not-yet-existing file fails to open. Creating
-            // an empty file is a valid empty SQLite DB and is idempotent for the
-            // `mode=rwc` form. Non-fatal — let the driver surface real errors.
-            if !db_path.as_os_str().is_empty()
-                && !db_path.exists()
-                && let Err(e) = std::fs::File::create(db_path)
-            {
+    if let Some(path) = sqlite_fs_path(url) {
+        let db_path = Path::new(&path);
+        if let Some(parent) = db_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            // Non-fatal: an unusual-but-driver-valid URL must still reach
+            // sea-orm and surface the driver's own error.
+            if let Err(e) = std::fs::create_dir_all(parent) {
                 tracing::warn!(
-                    "could not create SQLite database file '{}': {e}",
-                    db_path.display()
+                    "could not create SQLite parent directory '{}': {e}",
+                    parent.display()
                 );
             }
         }
@@ -139,9 +136,36 @@ mod tests {
         }
     }
 
-    // Both default URL shapes used by the two callers must create missing parent
-    // directories and connect: `cognee-lib`'s single-slash relative form and the
-    // absolute three-slash form the HTTP server produces.
+    // ── sqlite_fs_path: every URL shape, incl. the two-slash *relative* form
+    //    that a relative SYSTEM_ROOT_DIRECTORY produces on the HTTP server ──
+    #[test]
+    fn sqlite_fs_path_covers_all_shapes() {
+        assert_eq!(sqlite_fs_path("sqlite:./rel/db"), Some("./rel/db".into()));
+        assert_eq!(sqlite_fs_path("sqlite:/abs/db"), Some("/abs/db".into()));
+        // Two-slash relative — the regression case: must NOT be dropped as a host form.
+        assert_eq!(
+            sqlite_fs_path("sqlite://data/cognee.db"),
+            Some("data/cognee.db".into())
+        );
+        assert_eq!(sqlite_fs_path("sqlite:///abs/db"), Some("/abs/db".into()));
+        assert_eq!(
+            sqlite_fs_path("sqlite://localhost/abs/db"),
+            Some("/abs/db".into())
+        );
+        // Query strings are stripped.
+        assert_eq!(
+            sqlite_fs_path("sqlite://data/db?mode=rwc"),
+            Some("data/db".into())
+        );
+        // Non-file URLs yield None.
+        assert_eq!(sqlite_fs_path("sqlite::memory:"), None);
+        assert_eq!(sqlite_fs_path("postgres://h/db"), None);
+    }
+
+    // The two-slash forms both callers can produce must create missing parent
+    // directories and connect (file creation delegated to the driver via
+    // `?mode=rwc`): the relative form (relative SYSTEM_ROOT) and the absolute
+    // three-slash form.
     #[tokio::test]
     async fn build_database_creates_parent_dirs_for_relative_sqlite() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -157,8 +181,9 @@ mod tests {
     async fn build_database_creates_parent_dirs_for_absolute_sqlite() {
         let dir = tempfile::tempdir().expect("tempdir");
         let nested = dir.path().join("x").join("y").join("cognee.db");
-        // Absolute path → three-slash form (`sqlite://` + `/abs/...`).
-        let url = format!("sqlite://{}", nested.display());
+        // Absolute path → three-slash form; `?mode=rwc` lets the driver create
+        // the file (build_database no longer creates it itself).
+        let url = format!("sqlite://{}?mode=rwc", nested.display());
         build_database(&ctx_with_db_url(url))
             .await
             .expect("absolute sqlite URL should connect after dir creation");

--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -1,0 +1,174 @@
+//! Relational database construction. No provider choice (sea-orm dispatches on
+//! the URL scheme), so this is a free function rather than a registered factory.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use cognee_database::{DatabaseConnection, connect, initialize};
+
+use crate::context::BackendBuildContext;
+use crate::error::ComponentError;
+
+/// Connect to and initialize the relational database from the resolved URL.
+///
+/// For SQLite file-backed databases, the parent directory is created first:
+/// sea-orm's `?mode=rwc` creates the *file* but not missing ancestor
+/// directories, so a settings override that redirects the DB to a new path
+/// (e.g. per-test isolation) would otherwise fail with "unable to open
+/// database file".
+///
+/// URL shapes handled:
+///   `sqlite:./rel/path/db`       (relative, 1-slash)
+///   `sqlite:///abs/path/db`      (absolute, 3-slash)
+///   `sqlite://localhost/abs/db`  (host form)
+/// All others (postgres, in-memory `sqlite::memory:`) are left alone.
+pub async fn build_database(
+    ctx: &BackendBuildContext,
+) -> Result<Arc<DatabaseConnection>, ComponentError> {
+    let url = &ctx.relational_db_url;
+
+    if url.starts_with("sqlite:") && !url.contains(":memory:") {
+        // Strip the sqlite: scheme and any leading host ("//localhost") or
+        // extra slashes to get the raw filesystem path (before '?').
+        let after_scheme = url.trim_start_matches("sqlite:");
+        let path_part = if after_scheme.starts_with("//localhost/") {
+            Some(&after_scheme["//localhost".len()..])
+        } else if after_scheme.starts_with("///") {
+            // sqlite:///abs/path — empty authority, absolute path.
+            Some(&after_scheme[2..])
+        } else if after_scheme.starts_with("//") {
+            // sqlite://somehost/... — genuine host form; leave entirely to the
+            // driver instead of attempting create_dir_all("//somehost").
+            None
+        } else {
+            Some(after_scheme)
+        };
+        // Drop query string (e.g. ?mode=rwc).
+        if let Some(path_part) = path_part {
+            let path_no_query = path_part.split('?').next().unwrap_or(path_part);
+            let db_path = Path::new(path_no_query);
+            if let Some(parent) = db_path.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                // Non-fatal: an unusual-but-driver-valid URL must still reach
+                // sea-orm and surface the driver's own error.
+                if let Err(e) = std::fs::create_dir_all(parent) {
+                    tracing::warn!(
+                        "could not create SQLite parent directory '{}': {e}",
+                        parent.display()
+                    );
+                }
+            }
+            // Create the DB file when missing. `cognee-lib`'s default URL carries
+            // `?mode=rwc` (the driver would create it), but the HTTP server's
+            // `sqlite://{path}` form has no such query, so without this an
+            // absolute path to a not-yet-existing file fails to open. Creating
+            // an empty file is a valid empty SQLite DB and is idempotent for the
+            // `mode=rwc` form. Non-fatal — let the driver surface real errors.
+            if !db_path.as_os_str().is_empty()
+                && !db_path.exists()
+                && let Err(e) = std::fs::File::create(db_path)
+            {
+                tracing::warn!(
+                    "could not create SQLite database file '{}': {e}",
+                    db_path.display()
+                );
+            }
+        }
+    }
+
+    let db = connect(url)
+        .await
+        .map_err(|e| ComponentError::Database(format!("initialization failed: {e}")))?;
+    initialize(&db)
+        .await
+        .map_err(|e| ComponentError::Database(format!("schema initialization failed: {e}")))?;
+    Ok(Arc::new(db))
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    fn ctx_with_db_url(url: String) -> BackendBuildContext {
+        BackendBuildContext {
+            data_root_directory: std::path::PathBuf::from("/tmp"),
+            system_root_directory: std::path::PathBuf::from("/tmp"),
+            relational_db_url: url,
+            graph_provider: "ladybug".to_string(),
+            graph_file_path: String::new(),
+            graph_postgres_url: None,
+            vector_provider: "brute-force".to_string(),
+            vector_db_url: String::new(),
+            vector_postgres_url: None,
+            embedding_dimensions: 384,
+            embedding: crate::context::EmbeddingInputs {
+                provider: "mock".to_string(),
+                model: String::new(),
+                dimensions: 384,
+                endpoint: None,
+                api_key: None,
+                batch_size: 36,
+                mock: true,
+                mock_deterministic: false,
+                api_version: None,
+                huggingface_tokenizer: None,
+                max_completion_tokens: 8191,
+                onnx_model_path: std::path::PathBuf::new(),
+                onnx_tokenizer_path: std::path::PathBuf::new(),
+                onnx_model_name: String::new(),
+                onnx_dimensions: 384,
+                onnx_max_sequence_length: 512,
+                onnx_batch_size: 32,
+            },
+            llm: crate::context::LlmInputs {
+                provider: "openai".to_string(),
+                model: "gpt-4o-mini".to_string(),
+                api_key: "sk-test".to_string(),
+                endpoint: String::new(),
+                max_retries: 3,
+                mock: false,
+                cassette: String::new(),
+                record_path: String::new(),
+            },
+        }
+    }
+
+    // Both default URL shapes used by the two callers must create missing parent
+    // directories and connect: `cognee-lib`'s single-slash relative form and the
+    // absolute three-slash form the HTTP server produces.
+    #[tokio::test]
+    async fn build_database_creates_parent_dirs_for_relative_sqlite() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let nested = dir.path().join("a").join("b").join("cognee.db");
+        let url = format!("sqlite:{}?mode=rwc", nested.display());
+        build_database(&ctx_with_db_url(url))
+            .await
+            .expect("relative sqlite URL should connect after dir creation");
+        assert!(nested.parent().expect("parent").exists());
+    }
+
+    #[tokio::test]
+    async fn build_database_creates_parent_dirs_for_absolute_sqlite() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let nested = dir.path().join("x").join("y").join("cognee.db");
+        // Absolute path → three-slash form (`sqlite://` + `/abs/...`).
+        let url = format!("sqlite://{}", nested.display());
+        build_database(&ctx_with_db_url(url))
+            .await
+            .expect("absolute sqlite URL should connect after dir creation");
+        assert!(nested.parent().expect("parent").exists());
+    }
+
+    #[tokio::test]
+    async fn build_database_handles_in_memory() {
+        build_database(&ctx_with_db_url("sqlite::memory:".to_string()))
+            .await
+            .expect("in-memory sqlite should connect");
+    }
+}

--- a/crates/components/src/builtins/embedding.rs
+++ b/crates/components/src/builtins/embedding.rs
@@ -13,14 +13,21 @@ use crate::context::{BackendBuildContext, EmbeddingInputs};
 use crate::error::ComponentError;
 use crate::traits::EmbeddingFactory;
 
-/// Whether `provider` is a recognized embedding backend id (case-insensitive).
-/// An empty string is *not* recognized here; callers treat empty as "use the
-/// onnx default", while a non-empty unrecognized value is a misconfiguration.
-fn is_known_embedding_provider(provider: &str) -> bool {
-    matches!(
-        provider.trim().to_lowercase().as_str(),
-        "onnx" | "fastembed" | "openai" | "openai_compatible" | "ollama" | "mock"
-    )
+/// Parse a provider id (case-insensitive) into an [`EmbeddingProvider`], or
+/// `None` if it is not a recognized backend. This is the *single* source of
+/// truth for the provider-id set: validity is `is_some()`, and config mapping
+/// falls back to `onnx` via `unwrap_or`. The recognized ids mirror
+/// `EmbeddingProvider`'s serde `snake_case` names.
+fn parse_embedding_provider(provider: &str) -> Option<EmbeddingProvider> {
+    match provider.trim().to_lowercase().as_str() {
+        "onnx" => Some(EmbeddingProvider::Onnx),
+        "fastembed" => Some(EmbeddingProvider::Fastembed),
+        "openai" => Some(EmbeddingProvider::OpenAi),
+        "openai_compatible" => Some(EmbeddingProvider::OpenAiCompatible),
+        "ollama" => Some(EmbeddingProvider::Ollama),
+        "mock" => Some(EmbeddingProvider::Mock),
+        _ => None,
+    }
 }
 
 /// Map resolved [`EmbeddingInputs`] to a `cognee_embedding::EmbeddingConfig`.
@@ -30,15 +37,17 @@ fn is_known_embedding_provider(provider: &str) -> bool {
 /// a typo surfaces as an error rather than a silent ONNX fallback.
 /// `MOCK_EMBEDDING` handling is expressed through [`EmbeddingInputs::mock`] /
 /// [`EmbeddingInputs::mock_deterministic`], which the caller populates.
+#[allow(
+    clippy::field_reassign_with_default,
+    reason = "the `onnx` field is cfg-gated on the embedding crate's own feature \
+              (which can be enabled independently of this crate's), so the config \
+              must be default-constructed first and the fields assigned after"
+)]
 pub fn build_embedding_config(inputs: &EmbeddingInputs) -> EmbeddingConfig {
-    let provider = match inputs.provider.trim().to_lowercase().as_str() {
-        "onnx" => EmbeddingProvider::Onnx,
-        "fastembed" => EmbeddingProvider::Fastembed,
-        "openai" => EmbeddingProvider::OpenAi,
-        "openai_compatible" => EmbeddingProvider::OpenAiCompatible,
-        "ollama" => EmbeddingProvider::Ollama,
-        "mock" => EmbeddingProvider::Mock,
-        _ => EmbeddingProvider::Onnx,
+    let provider = if inputs.mock {
+        EmbeddingProvider::Mock
+    } else {
+        parse_embedding_provider(&inputs.provider).unwrap_or(EmbeddingProvider::Onnx)
     };
 
     let mock_mode = if inputs.mock_deterministic {
@@ -47,32 +56,37 @@ pub fn build_embedding_config(inputs: &EmbeddingInputs) -> EmbeddingConfig {
         MockVectorMode::Zero
     };
 
-    EmbeddingConfig {
-        provider: if inputs.mock {
-            EmbeddingProvider::Mock
-        } else {
-            provider
-        },
-        model: inputs.model.clone(),
-        dimensions: inputs.dimensions,
-        endpoint: inputs.endpoint.clone(),
-        api_key: inputs.api_key.clone(),
-        api_version: inputs.api_version.clone(),
-        max_completion_tokens: inputs.max_completion_tokens,
-        batch_size: inputs.batch_size,
-        mock: inputs.mock,
-        mock_mode,
-        #[cfg(feature = "onnx")]
-        onnx: cognee_embedding::OnnxEmbeddingConfig {
+    // Start from the embedding crate's own defaults and override the fields we
+    // resolve. Crucially, the `onnx` field's *existence* is gated on
+    // `cognee-embedding`'s `onnx` feature, which can be enabled independently of
+    // *this* crate's `onnx` feature under Cargo feature unification. Default-
+    // constructing first fills that field when present (regardless of our own
+    // feature), avoiding an `E0063 missing field 'onnx'` in mixed builds; we
+    // then override it from the context only when our `onnx` feature is on.
+    let mut config = EmbeddingConfig::default();
+    config.provider = provider;
+    config.model = inputs.model.clone();
+    config.dimensions = inputs.dimensions;
+    config.endpoint = inputs.endpoint.clone();
+    config.api_key = inputs.api_key.clone();
+    config.api_version = inputs.api_version.clone();
+    config.max_completion_tokens = inputs.max_completion_tokens;
+    config.batch_size = inputs.batch_size;
+    config.mock = inputs.mock;
+    config.mock_mode = mock_mode;
+    config.huggingface_tokenizer = inputs.huggingface_tokenizer.clone();
+    #[cfg(feature = "onnx")]
+    {
+        config.onnx = cognee_embedding::OnnxEmbeddingConfig {
             model_path: inputs.onnx_model_path.clone(),
             tokenizer_path: inputs.onnx_tokenizer_path.clone(),
             model_name: inputs.onnx_model_name.clone(),
             dimensions: inputs.onnx_dimensions,
             max_sequence_length: inputs.onnx_max_sequence_length,
             batch_size: inputs.onnx_batch_size,
-        },
-        huggingface_tokenizer: inputs.huggingface_tokenizer.clone(),
+        };
     }
+    config
 }
 
 /// Default embedding factory — maps the context's [`EmbeddingInputs`] to a
@@ -90,7 +104,10 @@ impl EmbeddingFactory for DefaultEmbeddingFactory {
         // ONNX. Empty means "use the default" and is allowed. `mock` short-
         // circuits provider selection, so skip the check when mocking.
         let provider = ctx.embedding.provider.trim();
-        if !ctx.embedding.mock && !provider.is_empty() && !is_known_embedding_provider(provider) {
+        if !ctx.embedding.mock
+            && !provider.is_empty()
+            && parse_embedding_provider(provider).is_none()
+        {
             return Err(ComponentError::EmbeddingEngine(format!(
                 "unknown embedding provider '{provider}'. Supported: onnx, fastembed, \
                  openai, openai_compatible, ollama, mock."
@@ -100,5 +117,76 @@ impl EmbeddingFactory for DefaultEmbeddingFactory {
         config.create_engine().await.map_err(|e| {
             ComponentError::EmbeddingEngine(format!("embedding engine init failed: {e}"))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_recognizes_all_ids_and_rejects_unknown() {
+        for id in [
+            "onnx",
+            "fastembed",
+            "openai",
+            "openai_compatible",
+            "ollama",
+            "mock",
+        ] {
+            assert!(parse_embedding_provider(id).is_some(), "'{id}' must parse");
+        }
+        assert!(
+            parse_embedding_provider("OpenAI").is_some(),
+            "case-insensitive"
+        );
+        assert!(
+            parse_embedding_provider("azure").is_none(),
+            "unknown must not parse"
+        );
+        assert!(
+            parse_embedding_provider("").is_none(),
+            "empty is not a known id"
+        );
+    }
+
+    fn inputs(provider: &str, mock: bool) -> EmbeddingInputs {
+        EmbeddingInputs {
+            provider: provider.to_string(),
+            model: String::new(),
+            dimensions: 384,
+            endpoint: None,
+            api_key: None,
+            batch_size: 36,
+            mock,
+            mock_deterministic: false,
+            api_version: None,
+            huggingface_tokenizer: None,
+            max_completion_tokens: 8191,
+            onnx_model_path: std::path::PathBuf::new(),
+            onnx_tokenizer_path: std::path::PathBuf::new(),
+            onnx_model_name: String::new(),
+            onnx_dimensions: 384,
+            onnx_max_sequence_length: 512,
+            onnx_batch_size: 32,
+        }
+    }
+
+    #[test]
+    fn config_maps_unknown_to_onnx_but_mock_wins() {
+        // build_embedding_config maps an unknown provider to onnx (the factory
+        // is what rejects it); mock overrides the provider regardless.
+        assert_eq!(
+            build_embedding_config(&inputs("azure", false)).provider,
+            EmbeddingProvider::Onnx
+        );
+        assert_eq!(
+            build_embedding_config(&inputs("openai", true)).provider,
+            EmbeddingProvider::Mock
+        );
+        assert_eq!(
+            build_embedding_config(&inputs("ollama", false)).provider,
+            EmbeddingProvider::Ollama
+        );
     }
 }

--- a/crates/components/src/builtins/embedding.rs
+++ b/crates/components/src/builtins/embedding.rs
@@ -1,0 +1,82 @@
+//! Built-in embedding engine factory.
+//!
+//! Provider selection happens inside `EmbeddingConfig::create_engine`, so there
+//! is a single default embedding factory (replaceable via
+//! [`crate::ComponentRegistry::set_embedding`]) rather than a per-provider map.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cognee_embedding::{EmbeddingConfig, EmbeddingEngine, EmbeddingProvider, MockVectorMode};
+
+use crate::context::{BackendBuildContext, EmbeddingInputs};
+use crate::error::ComponentError;
+use crate::traits::EmbeddingFactory;
+
+/// Map resolved [`EmbeddingInputs`] to a `cognee_embedding::EmbeddingConfig`.
+///
+/// Unknown provider strings fall back to `onnx`, matching the historical
+/// `ComponentManager::init_embedding_engine` behavior. `MOCK_EMBEDDING`
+/// handling is expressed through [`EmbeddingInputs::mock`] /
+/// [`EmbeddingInputs::mock_deterministic`], which the caller populates.
+pub fn build_embedding_config(inputs: &EmbeddingInputs) -> EmbeddingConfig {
+    let provider = match inputs.provider.trim().to_lowercase().as_str() {
+        "onnx" => EmbeddingProvider::Onnx,
+        "fastembed" => EmbeddingProvider::Fastembed,
+        "openai" => EmbeddingProvider::OpenAi,
+        "openai_compatible" => EmbeddingProvider::OpenAiCompatible,
+        "ollama" => EmbeddingProvider::Ollama,
+        "mock" => EmbeddingProvider::Mock,
+        _ => EmbeddingProvider::Onnx,
+    };
+
+    let mock_mode = if inputs.mock_deterministic {
+        MockVectorMode::Deterministic
+    } else {
+        MockVectorMode::Zero
+    };
+
+    EmbeddingConfig {
+        provider: if inputs.mock {
+            EmbeddingProvider::Mock
+        } else {
+            provider
+        },
+        model: inputs.model.clone(),
+        dimensions: inputs.dimensions,
+        endpoint: inputs.endpoint.clone(),
+        api_key: inputs.api_key.clone(),
+        api_version: inputs.api_version.clone(),
+        max_completion_tokens: inputs.max_completion_tokens,
+        batch_size: inputs.batch_size,
+        mock: inputs.mock,
+        mock_mode,
+        #[cfg(feature = "onnx")]
+        onnx: cognee_embedding::OnnxEmbeddingConfig {
+            model_path: inputs.onnx_model_path.clone(),
+            tokenizer_path: inputs.onnx_tokenizer_path.clone(),
+            model_name: inputs.onnx_model_name.clone(),
+            dimensions: inputs.onnx_dimensions,
+            max_sequence_length: inputs.onnx_max_sequence_length,
+            batch_size: inputs.onnx_batch_size,
+        },
+        huggingface_tokenizer: inputs.huggingface_tokenizer.clone(),
+    }
+}
+
+/// Default embedding factory — maps the context's [`EmbeddingInputs`] to a
+/// config and calls `create_engine`.
+pub struct DefaultEmbeddingFactory;
+
+#[async_trait]
+impl EmbeddingFactory for DefaultEmbeddingFactory {
+    async fn build(
+        &self,
+        ctx: &BackendBuildContext,
+    ) -> Result<Arc<dyn EmbeddingEngine>, ComponentError> {
+        let config = build_embedding_config(&ctx.embedding);
+        config.create_engine().await.map_err(|e| {
+            ComponentError::EmbeddingEngine(format!("embedding engine init failed: {e}"))
+        })
+    }
+}

--- a/crates/components/src/builtins/embedding.rs
+++ b/crates/components/src/builtins/embedding.rs
@@ -13,11 +13,22 @@ use crate::context::{BackendBuildContext, EmbeddingInputs};
 use crate::error::ComponentError;
 use crate::traits::EmbeddingFactory;
 
+/// Whether `provider` is a recognized embedding backend id (case-insensitive).
+/// An empty string is *not* recognized here; callers treat empty as "use the
+/// onnx default", while a non-empty unrecognized value is a misconfiguration.
+fn is_known_embedding_provider(provider: &str) -> bool {
+    matches!(
+        provider.trim().to_lowercase().as_str(),
+        "onnx" | "fastembed" | "openai" | "openai_compatible" | "ollama" | "mock"
+    )
+}
+
 /// Map resolved [`EmbeddingInputs`] to a `cognee_embedding::EmbeddingConfig`.
 ///
-/// Unknown provider strings fall back to `onnx`, matching the historical
-/// `ComponentManager::init_embedding_engine` behavior. `MOCK_EMBEDDING`
-/// handling is expressed through [`EmbeddingInputs::mock`] /
+/// Empty and unrecognized provider strings map to `onnx`; the factory validates
+/// non-empty unrecognized values separately (see [`DefaultEmbeddingFactory`]) so
+/// a typo surfaces as an error rather than a silent ONNX fallback.
+/// `MOCK_EMBEDDING` handling is expressed through [`EmbeddingInputs::mock`] /
 /// [`EmbeddingInputs::mock_deterministic`], which the caller populates.
 pub fn build_embedding_config(inputs: &EmbeddingInputs) -> EmbeddingConfig {
     let provider = match inputs.provider.trim().to_lowercase().as_str() {
@@ -74,6 +85,17 @@ impl EmbeddingFactory for DefaultEmbeddingFactory {
         &self,
         ctx: &BackendBuildContext,
     ) -> Result<Arc<dyn EmbeddingEngine>, ComponentError> {
+        // A non-empty but unrecognized provider is a misconfiguration (typo /
+        // unsupported backend): surface it instead of silently falling back to
+        // ONNX. Empty means "use the default" and is allowed. `mock` short-
+        // circuits provider selection, so skip the check when mocking.
+        let provider = ctx.embedding.provider.trim();
+        if !ctx.embedding.mock && !provider.is_empty() && !is_known_embedding_provider(provider) {
+            return Err(ComponentError::EmbeddingEngine(format!(
+                "unknown embedding provider '{provider}'. Supported: onnx, fastembed, \
+                 openai, openai_compatible, ollama, mock."
+            )));
+        }
         let config = build_embedding_config(&ctx.embedding);
         config.create_engine().await.map_err(|e| {
             ComponentError::EmbeddingEngine(format!("embedding engine init failed: {e}"))

--- a/crates/components/src/builtins/graph.rs
+++ b/crates/components/src/builtins/graph.rs
@@ -1,0 +1,96 @@
+//! Built-in graph database factories: ladybug/kuzu (embedded) and Postgres.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cognee_graph::GraphDBTrait;
+
+use crate::context::BackendBuildContext;
+use crate::error::ComponentError;
+use crate::traits::GraphDbFactory;
+
+/// Embedded ladybug/kuzu graph backend, stored at a local file path.
+#[cfg(feature = "ladybug")]
+pub struct LadybugGraphFactory {
+    provider: &'static str,
+}
+
+#[cfg(feature = "ladybug")]
+impl LadybugGraphFactory {
+    /// Construct a factory registered under `provider` (`"ladybug"` or `"kuzu"`).
+    pub fn new(provider: &'static str) -> Self {
+        Self { provider }
+    }
+}
+
+#[cfg(feature = "ladybug")]
+#[async_trait]
+impl GraphDbFactory for LadybugGraphFactory {
+    fn provider(&self) -> &str {
+        self.provider
+    }
+
+    async fn build(
+        &self,
+        ctx: &BackendBuildContext,
+    ) -> Result<Arc<dyn GraphDBTrait>, ComponentError> {
+        let graph_path = if ctx.graph_file_path.is_empty() {
+            format!("{}/graph", ctx.system_root_directory.display())
+        } else {
+            ctx.graph_file_path.clone()
+        };
+
+        if let Some(parent) = Path::new(&graph_path).parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let graph_db = cognee_graph::LadybugAdapter::new(&graph_path)
+            .await
+            .map_err(|e| ComponentError::GraphDb(format!("initialization failed: {e}")))?;
+        graph_db
+            .initialize()
+            .await
+            .map_err(|e| ComponentError::GraphDb(format!("schema initialization failed: {e}")))?;
+        Ok(Arc::new(graph_db))
+    }
+}
+
+/// Postgres-backed graph store. Consumes the caller-resolved
+/// [`BackendBuildContext::graph_postgres_url`].
+#[cfg(feature = "pggraph")]
+pub struct PgGraphFactory {
+    provider: &'static str,
+}
+
+#[cfg(feature = "pggraph")]
+impl PgGraphFactory {
+    /// Construct a factory registered under `provider` (`"postgres"` or
+    /// `"postgresql"`).
+    pub fn new(provider: &'static str) -> Self {
+        Self { provider }
+    }
+}
+
+#[cfg(feature = "pggraph")]
+#[async_trait]
+impl GraphDbFactory for PgGraphFactory {
+    fn provider(&self) -> &str {
+        self.provider
+    }
+
+    async fn build(
+        &self,
+        ctx: &BackendBuildContext,
+    ) -> Result<Arc<dyn GraphDBTrait>, ComponentError> {
+        let url = ctx.graph_postgres_url.as_ref().ok_or_else(|| {
+            ComponentError::Config(
+                "graph_database_provider=postgres requires a resolved Postgres URL".into(),
+            )
+        })?;
+        let adapter = cognee_graph::PgGraphAdapter::new(url)
+            .await
+            .map_err(|e| ComponentError::GraphDb(format!("pggraph init failed: {e}")))?;
+        Ok(Arc::new(adapter))
+    }
+}

--- a/crates/components/src/builtins/graph.rs
+++ b/crates/components/src/builtins/graph.rs
@@ -97,11 +97,18 @@ impl GraphDbFactory for PgGraphFactory {
         &self,
         ctx: &BackendBuildContext,
     ) -> Result<Arc<dyn GraphDBTrait>, ComponentError> {
-        let url = ctx.graph_postgres_url.as_ref().ok_or_else(|| {
-            ComponentError::Config(
-                "graph_database_provider=postgres requires a resolved Postgres URL".into(),
-            )
-        })?;
+        let url = match ctx.graph_postgres_url.as_ref() {
+            Some(Ok(url)) => url,
+            // Resolution failed — restate the specific cause (e.g. "Missing
+            // required Postgres graph credentials") in the returned error, so
+            // SDK users without a tracing subscriber still see it.
+            Some(Err(cause)) => return Err(ComponentError::Config(cause.clone())),
+            None => {
+                return Err(ComponentError::Config(
+                    "graph_database_provider=postgres requires a resolved Postgres URL".into(),
+                ));
+            }
+        };
         let adapter = cognee_graph::PgGraphAdapter::new(url)
             .await
             .map_err(|e| ComponentError::GraphDb(format!("pggraph init failed: {e}")))?;

--- a/crates/components/src/builtins/graph.rs
+++ b/crates/components/src/builtins/graph.rs
@@ -1,13 +1,25 @@
 //! Built-in graph database factories: ladybug/kuzu (embedded) and Postgres.
+//!
+//! Every item here lives behind a graph-backend feature, so the imports are
+//! gated too — otherwise a build with neither `ladybug` nor `pggraph` (e.g. a
+//! consumer depending on this crate with `default-features = false`) would warn
+//! on unused imports and fail under `-D warnings`.
 
+#[cfg(any(feature = "ladybug", feature = "pggraph"))]
 use std::path::Path;
+#[cfg(any(feature = "ladybug", feature = "pggraph"))]
 use std::sync::Arc;
 
+#[cfg(any(feature = "ladybug", feature = "pggraph"))]
 use async_trait::async_trait;
+#[cfg(any(feature = "ladybug", feature = "pggraph"))]
 use cognee_graph::GraphDBTrait;
 
+#[cfg(any(feature = "ladybug", feature = "pggraph"))]
 use crate::context::BackendBuildContext;
+#[cfg(any(feature = "ladybug", feature = "pggraph"))]
 use crate::error::ComponentError;
+#[cfg(any(feature = "ladybug", feature = "pggraph"))]
 use crate::traits::GraphDbFactory;
 
 /// Embedded ladybug/kuzu graph backend, stored at a local file path.

--- a/crates/components/src/builtins/graph.rs
+++ b/crates/components/src/builtins/graph.rs
@@ -42,7 +42,9 @@ impl GraphDbFactory for LadybugGraphFactory {
         };
 
         if let Some(parent) = Path::new(&graph_path).parent() {
-            std::fs::create_dir_all(parent)?;
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ComponentError::GraphDb(format!("create_dir_all({}): {e}", parent.display()))
+            })?;
         }
 
         let graph_db = cognee_graph::LadybugAdapter::new(&graph_path)

--- a/crates/components/src/builtins/llm.rs
+++ b/crates/components/src/builtins/llm.rs
@@ -1,0 +1,135 @@
+//! Built-in LLM factory (OpenAI + OpenAI-compatible providers) plus the
+//! cross-cutting mock-override and record-wrap helpers consumed by
+//! [`crate::ComponentRegistry::build_llm`].
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cognee_llm::{Llm, Transcriber, build_openai_compatible_adapter};
+
+use crate::context::BackendBuildContext;
+use crate::error::ComponentError;
+use crate::traits::LlmFactory;
+
+/// Provider ids served by [`OpenAiCompatibleLlmFactory`].
+pub const OPENAI_COMPATIBLE_PROVIDERS: &[&str] = &[
+    "openai",
+    "ollama",
+    "mistral",
+    "gemini",
+    "custom",
+    "openai_compatible",
+];
+
+/// Built-in factory covering OpenAI and every OpenAI-compatible provider,
+/// routed through the shared `build_openai_compatible_adapter` factory.
+pub struct OpenAiCompatibleLlmFactory {
+    provider: &'static str,
+}
+
+impl OpenAiCompatibleLlmFactory {
+    /// Construct a factory registered under `provider`.
+    pub fn new(provider: &'static str) -> Self {
+        Self { provider }
+    }
+}
+
+#[async_trait]
+impl LlmFactory for OpenAiCompatibleLlmFactory {
+    fn provider(&self) -> &str {
+        self.provider
+    }
+
+    async fn build(&self, ctx: &BackendBuildContext) -> Result<Arc<dyn Llm>, ComponentError> {
+        let adapter = build_openai_compatible_adapter(
+            &ctx.llm.provider,
+            &ctx.llm.model,
+            &ctx.llm.api_key,
+            &ctx.llm.endpoint,
+            ctx.llm.max_retries,
+        )
+        .map_err(|e| ComponentError::Llm(e.to_string()))?;
+        Ok(Arc::new(adapter))
+    }
+
+    async fn build_transcriber(
+        &self,
+        ctx: &BackendBuildContext,
+    ) -> Result<Option<Arc<dyn Transcriber>>, ComponentError> {
+        // Whisper-style transcription works against OpenAI and any user-pointed
+        // OpenAI-compatible server exposing /audio/transcriptions (Groq, vLLM, a
+        // LiteLLM proxy). Ollama/Mistral/Gemini do not expose that route via the
+        // chat path, so they return None (graceful no-audio) rather than an
+        // adapter that 404s at runtime.
+        if !matches!(
+            ctx.llm.provider.as_str(),
+            "openai" | "custom" | "openai_compatible"
+        ) {
+            return Ok(None);
+        }
+        let adapter = build_openai_compatible_adapter(
+            &ctx.llm.provider,
+            &ctx.llm.model,
+            &ctx.llm.api_key,
+            &ctx.llm.endpoint,
+            ctx.llm.max_retries,
+        )
+        .map_err(|e| ComponentError::Llm(e.to_string()))?;
+        Ok(Some(Arc::new(adapter) as Arc<dyn Transcriber>))
+    }
+}
+
+// ── Cross-cutting mock / record helpers ───────────────────────────────────
+//
+// These are applied uniformly by `ComponentRegistry::build_llm` regardless of
+// provider: a mock request replaces the adapter entirely (before provider
+// lookup), and a record path wraps whatever real adapter was built. Only the
+// real adapter is worth recording — replaying a recording of a mock is
+// pointless — so wrapping happens after the factory produces the adapter.
+
+/// Build the cassette-replay mock LLM (`MOCK_LLM` / `llm_provider=mock`).
+pub(crate) fn build_mock_llm(ctx: &BackendBuildContext) -> Result<Arc<dyn Llm>, ComponentError> {
+    #[cfg(feature = "mock-llm")]
+    {
+        let cassette = ctx.llm.cassette.trim();
+        if cassette.is_empty() {
+            return Err(ComponentError::Config(
+                "MOCK_LLM is set but MOCK_LLM_CASSETTE is empty; set it to a cassette path"
+                    .to_string(),
+            ));
+        }
+        let replay = cognee_llm::mock::ReplayLlm::from_path(cassette)
+            .map_err(|e| ComponentError::Llm(format!("mock cassette load failed: {e}")))?;
+        Ok(Arc::new(replay))
+    }
+    #[cfg(not(feature = "mock-llm"))]
+    {
+        let _ = ctx;
+        Err(ComponentError::Config(
+            "MOCK_LLM was requested but the mock LLM is unavailable; \
+             rebuild with the `mock-llm` feature"
+                .to_string(),
+        ))
+    }
+}
+
+/// Wrap a real adapter in a recorder (`COGNEE_RECORD_LLM`).
+pub(crate) fn wrap_recording(
+    adapter: Arc<dyn Llm>,
+    record_path: &str,
+) -> Result<Arc<dyn Llm>, ComponentError> {
+    #[cfg(feature = "mock-llm")]
+    {
+        let recorder = cognee_llm::mock::RecordingLlm::new(adapter, record_path.trim().to_string());
+        Ok(Arc::new(recorder))
+    }
+    #[cfg(not(feature = "mock-llm"))]
+    {
+        let _ = (adapter, record_path);
+        Err(ComponentError::Config(
+            "COGNEE_RECORD_LLM was set but LLM recording is unavailable; \
+             rebuild with the `mock-llm` feature"
+                .to_string(),
+        ))
+    }
+}

--- a/crates/components/src/builtins/mod.rs
+++ b/crates/components/src/builtins/mod.rs
@@ -1,0 +1,13 @@
+//! Built-in OSS component factories, registered by
+//! [`crate::ComponentRegistry::with_builtins`].
+
+pub mod database;
+pub mod embedding;
+pub mod graph;
+pub mod llm;
+pub mod storage;
+pub mod vector;
+
+pub use database::build_database;
+pub use embedding::build_embedding_config;
+pub use storage::build_storage;

--- a/crates/components/src/builtins/storage.rs
+++ b/crates/components/src/builtins/storage.rs
@@ -1,0 +1,21 @@
+//! Storage backend construction. There is no provider choice, so this is a
+//! free function rather than a registered factory.
+
+use std::sync::Arc;
+
+use cognee_storage::{LocalStorage, StorageTrait};
+
+use crate::context::BackendBuildContext;
+use crate::error::ComponentError;
+
+/// Build and initialize the file-storage backend (`LocalStorage`).
+pub async fn build_storage(
+    ctx: &BackendBuildContext,
+) -> Result<Arc<dyn StorageTrait>, ComponentError> {
+    let storage = LocalStorage::new(ctx.data_root_directory.clone());
+    storage
+        .initialize()
+        .await
+        .map_err(|e| ComponentError::Storage(format!("initialization failed: {e}")))?;
+    Ok(Arc::new(storage))
+}

--- a/crates/components/src/builtins/vector.rs
+++ b/crates/components/src/builtins/vector.rs
@@ -1,0 +1,111 @@
+//! Built-in vector database factories: pgvector, lancedb, brute-force, mock.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cognee_vector::{BruteForceVectorDB, VectorDB};
+
+use crate::context::BackendBuildContext;
+use crate::error::ComponentError;
+use crate::traits::VectorDbFactory;
+
+/// Postgres + pgvector backend. Consumes the caller-resolved
+/// [`BackendBuildContext::vector_postgres_url`].
+#[cfg(feature = "pgvector")]
+pub struct PgVectorFactory;
+
+#[cfg(feature = "pgvector")]
+#[async_trait]
+impl VectorDbFactory for PgVectorFactory {
+    fn provider(&self) -> &str {
+        "pgvector"
+    }
+
+    async fn build(&self, ctx: &BackendBuildContext) -> Result<Arc<dyn VectorDB>, ComponentError> {
+        let url = ctx.vector_postgres_url.as_ref().ok_or_else(|| {
+            ComponentError::Config(
+                "vector_db_provider=pgvector requires a resolved Postgres URL".into(),
+            )
+        })?;
+        let adapter = cognee_vector::PgVectorAdapter::new(url, ctx.embedding_dimensions)
+            .await
+            .map_err(|e| ComponentError::VectorDb(format!("pgvector init failed: {e}")))?;
+        Ok(Arc::new(adapter))
+    }
+}
+
+/// Embedded LanceDB backend on non-Android targets.
+///
+/// The provider id is target-invariant: on Android (where the LanceDB + Arrow
+/// native stack does not cross-compile) `build` transparently falls back to the
+/// in-memory brute-force backend. `vector_db_url = ":memory:"` is honored as an
+/// explicit brute-force opt-in for ephemeral / test workloads on all targets.
+pub struct LanceDbFactory;
+
+#[async_trait]
+impl VectorDbFactory for LanceDbFactory {
+    fn provider(&self) -> &str {
+        "lancedb"
+    }
+
+    async fn build(&self, ctx: &BackendBuildContext) -> Result<Arc<dyn VectorDB>, ComponentError> {
+        if ctx.vector_db_url == ":memory:" {
+            return Ok(Arc::new(BruteForceVectorDB::new()));
+        }
+
+        #[cfg(not(target_os = "android"))]
+        {
+            let path = if ctx.vector_db_url.is_empty() {
+                ctx.system_root_directory
+                    .join("databases")
+                    .join("cognee.lancedb")
+            } else {
+                std::path::PathBuf::from(&ctx.vector_db_url)
+            };
+            let adapter = cognee_vector::LanceDbAdapter::new(path)
+                .await
+                .map_err(|e| ComponentError::VectorDb(format!("lancedb init failed: {e}")))?;
+            Ok(Arc::new(adapter))
+        }
+        #[cfg(target_os = "android")]
+        {
+            tracing::warn!(
+                "vector_db_provider='lancedb' is not available on Android; falling back to \
+                 in-memory brute-force. Set vector_db_provider='pgvector' for production \
+                 durable storage."
+            );
+            Ok(Arc::new(BruteForceVectorDB::new()))
+        }
+    }
+}
+
+/// Pure-Rust in-memory brute-force backend (Android default + `:memory:`
+/// escape hatch).
+pub struct BruteForceFactory;
+
+#[async_trait]
+impl VectorDbFactory for BruteForceFactory {
+    fn provider(&self) -> &str {
+        "brute-force"
+    }
+
+    async fn build(&self, _ctx: &BackendBuildContext) -> Result<Arc<dyn VectorDB>, ComponentError> {
+        Ok(Arc::new(BruteForceVectorDB::new()))
+    }
+}
+
+/// In-memory mock backend for tests / Postgres-free local dev.
+#[cfg(feature = "testing")]
+pub struct MockVectorFactory;
+
+#[cfg(feature = "testing")]
+#[async_trait]
+impl VectorDbFactory for MockVectorFactory {
+    fn provider(&self) -> &str {
+        "mock"
+    }
+
+    async fn build(&self, _ctx: &BackendBuildContext) -> Result<Arc<dyn VectorDB>, ComponentError> {
+        Ok(Arc::new(cognee_vector::MockVectorDB::new()))
+    }
+}

--- a/crates/components/src/builtins/vector.rs
+++ b/crates/components/src/builtins/vector.rs
@@ -22,11 +22,15 @@ impl VectorDbFactory for PgVectorFactory {
     }
 
     async fn build(&self, ctx: &BackendBuildContext) -> Result<Arc<dyn VectorDB>, ComponentError> {
-        let url = ctx.vector_postgres_url.as_ref().ok_or_else(|| {
-            ComponentError::Config(
-                "vector_db_provider=pgvector requires a resolved Postgres URL".into(),
-            )
-        })?;
+        let url = match ctx.vector_postgres_url.as_ref() {
+            Some(Ok(url)) => url,
+            Some(Err(cause)) => return Err(ComponentError::Config(cause.clone())),
+            None => {
+                return Err(ComponentError::Config(
+                    "vector_db_provider=pgvector requires a resolved Postgres URL".into(),
+                ));
+            }
+        };
         let adapter = cognee_vector::PgVectorAdapter::new(url, ctx.embedding_dimensions)
             .await
             .map_err(|e| ComponentError::VectorDb(format!("pgvector init failed: {e}")))?;

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -58,8 +58,9 @@ pub struct BackendBuildContext {
 /// by [`crate::build_embedding_config`].
 #[derive(Clone)]
 pub struct EmbeddingInputs {
-    /// Lowercase provider string. Unknown values fall back to `onnx`, matching
-    /// the historical `ComponentManager` behavior.
+    /// Lowercase provider string. An empty value defaults to `onnx`; a
+    /// non-empty *unrecognized* value is rejected as a misconfiguration by the
+    /// default embedding factory (rather than silently falling back to `onnx`).
     pub provider: String,
     pub model: String,
     pub dimensions: usize,

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -1,0 +1,106 @@
+//! [`BackendBuildContext`] — the resolved, env-free input to every factory.
+//!
+//! The construction contract: **all config-specific resolution (assembling
+//! Postgres URLs from parts) and all environment-variable reads happen when a
+//! caller lowers its config into a `BackendBuildContext`** (see
+//! `Settings::backend_context` / `HttpServerConfig::backend_context`). The
+//! registry and its factories are pure — given the same context they build the
+//! same components, regardless of the process environment. This keeps
+//! provider-specific URL assembly where the field differences live and lets
+//! each caller opt into mock / recording behavior explicitly.
+
+use std::path::PathBuf;
+
+/// Resolved inputs consumed by [`crate::ComponentRegistry`] and the free
+/// `build_storage` / `build_database` constructors.
+#[derive(Clone)]
+pub struct BackendBuildContext {
+    // ── storage / relational database ─────────────────────────────────────
+    /// Root directory for ingested data files (LocalStorage).
+    pub data_root_directory: PathBuf,
+    /// Root for system state; graph / vector backends derive default paths from
+    /// it when their explicit path is unset.
+    pub system_root_directory: PathBuf,
+    /// Fully-resolved relational DB URL (sqlite:… or postgres://…).
+    pub relational_db_url: String,
+
+    // ── graph ─────────────────────────────────────────────────────────────
+    /// Lowercase graph provider id (`ladybug` | `kuzu` | `postgres`).
+    pub graph_provider: String,
+    /// Explicit ladybug/kuzu graph file path. Empty → the factory derives
+    /// `{system_root_directory}/graph`.
+    pub graph_file_path: String,
+    /// Resolved `postgres://` URL for the Postgres graph backend. `None` when
+    /// the provider is not Postgres or credentials are incomplete.
+    pub graph_postgres_url: Option<String>,
+
+    // ── vector ────────────────────────────────────────────────────────────
+    /// Lowercase vector provider id (`pgvector` | `lancedb` | `brute-force` |
+    /// `mock` | …).
+    pub vector_provider: String,
+    /// Raw vector DB URL/path as configured. Consulted for the `:memory:`
+    /// escape hatch and for the LanceDB on-disk path.
+    pub vector_db_url: String,
+    /// Resolved `postgres://` URL for the pgvector backend. `None` when the
+    /// provider is not pgvector.
+    pub vector_postgres_url: Option<String>,
+    /// Embedding vector dimensionality (needed by pgvector table creation).
+    pub embedding_dimensions: usize,
+
+    // ── embedding / llm ───────────────────────────────────────────────────
+    /// Resolved embedding-engine inputs.
+    pub embedding: EmbeddingInputs,
+    /// Resolved LLM / transcriber inputs.
+    pub llm: LlmInputs,
+}
+
+/// Resolved embedding-engine inputs. Mapped to a `cognee_embedding::EmbeddingConfig`
+/// by [`crate::build_embedding_config`].
+#[derive(Clone)]
+pub struct EmbeddingInputs {
+    /// Lowercase provider string. Unknown values fall back to `onnx`, matching
+    /// the historical `ComponentManager` behavior.
+    pub provider: String,
+    pub model: String,
+    pub dimensions: usize,
+    /// Resolved endpoint (embedding-specific, falling back to the LLM endpoint).
+    pub endpoint: Option<String>,
+    /// Resolved API key (embedding-specific, falling back to the LLM key).
+    pub api_key: Option<String>,
+    pub batch_size: usize,
+    /// `MOCK_EMBEDDING` opt-in — overrides `provider` to the mock engine.
+    pub mock: bool,
+    /// When `mock` is set, selects SHA-256-derived vectors instead of zeros.
+    pub mock_deterministic: bool,
+    /// Forward-compat fields historically read from the environment.
+    pub api_version: Option<String>,
+    pub huggingface_tokenizer: Option<String>,
+    pub max_completion_tokens: usize,
+
+    // ONNX asset paths — carried unconditionally; only consumed under the
+    // `onnx` feature.
+    pub onnx_model_path: PathBuf,
+    pub onnx_tokenizer_path: PathBuf,
+    pub onnx_model_name: String,
+    pub onnx_dimensions: usize,
+    pub onnx_max_sequence_length: usize,
+    pub onnx_batch_size: usize,
+}
+
+/// Resolved LLM / transcriber inputs.
+#[derive(Clone)]
+pub struct LlmInputs {
+    /// Lowercase provider string (`openai` | `ollama` | `mistral` | `gemini` |
+    /// `custom` | `openai_compatible` | `mock` | closed providers).
+    pub provider: String,
+    pub model: String,
+    pub api_key: String,
+    pub endpoint: String,
+    pub max_retries: u32,
+    /// Replaces the provider adapter with a cassette replay mock.
+    pub mock: bool,
+    /// Cassette path for the replay mock (consumed only under `mock-llm`).
+    pub cassette: String,
+    /// When non-empty, wraps the real adapter in a recorder (`mock-llm`).
+    pub record_path: String,
+}

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -30,9 +30,12 @@ pub struct BackendBuildContext {
     /// Explicit ladybug/kuzu graph file path. Empty → the factory derives
     /// `{system_root_directory}/graph`.
     pub graph_file_path: String,
-    /// Resolved `postgres://` URL for the Postgres graph backend. `None` when
-    /// the provider is not Postgres or credentials are incomplete.
-    pub graph_postgres_url: Option<String>,
+    /// Resolution outcome for the Postgres graph backend: `None` when the
+    /// provider is not Postgres, `Some(Ok(url))` on success, `Some(Err(msg))`
+    /// when the provider *is* Postgres but URL resolution failed — carrying the
+    /// specific cause (e.g. missing credentials) so the factory can restate it
+    /// in the returned error rather than only logging it.
+    pub graph_postgres_url: Option<Result<String, String>>,
 
     // ── vector ────────────────────────────────────────────────────────────
     /// Lowercase vector provider id (`pgvector` | `lancedb` | `brute-force` |
@@ -41,9 +44,10 @@ pub struct BackendBuildContext {
     /// Raw vector DB URL/path as configured. Consulted for the `:memory:`
     /// escape hatch and for the LanceDB on-disk path.
     pub vector_db_url: String,
-    /// Resolved `postgres://` URL for the pgvector backend. `None` when the
-    /// provider is not pgvector.
-    pub vector_postgres_url: Option<String>,
+    /// Resolution outcome for the pgvector backend: `None` when the provider is
+    /// not pgvector, `Some(Ok(url))` on success, `Some(Err(msg))` when the
+    /// provider *is* pgvector but URL resolution failed (carries the cause).
+    pub vector_postgres_url: Option<Result<String, String>>,
     /// Embedding vector dimensionality (needed by pgvector table creation).
     pub embedding_dimensions: usize,
 

--- a/crates/components/src/error.rs
+++ b/crates/components/src/error.rs
@@ -1,0 +1,34 @@
+//! Error type shared by all component factories.
+//!
+//! This type is re-exported by `cognee-lib` as `cognee_lib::ComponentError`, so
+//! it stays the identical type across the OSS crates and the closed cloud repo.
+
+use thiserror::Error;
+
+/// Errors that can occur during component initialization or access.
+#[derive(Debug, Error)]
+pub enum ComponentError {
+    #[error("Storage error: {0}")]
+    Storage(String),
+
+    #[error("Database error: {0}")]
+    Database(String),
+
+    #[error("Graph database error: {0}")]
+    GraphDb(String),
+
+    #[error("Vector database error: {0}")]
+    VectorDb(String),
+
+    #[error("Embedding engine error: {0}")]
+    EmbeddingEngine(String),
+
+    #[error("LLM error: {0}")]
+    Llm(String),
+
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -1,0 +1,51 @@
+//! `cognee-components` — shared construction of pipeline backends.
+//!
+//! Both the `ComponentManager` (cognee-lib, lazy version-cached) and the HTTP
+//! server's standalone wiring (eager) build the same seven backends — storage,
+//! relational database, graph DB, vector DB, embedding engine, LLM, and
+//! transcriber. This crate holds that construction logic once, behind a
+//! [`ComponentRegistry`] that maps provider ids to adapter factories.
+//!
+//! ## Extension
+//!
+//! External adapter crates (e.g. the closed `cognee-vector-qdrant` /
+//! `cognee-llm-litert`) implement [`VectorDbFactory`] / [`GraphDbFactory`] /
+//! [`LlmFactory`] / [`EmbeddingFactory`] and register them via explicit
+//! dependency injection:
+//!
+//! ```ignore
+//! let mut reg = ComponentRegistry::with_builtins();
+//! reg.register_vector(Arc::new(QdrantVectorFactory));
+//! reg.register_llm(Arc::new(LiteRtLlmFactory));
+//! // hand `reg` to ComponentManager::with_registry / wire_default_backends_with
+//! ```
+//!
+//! ## The construction contract
+//!
+//! Callers lower their own config type into a [`BackendBuildContext`], doing all
+//! provider-specific URL resolution and environment reads at that boundary. The
+//! registry and its factories are pure over the context — see
+//! [`context`] for details.
+
+mod builtins;
+mod context;
+mod error;
+mod registry;
+mod traits;
+
+pub use builtins::{build_database, build_embedding_config, build_storage};
+pub use context::{BackendBuildContext, EmbeddingInputs, LlmInputs};
+pub use error::ComponentError;
+pub use registry::ComponentRegistry;
+pub use traits::{EmbeddingFactory, GraphDbFactory, LlmFactory, VectorDbFactory};
+
+// Re-export the default embedding factory so external callers can compose it.
+pub use builtins::embedding::DefaultEmbeddingFactory;
+
+/// Compile-time assertion that the registry is `Send + Sync`, so a
+/// `ComponentManager` holding one stays `Send + Sync` (required by the
+/// `Arc<HandleState>` bindings layer).
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<ComponentRegistry>();
+};

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -51,12 +51,11 @@ impl ComponentRegistry {
         let mut reg = Self::empty();
 
         // ── vector ────────────────────────────────────────────────────────
-        // brute-force is always available; register it under its spelling
-        // variants so any configured form resolves.
-        let brute: Arc<dyn VectorDbFactory> = Arc::new(crate::builtins::vector::BruteForceFactory);
-        for id in ["brute-force", "brute_force", "bruteforce"] {
-            reg.vector.insert(id.to_string(), Arc::clone(&brute));
-        }
+        // brute-force is always available. Its spelling variants (brute_force,
+        // bruteforce) are canonicalized at lookup time (see `build_vector`), so
+        // it registers under the single canonical key — this keeps a
+        // `register_vector` override consistent across all spellings.
+        reg.register_vector(Arc::new(crate::builtins::vector::BruteForceFactory));
         // lancedb is registered unconditionally; the Android fallback lives
         // inside its build(), keeping the provider id target-invariant.
         reg.register_vector(Arc::new(crate::builtins::vector::LanceDbFactory));
@@ -145,7 +144,7 @@ impl ComponentRegistry {
         &self,
         ctx: &BackendBuildContext,
     ) -> Result<Arc<dyn VectorDB>, ComponentError> {
-        let key = ctx.vector_provider.to_lowercase();
+        let key = canonical_vector_provider(&ctx.vector_provider);
         let factory = self.vector.get(&key).ok_or_else(|| {
             ComponentError::Config(unsupported_msg(
                 "vector_db_provider",
@@ -232,6 +231,16 @@ impl Default for ComponentRegistry {
     }
 }
 
+/// Canonicalize a vector-provider string, collapsing the historical
+/// brute-force spelling variants (`brute_force`, `bruteforce`) onto the single
+/// registered key `brute-force`. All other providers pass through lowercased.
+fn canonical_vector_provider(provider: &str) -> String {
+    match provider.to_lowercase().as_str() {
+        "brute-force" | "brute_force" | "bruteforce" => "brute-force".to_string(),
+        other => other.to_string(),
+    }
+}
+
 fn unsupported_msg(field: &str, provider: &str, supported: &[String]) -> String {
     // Feature-gated built-ins are simply absent from the registry when their
     // cargo feature is off; point the operator at the feature rather than
@@ -264,14 +273,17 @@ mod tests {
     fn builtins_register_documented_providers() {
         let reg = ComponentRegistry::with_builtins();
 
-        // Vector: brute-force (+ spelling variants) and lancedb are always present.
-        for id in ["brute-force", "brute_force", "bruteforce", "lancedb"] {
+        // Vector: brute-force (canonical) and lancedb are always present.
+        for id in ["brute-force", "lancedb"] {
             assert!(
                 reg.vector_providers().iter().any(|p| p == id),
                 "vector provider '{id}' must be registered; have {:?}",
                 reg.vector_providers()
             );
         }
+        // The brute-force spelling variants canonicalize to the same key.
+        assert_eq!(canonical_vector_provider("brute_force"), "brute-force");
+        assert_eq!(canonical_vector_provider("bruteforce"), "brute-force");
         #[cfg(feature = "pgvector")]
         assert!(reg.vector_providers().iter().any(|p| p == "pgvector"));
         #[cfg(feature = "testing")]

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -1,0 +1,355 @@
+//! [`ComponentRegistry`] — the pluggable provider → factory map shared by the
+//! `ComponentManager` (cognee-lib) and the HTTP server's standalone wiring.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use cognee_embedding::EmbeddingEngine;
+use cognee_graph::GraphDBTrait;
+use cognee_llm::{Llm, Transcriber};
+use cognee_vector::VectorDB;
+
+use crate::builtins::embedding::DefaultEmbeddingFactory;
+use crate::builtins::llm::{self, OpenAiCompatibleLlmFactory};
+use crate::context::BackendBuildContext;
+use crate::error::ComponentError;
+use crate::traits::{EmbeddingFactory, GraphDbFactory, LlmFactory, VectorDbFactory};
+
+/// Maps lowercase provider ids to adapter factories, per component kind.
+///
+/// Construct with [`with_builtins`](Self::with_builtins) to get the OSS
+/// provider set, then `register_*` external adapters before handing the
+/// registry to a `ComponentManager` or the HTTP server wiring. `build_*` is the
+/// single construction path both callers share.
+///
+/// Vector / graph / llm are keyed by provider id (the real extension points).
+/// Embedding holds a single replaceable factory, because provider selection
+/// happens inside `EmbeddingConfig::create_engine`.
+pub struct ComponentRegistry {
+    vector: HashMap<String, Arc<dyn VectorDbFactory>>,
+    graph: HashMap<String, Arc<dyn GraphDbFactory>>,
+    llm: HashMap<String, Arc<dyn LlmFactory>>,
+    embedding: Arc<dyn EmbeddingFactory>,
+}
+
+impl ComponentRegistry {
+    /// An empty registry with only the default embedding factory installed.
+    /// Prefer [`with_builtins`](Self::with_builtins) unless you are assembling
+    /// a bespoke provider set from scratch.
+    pub fn empty() -> Self {
+        Self {
+            vector: HashMap::new(),
+            graph: HashMap::new(),
+            llm: HashMap::new(),
+            embedding: Arc::new(DefaultEmbeddingFactory),
+        }
+    }
+
+    /// Registry pre-populated with the OSS built-in factories that the enabled
+    /// cargo features make available.
+    pub fn with_builtins() -> Self {
+        let mut reg = Self::empty();
+
+        // ── vector ────────────────────────────────────────────────────────
+        // brute-force is always available; register it under its spelling
+        // variants so any configured form resolves.
+        let brute: Arc<dyn VectorDbFactory> = Arc::new(crate::builtins::vector::BruteForceFactory);
+        for id in ["brute-force", "brute_force", "bruteforce"] {
+            reg.vector.insert(id.to_string(), Arc::clone(&brute));
+        }
+        // lancedb is registered unconditionally; the Android fallback lives
+        // inside its build(), keeping the provider id target-invariant.
+        reg.register_vector(Arc::new(crate::builtins::vector::LanceDbFactory));
+        #[cfg(feature = "pgvector")]
+        reg.register_vector(Arc::new(crate::builtins::vector::PgVectorFactory));
+        #[cfg(feature = "testing")]
+        reg.register_vector(Arc::new(crate::builtins::vector::MockVectorFactory));
+
+        // ── graph ─────────────────────────────────────────────────────────
+        #[cfg(feature = "ladybug")]
+        {
+            reg.register_graph(Arc::new(crate::builtins::graph::LadybugGraphFactory::new(
+                "ladybug",
+            )));
+            reg.register_graph(Arc::new(crate::builtins::graph::LadybugGraphFactory::new(
+                "kuzu",
+            )));
+        }
+        #[cfg(feature = "pggraph")]
+        {
+            reg.register_graph(Arc::new(crate::builtins::graph::PgGraphFactory::new(
+                "postgres",
+            )));
+            reg.register_graph(Arc::new(crate::builtins::graph::PgGraphFactory::new(
+                "postgresql",
+            )));
+        }
+
+        // ── llm ───────────────────────────────────────────────────────────
+        for id in llm::OPENAI_COMPATIBLE_PROVIDERS {
+            reg.register_llm(Arc::new(OpenAiCompatibleLlmFactory::new(id)));
+        }
+
+        reg
+    }
+
+    // ── registration (extension points) ───────────────────────────────────
+
+    /// Register (or override) a vector backend factory under `f.provider()`.
+    pub fn register_vector(&mut self, f: Arc<dyn VectorDbFactory>) {
+        self.vector.insert(f.provider().to_lowercase(), f);
+    }
+
+    /// Register (or override) a graph backend factory under `f.provider()`.
+    pub fn register_graph(&mut self, f: Arc<dyn GraphDbFactory>) {
+        self.graph.insert(f.provider().to_lowercase(), f);
+    }
+
+    /// Register (or override) an LLM factory under `f.provider()`.
+    pub fn register_llm(&mut self, f: Arc<dyn LlmFactory>) {
+        self.llm.insert(f.provider().to_lowercase(), f);
+    }
+
+    /// Replace the embedding factory (provider selection is internal to the
+    /// engine, so there is a single slot).
+    pub fn set_embedding(&mut self, f: Arc<dyn EmbeddingFactory>) {
+        self.embedding = f;
+    }
+
+    /// Provider ids with a registered vector factory (sorted). Used by the
+    /// drift-guard test and for actionable error messages.
+    pub fn vector_providers(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.vector.keys().cloned().collect();
+        v.sort();
+        v
+    }
+
+    /// Provider ids with a registered graph factory (sorted).
+    pub fn graph_providers(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.graph.keys().cloned().collect();
+        v.sort();
+        v
+    }
+
+    /// Provider ids with a registered LLM factory (sorted).
+    pub fn llm_providers(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.llm.keys().cloned().collect();
+        v.sort();
+        v
+    }
+
+    // ── construction (shared build path) ───────────────────────────────────
+
+    /// Build the vector backend selected by `ctx.vector_provider`.
+    pub async fn build_vector(
+        &self,
+        ctx: &BackendBuildContext,
+    ) -> Result<Arc<dyn VectorDB>, ComponentError> {
+        let key = ctx.vector_provider.to_lowercase();
+        let factory = self.vector.get(&key).ok_or_else(|| {
+            ComponentError::Config(unsupported_msg(
+                "vector_db_provider",
+                &ctx.vector_provider,
+                &self.vector_providers(),
+            ))
+        })?;
+        factory.build(ctx).await
+    }
+
+    /// Build the graph backend selected by `ctx.graph_provider`.
+    pub async fn build_graph(
+        &self,
+        ctx: &BackendBuildContext,
+    ) -> Result<Arc<dyn GraphDBTrait>, ComponentError> {
+        let key = ctx.graph_provider.to_lowercase();
+        let factory = self.graph.get(&key).ok_or_else(|| {
+            ComponentError::Config(unsupported_msg(
+                "graph_database_provider",
+                &ctx.graph_provider,
+                &self.graph_providers(),
+            ))
+        })?;
+        factory.build(ctx).await
+    }
+
+    /// Build the LLM adapter selected by `ctx.llm.provider`.
+    ///
+    /// A mock request (`ctx.llm.mock` or `provider == "mock"`) replaces the
+    /// adapter entirely, before provider lookup. A non-empty
+    /// `ctx.llm.record_path` wraps the built real adapter in a recorder. Both
+    /// are applied here so every provider — including externally-registered
+    /// ones — gets identical mock/record semantics.
+    pub async fn build_llm(
+        &self,
+        ctx: &BackendBuildContext,
+    ) -> Result<Arc<dyn Llm>, ComponentError> {
+        if ctx.llm.mock || ctx.llm.provider == "mock" {
+            return llm::build_mock_llm(ctx);
+        }
+
+        let key = ctx.llm.provider.to_lowercase();
+        let factory = self.llm.get(&key).ok_or_else(|| {
+            ComponentError::Config(unsupported_msg(
+                "llm_provider",
+                &ctx.llm.provider,
+                &self.llm_providers(),
+            ))
+        })?;
+        let adapter = factory.build(ctx).await?;
+
+        if !ctx.llm.record_path.trim().is_empty() {
+            return llm::wrap_recording(adapter, &ctx.llm.record_path);
+        }
+        Ok(adapter)
+    }
+
+    /// Build a transcriber for `ctx.llm.provider`, or `Ok(None)` when the
+    /// provider does not support audio transcription. Never mock-overridden or
+    /// record-wrapped (only the real adapter implements `Transcriber`).
+    pub async fn build_transcriber(
+        &self,
+        ctx: &BackendBuildContext,
+    ) -> Result<Option<Arc<dyn Transcriber>>, ComponentError> {
+        let key = ctx.llm.provider.to_lowercase();
+        match self.llm.get(&key) {
+            Some(factory) => factory.build_transcriber(ctx).await,
+            None => Ok(None),
+        }
+    }
+
+    /// Build the embedding engine via the (single) embedding factory.
+    pub async fn build_embedding(
+        &self,
+        ctx: &BackendBuildContext,
+    ) -> Result<Arc<dyn EmbeddingEngine>, ComponentError> {
+        self.embedding.build(ctx).await
+    }
+}
+
+impl Default for ComponentRegistry {
+    fn default() -> Self {
+        Self::with_builtins()
+    }
+}
+
+fn unsupported_msg(field: &str, provider: &str, supported: &[String]) -> String {
+    format!(
+        "Unsupported {field} '{provider}'. Registered providers: [{}]. \
+         Closed adapters (e.g. qdrant, litert) must be registered via \
+         ComponentRegistry::register_* at the binary entry point.",
+        supported.join(", ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Drift-guard: `with_builtins()` must register the documented provider set
+    // for the enabled feature-set. Run with `--features testing` (and pgvector/
+    // pggraph) to cover the gated providers. This test locks in the coverage so
+    // a provider cannot silently vanish from one caller as it did before the
+    // registry unified the two construction paths.
+    #[test]
+    fn builtins_register_documented_providers() {
+        let reg = ComponentRegistry::with_builtins();
+
+        // Vector: brute-force (+ spelling variants) and lancedb are always present.
+        for id in ["brute-force", "brute_force", "bruteforce", "lancedb"] {
+            assert!(
+                reg.vector_providers().iter().any(|p| p == id),
+                "vector provider '{id}' must be registered; have {:?}",
+                reg.vector_providers()
+            );
+        }
+        #[cfg(feature = "pgvector")]
+        assert!(reg.vector_providers().iter().any(|p| p == "pgvector"));
+        #[cfg(feature = "testing")]
+        assert!(
+            reg.vector_providers().iter().any(|p| p == "mock"),
+            "the `testing` feature must register the `mock` vector provider"
+        );
+
+        // Graph.
+        #[cfg(feature = "ladybug")]
+        for id in ["ladybug", "kuzu"] {
+            assert!(reg.graph_providers().iter().any(|p| p == id));
+        }
+        #[cfg(feature = "pggraph")]
+        for id in ["postgres", "postgresql"] {
+            assert!(reg.graph_providers().iter().any(|p| p == id));
+        }
+
+        // LLM: every OpenAI-compatible provider id.
+        for id in crate::builtins::llm::OPENAI_COMPATIBLE_PROVIDERS {
+            assert!(
+                reg.llm_providers().iter().any(|p| p == id),
+                "llm provider '{id}' must be registered; have {:?}",
+                reg.llm_providers()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn build_vector_errors_on_unregistered_provider() {
+        let reg = ComponentRegistry::with_builtins();
+        let mut ctx = test_ctx();
+        ctx.vector_provider = "qdrant".to_string();
+        let msg = match reg.build_vector(&ctx).await {
+            Ok(_) => panic!("qdrant must not be registered in OSS builtins"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("qdrant"),
+            "message should name the provider: {msg}"
+        );
+        assert!(
+            msg.contains("register_"),
+            "message should point at the registration seam: {msg}"
+        );
+    }
+
+    fn test_ctx() -> BackendBuildContext {
+        BackendBuildContext {
+            data_root_directory: std::path::PathBuf::from("/tmp/cognee-test-data"),
+            system_root_directory: std::path::PathBuf::from("/tmp/cognee-test-system"),
+            relational_db_url: "sqlite::memory:".to_string(),
+            graph_provider: "ladybug".to_string(),
+            graph_file_path: String::new(),
+            graph_postgres_url: None,
+            vector_provider: "brute-force".to_string(),
+            vector_db_url: String::new(),
+            vector_postgres_url: None,
+            embedding_dimensions: 384,
+            embedding: crate::context::EmbeddingInputs {
+                provider: "onnx".to_string(),
+                model: "bge-small-en-v1.5".to_string(),
+                dimensions: 384,
+                endpoint: None,
+                api_key: None,
+                batch_size: 36,
+                mock: false,
+                mock_deterministic: false,
+                api_version: None,
+                huggingface_tokenizer: None,
+                max_completion_tokens: 8191,
+                onnx_model_path: std::path::PathBuf::new(),
+                onnx_tokenizer_path: std::path::PathBuf::new(),
+                onnx_model_name: "bge-small-en-v1.5".to_string(),
+                onnx_dimensions: 384,
+                onnx_max_sequence_length: 512,
+                onnx_batch_size: 32,
+            },
+            llm: crate::context::LlmInputs {
+                provider: "openai".to_string(),
+                model: "gpt-4o-mini".to_string(),
+                api_key: "sk-test".to_string(),
+                endpoint: String::new(),
+                max_retries: 3,
+                mock: false,
+                cassette: String::new(),
+                record_path: String::new(),
+            },
+        }
+    }
+}

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -244,12 +244,21 @@ fn canonical_vector_provider(provider: &str) -> String {
 fn unsupported_msg(field: &str, provider: &str, supported: &[String]) -> String {
     // Feature-gated built-ins are simply absent from the registry when their
     // cargo feature is off; point the operator at the feature rather than
-    // letting it read as an unknown-backend problem.
-    let hint = match provider.to_lowercase().as_str() {
-        "postgres" | "postgresql" => {
-            " If you intended the Postgres graph backend, rebuild with the `pggraph` crate feature."
-        }
-        "pgvector" => " If you intended pgvector, rebuild with the `pgvector` crate feature.",
+    // letting it read as an unknown-backend problem. The hint is keyed on BOTH
+    // the component kind (`field`) and the provider, so a graph feature is never
+    // suggested for a vector error (or vice versa), and the ladybug/pggraph
+    // built-ins each map to the feature that gates them.
+    let p = provider.to_lowercase();
+    let hint = match field {
+        "graph_database_provider" => match p.as_str() {
+            "ladybug" | "kuzu" => " Rebuild with the `ladybug` crate feature to enable it.",
+            "postgres" | "postgresql" => " Rebuild with the `pggraph` crate feature to enable it.",
+            _ => "",
+        },
+        "vector_db_provider" => match p.as_str() {
+            "pgvector" => " Rebuild with the `pgvector` crate feature to enable it.",
+            _ => "",
+        },
         _ => "",
     };
     format!(
@@ -263,6 +272,25 @@ fn unsupported_msg(field: &str, provider: &str, supported: &[String]) -> String 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The unsupported-provider feature hint must be keyed on BOTH the component
+    // kind and the provider: a graph feature must never be suggested for a
+    // vector error, and the ladybug/pggraph/pgvector built-ins each map to the
+    // cargo feature that gates them.
+    #[test]
+    fn unsupported_msg_hint_is_field_aware() {
+        let g = |p: &str| unsupported_msg("graph_database_provider", p, &[]);
+        let v = |p: &str| unsupported_msg("vector_db_provider", p, &[]);
+        // The message always echoes the provider name, so assert on the *hint*
+        // phrase ("`<feature>` crate feature") rather than the provider substring.
+        assert!(g("postgres").contains("`pggraph` crate feature"));
+        assert!(g("ladybug").contains("`ladybug` crate feature"));
+        assert!(v("pgvector").contains("`pgvector` crate feature"));
+        // No cross-kind hint: a graph provider in a vector error (and vice-versa)
+        // gets no feature hint at all.
+        assert!(!v("postgres").contains("crate feature"));
+        assert!(!g("pgvector").contains("crate feature"));
+    }
 
     // Drift-guard: `with_builtins()` must register the documented provider set
     // for the enabled feature-set. Run with `--features testing` (and pgvector/

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -233,8 +233,18 @@ impl Default for ComponentRegistry {
 }
 
 fn unsupported_msg(field: &str, provider: &str, supported: &[String]) -> String {
+    // Feature-gated built-ins are simply absent from the registry when their
+    // cargo feature is off; point the operator at the feature rather than
+    // letting it read as an unknown-backend problem.
+    let hint = match provider.to_lowercase().as_str() {
+        "postgres" | "postgresql" => {
+            " If you intended the Postgres graph backend, rebuild with the `pggraph` crate feature."
+        }
+        "pgvector" => " If you intended pgvector, rebuild with the `pgvector` crate feature.",
+        _ => "",
+    };
     format!(
-        "Unsupported {field} '{provider}'. Registered providers: [{}]. \
+        "Unsupported {field} '{provider}'. Registered providers: [{}].{hint} \
          Closed adapters (e.g. qdrant, litert) must be registered via \
          ComponentRegistry::register_* at the binary entry point.",
         supported.join(", ")

--- a/crates/components/src/traits.rs
+++ b/crates/components/src/traits.rs
@@ -1,0 +1,86 @@
+//! Adapter factory traits — the extension surface.
+//!
+//! Each trait maps a lowercase provider id to a constructor over a
+//! [`BackendBuildContext`]. OSS registers built-in factories in
+//! [`crate::ComponentRegistry::with_builtins`]; external crates (e.g. the
+//! closed `cognee-vector-qdrant` / `cognee-llm-litert`) implement these traits
+//! and register their factories at their own binary entry points.
+//!
+//! All traits are `Send + Sync` and use `#[async_trait]` so that
+//! `Arc<dyn XFactory>` is dyn-compatible and the holding `ComponentManager`
+//! stays `Send + Sync` (required by the `Arc<HandleState>` bindings layer).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cognee_embedding::EmbeddingEngine;
+use cognee_graph::GraphDBTrait;
+use cognee_llm::{Llm, Transcriber};
+use cognee_vector::VectorDB;
+
+use crate::context::BackendBuildContext;
+use crate::error::ComponentError;
+
+/// Builds a vector database backend for one provider id.
+#[async_trait]
+pub trait VectorDbFactory: Send + Sync {
+    /// Lowercase provider id this factory serves (e.g. `"lancedb"`, `"qdrant"`).
+    fn provider(&self) -> &str;
+    /// Construct the backend from the resolved context.
+    async fn build(&self, ctx: &BackendBuildContext) -> Result<Arc<dyn VectorDB>, ComponentError>;
+}
+
+/// Builds a knowledge-graph database backend for one provider id.
+#[async_trait]
+pub trait GraphDbFactory: Send + Sync {
+    /// Lowercase provider id this factory serves (e.g. `"ladybug"`).
+    fn provider(&self) -> &str;
+    /// Construct the backend from the resolved context.
+    async fn build(
+        &self,
+        ctx: &BackendBuildContext,
+    ) -> Result<Arc<dyn GraphDBTrait>, ComponentError>;
+}
+
+/// Builds an LLM adapter (and, optionally, a matching transcriber) for one
+/// provider id.
+///
+/// [`build`](Self::build) returns the *raw* provider adapter; cross-cutting
+/// mock-override and record-wrapping are applied by
+/// [`crate::ComponentRegistry::build_llm`], not here.
+/// [`build_transcriber`](Self::build_transcriber) likewise builds a *raw*
+/// adapter — it is never mock-overridden or record-wrapped, because only the
+/// real OpenAI-compatible adapter implements [`Transcriber`].
+#[async_trait]
+pub trait LlmFactory: Send + Sync {
+    /// Lowercase provider id this factory serves.
+    fn provider(&self) -> &str;
+    /// Construct the raw LLM adapter from the resolved context.
+    async fn build(&self, ctx: &BackendBuildContext) -> Result<Arc<dyn Llm>, ComponentError>;
+    /// Construct a transcriber for this provider, or `Ok(None)` when the
+    /// provider does not support audio transcription (graceful no-audio).
+    ///
+    /// Defaults to `Ok(None)`.
+    async fn build_transcriber(
+        &self,
+        _ctx: &BackendBuildContext,
+    ) -> Result<Option<Arc<dyn Transcriber>>, ComponentError> {
+        Ok(None)
+    }
+}
+
+/// Builds the embedding engine.
+///
+/// Unlike the other kinds, embedding provider selection happens *inside*
+/// `EmbeddingConfig::create_engine`, so the registry holds a single replaceable
+/// embedding factory rather than a per-provider map. The default factory maps
+/// [`crate::EmbeddingInputs`] to a config and preserves the historical
+/// unknown-provider → `onnx` fallback.
+#[async_trait]
+pub trait EmbeddingFactory: Send + Sync {
+    /// Construct the embedding engine from the resolved context.
+    async fn build(
+        &self,
+        ctx: &BackendBuildContext,
+    ) -> Result<Arc<dyn EmbeddingEngine>, ComponentError>;
+}

--- a/crates/components/src/traits.rs
+++ b/crates/components/src/traits.rs
@@ -74,8 +74,11 @@ pub trait LlmFactory: Send + Sync {
 /// Unlike the other kinds, embedding provider selection happens *inside*
 /// `EmbeddingConfig::create_engine`, so the registry holds a single replaceable
 /// embedding factory rather than a per-provider map. The default factory maps
-/// [`crate::EmbeddingInputs`] to a config and preserves the historical
-/// unknown-provider → `onnx` fallback.
+/// [`crate::EmbeddingInputs`] to a config. An empty provider defaults to `onnx`;
+/// a non-empty *unrecognized* provider is rejected with an error (rather than
+/// the pre-refactor silent `onnx` fallback), so a typo / unsupported backend
+/// fails loudly instead of embedding with the wrong model. This is an
+/// intentional behavior change — see the PR notes.
 #[async_trait]
 pub trait EmbeddingFactory: Send + Sync {
     /// Construct the embedding engine from the resolved context.

--- a/crates/http-server/Cargo.toml
+++ b/crates/http-server/Cargo.toml
@@ -77,7 +77,10 @@ telemetry = [
 # is `publish = false` (in-repo harness), so we enable `cognee-vector/testing`
 # directly — `MockVectorDB` is defined there and `cognee-test-utils` only
 # re-exports it.
-dev-mock = ["cognee-vector/testing"]
+# Enabling `cognee-components/testing` is what registers the `mock` vector
+# provider in `ComponentRegistry::with_builtins()` — without this remap the
+# provider would silently vanish from the server's registry-driven wiring.
+dev-mock = ["cognee-vector/testing", "cognee-components/testing"]
 
 [dependencies]
 # Web framework and HTTP stack. axum 0.8 requires hyper 1.x, declared
@@ -102,6 +105,11 @@ cognee-observability = { path = "../observability", version = "0.1.3", optional 
 # in `telemetry.rs` compiles to a noop when absent.
 cognee-telemetry = { path = "../telemetry", version = "0.1.3", optional = true, features = ["telemetry"] }
 cognee-core = { path = "../core", version = "0.1.3", features = ["pipeline-run-registry"] }
+# Shared backend construction + adapter registry. Standalone wiring builds a
+# `ComponentRegistry::with_builtins()`; the enabled features here determine
+# which providers `with_builtins()` registers (onnx/ladybug/pgvector; mock-llm
+# is intentionally NOT enabled so a production server never honors MOCK_LLM).
+cognee-components = { path = "../components", version = "0.1.3", default-features = false, features = ["onnx", "ladybug", "pgvector"] }
 cognee-database = { path = "../database", version = "0.1.3", features = ["sqlite"] }
 sea-orm = { version = "1", default-features = false, features = ["runtime-tokio-rustls", "with-chrono", "with-uuid", "with-json"] }
 cognee-storage = { path = "../storage", version = "0.1.3" }

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -273,6 +273,18 @@ fn first_non_empty_env(keys: &[&str]) -> Option<String> {
     None
 }
 
+/// Append `?mode=rwc` to a file-backed SQLite URL that has no query string, so
+/// the sea-orm/sqlx driver creates the database file when it does not yet
+/// exist. Leaves in-memory URLs, URLs that already carry a query, and non-SQLite
+/// URLs untouched.
+fn ensure_sqlite_rwc(url: &str) -> String {
+    if url.starts_with("sqlite:") && !url.contains(":memory:") && !url.contains('?') {
+        format!("{url}?mode=rwc")
+    } else {
+        url.to_string()
+    }
+}
+
 fn default_relational_db_url(system_root_directory: &std::path::Path) -> String {
     format!(
         "sqlite://{}",
@@ -570,9 +582,11 @@ impl HttpServerConfig {
         let vector_provider = self.vector_provider.to_ascii_lowercase();
         // The pgvector coherence guard runs in `wire_vector_db` before build;
         // by the time the factory runs, `vector_db_url` is a validated
-        // `postgres://…` string.
+        // `postgres://…` string. Trim it here so a copy-pasted value with
+        // surrounding whitespace reaches PgVectorAdapter::new cleanly (the
+        // validator checks the trimmed form).
         let vector_postgres_url = if vector_provider == "pgvector" {
-            Some(self.vector_db_url.clone())
+            Some(self.vector_db_url.trim().to_string())
         } else {
             None
         };
@@ -591,7 +605,12 @@ impl HttpServerConfig {
         cognee_components::BackendBuildContext {
             data_root_directory: self.data_root_directory.clone(),
             system_root_directory: self.system_root_directory.clone(),
-            relational_db_url: self.relational_db_url.clone(),
+            // Ensure a file-backed SQLite URL carries `?mode=rwc` so the driver
+            // creates the DB file when missing. The standalone server's default
+            // URL (and operator-provided ones) have no query, and the shared
+            // `build_database` no longer creates the file itself — this restores
+            // the old wire_database "create on boot" behavior via the driver.
+            relational_db_url: ensure_sqlite_rwc(&self.relational_db_url),
             graph_provider: self.graph_provider.to_ascii_lowercase(),
             graph_file_path: self.graph_file_path.to_string_lossy().into_owned(),
             // The standalone server supports only the embedded ladybug graph;

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -586,7 +586,11 @@ impl HttpServerConfig {
         // surrounding whitespace reaches PgVectorAdapter::new cleanly (the
         // validator checks the trimmed form).
         let vector_postgres_url = if vector_provider == "pgvector" {
-            Some(self.vector_db_url.trim().to_string())
+            // Already validated as a postgres URL by wire_vector_db; trim so a
+            // copy-pasted value with surrounding whitespace reaches the adapter
+            // cleanly. Wrapped in `Ok` — the standalone server assembles this URL
+            // directly, so resolution never fails here.
+            Some(Ok(self.vector_db_url.trim().to_string()))
         } else {
             None
         };
@@ -601,6 +605,13 @@ impl HttpServerConfig {
         } else {
             Some(self.embedding_api_key.expose_secret().to_string())
         };
+
+        // Source embedding scalar + ONNX-asset defaults from the embedding
+        // crate's own constructors rather than duplicating magic literals here
+        // (this crate always enables `cognee-embedding/onnx`, so both are
+        // available). Keeps these in lockstep with the embedding crate.
+        let emb_defaults = cognee_embedding::EmbeddingConfig::default();
+        let onnx_defaults = cognee_embedding::OnnxEmbeddingConfig::default();
 
         cognee_components::BackendBuildContext {
             data_root_directory: self.data_root_directory.clone(),
@@ -626,26 +637,26 @@ impl HttpServerConfig {
                 dimensions: self.embedding_dimensions as usize,
                 endpoint,
                 api_key,
-                batch_size: 36,
+                batch_size: emb_defaults.batch_size,
                 mock: false,
                 mock_deterministic: false,
                 api_version: None,
                 huggingface_tokenizer: None,
-                max_completion_tokens: 8191,
-                // Preserve the historical fallback: when no explicit ONNX asset
-                // path is configured, use the BGE-Small default paths under
-                // `./target/models` (matches `OnnxEmbeddingConfig::default()`).
-                onnx_model_path: self.embedding_model_path.clone().unwrap_or_else(|| {
-                    PathBuf::from("./target/models/BGE-Small-v1.5-model_quantized.onnx")
-                }),
+                max_completion_tokens: emb_defaults.max_completion_tokens,
+                // When no explicit ONNX asset path is configured, fall back to
+                // the embedding crate's own BGE-Small defaults.
+                onnx_model_path: self
+                    .embedding_model_path
+                    .clone()
+                    .unwrap_or(onnx_defaults.model_path),
                 onnx_tokenizer_path: self
                     .embedding_tokenizer_path
                     .clone()
-                    .unwrap_or_else(|| PathBuf::from("./target/models/bge-small-tokenizer.json")),
+                    .unwrap_or(onnx_defaults.tokenizer_path),
                 onnx_model_name: self.embedding_model_name.clone(),
                 onnx_dimensions: self.embedding_dimensions as usize,
-                onnx_max_sequence_length: 512,
-                onnx_batch_size: 32,
+                onnx_max_sequence_length: onnx_defaults.max_sequence_length,
+                onnx_batch_size: onnx_defaults.batch_size,
             },
             llm: cognee_components::LlmInputs {
                 provider: self.llm_provider.to_ascii_lowercase(),

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -559,6 +559,88 @@ impl HttpServerConfig {
 }
 
 impl HttpServerConfig {
+    /// Lower these settings into a [`cognee_components::BackendBuildContext`].
+    ///
+    /// Unlike `cognee-lib`'s `Settings::backend_context`, the standalone server
+    /// deliberately does **not** read `MOCK_LLM` / `MOCK_EMBEDDING` or wire the
+    /// recording path: a production server must never silently honor those.
+    /// Mock backends are opt-in through the `dev-mock` feature + an explicit
+    /// `vector_provider="mock"`.
+    pub fn backend_context(&self) -> cognee_components::BackendBuildContext {
+        let vector_provider = self.vector_provider.to_ascii_lowercase();
+        // The pgvector coherence guard runs in `wire_vector_db` before build;
+        // by the time the factory runs, `vector_db_url` is a validated
+        // `postgres://…` string.
+        let vector_postgres_url = if vector_provider == "pgvector" {
+            Some(self.vector_db_url.clone())
+        } else {
+            None
+        };
+
+        let endpoint = if self.embedding_endpoint.trim().is_empty() {
+            None
+        } else {
+            Some(self.embedding_endpoint.clone())
+        };
+        let api_key = if self.embedding_api_key.expose_secret().is_empty() {
+            None
+        } else {
+            Some(self.embedding_api_key.expose_secret().to_string())
+        };
+
+        cognee_components::BackendBuildContext {
+            data_root_directory: self.data_root_directory.clone(),
+            system_root_directory: self.system_root_directory.clone(),
+            relational_db_url: self.relational_db_url.clone(),
+            graph_provider: self.graph_provider.to_ascii_lowercase(),
+            graph_file_path: self.graph_file_path.to_string_lossy().into_owned(),
+            // The standalone server supports only the embedded ladybug graph;
+            // Postgres graph is not wired here.
+            graph_postgres_url: None,
+            vector_provider,
+            vector_db_url: self.vector_db_url.clone(),
+            vector_postgres_url,
+            embedding_dimensions: self.embedding_dimensions as usize,
+            embedding: cognee_components::EmbeddingInputs {
+                provider: self.embedding_provider.trim().to_ascii_lowercase(),
+                model: self.embedding_model_name.clone(),
+                dimensions: self.embedding_dimensions as usize,
+                endpoint,
+                api_key,
+                batch_size: 36,
+                mock: false,
+                mock_deterministic: false,
+                api_version: None,
+                huggingface_tokenizer: None,
+                max_completion_tokens: 8191,
+                // Preserve the historical fallback: when no explicit ONNX asset
+                // path is configured, use the BGE-Small default paths under
+                // `./target/models` (matches `OnnxEmbeddingConfig::default()`).
+                onnx_model_path: self.embedding_model_path.clone().unwrap_or_else(|| {
+                    PathBuf::from("./target/models/BGE-Small-v1.5-model_quantized.onnx")
+                }),
+                onnx_tokenizer_path: self
+                    .embedding_tokenizer_path
+                    .clone()
+                    .unwrap_or_else(|| PathBuf::from("./target/models/bge-small-tokenizer.json")),
+                onnx_model_name: self.embedding_model_name.clone(),
+                onnx_dimensions: self.embedding_dimensions as usize,
+                onnx_max_sequence_length: 512,
+                onnx_batch_size: 32,
+            },
+            llm: cognee_components::LlmInputs {
+                provider: self.llm_provider.to_ascii_lowercase(),
+                model: self.llm_model.clone(),
+                api_key: self.llm_api_key.expose_secret().to_string(),
+                endpoint: self.llm_endpoint.clone(),
+                max_retries: self.llm_max_retries,
+                mock: false,
+                cassette: String::new(),
+                record_path: String::new(),
+            },
+        }
+    }
+
     /// Build a `RegistryConfig` from the matching `HttpServerConfig` fields.
     pub fn to_registry_config(&self) -> RegistryConfig {
         RegistryConfig {

--- a/crates/http-server/src/error.rs
+++ b/crates/http-server/src/error.rs
@@ -423,6 +423,10 @@ pub enum ServerError {
     #[error("lifecycle error: {0}")]
     Lifecycle(#[from] crate::lifecycle::LifecycleError),
 
+    /// Component construction failed (shared `cognee-components` factories).
+    #[error("component error: {0}")]
+    Component(#[from] cognee_components::ComponentError),
+
     /// Catch-all for other startup failures.
     #[error("server error: {0}")]
     Other(#[from] anyhow::Error),

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -347,12 +347,16 @@ mod tests {
             ..Default::default()
         };
         let ctx = cfg.backend_context();
+        // Normalize separators so the assertion holds on Windows too (PathBuf
+        // stringifies with `\`).
+        let model_path = ctx
+            .embedding
+            .onnx_model_path
+            .to_string_lossy()
+            .replace('\\', "/");
         assert!(
-            ctx.embedding
-                .onnx_model_path
-                .to_string_lossy()
-                .contains("target/models"),
-            "unset ONNX model path must fall back to the ./target/models default"
+            model_path.contains("target/models"),
+            "unset ONNX model path must fall back to the ./target/models default, got {model_path}"
         );
     }
 

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -59,7 +59,7 @@ pub async fn wire_default_backends_with(
     // Required backends — a failure here aborts startup.
     let storage = build_storage(&ctx).await?;
     let database = build_database(&ctx).await?;
-    let graph_db = wire_graph_db(cfg, registry, &ctx).await?;
+    let graph_db = wire_graph_db(registry, &ctx).await?;
     let vector_db = wire_vector_db(cfg, registry, &ctx).await?;
 
     // Optional backends — a failure downgrades to `None` (handlers surface a
@@ -130,19 +130,14 @@ pub async fn wire_default_backends_with(
 }
 
 async fn wire_graph_db(
-    cfg: &HttpServerConfig,
     registry: &ComponentRegistry,
     ctx: &cognee_components::BackendBuildContext,
 ) -> Result<Arc<dyn GraphDBTrait>, ServerError> {
-    // The standalone server ships only the embedded ladybug graph; guard early
-    // with an actionable message rather than the registry's generic
-    // "unregistered provider" error.
-    if !cfg.graph_provider.eq_ignore_ascii_case("ladybug") {
-        return Err(ServerError::Other(anyhow!(
-            "unsupported graph provider '{}'; only 'ladybug' is supported",
-            cfg.graph_provider
-        )));
-    }
+    // Delegate to the registry (like wire_vector_db): it already errors with an
+    // actionable "registered providers: [...]" message for anything it doesn't
+    // know, and — crucially — this keeps the extension seam intact so a
+    // caller-registered graph factory (and the built-in `kuzu` alias) is
+    // reachable, instead of a hardcoded ladybug-only guard rejecting them.
     Ok(registry.build_graph(ctx).await?)
 }
 

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -1,26 +1,28 @@
 //! Construct default standalone backend handles for the HTTP server binary.
+//!
+//! Backend construction is delegated to the shared `cognee-components`
+//! registry; this module owns the eager `ComponentHandles` assembly and the
+//! server-specific policies (required-vs-optional downgrade, the pgvector
+//! coherence guard, session / search / responses wiring).
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use cognee_components::{ComponentRegistry, build_database, build_storage};
 use cognee_core::{CpuPool, RayonThreadPool};
 use cognee_database::{
-    CheckpointStore, DatabaseConnection, DeleteDb, IngestDb, SeaOrmCheckpointStore,
-    SearchHistoryDb, connect, initialize,
+    CheckpointStore, DatabaseConnection, DeleteDb, IngestDb, SeaOrmCheckpointStore, SearchHistoryDb,
 };
 use cognee_delete::DeleteService;
-use cognee_embedding::{EmbeddingConfig, EmbeddingEngine, EmbeddingProvider};
-use cognee_graph::{GraphDBTrait, LadybugAdapter};
-use cognee_llm::{
-    Llm, OpenAIResponsesClient, ResponsesClient, Transcriber, build_openai_compatible_adapter,
-};
+use cognee_embedding::EmbeddingEngine;
+use cognee_graph::GraphDBTrait;
+use cognee_llm::{Llm, OpenAIResponsesClient, ResponsesClient, Transcriber};
 use cognee_ontology::{OntologyManager, OntologyResolver};
 use cognee_search::{
     SeaOrmSessionStore, SearchBuilder, SearchOrchestrator, SessionManager, SessionStore,
 };
-use cognee_storage::{LocalStorage, StorageTrait};
-use cognee_vector::{PgVectorAdapter, VectorDB};
+use cognee_vector::VectorDB;
 use secrecy::ExposeSecret;
 
 use crate::components::ComponentHandles;
@@ -33,20 +35,38 @@ fn ensure_dir(path: &Path) -> Result<(), ServerError> {
         .map_err(|e| ServerError::Other(anyhow!("create_dir_all({}): {e}", path.display())))
 }
 
+/// Wire the default standalone backends using the OSS built-in registry.
 pub async fn wire_default_backends(
     cfg: &HttpServerConfig,
+) -> Result<ComponentHandles, ServerError> {
+    wire_default_backends_with(cfg, &ComponentRegistry::with_builtins()).await
+}
+
+/// Wire the default standalone backends using a caller-supplied registry.
+///
+/// Closed/embedding entry points call this with a registry that has external
+/// adapter factories registered (e.g. qdrant / litert) so a configured
+/// `vector_provider="qdrant"` resolves without editing OSS.
+pub async fn wire_default_backends_with(
+    cfg: &HttpServerConfig,
+    registry: &ComponentRegistry,
 ) -> Result<ComponentHandles, ServerError> {
     ensure_dir(&cfg.data_root_directory)?;
     ensure_dir(&cfg.system_root_directory)?;
 
-    let storage = wire_storage(cfg).await?;
-    let database = wire_database(cfg).await?;
-    let graph_db = wire_graph_db(cfg).await?;
-    let vector_db = wire_vector_db(cfg).await?;
+    let ctx = cfg.backend_context();
 
-    let embedding_engine = wire_embedding_engine(cfg).await;
-    let llm = wire_llm(cfg);
-    let transcriber = wire_transcriber(cfg);
+    // Required backends — a failure here aborts startup.
+    let storage = build_storage(&ctx).await?;
+    let database = build_database(&ctx).await?;
+    let graph_db = wire_graph_db(cfg, registry, &ctx).await?;
+    let vector_db = wire_vector_db(cfg, registry, &ctx).await?;
+
+    // Optional backends — a failure downgrades to `None` (handlers surface a
+    // 500-level envelope at runtime), preserving the historical behavior.
+    let embedding_engine = wire_embedding_engine(registry, &ctx).await;
+    let llm = wire_llm(registry, &ctx).await;
+    let transcriber = wire_transcriber(registry, &ctx).await;
 
     let thread_pool: Option<Arc<dyn CpuPool>> = Some(Arc::new(
         RayonThreadPool::with_default_threads()
@@ -109,159 +129,69 @@ pub async fn wire_default_backends(
     })
 }
 
-async fn wire_storage(cfg: &HttpServerConfig) -> Result<Arc<dyn StorageTrait>, ServerError> {
-    let storage =
-        Arc::new(LocalStorage::new(cfg.data_root_directory.clone())) as Arc<dyn StorageTrait>;
-    storage
-        .initialize()
-        .await
-        .map_err(|e| ServerError::Other(anyhow!("storage init failed: {e}")))?;
-    Ok(storage)
-}
-
-async fn wire_database(cfg: &HttpServerConfig) -> Result<Arc<DatabaseConnection>, ServerError> {
-    let url = cfg.relational_db_url.clone();
-
-    if let Some(path) = url.strip_prefix("sqlite://")
-        && !path.starts_with(':')
-    {
-        let db_path = PathBuf::from(path);
-        if let Some(parent) = db_path.parent() {
-            ensure_dir(parent)?;
-        }
-        if !db_path.exists() {
-            std::fs::File::create(&db_path).map_err(|e| {
-                ServerError::Other(anyhow!("create sqlite file {}: {e}", db_path.display()))
-            })?;
-        }
-    }
-
-    let db = connect(&url)
-        .await
-        .map_err(|e| ServerError::Other(anyhow!("database connect failed: {e}")))?;
-    initialize(&db)
-        .await
-        .map_err(|e| ServerError::Other(anyhow!("database migrate failed: {e}")))?;
-
-    Ok(Arc::new(db))
-}
-
-async fn wire_graph_db(cfg: &HttpServerConfig) -> Result<Arc<dyn GraphDBTrait>, ServerError> {
+async fn wire_graph_db(
+    cfg: &HttpServerConfig,
+    registry: &ComponentRegistry,
+    ctx: &cognee_components::BackendBuildContext,
+) -> Result<Arc<dyn GraphDBTrait>, ServerError> {
+    // The standalone server ships only the embedded ladybug graph; guard early
+    // with an actionable message rather than the registry's generic
+    // "unregistered provider" error.
     if !cfg.graph_provider.eq_ignore_ascii_case("ladybug") {
         return Err(ServerError::Other(anyhow!(
             "unsupported graph provider '{}'; only 'ladybug' is supported",
             cfg.graph_provider
         )));
     }
-
-    if let Some(parent) = cfg.graph_file_path.parent() {
-        ensure_dir(parent)?;
-    }
-
-    let path = cfg.graph_file_path.to_string_lossy().to_string();
-    let graph = LadybugAdapter::new(&path)
-        .await
-        .map_err(|e| ServerError::Other(anyhow!("graph init failed: {e}")))?;
-    graph
-        .initialize()
-        .await
-        .map_err(|e| ServerError::Other(anyhow!("graph schema init failed: {e}")))?;
-    Ok(Arc::new(graph) as Arc<dyn GraphDBTrait>)
+    Ok(registry.build_graph(ctx).await?)
 }
 
-async fn wire_vector_db(cfg: &HttpServerConfig) -> Result<Arc<dyn VectorDB>, ServerError> {
-    // The qdrant adapter has been extracted to the closed `cognee-vector-qdrant`
-    // crate; the OSS http-server wires pgvector as the production default and
-    // exposes an opt-in in-memory mock behind the `dev-mock` feature so local
-    // dev / `cargo test` work without a Postgres instance.
+/// Validate the pgvector configuration. Kept in the server wrapper (not the
+/// shared factory) so `cognee-lib`'s empty-URL→localhost synthesis is
+/// unaffected.
+fn validate_vector_config(cfg: &HttpServerConfig) -> Result<(), ServerError> {
     let provider = cfg.vector_provider.to_ascii_lowercase();
-    match provider.as_str() {
-        "pgvector" => {
-            let url = cfg.vector_db_url.trim();
-            if url.is_empty() {
-                return Err(ServerError::Other(anyhow!(
-                    "VECTOR_DB_URL (postgres connection string) is required when \
-                     VECTOR_DB_PROVIDER=pgvector"
-                )));
-            }
-            // Guard against the incoherent default (VECTOR_DB_PROVIDER unset →
-            // pgvector, VECTOR_DB_URL unset → derived from SYSTEM_ROOT_DIRECTORY,
-            // i.e. a filesystem path). Without this, pgvector reports a cryptic
-            // "connection string '…/vectors' cannot be parsed". Point the
-            // operator at the actual misconfiguration instead.
-            if !(url.starts_with("postgres://") || url.starts_with("postgresql://")) {
-                return Err(ServerError::Other(anyhow!(
-                    "VECTOR_DB_PROVIDER=pgvector requires a postgres connection \
-                     string in VECTOR_DB_URL (postgres://… or postgresql://…), but \
-                     got '{url}'. If you did not intend to use pgvector, set \
-                     VECTOR_DB_PROVIDER explicitly (e.g. 'mock' in a dev-mock \
-                     build); the default derives this value from \
-                     SYSTEM_ROOT_DIRECTORY, which is not a valid Postgres URL."
-                )));
-            }
-            let adapter = PgVectorAdapter::new(url, cfg.embedding_dimensions as usize)
-                .await
-                .map_err(|e| ServerError::Other(anyhow!("pgvector adapter init: {e}")))?;
-            Ok(Arc::new(adapter) as Arc<dyn VectorDB>)
-        }
-        #[cfg(feature = "dev-mock")]
-        "mock" => {
-            // OSS single-user dev path — keeps `cargo test` + local dev working
-            // without a Postgres instance. Off in production builds.
-            // The `dev-mock` feature enables `cognee-vector/testing`, which
-            // is where `MockVectorDB` actually lives.
-            Ok(Arc::new(cognee_vector::MockVectorDB::new()) as Arc<dyn VectorDB>)
-        }
-        other => Err(ServerError::Other(anyhow!(
-            "vector_db_provider='{other}' not supported in the OSS http-server. \
-             Supported: 'pgvector' (and 'mock' when built with the `dev-mock` \
-             feature). The Qdrant adapter has been extracted to the closed \
-             cognee-vector-qdrant crate."
-        ))),
+    if provider != "pgvector" {
+        return Ok(());
     }
+    let url = cfg.vector_db_url.trim();
+    if url.is_empty() {
+        return Err(ServerError::Other(anyhow!(
+            "VECTOR_DB_URL (postgres connection string) is required when \
+             VECTOR_DB_PROVIDER=pgvector"
+        )));
+    }
+    // Guard against the incoherent default (VECTOR_DB_PROVIDER unset → pgvector,
+    // VECTOR_DB_URL unset → derived from SYSTEM_ROOT_DIRECTORY, i.e. a
+    // filesystem path). Without this, pgvector reports a cryptic "connection
+    // string '…/vectors' cannot be parsed". Point the operator at the actual
+    // misconfiguration instead.
+    if !(url.starts_with("postgres://") || url.starts_with("postgresql://")) {
+        return Err(ServerError::Other(anyhow!(
+            "VECTOR_DB_PROVIDER=pgvector requires a postgres connection string in \
+             VECTOR_DB_URL (postgres://… or postgresql://…), but got '{url}'. If you \
+             did not intend to use pgvector, set VECTOR_DB_PROVIDER explicitly (e.g. \
+             'mock' in a dev-mock build); the default derives this value from \
+             SYSTEM_ROOT_DIRECTORY, which is not a valid Postgres URL."
+        )));
+    }
+    Ok(())
 }
 
-fn build_embedding_config(cfg: &HttpServerConfig) -> Option<EmbeddingConfig> {
-    let provider = match cfg.embedding_provider.trim().to_ascii_lowercase().as_str() {
-        "onnx" => EmbeddingProvider::Onnx,
-        "fastembed" => EmbeddingProvider::Fastembed,
-        "openai" => EmbeddingProvider::OpenAi,
-        "openai_compatible" => EmbeddingProvider::OpenAiCompatible,
-        "ollama" => EmbeddingProvider::Ollama,
-        "mock" => EmbeddingProvider::Mock,
-        other => {
-            tracing::warn!("unknown embedding provider '{other}', embedding engine not wired");
-            return None;
-        }
-    };
-    let mut embedding_cfg = EmbeddingConfig {
-        provider,
-        model: cfg.embedding_model_name.clone(),
-        dimensions: cfg.embedding_dimensions as usize,
-        ..Default::default()
-    };
-    if !cfg.embedding_endpoint.trim().is_empty() {
-        embedding_cfg.endpoint = Some(cfg.embedding_endpoint.clone());
-    }
-    if !cfg.embedding_api_key.expose_secret().is_empty() {
-        embedding_cfg.api_key = Some(cfg.embedding_api_key.expose_secret().to_string());
-    }
-    embedding_cfg.onnx.model_name = cfg.embedding_model_name.clone();
-    embedding_cfg.onnx.dimensions = cfg.embedding_dimensions as usize;
-    if let Some(model_path) = &cfg.embedding_model_path {
-        embedding_cfg.onnx.model_path = model_path.clone();
-    }
-    if let Some(tokenizer_path) = &cfg.embedding_tokenizer_path {
-        embedding_cfg.onnx.tokenizer_path = tokenizer_path.clone();
-    }
-
-    Some(embedding_cfg)
+async fn wire_vector_db(
+    cfg: &HttpServerConfig,
+    registry: &ComponentRegistry,
+    ctx: &cognee_components::BackendBuildContext,
+) -> Result<Arc<dyn VectorDB>, ServerError> {
+    validate_vector_config(cfg)?;
+    Ok(registry.build_vector(ctx).await?)
 }
 
-async fn wire_embedding_engine(cfg: &HttpServerConfig) -> Option<Arc<dyn EmbeddingEngine>> {
-    let embedding_cfg = build_embedding_config(cfg)?;
-
-    match embedding_cfg.create_engine().await {
+async fn wire_embedding_engine(
+    registry: &ComponentRegistry,
+    ctx: &cognee_components::BackendBuildContext,
+) -> Option<Arc<dyn EmbeddingEngine>> {
+    match registry.build_embedding(ctx).await {
         Ok(engine) => Some(engine),
         Err(err) => {
             tracing::warn!("embedding engine unavailable, wiring as None: {err}");
@@ -270,42 +200,34 @@ async fn wire_embedding_engine(cfg: &HttpServerConfig) -> Option<Arc<dyn Embeddi
     }
 }
 
-fn wire_llm(cfg: &HttpServerConfig) -> Option<Arc<dyn Llm>> {
-    // Provider routing (and the required-key / required-endpoint validation) lives
-    // in the shared factory; an unsupported provider or missing credential errors
-    // there and we wire None.
-    match build_openai_compatible_adapter(
-        &cfg.llm_provider,
-        &cfg.llm_model,
-        cfg.llm_api_key.expose_secret(),
-        &cfg.llm_endpoint,
-        cfg.llm_max_retries,
-    ) {
-        Ok(adapter) => Some(Arc::new(adapter) as Arc<dyn Llm>),
+fn wire_llm_downgrade<T>(
+    result: Result<T, cognee_components::ComponentError>,
+    what: &str,
+) -> Option<T> {
+    match result {
+        Ok(v) => Some(v),
         Err(err) => {
-            tracing::warn!("llm not wired: {err}");
+            tracing::warn!("{what} not wired: {err}");
             None
         }
     }
 }
 
-fn wire_transcriber(cfg: &HttpServerConfig) -> Option<Arc<dyn Transcriber>> {
-    // Whisper-style transcription only works against OpenAI and user-pointed
-    // OpenAI-compatible servers that expose /audio/transcriptions; other providers
-    // get graceful no-audio (None).
-    let provider = cfg.llm_provider.to_ascii_lowercase();
-    if !matches!(provider.as_str(), "openai" | "custom" | "openai_compatible") {
-        return None;
-    }
+async fn wire_llm(
+    registry: &ComponentRegistry,
+    ctx: &cognee_components::BackendBuildContext,
+) -> Option<Arc<dyn Llm>> {
+    wire_llm_downgrade(registry.build_llm(ctx).await, "llm")
+}
 
-    match build_openai_compatible_adapter(
-        &cfg.llm_provider,
-        &cfg.llm_model,
-        cfg.llm_api_key.expose_secret(),
-        &cfg.llm_endpoint,
-        cfg.llm_max_retries,
-    ) {
-        Ok(adapter) => Some(Arc::new(adapter) as Arc<dyn Transcriber>),
+async fn wire_transcriber(
+    registry: &ComponentRegistry,
+    ctx: &cognee_components::BackendBuildContext,
+) -> Option<Arc<dyn Transcriber>> {
+    // `build_transcriber` already yields `Ok(None)` for providers without audio
+    // support; a hard error (bad credentials) downgrades to None as before.
+    match registry.build_transcriber(ctx).await {
+        Ok(opt) => opt,
         Err(err) => {
             tracing::warn!("transcriber not wired: {err}");
             None
@@ -403,9 +325,10 @@ fn wire_responses_client(cfg: &HttpServerConfig) -> Option<Arc<dyn ResponsesClie
 )]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
-    fn build_embedding_config_applies_explicit_onnx_asset_paths() {
+    fn backend_context_applies_explicit_onnx_asset_paths() {
         let cfg = HttpServerConfig {
             embedding_provider: "onnx".to_string(),
             embedding_model_name: "custom-bge".to_string(),
@@ -415,20 +338,38 @@ mod tests {
             ..Default::default()
         };
 
-        let embedding_cfg = build_embedding_config(&cfg).expect("embedding config");
+        let ctx = cfg.backend_context();
 
-        assert_eq!(embedding_cfg.provider, EmbeddingProvider::Onnx);
-        assert_eq!(embedding_cfg.model, "custom-bge");
-        assert_eq!(embedding_cfg.dimensions, 768);
-        assert_eq!(embedding_cfg.onnx.model_name, "custom-bge");
-        assert_eq!(embedding_cfg.onnx.dimensions, 768);
+        assert_eq!(ctx.embedding.provider, "onnx");
+        assert_eq!(ctx.embedding.model, "custom-bge");
+        assert_eq!(ctx.embedding.dimensions, 768);
+        assert_eq!(ctx.embedding.onnx_model_name, "custom-bge");
+        assert_eq!(ctx.embedding.onnx_dimensions, 768);
         assert_eq!(
-            embedding_cfg.onnx.model_path,
+            ctx.embedding.onnx_model_path,
             PathBuf::from("/tmp/model.onnx")
         );
         assert_eq!(
-            embedding_cfg.onnx.tokenizer_path,
+            ctx.embedding.onnx_tokenizer_path,
             PathBuf::from("/tmp/tokenizer.json")
+        );
+    }
+
+    #[test]
+    fn backend_context_defaults_onnx_paths_when_unset() {
+        let cfg = HttpServerConfig {
+            embedding_provider: "onnx".to_string(),
+            embedding_model_path: None,
+            embedding_tokenizer_path: None,
+            ..Default::default()
+        };
+        let ctx = cfg.backend_context();
+        assert!(
+            ctx.embedding
+                .onnx_model_path
+                .to_string_lossy()
+                .contains("target/models"),
+            "unset ONNX model path must fall back to the ./target/models default"
         );
     }
 
@@ -453,11 +394,14 @@ mod tests {
             Ok(_) => String::new(),
             Err(err) => err.to_string(),
         };
-        assert!(msg.contains("database connect failed"));
+        assert!(
+            msg.contains("initialization failed") || msg.contains("component error"),
+            "expected a database init failure, got: {msg}"
+        );
     }
 
-    #[tokio::test]
-    async fn wire_vector_db_pgvector_rejects_non_postgres_url() {
+    #[test]
+    fn validate_vector_config_pgvector_rejects_non_postgres_url() {
         // The incoherent default (VECTOR_DB_PROVIDER unset → pgvector, plus a
         // VECTOR_DB_URL derived from SYSTEM_ROOT_DIRECTORY → a filesystem path)
         // must fail with an actionable message, not the cryptic connection-
@@ -468,8 +412,8 @@ mod tests {
             ..Default::default()
         };
 
-        let msg = match wire_vector_db(&cfg).await {
-            Ok(_) => String::new(),
+        let msg = match validate_vector_config(&cfg) {
+            Ok(()) => String::new(),
             Err(err) => err.to_string(),
         };
         assert!(

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -187,23 +187,10 @@ async fn wire_vector_db(
     Ok(registry.build_vector(ctx).await?)
 }
 
-async fn wire_embedding_engine(
-    registry: &ComponentRegistry,
-    ctx: &cognee_components::BackendBuildContext,
-) -> Option<Arc<dyn EmbeddingEngine>> {
-    match registry.build_embedding(ctx).await {
-        Ok(engine) => Some(engine),
-        Err(err) => {
-            tracing::warn!("embedding engine unavailable, wiring as None: {err}");
-            None
-        }
-    }
-}
-
-fn wire_llm_downgrade<T>(
-    result: Result<T, cognee_components::ComponentError>,
-    what: &str,
-) -> Option<T> {
+/// Downgrade a required-backend build error to `None` with a warning — the
+/// standalone server's policy for the optional (search/llm/audio) backends,
+/// which surface a 500-level envelope at runtime when unwired.
+fn downgrade<T>(result: Result<T, cognee_components::ComponentError>, what: &str) -> Option<T> {
     match result {
         Ok(v) => Some(v),
         Err(err) => {
@@ -213,11 +200,18 @@ fn wire_llm_downgrade<T>(
     }
 }
 
+async fn wire_embedding_engine(
+    registry: &ComponentRegistry,
+    ctx: &cognee_components::BackendBuildContext,
+) -> Option<Arc<dyn EmbeddingEngine>> {
+    downgrade(registry.build_embedding(ctx).await, "embedding engine")
+}
+
 async fn wire_llm(
     registry: &ComponentRegistry,
     ctx: &cognee_components::BackendBuildContext,
 ) -> Option<Arc<dyn Llm>> {
-    wire_llm_downgrade(registry.build_llm(ctx).await, "llm")
+    downgrade(registry.build_llm(ctx).await, "llm")
 }
 
 async fn wire_transcriber(
@@ -226,13 +220,7 @@ async fn wire_transcriber(
 ) -> Option<Arc<dyn Transcriber>> {
     // `build_transcriber` already yields `Ok(None)` for providers without audio
     // support; a hard error (bad credentials) downgrades to None as before.
-    match registry.build_transcriber(ctx).await {
-        Ok(opt) => opt,
-        Err(err) => {
-            tracing::warn!("transcriber not wired: {err}");
-            None
-        }
-    }
+    downgrade(registry.build_transcriber(ctx).await, "transcriber").flatten()
 }
 
 async fn wire_session(

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -70,15 +70,15 @@ default = [
 ]
 # Record/replay cassette-based mock LLM support (MOCK_LLM / COGNEE_RECORD_LLM).
 # Pulls in no heavy deps, so it is default-on.
-mock-llm       = ["cognee-llm/mock"]
+mock-llm       = ["cognee-llm/mock", "cognee-components/mock-llm"]
 visualization  = ["dep:cognee-visualization"]
-onnx           = ["cognee-embedding/onnx"]
-onnx-dynamic   = ["cognee-embedding/onnx-dynamic"]
-ort-cuda       = ["cognee-embedding/ort-cuda"]
-ort-tensorrt   = ["cognee-embedding/ort-tensorrt"]
-ladybug        = ["cognee-graph/ladybug"]
-pgvector       = ["cognee-vector/pgvector", "dep:url"]
-pggraph        = ["cognee-graph/postgres", "dep:url"]
+onnx           = ["cognee-embedding/onnx", "cognee-components/onnx"]
+onnx-dynamic   = ["cognee-embedding/onnx-dynamic", "cognee-components/onnx-dynamic"]
+ort-cuda       = ["cognee-embedding/ort-cuda", "cognee-components/ort-cuda"]
+ort-tensorrt   = ["cognee-embedding/ort-tensorrt", "cognee-components/ort-tensorrt"]
+ladybug        = ["cognee-graph/ladybug", "cognee-components/ladybug"]
+pgvector       = ["cognee-vector/pgvector", "cognee-components/pgvector", "dep:url"]
+pggraph        = ["cognee-graph/postgres", "cognee-components/pggraph", "dep:url"]
 sqlite         = ["cognee-database/sqlite"]
 postgres       = ["cognee-database/postgres"]
 hf-tokenizer   = ["cognee-chunking/hf-tokenizer"]
@@ -138,12 +138,14 @@ testing = [
     "cognee-graph/testing",
     "cognee-storage/testing",
     "cognee-vector/testing",
+    "cognee-components/testing",
 ]
 
 [dependencies]
 cognee-chunking = { path = "../chunking", version = "0.1.3" }
 cognee-utils = { path = "../utils", version = "0.1.3" }
 cognee-cognify = { path = "../cognify", version = "0.1.3" }
+cognee-components = { path = "../components", version = "0.1.3", default-features = false }
 cognee-core = { path = "../core", version = "0.1.3", features = ["pipeline-run-registry"] }
 cognee-delete = { path = "../delete", version = "0.1.3" }
 cognee-database = { path = "../database", version = "0.1.3" }

--- a/crates/lib/src/component_manager.rs
+++ b/crates/lib/src/component_manager.rs
@@ -48,6 +48,10 @@ pub struct ComponentManager {
     // the version-keyed cache envelope.
     #[allow(clippy::type_complexity)]
     transcriber: TokioRwLock<Option<(u64, Option<Arc<dyn Transcriber>>)>>,
+    // Version-keyed cache of the lowered build context, so `Settings::backend_context`
+    // (env reads + the Postgres credential-fallback warning) runs once per config
+    // version instead of once per component (7×).
+    context: TokioRwLock<Option<(u64, cognee_components::BackendBuildContext)>>,
 }
 
 impl ComponentManager {
@@ -70,6 +74,7 @@ impl ComponentManager {
             embedding_engine: TokioRwLock::new(None),
             llm: TokioRwLock::new(None),
             transcriber: TokioRwLock::new(None),
+            context: TokioRwLock::new(None),
         }
     }
 
@@ -91,41 +96,63 @@ impl ComponentManager {
         &self.registry
     }
 
-    /// Snapshot the current settings into an owned, `Send` build context.
+    /// Return the lowered build context for the current config version.
     ///
-    /// Binding the context to a local drops the (non-`Send`) config read guard
-    /// before any `.await`, keeping the delegating futures `Send`.
-    fn build_context(&self) -> cognee_components::BackendBuildContext {
-        self.config.read().backend_context()
+    /// Cached per config version: `Settings::backend_context` reads several env
+    /// vars and may emit the Postgres credential-fallback warning, so building it
+    /// once per version (rather than once per component) avoids duplicated work
+    /// and duplicated warnings. The returned owned context is `Send`, so binding
+    /// it to a local before an `.await` keeps the delegating futures `Send`.
+    async fn build_context(&self) -> cognee_components::BackendBuildContext {
+        let current_ver = self.config.version();
+        {
+            let guard = self.context.read().await;
+            if let Some((ver, ctx)) = &*guard
+                && *ver == current_ver
+            {
+                return ctx.clone();
+            }
+        }
+        let mut guard = self.context.write().await;
+        if let Some((ver, ctx)) = &*guard
+            && *ver == current_ver
+        {
+            return ctx.clone();
+        }
+        // No `.await` between the config read and storing the result, so the
+        // (non-`Send`) settings guard never crosses an await point.
+        let ctx = self.config.read().backend_context();
+        *guard = Some((current_ver, ctx.clone()));
+        ctx
     }
 
     async fn init_storage(&self) -> Result<Arc<dyn StorageTrait>, ComponentError> {
-        let ctx = self.build_context();
+        let ctx = self.build_context().await;
         cognee_components::build_storage(&ctx).await
     }
 
     async fn init_database(&self) -> Result<Arc<DatabaseConnection>, ComponentError> {
-        let ctx = self.build_context();
+        let ctx = self.build_context().await;
         cognee_components::build_database(&ctx).await
     }
 
     async fn init_graph_db(&self) -> Result<Arc<dyn GraphDBTrait>, ComponentError> {
-        let ctx = self.build_context();
+        let ctx = self.build_context().await;
         self.registry.build_graph(&ctx).await
     }
 
     async fn init_vector_db(&self) -> Result<Arc<dyn VectorDB>, ComponentError> {
-        let ctx = self.build_context();
+        let ctx = self.build_context().await;
         self.registry.build_vector(&ctx).await
     }
 
     async fn init_embedding_engine(&self) -> Result<Arc<dyn EmbeddingEngine>, ComponentError> {
-        let ctx = self.build_context();
+        let ctx = self.build_context().await;
         self.registry.build_embedding(&ctx).await
     }
 
     async fn init_llm(&self) -> Result<Arc<dyn Llm>, ComponentError> {
-        let ctx = self.build_context();
+        let ctx = self.build_context().await;
         self.registry.build_llm(&ctx).await
     }
 
@@ -152,7 +179,7 @@ impl ComponentManager {
         {
             return Ok(opt.clone());
         }
-        let ctx = self.build_context();
+        let ctx = self.build_context().await;
         let new = self.registry.build_transcriber(&ctx).await?;
         *guard = Some((current_ver, new.clone()));
         Ok(new)

--- a/crates/lib/src/component_manager.rs
+++ b/crates/lib/src/component_manager.rs
@@ -1,55 +1,27 @@
 //! ComponentManager: lazy-initializing, shared component store.
+//!
+//! Construction logic lives in `cognee-components`; this type owns the
+//! version-keyed cache and delegates each backend build to a
+//! [`ComponentRegistry`]. Supply a custom registry via [`ComponentManager::with_registry`]
+//! to plug in external adapters (e.g. the closed qdrant / litert factories);
+//! [`ComponentManager::new`] uses [`ComponentRegistry::with_builtins`].
 
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use tokio::sync::RwLock as TokioRwLock;
 
-use cognee_database::{DatabaseConnection, connect, initialize};
-use cognee_embedding::{EmbeddingConfig, EmbeddingEngine, EmbeddingProvider};
+use cognee_components::ComponentRegistry;
+use cognee_database::DatabaseConnection;
+use cognee_embedding::EmbeddingEngine;
 use cognee_graph::GraphDBTrait;
-#[cfg(feature = "ladybug")]
-use cognee_graph::LadybugAdapter;
-#[cfg(feature = "pggraph")]
-use cognee_graph::PgGraphAdapter;
-use cognee_llm::{Llm, Transcriber, build_openai_compatible_adapter};
-use cognee_storage::{LocalStorage, StorageTrait};
-#[cfg(feature = "pgvector")]
-use cognee_vector::PgVectorAdapter;
-use cognee_vector::{BruteForceVectorDB, VectorDB};
+use cognee_llm::{Llm, Transcriber};
+use cognee_storage::StorageTrait;
+use cognee_vector::VectorDB;
 
 use crate::config::{ConfigManager, Settings};
 use crate::context::PipelineContext;
 use crate::error::ComponentError;
-
-/// Assemble a `postgres://user:pass@host:port/dbname` URL with percent-encoded
-/// credentials. Shared by the vector and graph URL resolvers.
-#[cfg(any(feature = "pgvector", feature = "pggraph"))]
-fn build_postgres_url(
-    host: &str,
-    port: u16,
-    name: &str,
-    user: &str,
-    pass: &str,
-) -> Result<String, String> {
-    #[allow(clippy::expect_used, reason = "invariant is upheld by construction")]
-    let mut parsed = url::Url::parse("postgres://localhost").expect("static URL is always valid");
-    parsed
-        .set_host(Some(host))
-        .map_err(|e| format!("invalid host '{host}': {e}"))?;
-    parsed
-        .set_port(Some(port))
-        .map_err(|_| format!("invalid port {port}"))?;
-    parsed.set_path(&format!("/{name}"));
-    parsed
-        .set_username(user)
-        .map_err(|_| format!("invalid username '{user}'"))?;
-    parsed
-        .set_password(Some(pass))
-        .map_err(|_| "invalid password".to_string())?;
-    Ok(parsed.to_string())
-}
 
 /// Manages shared, lazily-initialized pipeline components.
 ///
@@ -57,10 +29,11 @@ fn build_postgres_url(
 /// When the underlying [`ConfigManager`]'s version advances (due to a setter
 /// call), cached components are lazily re-created on the next access.
 ///
-/// Constructed from [`ConfigManager`] — typically loaded once via
-/// `ConfigManager::from_env()` or `ConfigManager::new(settings)`.
+/// Backend construction is delegated to a [`ComponentRegistry`]; the cache
+/// policy and the transcriber's bespoke `Option<Arc>` slot live here.
 pub struct ComponentManager {
     config: ConfigManager,
+    registry: ComponentRegistry,
     // Each cached component stores (version_at_creation, component_arc).
     // When the config version advances past the cached version, the
     // component is lazily re-created on next access.
@@ -78,9 +51,18 @@ pub struct ComponentManager {
 }
 
 impl ComponentManager {
+    /// Construct with the OSS built-in registry
+    /// ([`ComponentRegistry::with_builtins`]).
     pub fn new(config: ConfigManager) -> Self {
+        Self::with_registry(config, ComponentRegistry::with_builtins())
+    }
+
+    /// Construct with an explicit registry. Use this to inject external adapter
+    /// factories (register them on the registry before passing it in).
+    pub fn with_registry(config: ConfigManager, registry: ComponentRegistry) -> Self {
         Self {
             config,
+            registry,
             storage: TokioRwLock::new(None),
             database: TokioRwLock::new(None),
             graph_db: TokioRwLock::new(None),
@@ -104,590 +86,53 @@ impl ComponentManager {
         &self.config
     }
 
+    /// Access the component registry (e.g. to inspect registered providers).
+    pub fn registry(&self) -> &ComponentRegistry {
+        &self.registry
+    }
+
+    /// Snapshot the current settings into an owned, `Send` build context.
+    ///
+    /// Binding the context to a local drops the (non-`Send`) config read guard
+    /// before any `.await`, keeping the delegating futures `Send`.
+    fn build_context(&self) -> cognee_components::BackendBuildContext {
+        self.config.read().backend_context()
+    }
+
     async fn init_storage(&self) -> Result<Arc<dyn StorageTrait>, ComponentError> {
-        let data_root = self.config.read().data_root_directory.clone();
-        let storage = LocalStorage::new(PathBuf::from(&data_root));
-        storage
-            .initialize()
-            .await
-            .map_err(|e| ComponentError::Storage(format!("initialization failed: {e}")))?;
-        Ok(Arc::new(storage))
+        let ctx = self.build_context();
+        cognee_components::build_storage(&ctx).await
     }
 
     async fn init_database(&self) -> Result<Arc<DatabaseConnection>, ComponentError> {
-        let url = self.config.read().resolved_relational_db_url();
-
-        // For SQLite file-backed databases, ensure the parent directory exists
-        // before handing the URL to sea-orm.  sea-orm's `?mode=rwc` creates the
-        // *file* but not missing ancestor directories, so without this step any
-        // settings override that redirects the DB to a new path (e.g. per-test
-        // isolation) would fail with "unable to open database file".
-        //
-        // URL shapes we handle:
-        //   sqlite:./rel/path/db       (relative, 1-slash)
-        //   sqlite:///abs/path/db      (absolute, 3-slash)
-        //   sqlite://localhost/abs/db  (host form)
-        // All others (postgres, in-memory `sqlite::memory:`) are left alone.
-        if url.starts_with("sqlite:") && !url.contains(":memory:") {
-            // Strip the sqlite: scheme and any leading host ("//localhost") or
-            // extra slashes to get the raw filesystem path (before '?').
-            let after_scheme = url.trim_start_matches("sqlite:");
-            let path_part = if after_scheme.starts_with("//localhost/") {
-                Some(&after_scheme["//localhost".len()..])
-            } else if after_scheme.starts_with("///") {
-                // sqlite:///abs/path — empty authority, absolute path.
-                Some(&after_scheme[2..])
-            } else if after_scheme.starts_with("//") {
-                // sqlite://somehost/... — genuine host form; leave entirely to
-                // the driver instead of attempting create_dir_all("//somehost").
-                None
-            } else {
-                Some(after_scheme)
-            };
-            // Drop query string (e.g. ?mode=rwc).
-            if let Some(path_part) = path_part {
-                let path_no_query = path_part.split('?').next().unwrap_or(path_part);
-                let db_path = Path::new(path_no_query);
-                if let Some(parent) = db_path.parent()
-                    && !parent.as_os_str().is_empty()
-                {
-                    // Non-fatal: an unusual-but-driver-valid URL must still
-                    // reach sea-orm and surface the driver's own error.
-                    if let Err(e) = std::fs::create_dir_all(parent) {
-                        tracing::warn!(
-                            "could not create SQLite parent directory '{}': {e}",
-                            parent.display()
-                        );
-                    }
-                }
-            }
-        }
-
-        let db = connect(&url)
-            .await
-            .map_err(|e| ComponentError::Database(format!("initialization failed: {e}")))?;
-        initialize(&db)
-            .await
-            .map_err(|e| ComponentError::Database(format!("schema initialization failed: {e}")))?;
-        Ok(Arc::new(db))
+        let ctx = self.build_context();
+        cognee_components::build_database(&ctx).await
     }
 
     async fn init_graph_db(&self) -> Result<Arc<dyn GraphDBTrait>, ComponentError> {
-        let provider = self.config.read().graph_database_provider.to_lowercase();
-
-        match provider.as_str() {
-            "ladybug" | "kuzu" => self.init_ladybug_graph_db().await,
-
-            #[cfg(feature = "pggraph")]
-            "postgres" | "postgresql" => {
-                let url = {
-                    let s = self.config.read();
-                    self.resolved_graph_db_url(&s)?
-                };
-                let adapter = PgGraphAdapter::new(&url)
-                    .await
-                    .map_err(|e| ComponentError::GraphDb(format!("pggraph init failed: {e}")))?;
-                Ok(Arc::new(adapter))
-            }
-
-            #[cfg(not(feature = "pggraph"))]
-            "postgres" | "postgresql" => Err(ComponentError::Config(
-                "graph_database_provider=postgres requires the `pggraph` crate feature".into(),
-            )),
-
-            other => Err(ComponentError::Config(format!(
-                "Unsupported graph_database_provider '{other}'. Supported: ladybug, kuzu, postgres.",
-            ))),
-        }
-    }
-
-    async fn init_ladybug_graph_db(&self) -> Result<Arc<dyn GraphDBTrait>, ComponentError> {
-        let graph_path = {
-            let s = self.config.read();
-            if !s.graph_file_path.is_empty() {
-                s.graph_file_path.clone()
-            } else {
-                format!("{}/graph", s.system_root_directory)
-            }
-        };
-
-        if let Some(parent) = Path::new(&graph_path).parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        #[cfg(feature = "ladybug")]
-        {
-            let graph_db = LadybugAdapter::new(&graph_path)
-                .await
-                .map_err(|e| ComponentError::GraphDb(format!("initialization failed: {e}")))?;
-            graph_db.initialize().await.map_err(|e| {
-                ComponentError::GraphDb(format!("schema initialization failed: {e}"))
-            })?;
-            Ok(Arc::new(graph_db))
-        }
-
-        #[cfg(not(feature = "ladybug"))]
-        Err(ComponentError::Config(
-            "graph_database_provider=ladybug requires the `ladybug` crate feature".to_string(),
-        ))
-    }
-
-    /// Build a Postgres connection URL from the graph_database_* settings,
-    /// falling back to the relational db_* fields when graph-specific creds
-    /// are not fully configured (Python `get_graph_engine.py:332-367` parity).
-    ///
-    /// Precedence:
-    /// 1. `graph_database_url` already looks like a full `postgres://` URL → return as-is.
-    /// 2. All graph-specific fields are set (username, password, host, port, name) → build from those.
-    /// 3. Fall back to the relational `db_*` fields with a warning.
-    /// 4. Neither complete → error.
-    #[cfg(feature = "pggraph")]
-    fn resolved_graph_db_url(&self, s: &Settings) -> Result<String, ComponentError> {
-        if s.graph_database_url.starts_with("postgres://")
-            || s.graph_database_url.starts_with("postgresql://")
-        {
-            return Ok(s.graph_database_url.clone());
-        }
-
-        let graph_host = if s.graph_database_host.is_empty() {
-            None
-        } else {
-            Some(s.graph_database_host.as_str())
-        };
-
-        let graph_creds_complete = graph_host.is_some()
-            && !s.graph_database_username.is_empty()
-            && !s.graph_database_name.is_empty();
-
-        let (host, port, name, user, pass) = if graph_creds_complete {
-            (
-                #[allow(clippy::expect_used, reason = "invariant is upheld by construction")]
-                graph_host.expect("checked above"),
-                s.graph_database_port,
-                s.graph_database_name.as_str(),
-                s.graph_database_username.as_str(),
-                s.graph_database_password.as_str(),
-            )
-        } else {
-            tracing::warn!(
-                "Postgres graph credentials not fully configured; falling back to the \
-                 relational database configuration. Set GRAPH_DATABASE_* explicitly to avoid this."
-            );
-            if s.db_host.is_empty() || s.db_name.is_empty() || s.db_username.is_empty() {
-                return Err(ComponentError::Config(
-                    "Missing required Postgres graph credentials".into(),
-                ));
-            }
-            (
-                s.db_host.as_str(),
-                s.db_port,
-                s.db_name.as_str(),
-                s.db_username.as_str(),
-                s.db_password.as_str(),
-            )
-        };
-
-        build_postgres_url(host, port, name, user, pass)
-            .map_err(|e| ComponentError::Config(format!("failed to build graph DB URL: {e}")))
+        let ctx = self.build_context();
+        self.registry.build_graph(&ctx).await
     }
 
     async fn init_vector_db(&self) -> Result<Arc<dyn VectorDB>, ComponentError> {
-        // Clone all needed fields out of the read guard before any await.
-        let (provider, _dim) = {
-            let s = self.config.read();
-            (
-                s.vector_db_provider.to_lowercase(),
-                s.embedding_dimensions as usize,
-            )
-        };
-
-        match provider.as_str() {
-            "pgvector" => {
-                #[cfg(feature = "pgvector")]
-                {
-                    let url = {
-                        let s = self.config.read();
-                        self.resolved_vector_db_url(&s)?
-                    };
-                    let adapter = PgVectorAdapter::new(&url, _dim).await.map_err(|e| {
-                        ComponentError::VectorDb(format!("pgvector init failed: {e}"))
-                    })?;
-                    Ok(Arc::new(adapter))
-                }
-
-                #[cfg(not(feature = "pgvector"))]
-                Err(ComponentError::Config(
-                    "vector_db_provider=pgvector requires the `pgvector` crate feature".to_string(),
-                ))
-            }
-            // Pure-Rust in-memory brute-force backend (Android default + ":memory:" escape hatch).
-            "brute-force" | "brute_force" | "bruteforce" => Ok(Arc::new(BruteForceVectorDB::new())),
-            // Embedded LanceDB on non-Android targets; falls back to brute-force
-            // on Android (LanceDB + Arrow native stack does not cross-compile
-            // there). Honours `vector_db_url = ":memory:"` as an explicit
-            // brute-force opt-in for ephemeral / test workloads.
-            "lancedb" => {
-                let url = {
-                    let s = self.config.read();
-                    s.vector_db_url.clone()
-                };
-                if url == ":memory:" {
-                    return Ok(Arc::new(BruteForceVectorDB::new()));
-                }
-                #[cfg(not(target_os = "android"))]
-                {
-                    let path = self.resolved_lancedb_path(&url);
-                    let adapter = cognee_vector::LanceDbAdapter::new(path)
-                        .await
-                        .map_err(|e| {
-                            ComponentError::VectorDb(format!("lancedb init failed: {e}"))
-                        })?;
-                    Ok(Arc::new(adapter))
-                }
-                #[cfg(target_os = "android")]
-                {
-                    tracing::warn!(
-                        "vector_db_provider='lancedb' is not available on Android; \
-                         falling back to in-memory brute-force. Set \
-                         vector_db_provider='pgvector' for production durable storage."
-                    );
-                    Ok(Arc::new(BruteForceVectorDB::new()))
-                }
-            }
-            // the closed split extracted the Qdrant adapter out of OSS into the closed
-            // `cognee-vector-qdrant` crate. OSS hard-errors rather than silently
-            // substituting a different backend, mirroring the closed-adapter
-            // handling elsewhere in this file (e.g. LiteRT). LanceDB stays OSS
-            // (handled above); only Qdrant is closed.
-            "qdrant" => Err(ComponentError::Config(format!(
-                "vector_db_provider='{provider}' is not available in this build. \
-                 The Qdrant adapter has been extracted to the closed \
-                 cognee-vector-qdrant crate. Use vector_db_provider='pgvector', \
-                 'lancedb', or 'brute-force' in OSS."
-            ))),
-            #[cfg(feature = "testing")]
-            "mock" => Ok(Arc::new(cognee_vector::MockVectorDB::new())),
-            other => Err(ComponentError::Config(format!(
-                "Unsupported vector_db_provider '{other}'. \
-                 Supported: pgvector, lancedb (non-Android), brute-force, mock (testing feature only).",
-            ))),
-        }
+        let ctx = self.build_context();
+        self.registry.build_vector(&ctx).await
     }
 
-    /// Resolve the on-disk path for the LanceDB store.
-    ///
-    /// Honours an explicit `vector_db_url` when set; otherwise defaults to
-    /// `{system_root_directory}/databases/cognee.lancedb` — matching the
-    /// Python SDK file layout so a Rust deployment can be opened from
-    /// Python and vice versa.
-    #[cfg(not(target_os = "android"))]
-    fn resolved_lancedb_path(&self, vector_db_url: &str) -> std::path::PathBuf {
-        use std::path::PathBuf;
-        if !vector_db_url.is_empty() {
-            return PathBuf::from(vector_db_url);
-        }
-        let root = {
-            let s = self.config.read();
-            s.system_root_directory.clone()
-        };
-        PathBuf::from(root).join("databases").join("cognee.lancedb")
-    }
-
-    /// Build a Postgres connection URL from the vector_db_* settings.
-    ///
-    /// If `vector_db_url` already looks like a full `postgres://` URL it is
-    /// returned as-is. Otherwise the URL is assembled from the individual
-    /// `vector_db_*` / `db_*` fields using the `url` crate so that special
-    /// characters in passwords are percent-encoded correctly.
-    #[cfg(feature = "pgvector")]
-    fn resolved_vector_db_url(&self, settings: &Settings) -> Result<String, ComponentError> {
-        if settings.vector_db_url.starts_with("postgres://")
-            || settings.vector_db_url.starts_with("postgresql://")
-        {
-            return Ok(settings.vector_db_url.clone());
-        }
-
-        let host = if settings.vector_db_url.is_empty() {
-            "localhost"
-        } else {
-            &settings.vector_db_url
-        };
-        let port = settings.vector_db_port;
-        let name = if settings.vector_db_name.is_empty() {
-            "cognee_vectors"
-        } else {
-            &settings.vector_db_name
-        };
-        let user = if settings.db_username.is_empty() {
-            "postgres"
-        } else {
-            &settings.db_username
-        };
-        let pass = &settings.db_password;
-
-        build_postgres_url(host, port, name, user, pass)
-            .map_err(|e| ComponentError::Config(format!("failed to build vector DB URL: {e}")))
-    }
-
-    /// Initialize the embedding engine from Settings fields instead of
-    /// calling `EmbeddingConfig::from_env()` directly.
-    ///
-    /// This ensures that runtime config changes via `ConfigManager` flow
-    /// through to the embedding engine.
     async fn init_embedding_engine(&self) -> Result<Arc<dyn EmbeddingEngine>, ComponentError> {
-        // Build EmbeddingConfig from Settings inside a block so the guard
-        // is dropped before any .await point.
-        let mut config = {
-            let settings = self.config.read();
-
-            // Map Settings.embedding_provider string to EmbeddingProvider enum.
-            let provider_str = settings.embedding_provider.trim().to_lowercase();
-            let provider = match provider_str.as_str() {
-                "onnx" => EmbeddingProvider::Onnx,
-                "fastembed" => EmbeddingProvider::Fastembed,
-                "openai" => EmbeddingProvider::OpenAi,
-                "openai_compatible" => EmbeddingProvider::OpenAiCompatible,
-                "ollama" => EmbeddingProvider::Ollama,
-                "mock" => EmbeddingProvider::Mock,
-                _ => EmbeddingProvider::Onnx,
-            };
-
-            // Endpoint/key fall back to the LLM provider's when no embedding-
-            // specific values are set. The default embedding provider is OpenAI
-            // (off-Android), and cognee typically shares one OpenAI-compatible
-            // account for chat + embeddings, so this makes the default work with
-            // just OPENAI_URL/OPENAI_TOKEN (→ llm_endpoint/llm_api_key) — no
-            // separate EMBEDDING_ENDPOINT/EMBEDDING_API_KEY required.
-            let endpoint = [&settings.embedding_endpoint, &settings.llm_endpoint]
-                .into_iter()
-                .find(|v| !v.is_empty())
-                .cloned();
-
-            let api_key = [&settings.embedding_api_key, &settings.llm_api_key]
-                .into_iter()
-                .find(|v| !v.is_empty())
-                .cloned();
-
-            // Check MOCK_EMBEDDING env var as a fallback (preserves backward compat).
-            // `deterministic`/`hash` selects SHA-256-derived vectors; other truthy
-            // values keep the legacy zero-vector mode.
-            let mock_mode = std::env::var("MOCK_EMBEDDING")
-                .ok()
-                .map(|v| v.trim().to_lowercase());
-            let mock_deterministic =
-                matches!(mock_mode.as_deref(), Some("deterministic") | Some("hash"));
-            let mock = mock_deterministic
-                || matches!(mock_mode.as_deref(), Some("true") | Some("1") | Some("yes"));
-            let mock_mode = if mock_deterministic {
-                cognee_embedding::MockVectorMode::Deterministic
-            } else {
-                cognee_embedding::MockVectorMode::Zero
-            };
-
-            EmbeddingConfig {
-                provider: if mock {
-                    EmbeddingProvider::Mock
-                } else {
-                    provider
-                },
-                model: settings.embedding_model_name.clone(),
-                dimensions: settings.embedding_dimensions as usize,
-                endpoint,
-                api_key,
-                api_version: None,
-                max_completion_tokens: 8191,
-                batch_size: settings.embedding_batch_size as usize,
-                mock,
-                mock_mode,
-                #[cfg(feature = "onnx")]
-                onnx: cognee_embedding::OnnxEmbeddingConfig {
-                    model_path: PathBuf::from(&settings.embedding_model_path),
-                    tokenizer_path: PathBuf::from(&settings.embedding_tokenizer_path),
-                    model_name: settings.embedding_model_name.clone(),
-                    dimensions: settings.embedding_dimensions as usize,
-                    max_sequence_length: settings.embedding_max_sequence_length as usize,
-                    batch_size: settings.embedding_onnx_batch_size as usize,
-                },
-                huggingface_tokenizer: None,
-            }
-        };
-        // settings guard is now dropped — safe to await.
-
-        // Still check env vars for fields not yet in Settings (api_version,
-        // huggingface_tokenizer, max_completion_tokens) — forward compatibility.
-        if let Ok(val) = std::env::var("EMBEDDING_API_VERSION") {
-            let val = val.trim().to_string();
-            if !val.is_empty() {
-                config.api_version = Some(val);
-            }
-        }
-        if let Ok(val) = std::env::var("HUGGINGFACE_TOKENIZER") {
-            let val = val.trim().to_string();
-            if !val.is_empty() {
-                config.huggingface_tokenizer = Some(val);
-            }
-        }
-        if let Ok(val) = std::env::var("EMBEDDING_MAX_COMPLETION_TOKENS")
-            && let Ok(n) = val.trim().parse::<usize>()
-        {
-            config.max_completion_tokens = n;
-        }
-
-        config.create_engine().await.map_err(|e| {
-            ComponentError::EmbeddingEngine(format!("embedding engine init failed: {e}"))
-        })
+        let ctx = self.build_context();
+        self.registry.build_embedding(&ctx).await
     }
 
     async fn init_llm(&self) -> Result<Arc<dyn Llm>, ComponentError> {
-        // Clone all needed fields out of the read guard before any await.
-        let (
-            provider,
-            llm_model,
-            llm_api_key,
-            llm_endpoint,
-            llm_max_retries,
-            llm_mock,
-            llm_cassette,
-            llm_record_path,
-        ) = {
-            let s = self.config.read();
-            (
-                s.llm_provider.to_lowercase(),
-                s.llm_model.clone(),
-                s.llm_api_key.clone(),
-                s.llm_endpoint.clone(),
-                s.llm_max_retries,
-                s.llm_mock,
-                s.llm_cassette.clone(),
-                s.llm_record_path.clone(),
-            )
-        };
-
-        // `llm_cassette` is only consumed on the mock path; silence the
-        // unused-variable lint in builds without the `mock` feature.
-        #[cfg(not(feature = "mock-llm"))]
-        let _ = &llm_cassette;
-
-        // Mock first — like MOCK_EMBEDDING, this overrides the configured
-        // provider. Selected by `MOCK_LLM` (llm_mock) or `llm_provider=mock`.
-        if llm_mock || provider == "mock" {
-            #[cfg(feature = "mock-llm")]
-            {
-                let cassette = llm_cassette.trim();
-                if cassette.is_empty() {
-                    return Err(ComponentError::Config(
-                        "MOCK_LLM is set but MOCK_LLM_CASSETTE is empty; set it to a cassette path"
-                            .to_string(),
-                    ));
-                }
-                let replay = cognee_llm::mock::ReplayLlm::from_path(cassette)
-                    .map_err(|e| ComponentError::Llm(format!("mock cassette load failed: {e}")))?;
-                return Ok(Arc::new(replay));
-            }
-            #[cfg(not(feature = "mock-llm"))]
-            {
-                return Err(ComponentError::Config(
-                    "MOCK_LLM was requested but the mock LLM is unavailable; \
-                     rebuild with the `mock-llm` feature"
-                        .to_string(),
-                ));
-            }
-        }
-
-        // Build the real adapter. OpenAI and the OpenAI-compatible providers all
-        // route through the shared factory (issue #17, Tier 1).
-        let adapter: Arc<dyn Llm> = match provider.as_str() {
-            "openai" | "ollama" | "mistral" | "gemini" | "custom" | "openai_compatible" => {
-                let adapter = build_openai_compatible_adapter(
-                    &provider,
-                    &llm_model,
-                    &llm_api_key,
-                    &llm_endpoint,
-                    llm_max_retries,
-                )
-                .map_err(|e| ComponentError::Llm(e.to_string()))?;
-
-                Arc::new(adapter)
-            }
-            "litert" => {
-                return Err(ComponentError::Config(
-                    "llm_provider=litert is not available in this build. \
-                     The LiteRT adapter has been extracted to the closed cognee-llm-litert crate."
-                        .to_string(),
-                ));
-            }
-            _ => {
-                return Err(ComponentError::Config(format!(
-                    "Unsupported llm_provider '{provider}'. \
-                     Supported: openai, ollama, mistral, gemini, custom, mock.",
-                )));
-            }
-        };
-
-        // Optional recording wrap (`COGNEE_RECORD_LLM`). Only the real adapter is
-        // worth recording — replaying a recording of a mock is pointless.
-        if !llm_record_path.trim().is_empty() {
-            #[cfg(feature = "mock-llm")]
-            {
-                let recorder = cognee_llm::mock::RecordingLlm::new(
-                    adapter,
-                    llm_record_path.trim().to_string(),
-                );
-                return Ok(Arc::new(recorder));
-            }
-            #[cfg(not(feature = "mock-llm"))]
-            {
-                return Err(ComponentError::Config(
-                    "COGNEE_RECORD_LLM was set but LLM recording is unavailable; \
-                     rebuild with the `mock-llm` feature"
-                        .to_string(),
-                ));
-            }
-        }
-
-        Ok(adapter)
-    }
-
-    async fn init_transcriber(&self) -> Result<Option<Arc<dyn Transcriber>>, ComponentError> {
-        let (provider, llm_model, llm_api_key, llm_endpoint, llm_max_retries) = {
-            let s = self.config.read();
-            (
-                s.llm_provider.to_lowercase(),
-                s.llm_model.clone(),
-                s.llm_api_key.clone(),
-                s.llm_endpoint.clone(),
-                s.llm_max_retries,
-            )
-        };
-
-        match provider.as_str() {
-            // Whisper-style transcription works against OpenAI and any user-pointed
-            // OpenAI-compatible server that exposes /audio/transcriptions
-            // (Groq, vLLM, a LiteLLM proxy). Ollama/Mistral/Gemini do not expose
-            // that route via the chat path, so they return None (graceful no-audio)
-            // rather than building an adapter that 404s at runtime.
-            "openai" | "custom" | "openai_compatible" => {
-                let adapter = build_openai_compatible_adapter(
-                    &provider,
-                    &llm_model,
-                    &llm_api_key,
-                    &llm_endpoint,
-                    llm_max_retries,
-                )
-                .map_err(|e| ComponentError::Llm(e.to_string()))?;
-
-                Ok(Some(Arc::new(adapter) as Arc<dyn Transcriber>))
-            }
-            // litert and providers that do not expose OpenAI-compatible audio
-            // return None — audio stays gracefully unsupported (D5).
-            _ => Ok(None),
-        }
+        let ctx = self.build_context();
+        self.registry.build_llm(&ctx).await
     }
 
     /// Return the [`Transcriber`] for the configured LLM provider, if supported.
     ///
-    /// Returns `Ok(Some(_))` for OpenAI (Whisper). Returns `Ok(None)` for
-    /// providers that do not support audio transcription (e.g. `litert`), so
+    /// Returns `Ok(Some(_))` for OpenAI-compatible providers that expose audio
+    /// transcription; `Ok(None)` for providers that do not (e.g. `litert`), so
     /// callers can skip registering the `AudioLoader` rather than failing.
     pub async fn transcriber(&self) -> Result<Option<Arc<dyn Transcriber>>, ComponentError> {
         let current_ver = self.config.version();
@@ -707,7 +152,8 @@ impl ComponentManager {
         {
             return Ok(opt.clone());
         }
-        let new = self.init_transcriber().await?;
+        let ctx = self.build_context();
+        let new = self.registry.build_transcriber(&ctx).await?;
         *guard = Some((current_ver, new.clone()));
         Ok(new)
     }
@@ -826,30 +272,24 @@ mod tests {
         assert!(Arc::ptr_eq(&first, &second), "transcriber should be cached");
     }
 
-    // -- resolved_graph_db_url / PgGraph provider dispatch --------------------
-
-    #[cfg(feature = "pggraph")]
-    fn cm_with_graph_settings(settings: Settings) -> ComponentManager {
-        ComponentManager::new(ConfigManager::new(settings))
-    }
+    // -- resolved graph/vector Postgres URL / PgGraph provider dispatch -------
 
     #[cfg(feature = "pggraph")]
     #[test]
-    fn resolved_graph_db_url_returns_explicit_url_as_is() {
+    fn resolved_graph_url_returns_explicit_url_as_is() {
         let settings = Settings {
             graph_database_url: "postgres://user:pw@myhost:5432/graphs".to_string(),
             ..Settings::default()
         };
-        let cm = cm_with_graph_settings(settings.clone());
-        let url = cm
-            .resolved_graph_db_url(&settings)
+        let url = settings
+            .resolved_graph_postgres_url()
             .expect("should succeed with full URL");
         assert_eq!(url, "postgres://user:pw@myhost:5432/graphs");
     }
 
     #[cfg(feature = "pggraph")]
     #[test]
-    fn resolved_graph_db_url_builds_from_graph_creds() {
+    fn resolved_graph_url_builds_from_graph_creds() {
         let settings = Settings {
             graph_database_host: "graphhost".to_string(),
             graph_database_port: 5432,
@@ -858,9 +298,8 @@ mod tests {
             graph_database_password: "gpass".to_string(),
             ..Settings::default()
         };
-        let cm = cm_with_graph_settings(settings.clone());
-        let url = cm
-            .resolved_graph_db_url(&settings)
+        let url = settings
+            .resolved_graph_postgres_url()
             .expect("should build from graph creds");
         assert!(url.contains("guser"), "URL should contain username");
         assert!(url.contains("graphhost"), "URL should contain host");
@@ -869,8 +308,7 @@ mod tests {
 
     #[cfg(feature = "pggraph")]
     #[test]
-    fn resolved_graph_db_url_falls_back_to_relational_creds() {
-        // Graph creds not set, relational creds are set → fallback.
+    fn resolved_graph_url_falls_back_to_relational_creds() {
         let settings = Settings {
             db_host: "relhost".to_string(),
             db_port: 5432,
@@ -879,9 +317,8 @@ mod tests {
             db_password: "relpass".to_string(),
             ..Settings::default()
         };
-        let cm = cm_with_graph_settings(settings.clone());
-        let url = cm
-            .resolved_graph_db_url(&settings)
+        let url = settings
+            .resolved_graph_postgres_url()
             .expect("should fall back to relational creds");
         assert!(
             url.contains("reluser"),
@@ -899,16 +336,14 @@ mod tests {
 
     #[cfg(feature = "pggraph")]
     #[test]
-    fn resolved_graph_db_url_errors_when_no_creds() {
-        // Neither graph nor relational creds → config error.
+    fn resolved_graph_url_errors_when_no_creds() {
         let settings = Settings {
             db_host: String::new(),
             db_name: String::new(),
             db_username: String::new(),
             ..Settings::default()
         };
-        let cm = cm_with_graph_settings(settings.clone());
-        let result = cm.resolved_graph_db_url(&settings);
+        let result = settings.resolved_graph_postgres_url();
         assert!(result.is_err(), "should error when no creds available");
     }
 
@@ -926,8 +361,8 @@ mod tests {
             Ok(_) => panic!("expected error"),
         };
         assert!(
-            err_msg.contains("postgres"),
-            "error message should list 'postgres' as supported: {err_msg}"
+            err_msg.contains("neo4j"),
+            "error message should name the unsupported provider: {err_msg}"
         );
     }
 
@@ -938,8 +373,6 @@ mod tests {
     fn write_cassette() -> (tempfile::TempDir, std::path::PathBuf) {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("cassette.json");
-        // A schema-valid, empty cassette: the replay mock falls back to its
-        // default EmptyGraph miss policy, so the pipeline runs with no entries.
         let body = r#"{"version":1,"model":"mock-model","entries":{}}"#;
         std::fs::write(&path, body).expect("write cassette");
         (dir, path)
@@ -949,7 +382,6 @@ mod tests {
     #[tokio::test]
     async fn init_llm_uses_replay_mock_when_llm_mock_set_without_api_key() {
         let (_dir, cassette) = write_cassette();
-        // No api_key and a non-openai-ready config — the mock must override.
         let settings = Settings {
             llm_mock: true,
             llm_cassette: cassette.to_string_lossy().into_owned(),
@@ -963,7 +395,6 @@ mod tests {
             "mock-model",
             "replay mock reports cassette model"
         );
-        // A generate() call must succeed offline (empty response on cache miss).
         let resp = llm
             .generate(
                 vec![cognee_llm::Message {
@@ -1019,7 +450,6 @@ mod tests {
     async fn init_llm_wraps_real_adapter_in_recorder_when_record_path_set() {
         let dir = tempfile::tempdir().expect("tempdir");
         let record_path = dir.path().join("recorded.json");
-        // Real openai provider + a record path → wrapped in RecordingLlm.
         let settings = Settings {
             llm_provider: "openai".to_string(),
             llm_api_key: "sk-test".to_string(),
@@ -1028,8 +458,6 @@ mod tests {
             ..Settings::default()
         };
         let cm = ComponentManager::new(ConfigManager::new(settings));
-        // Construction must succeed (no network call happens at init time);
-        // the recorder model() delegates to the wrapped openai adapter.
         let llm = cm
             .llm()
             .await

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -620,20 +620,14 @@ impl Settings {
         use std::path::PathBuf;
 
         let graph_provider = self.graph_database_provider.to_lowercase();
+        // Carry the resolution `Result` through to the factory so it can restate
+        // the specific cause (e.g. "Missing required Postgres graph credentials")
+        // in the returned error, not just in a log line an SDK user may not see.
         let graph_postgres_url = {
             #[cfg(feature = "pggraph")]
             {
                 if matches!(graph_provider.as_str(), "postgres" | "postgresql") {
-                    // Log the specific resolution failure (e.g. "Missing required
-                    // Postgres graph credentials") rather than swallowing it — the
-                    // factory only sees `None` and can't restate the cause.
-                    match self.resolved_graph_postgres_url() {
-                        Ok(u) => Some(u),
-                        Err(e) => {
-                            tracing::warn!("graph Postgres URL could not be resolved: {e}");
-                            None
-                        }
-                    }
+                    Some(self.resolved_graph_postgres_url())
                 } else {
                     None
                 }
@@ -649,13 +643,7 @@ impl Settings {
             #[cfg(feature = "pgvector")]
             {
                 if vector_provider == "pgvector" {
-                    match self.resolved_vector_postgres_url() {
-                        Ok(u) => Some(u),
-                        Err(e) => {
-                            tracing::warn!("vector Postgres URL could not be resolved: {e}");
-                            None
-                        }
-                    }
+                    Some(self.resolved_vector_postgres_url())
                 } else {
                     None
                 }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -624,7 +624,16 @@ impl Settings {
             #[cfg(feature = "pggraph")]
             {
                 if matches!(graph_provider.as_str(), "postgres" | "postgresql") {
-                    self.resolved_graph_postgres_url().ok()
+                    // Log the specific resolution failure (e.g. "Missing required
+                    // Postgres graph credentials") rather than swallowing it — the
+                    // factory only sees `None` and can't restate the cause.
+                    match self.resolved_graph_postgres_url() {
+                        Ok(u) => Some(u),
+                        Err(e) => {
+                            tracing::warn!("graph Postgres URL could not be resolved: {e}");
+                            None
+                        }
+                    }
                 } else {
                     None
                 }
@@ -640,7 +649,13 @@ impl Settings {
             #[cfg(feature = "pgvector")]
             {
                 if vector_provider == "pgvector" {
-                    self.resolved_vector_postgres_url().ok()
+                    match self.resolved_vector_postgres_url() {
+                        Ok(u) => Some(u),
+                        Err(e) => {
+                            tracing::warn!("vector Postgres URL could not be resolved: {e}");
+                            None
+                        }
+                    }
                 } else {
                     None
                 }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -12,6 +12,34 @@ use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_SYSTEM_PROMPT_PATH: &str = "answer_simple_question.txt";
 
+/// Assemble a `postgres://user:pass@host:port/dbname` URL with percent-encoded
+/// credentials. Shared by the vector and graph URL resolvers.
+#[cfg(any(feature = "pgvector", feature = "pggraph"))]
+fn build_postgres_url(
+    host: &str,
+    port: u16,
+    name: &str,
+    user: &str,
+    pass: &str,
+) -> Result<String, String> {
+    let mut parsed =
+        url::Url::parse("postgres://localhost").map_err(|e| format!("static URL invalid: {e}"))?;
+    parsed
+        .set_host(Some(host))
+        .map_err(|e| format!("invalid host '{host}': {e}"))?;
+    parsed
+        .set_port(Some(port))
+        .map_err(|_| format!("invalid port {port}"))?;
+    parsed.set_path(&format!("/{name}"));
+    parsed
+        .set_username(user)
+        .map_err(|_| format!("invalid username '{user}'"))?;
+    parsed
+        .set_password(Some(pass))
+        .map_err(|_| "invalid password".to_string())?;
+    Ok(parsed.to_string())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Settings {
@@ -580,6 +608,203 @@ impl Settings {
         } else {
             self.relational_db_url.clone()
         }
+    }
+
+    /// Lower these settings into a [`BackendBuildContext`] for
+    /// `cognee-components`. All config-specific URL resolution and the
+    /// component-relevant environment reads (`MOCK_EMBEDDING`,
+    /// `EMBEDDING_API_VERSION`, `HUGGINGFACE_TOKENIZER`,
+    /// `EMBEDDING_MAX_COMPLETION_TOKENS`) happen here so the registry stays
+    /// env-free.
+    pub fn backend_context(&self) -> cognee_components::BackendBuildContext {
+        use std::path::PathBuf;
+
+        let graph_provider = self.graph_database_provider.to_lowercase();
+        let graph_postgres_url = {
+            #[cfg(feature = "pggraph")]
+            {
+                if matches!(graph_provider.as_str(), "postgres" | "postgresql") {
+                    self.resolved_graph_postgres_url().ok()
+                } else {
+                    None
+                }
+            }
+            #[cfg(not(feature = "pggraph"))]
+            {
+                None
+            }
+        };
+
+        let vector_provider = self.vector_db_provider.to_lowercase();
+        let vector_postgres_url = {
+            #[cfg(feature = "pgvector")]
+            {
+                if vector_provider == "pgvector" {
+                    self.resolved_vector_postgres_url().ok()
+                } else {
+                    None
+                }
+            }
+            #[cfg(not(feature = "pgvector"))]
+            {
+                None
+            }
+        };
+
+        // Embedding endpoint/key fall back to the LLM provider's when no
+        // embedding-specific values are set (shared OpenAI-compatible account).
+        let endpoint = [&self.embedding_endpoint, &self.llm_endpoint]
+            .into_iter()
+            .find(|v| !v.is_empty())
+            .cloned();
+        let api_key = [&self.embedding_api_key, &self.llm_api_key]
+            .into_iter()
+            .find(|v| !v.is_empty())
+            .cloned();
+
+        // MOCK_EMBEDDING: `deterministic`/`hash` selects SHA-256-derived
+        // vectors; other truthy values keep the legacy zero-vector mode.
+        let mock_mode = std::env::var("MOCK_EMBEDDING")
+            .ok()
+            .map(|v| v.trim().to_lowercase());
+        let mock_deterministic =
+            matches!(mock_mode.as_deref(), Some("deterministic") | Some("hash"));
+        let mock = mock_deterministic
+            || matches!(mock_mode.as_deref(), Some("true") | Some("1") | Some("yes"));
+
+        // Forward-compat env fields not yet on Settings.
+        let api_version = std::env::var("EMBEDDING_API_VERSION")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        let huggingface_tokenizer = std::env::var("HUGGINGFACE_TOKENIZER")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        let max_completion_tokens = std::env::var("EMBEDDING_MAX_COMPLETION_TOKENS")
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .unwrap_or(8191);
+
+        cognee_components::BackendBuildContext {
+            data_root_directory: PathBuf::from(&self.data_root_directory),
+            system_root_directory: PathBuf::from(&self.system_root_directory),
+            relational_db_url: self.resolved_relational_db_url(),
+            graph_provider,
+            graph_file_path: self.graph_file_path.clone(),
+            graph_postgres_url,
+            vector_provider,
+            vector_db_url: self.vector_db_url.clone(),
+            vector_postgres_url,
+            embedding_dimensions: self.embedding_dimensions as usize,
+            embedding: cognee_components::EmbeddingInputs {
+                provider: self.embedding_provider.trim().to_lowercase(),
+                model: self.embedding_model_name.clone(),
+                dimensions: self.embedding_dimensions as usize,
+                endpoint,
+                api_key,
+                batch_size: self.embedding_batch_size as usize,
+                mock,
+                mock_deterministic,
+                api_version,
+                huggingface_tokenizer,
+                max_completion_tokens,
+                onnx_model_path: PathBuf::from(&self.embedding_model_path),
+                onnx_tokenizer_path: PathBuf::from(&self.embedding_tokenizer_path),
+                onnx_model_name: self.embedding_model_name.clone(),
+                onnx_dimensions: self.embedding_dimensions as usize,
+                onnx_max_sequence_length: self.embedding_max_sequence_length as usize,
+                onnx_batch_size: self.embedding_onnx_batch_size as usize,
+            },
+            llm: cognee_components::LlmInputs {
+                provider: self.llm_provider.to_lowercase(),
+                model: self.llm_model.clone(),
+                api_key: self.llm_api_key.clone(),
+                endpoint: self.llm_endpoint.clone(),
+                max_retries: self.llm_max_retries,
+                mock: self.llm_mock,
+                cassette: self.llm_cassette.clone(),
+                record_path: self.llm_record_path.clone(),
+            },
+        }
+    }
+
+    /// Build a Postgres connection URL from the `graph_database_*` settings,
+    /// falling back to the relational `db_*` fields when graph-specific creds
+    /// are not fully configured (Python `get_graph_engine.py:332-367` parity).
+    #[cfg(feature = "pggraph")]
+    pub(crate) fn resolved_graph_postgres_url(&self) -> Result<String, String> {
+        if self.graph_database_url.starts_with("postgres://")
+            || self.graph_database_url.starts_with("postgresql://")
+        {
+            return Ok(self.graph_database_url.clone());
+        }
+
+        let graph_host = if self.graph_database_host.is_empty() {
+            None
+        } else {
+            Some(self.graph_database_host.as_str())
+        };
+        let graph_creds_complete = graph_host.is_some()
+            && !self.graph_database_username.is_empty()
+            && !self.graph_database_name.is_empty();
+
+        let (host, port, name, user, pass) = if graph_creds_complete {
+            (
+                graph_host.unwrap_or_default(),
+                self.graph_database_port,
+                self.graph_database_name.as_str(),
+                self.graph_database_username.as_str(),
+                self.graph_database_password.as_str(),
+            )
+        } else {
+            tracing::warn!(
+                "Postgres graph credentials not fully configured; falling back to the \
+                 relational database configuration. Set GRAPH_DATABASE_* explicitly to avoid this."
+            );
+            if self.db_host.is_empty() || self.db_name.is_empty() || self.db_username.is_empty() {
+                return Err("Missing required Postgres graph credentials".into());
+            }
+            (
+                self.db_host.as_str(),
+                self.db_port,
+                self.db_name.as_str(),
+                self.db_username.as_str(),
+                self.db_password.as_str(),
+            )
+        };
+
+        build_postgres_url(host, port, name, user, pass)
+    }
+
+    /// Build a Postgres connection URL from the `vector_db_*` settings.
+    #[cfg(feature = "pgvector")]
+    pub(crate) fn resolved_vector_postgres_url(&self) -> Result<String, String> {
+        if self.vector_db_url.starts_with("postgres://")
+            || self.vector_db_url.starts_with("postgresql://")
+        {
+            return Ok(self.vector_db_url.clone());
+        }
+
+        let host = if self.vector_db_url.is_empty() {
+            "localhost"
+        } else {
+            &self.vector_db_url
+        };
+        let port = self.vector_db_port;
+        let name = if self.vector_db_name.is_empty() {
+            "cognee_vectors"
+        } else {
+            &self.vector_db_name
+        };
+        let user = if self.db_username.is_empty() {
+            "postgres"
+        } else {
+            &self.db_username
+        };
+        let pass = &self.db_password;
+
+        build_postgres_url(host, port, name, user, pass)
     }
 
     /// Returns the redacted property dict merged into `Pipeline Run *`

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -1,31 +1,8 @@
 //! Error types for the cognee-lib crate.
+//!
+//! [`ComponentError`] is defined in `cognee-components` and re-exported here so
+//! that `cognee_lib::ComponentError` stays the identical type across the OSS
+//! crates and the closed cloud repo (preserving `#[from]` / `From` impls in the
+//! bindings and CLI error enums).
 
-use thiserror::Error;
-
-/// Errors that can occur during component initialization or access.
-#[derive(Debug, Error)]
-pub enum ComponentError {
-    #[error("Storage error: {0}")]
-    Storage(String),
-
-    #[error("Database error: {0}")]
-    Database(String),
-
-    #[error("Graph database error: {0}")]
-    GraphDb(String),
-
-    #[error("Vector database error: {0}")]
-    VectorDb(String),
-
-    #[error("Embedding engine error: {0}")]
-    EmbeddingEngine(String),
-
-    #[error("LLM error: {0}")]
-    Llm(String),
-
-    #[error("Configuration error: {0}")]
-    Config(String),
-
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-}
+pub use cognee_components::ComponentError;

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -166,6 +166,13 @@ pub use component_manager::ComponentManager;
 pub use config::{ConfigError, ConfigManager, Settings};
 pub use context::PipelineContext;
 pub use error::ComponentError;
+// Adapter-registry surface — so external (closed) entry points can build and
+// register factories via `cognee_lib::` paths without a direct dependency edge
+// beyond where they define the impls.
+pub use cognee_components::{
+    BackendBuildContext, ComponentRegistry, DefaultEmbeddingFactory, EmbeddingFactory,
+    EmbeddingInputs, GraphDbFactory, LlmFactory, LlmInputs, VectorDbFactory,
+};
 
 /// Convenience re-exports for common usage.
 pub mod prelude {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,6 +90,8 @@ cognee-rust-oss/
 
 **cognee-core** — Async runtime, task scheduling, and pipeline-execution primitives. Traits: `PipelineWatcher`, `ExecStatusManager`. Impls: `NoopWatcher`, `RayonThreadPool`, `NoopExecStatusManager`.
 
+**cognee-components** — Shared backend construction. Owns `ComponentError`, the `BackendBuildContext` (the resolved, env-free input both callers lower their config into), the adapter factory traits (`VectorDbFactory`, `GraphDbFactory`, `LlmFactory`, `EmbeddingFactory`), and the `ComponentRegistry` (provider-id → factory) with `with_builtins()`. Sits below `cognee-lib` and `cognee-http-server`; both delegate their backend construction here, so the two paths can't drift. The registry is the explicit-DI extension seam — external adapters (closed `cognee-vector-qdrant` / `cognee-llm-litert`) implement a factory trait and `register_*` it at their binary entry point. See [operations.md](operations.md).
+
 **cognee-http-server** — `axum`-based HTTP server. Library exposes `build_router`, `run`, and `AppState`; also builds the `cognee-http-server` binary. Routers mirror the Python FastAPI surface under `/api/v1/*`. See [http-server/](http-server/README.md).
 
 **cognee-visualization** — Self-contained HTML knowledge-graph visualization (d3.js v7, force-directed, Canvas). Entry points: `visualize`/`render`/`render_multi_user`. Surfaces via the CLI `visualize` subcommand.
@@ -104,7 +106,7 @@ cognee-rust-oss/
 
 **cognee-bindings-common** — Shared SDK facade for the Neon JS and C-API bindings: `SdkError` (+ `code()`), `HandleState`, `CogneeServices`, and neon-free JSON wire helpers. Not a new user-facing Rust API — that remains `cognee_lib::api`.
 
-**cognee-lib** — Unified public API facade. Re-exports all crates and adds an `api/` module mirroring the Python SDK: `forget`, `update`, `prune`, `recall`, `remember`, `improve`, plus `DatasetManager`. Houses the shared `Settings`/`ConfigManager` and runtime setters.
+**cognee-lib** — Unified public API facade. Re-exports all crates and adds an `api/` module mirroring the Python SDK: `forget`, `update`, `prune`, `recall`, `remember`, `improve`, plus `DatasetManager`. Houses the shared `Settings`/`ConfigManager` and runtime setters. `ComponentManager` (lazy, version-cached) delegates backend construction to a `cognee-components` `ComponentRegistry`; use `ComponentManager::with_registry` (or `HandleState::from_settings_with_registry` in the bindings) to inject external adapter factories. The registry API is re-exported here so closed entry points use `cognee_lib::` paths.
 
 **cognee-cli** — Command-line binary (`cognee-cli`). See [tools/cli.md](tools/cli.md).
 


### PR DESCRIPTION
## What & why

The `ComponentManager` (cognee-lib) and the HTTP server's standalone `wiring.rs` each built the same seven pipeline backends from config, by hand — and had **drifted**: http-server lacked lancedb/brute-force vector backends, pggraph, mock-llm, `MOCK_EMBEDDING`, and had weaker sqlite parent-dir handling. This extracts the construction logic into a new **`cognee-components`** crate behind a pluggable **`ComponentRegistry`**, so both callers share one implementation and the drift is resolved by construction.

The registry is also the **extension seam** for the closed `cognee-cloud-rs` repo: external adapters (qdrant, litert) implement a factory trait and `register_*` it at their binary entry point — no OSS edits, no `match` arms to touch.

## Design

- New crate `crates/components`:
  - `ComponentError` (re-exported by `cognee-lib`, so the type is unchanged for downstream `#[from]`/`From` impls)
  - `BackendBuildContext` — the resolved, env-free input both configs lower into (all URL resolution + env reads happen at that boundary)
  - factory traits `VectorDbFactory` / `GraphDbFactory` / `LlmFactory` / `EmbeddingFactory` (`#[async_trait] + Send + Sync` so `Arc<dyn _>` is dyn-compatible and holders stay `Sync`)
  - `ComponentRegistry` (provider-id → factory) with `with_builtins()` + `register_*` + a single `build_*` path; free `build_storage` / `build_database`
  - drift-guard + sqlite-URL-shape tests
- Migration (backward-compatible on the OSS side):
  - `ComponentManager` gains a registry field; `new()` = `with_registry(with_builtins())`; each `init_*` / `transcriber()` delegates; version-cache + transcriber slot unchanged
  - http-server: `HttpServerConfig::backend_context()`, `wire_default_backends_with()`; the `Err→warn+None` downgrade and pgvector coherence guard stay in the wrappers; `mock-llm` stays default-off (production safety); `dev-mock` remapped to `cognee-components/testing`
  - bindings-common: `HandleState::from_settings_with_registry()` — the injection seam the py/ts/c cloud SDKs route through

## Extension example (closed repo)

```rust
let mut reg = ComponentRegistry::with_builtins();
reg.register_vector(Arc::new(QdrantVectorFactory));
reg.register_llm(Arc::new(LiteRtLlmFactory));
// -> ComponentManager::with_registry / HandleState::from_settings_with_registry / wire_default_backends_with
```

## Verification

- `cargo check --all-targets` (workspace) — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Unit tests: components, lib (`component_manager`, `config`), http-server (`wiring`, `config`) — pass
- capi cargo-check **default + slim** (`--no-default-features --features sqlite,testing`) — clean
- Neon (TS) binding cargo-check — clean

## Review history

This branch went through two adversarial-review passes (design review before implementation, workflow code-review after). The second commit fixes the regressions the code-review surfaced — most notably a `sqlite://<relative>` startup break and a silent empty-DB footgun from a preemptive `File::create` (now delegated to the driver via `?mode=rwc`), plus restoring several diagnostic messages that the two old paths had.

## Follow-up (separate, in `cognee-cloud-rs`, after this lands + rev bump)

Register `QdrantVectorFactory` / `LiteRtLlmFactory` at the closed entry points.

## Open question for reviewers

The standalone http-server now accepts `VECTOR_DB_PROVIDER=brute-force` (ephemeral, data lost on restart) for parity with lib/CLI, where it previously hard-rejected it. Intentional per the design, but flagging in case the server should keep rejecting brute-force specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)