### PR TITLE
fix(release-publish): correct cargo owner preflight + add workflow_dispatch re-trigger

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -23,6 +23,16 @@ name: release-publish
 on:
   pull_request:
     types: [closed]
+  # Manual re-trigger for recovery — e.g. the merge-triggered run failed and the
+  # `pull_request: closed` event can't be re-fired, or a partial publish needs
+  # to be resumed. The version must already be bumped + committed on main; the
+  # `release` environment approval still gates the publish.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, e.g. 0.1.3 (must already be on main)"
+        required: true
+        type: string
 
 concurrency:
   group: release-publish
@@ -35,24 +45,33 @@ jobs:
   publish:
     name: Publish release
     if: >-
-      github.event.pull_request.merged == true &&
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
       startsWith(github.event.pull_request.head.ref, 'release/') &&
-      contains(github.event.pull_request.labels.*.name, 'autorelease:pending')
+      contains(github.event.pull_request.labels.*.name, 'autorelease:pending'))
     runs-on: ubuntu-latest
     timeout-minutes: 120
     # Required-reviewer gate: CARGO_REGISTRY_TOKEN lives as an environment secret
     # and is not decrypted onto the runner until a reviewer approves this job.
     environment: release
     steps:
-      - name: Resolve version from merged branch
+      - name: Resolve version
         id: v
+        env:
+          # Via env (not inline ${{ }}) so the branch/input can't inject shell.
+          EVENT: ${{ github.event_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          version="${{ github.event.pull_request.head.ref }}"
-          version="${version#release/}"
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            version="$INPUT_VERSION"
+          else
+            version="${HEAD_REF#release/}"
+          fi
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::merged branch does not encode a bare X.Y.Z version"
+            echo "::error::could not resolve a bare X.Y.Z version (event=$EVENT)"
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -61,9 +80,10 @@ jobs:
       - name: Checkout the merged release commit
         uses: actions/checkout@v4
         with:
-          # Pin to THIS PR's merge commit, not main's HEAD — otherwise a PR that
-          # merges immediately after would make us publish/tag the wrong tree.
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          # PR-merge path: pin to THIS PR's merge commit, not main's HEAD, so a
+          # PR that merges immediately after can't shift what we publish/tag.
+          # workflow_dispatch path: no merge commit, so use main (already bumped).
+          ref: ${{ github.event.pull_request.merge_commit_sha || 'main' }}
           fetch-depth: 0
           # PAT so the tag push cascades into capi-release.yml / ts-prebuild.yml.
           token: ${{ secrets.RELEASE_PAT }}
@@ -115,7 +135,7 @@ jobs:
           # on crates.io. Do NOT derive this from publish-order.sh — its first
           # entry is a dependency-free leaf that could be a brand-new,
           # not-yet-published crate, which would make a valid token look invalid.
-          cargo owner --list -p cognee-models
+          cargo owner --list cognee-models
 
       - name: Preflight — npm token
         env:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -143,9 +143,13 @@ git push origin main v0.1.3
 The publish order is: crates.io → tag push → (cascade) npm + C-API → GitHub
 Release. If it fails partway:
 
-- **crates.io loop failed midway** — fix the cause and **re-run the failed
-  `release-publish` job** ("Re-run failed jobs"). Already-published crates are
-  skipped; the tag is only pushed after all crates succeed.
+- **crates.io loop failed midway** — for a transient failure, use **"Re-run
+  failed jobs"** (reuses the same workflow; already-published crates are skipped
+  and the tag is only pushed after all crates succeed). If the fix was a change
+  to `release-publish.yml` itself, "Re-run" would reuse the *old* file — instead
+  land the fix on `main` and re-trigger with
+  `gh workflow run release-publish.yml -f version=X.Y.Z` (the `workflow_dispatch`
+  path publishes from `main`, still behind the `release` approval gate).
 - **Tag pushed but the npm / C-API cascade failed** (e.g. `ts-prebuild.yml` hit a
   transient npm error) — re-running `release-publish` will **not** re-fire the
   cascade (it skips the already-pushed tag). Instead re-run the failed workflow


### PR DESCRIPTION
The v0.1.3 publish failed at the crates.io token preflight:

```
cargo owner --list -p cognee-models
error: unexpected argument '-p' found
```

`cargo owner` takes the crate as a **positional** argument, so it errored on arg-parsing **before** contacting crates.io — the token was never tested. The fail-fast gate worked: **nothing was published/tagged/released** (all downstream steps skipped).

## Changes
- **Fix:** `cargo owner --list -p cognee-models` → `cargo owner --list cognee-models`.
- **Add `workflow_dispatch`** (version input) to `release-publish.yml` so the publish can be re-triggered after the `pull_request: closed` event already fired (`gh run rerun` would reuse the buggy workflow from the merge commit). The dispatch path resolves the version from the input, checks out `main`, and remains behind the `release` environment approval gate.
- Update the recovery runbook (`workflow_dispatch` re-trigger after a workflow-file fix).

## After merge
`gh workflow run release-publish.yml -f version=0.1.3` → approve the `release` environment → publishes 0.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsdjmRwm3Xuu3QFCKGGoq2