### PR TITLE
feat(llm): add ThrottleLlm rate-limit instrument for cognify load measurement

### DIFF
--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -53,4 +53,4 @@ cognee-test-utils = { path = "../test-utils" }
 dotenv.workspace = true
 httpmock = "0.8"
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/crates/llm/src/mock/mod.rs
+++ b/crates/llm/src/mock/mod.rs
@@ -2,6 +2,8 @@
 mod cassette;
 mod recording;
 mod replay;
+mod throttle;
 pub use cassette::{CassetteEntry, CassetteMethod, LlmCassette, input_hash, vision_hash};
 pub use recording::RecordingLlm;
 pub use replay::{MissPolicy, ReplayLlm};
+pub use throttle::{ThrottleConfig, ThrottleLlm, ThrottleMetrics};

--- a/crates/llm/src/mock/throttle.rs
+++ b/crates/llm/src/mock/throttle.rs
@@ -1,0 +1,349 @@
+//! Throttle and counting decorator for the offline load harness (issue #19).
+//!
+//! [`ReplayLlm`](super::replay::ReplayLlm) answers instantly, which is ideal for
+//! deterministic replay but hides the one regime that matters for the cognify
+//! LLM-call optimization: the high-load case where the provider rate limit, not
+//! the network, is the bottleneck. [`ThrottleLlm`] wraps any [`Llm`] and adds the
+//! two properties the instant mock lacks, so a benchmark can reproduce that
+//! regime offline and for free:
+//!
+//! 1. Request counting. Every call is counted per outcome, so a run reports how
+//!    many requests it issued. Request count is the direct measure of RPM
+//!    pressure, and it is deterministic (the same corpus always issues the same
+//!    number of calls), so it is the headline metric a caching or batching change
+//!    moves, not wall-clock.
+//! 2. A rolling requests-per-minute budget. With [`ThrottleConfig::rpm_limit`]
+//!    set, calls beyond the budget in the current 60s window are rejected with
+//!    the same [`LlmError::RateLimitExceeded`] a real HTTP 429 maps to, so retry
+//!    and backoff paths are exercised deterministically.
+//! 3. An optional per-call latency ([`ThrottleConfig::per_call_latency`]) so the
+//!    overlap a pipelining change buys becomes visible against the instant mock.
+//!
+//! With `rpm_limit = None` the decorator is a pure request counter (the "before"
+//! measurement). With a limit set it reproduces the rate-limited regime. The
+//! simulated 429 is a model, not a promise that it matches a specific provider;
+//! the deterministic request count is the metric meant to carry a headline claim.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::time::Instant;
+
+use crate::error::{LlmError, LlmResult};
+use crate::llm_trait::Llm;
+use crate::types::{GenerationOptions, GenerationResponse, Message};
+
+/// Rolling window over which [`ThrottleConfig::rpm_limit`] is enforced.
+const WINDOW: Duration = Duration::from_secs(60);
+
+/// Configuration for [`ThrottleLlm`].
+#[derive(Clone, Debug, Default)]
+pub struct ThrottleConfig {
+    /// Maximum number of allowed (non-429) requests per rolling 60s window.
+    /// `None` disables throttling, making the decorator a pure request counter.
+    pub rpm_limit: Option<u32>,
+    /// Latency injected before each allowed call, to simulate provider
+    /// turnaround. `None` keeps the inner mock's instant response.
+    pub per_call_latency: Option<Duration>,
+}
+
+/// Snapshot of what a [`ThrottleLlm`] has observed.
+///
+/// `allowed + rate_limited == total_calls`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ThrottleMetrics {
+    /// Every call the decorator received, including those rejected with a 429.
+    pub total_calls: u64,
+    /// Calls passed through to the inner LLM.
+    pub allowed: u64,
+    /// Calls rejected with a simulated 429 because the RPM budget was exceeded.
+    pub rate_limited: u64,
+}
+
+struct State {
+    /// Instants of the allowed requests still inside the current window.
+    window: VecDeque<Instant>,
+    metrics: ThrottleMetrics,
+}
+
+/// A decorator that wraps an inner [`Llm`], counts requests, and optionally
+/// enforces a rolling requests-per-minute budget and per-call latency.
+///
+/// Cloneable-friendly: hold it behind an [`Arc`] and share it across the
+/// concurrent extraction and summarization tasks so the counts and the budget
+/// are global, exactly as a single provider account would see them.
+pub struct ThrottleLlm {
+    inner: Arc<dyn Llm>,
+    config: ThrottleConfig,
+    state: Mutex<State>,
+}
+
+impl ThrottleLlm {
+    /// Wrap `inner` with the given throttle configuration.
+    pub fn new(inner: Arc<dyn Llm>, config: ThrottleConfig) -> Self {
+        Self {
+            inner,
+            config,
+            state: Mutex::new(State {
+                window: VecDeque::new(),
+                metrics: ThrottleMetrics::default(),
+            }),
+        }
+    }
+
+    /// Snapshot the metrics observed so far.
+    #[allow(clippy::unwrap_used, reason = "lock poison is unrecoverable")]
+    pub fn metrics(&self) -> ThrottleMetrics {
+        self.state.lock().unwrap().metrics
+    }
+
+    /// Account for one call and enforce the RPM budget.
+    ///
+    /// Evicts timestamps older than [`WINDOW`], then either records an allowed
+    /// request or returns [`LlmError::RateLimitExceeded`] when the budget is
+    /// full. The lock is released before any `.await` in [`gate`](Self::gate),
+    /// so it is never held across a suspension point.
+    #[allow(clippy::unwrap_used, reason = "lock poison is unrecoverable")]
+    fn admit(&self) -> LlmResult<()> {
+        let mut state = self.state.lock().unwrap();
+        state.metrics.total_calls += 1;
+
+        if let Some(limit) = self.config.rpm_limit {
+            let now = Instant::now();
+            while let Some(oldest) = state.window.front() {
+                if now.duration_since(*oldest) >= WINDOW {
+                    state.window.pop_front();
+                } else {
+                    break;
+                }
+            }
+            if state.window.len() as u32 >= limit {
+                state.metrics.rate_limited += 1;
+                return Err(LlmError::RateLimitExceeded(
+                    "simulated 429: RPM budget exceeded (ThrottleLlm)".to_string(),
+                ));
+            }
+            state.window.push_back(now);
+        }
+
+        state.metrics.allowed += 1;
+        Ok(())
+    }
+
+    /// Admit one call (enforcing the budget), then replay the configured latency.
+    async fn gate(&self) -> LlmResult<()> {
+        self.admit()?;
+        if let Some(latency) = self.config.per_call_latency {
+            tokio::time::sleep(latency).await;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Llm for ThrottleLlm {
+    async fn generate(
+        &self,
+        messages: Vec<Message>,
+        options: Option<GenerationOptions>,
+    ) -> LlmResult<GenerationResponse> {
+        self.gate().await?;
+        self.inner.generate(messages, options).await
+    }
+
+    async fn create_structured_output_with_messages_raw(
+        &self,
+        messages: Vec<Message>,
+        json_schema: &Value,
+        options: Option<GenerationOptions>,
+    ) -> LlmResult<Value> {
+        self.gate().await?;
+        self.inner
+            .create_structured_output_with_messages_raw(messages, json_schema, options)
+            .await
+    }
+
+    async fn transcribe_image(
+        &self,
+        image_bytes: &[u8],
+        mime_type: &str,
+        options: Option<GenerationOptions>,
+    ) -> LlmResult<String> {
+        self.gate().await?;
+        self.inner
+            .transcribe_image(image_bytes, mime_type, options)
+            .await
+    }
+
+    fn model(&self) -> &str {
+        self.inner.model()
+    }
+
+    fn supports_streaming(&self) -> bool {
+        self.inner.supports_streaming()
+    }
+
+    fn supports_function_calling(&self) -> bool {
+        self.inner.supports_function_calling()
+    }
+
+    fn max_context_length(&self) -> u32 {
+        self.inner.max_context_length()
+    }
+
+    fn supports_vision(&self) -> bool {
+        self.inner.supports_vision()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        reason = "test code — panics are acceptable"
+    )]
+    use super::*;
+    use serde_json::json;
+
+    use crate::types::MessageRole;
+
+    // A trivial always-succeeding LLM. A local stub avoids the dev-dependency
+    // cycle described in `recording.rs` (cognee-test-utils depends on cognee-llm
+    // without the `mock` feature).
+    struct OkLlm;
+
+    #[async_trait]
+    impl Llm for OkLlm {
+        async fn generate(
+            &self,
+            _messages: Vec<Message>,
+            _options: Option<GenerationOptions>,
+        ) -> LlmResult<GenerationResponse> {
+            Ok(GenerationResponse {
+                content: "ok".to_string(),
+                model: "ok-llm".to_string(),
+                usage: None,
+                finish_reason: Some("stop".to_string()),
+            })
+        }
+
+        async fn create_structured_output_with_messages_raw(
+            &self,
+            _messages: Vec<Message>,
+            _json_schema: &Value,
+            _options: Option<GenerationOptions>,
+        ) -> LlmResult<Value> {
+            Ok(json!({"nodes": [], "relationships": []}))
+        }
+
+        fn model(&self) -> &str {
+            "ok-llm"
+        }
+    }
+
+    fn msgs() -> Vec<Message> {
+        vec![Message {
+            role: MessageRole::User,
+            content: "hi".to_string(),
+        }]
+    }
+
+    async fn call(t: &ThrottleLlm) -> LlmResult<GenerationResponse> {
+        t.generate(msgs(), None).await
+    }
+
+    #[tokio::test]
+    async fn counts_every_call_when_unlimited() {
+        let t = ThrottleLlm::new(Arc::new(OkLlm), ThrottleConfig::default());
+        for _ in 0..5 {
+            call(&t).await.expect("unlimited call succeeds");
+        }
+        assert_eq!(
+            t.metrics(),
+            ThrottleMetrics {
+                total_calls: 5,
+                allowed: 5,
+                rate_limited: 0,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn counts_structured_and_generate_paths() {
+        let t = ThrottleLlm::new(Arc::new(OkLlm), ThrottleConfig::default());
+        t.generate(msgs(), None).await.expect("generate");
+        let schema = json!({"type": "object"});
+        t.create_structured_output_with_messages_raw(msgs(), &schema, None)
+            .await
+            .expect("structured");
+        assert_eq!(t.metrics().total_calls, 2);
+        assert_eq!(t.metrics().allowed, 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn enforces_rpm_budget_within_window() {
+        let t = ThrottleLlm::new(
+            Arc::new(OkLlm),
+            ThrottleConfig {
+                rpm_limit: Some(3),
+                per_call_latency: None,
+            },
+        );
+        // First 3 succeed, the next 2 are rejected with a simulated 429.
+        for _ in 0..3 {
+            call(&t).await.expect("within budget");
+        }
+        for _ in 0..2 {
+            let err = call(&t).await.expect_err("over budget must 429");
+            assert!(matches!(err, LlmError::RateLimitExceeded(_)));
+        }
+        assert_eq!(
+            t.metrics(),
+            ThrottleMetrics {
+                total_calls: 5,
+                allowed: 3,
+                rate_limited: 2,
+            }
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn budget_refills_as_the_window_slides() {
+        let t = ThrottleLlm::new(
+            Arc::new(OkLlm),
+            ThrottleConfig {
+                rpm_limit: Some(2),
+                per_call_latency: None,
+            },
+        );
+        call(&t).await.expect("1st");
+        call(&t).await.expect("2nd");
+        call(&t).await.expect_err("3rd exceeds budget");
+
+        // Advance past the window so the first two timestamps are evicted.
+        tokio::time::advance(WINDOW + Duration::from_secs(1)).await;
+
+        call(&t).await.expect("budget refilled after window");
+        assert_eq!(t.metrics().allowed, 3);
+        assert_eq!(t.metrics().rate_limited, 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn injects_configured_latency() {
+        let t = ThrottleLlm::new(
+            Arc::new(OkLlm),
+            ThrottleConfig {
+                rpm_limit: None,
+                per_call_latency: Some(Duration::from_millis(200)),
+            },
+        );
+        let start = Instant::now();
+        call(&t).await.expect("call with latency");
+        // Under paused time, the sleep advances the clock by exactly the latency.
+        assert_eq!(start.elapsed(), Duration::from_millis(200));
+    }
+}


### PR DESCRIPTION
## Summary

Part of #19. Adds `ThrottleLlm`, a deterministic instrument for measuring cognify's LLM-call behaviour under the one regime that matters for this issue: the high-load case where the provider rate limit, not the network, is the bottleneck.

The discussion on #19 kept returning to a single question: how do you measure the win in the real, rate-limited regime, given that `ReplayLlm` answers instantly (so it hides latency and never hits a rate limit) and a low-sample live run is flaky and never saturates the limit? This is the tool that answers it, offline and at zero token cost.

## What it does

`ThrottleLlm` wraps any `Llm` (in practice `ReplayLlm`) and adds the two properties the instant mock lacks:

- Request counting per outcome (total, allowed, rate_limited). Request count is the deterministic measure of RPM pressure, and it is the headline metric a caching or batching change moves, where wall-clock cannot. The same corpus always issues the same number of requests.
- A rolling 60s requests-per-minute budget. Calls over the budget return the same `LlmError::RateLimitExceeded` a real HTTP 429 maps to, so the retry and backoff paths are exercised deterministically.
- An optional per-call latency, so the overlap a pipelining change buys becomes visible against the instant mock.

With `rpm_limit = None` it is a pure request counter (the "before" measurement); with a limit set it reproduces the rate-limited regime. The simulated 429 is a model, not a claim to match a specific provider; the deterministic request count is the metric meant to carry a headline, and the 429 path is there to exercise retry and backoff.

## Why this shape

- No trait-signature change. It lives behind the existing `mock` feature and delegates every `Llm` method, so it composes with `ReplayLlm` and `RecordingLlm` without touching the core trait. Surfacing byte-exact token counts (for TPM) would need a return-type change on the structured-output path, which I propose as a separate follow-up rather than folding it in here. Shared, global accounting. Hold it behind an `Arc` and share it across the concurrent extraction and summarization tasks, so the counts and the budget are global, exactly as a single provider account would see them. The lock is never held across an await point.

## Tests

Five unit tests (`cargo test -p cognee-llm --features mock throttle`), all deterministic and offline:

- counts every call when unlimited,
- counts both the generate and structured-output paths,
- enforces the RPM budget within a window,
- budget refills as the window slides (using paused tokio time),
- injects the configured latency.

Verified locally: fmt, `clippy --all-targets -D warnings` (with the mock feature), and the five tests.

## What follows

The immediate next step is a cognify bench that drives a representative run through `ThrottleLlm` and prints the before/after request-count table, plus the token surfacing for TPM. This PR is the instrument those build on, kept separate so the tool is reviewable on its own.

## Scope

Part of #19. Does not close it.