### PR TITLE
fix(lib): drop the crates.io-unpublishable server feature (unblocks 0.1.3)

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -71,7 +71,6 @@ default = [
 # Record/replay cassette-based mock LLM support (MOCK_LLM / COGNEE_RECORD_LLM).
 # Pulls in no heavy deps, so it is default-on.
 mock-llm       = ["cognee-llm/mock"]
-server         = ["dep:cognee-http-server"]
 visualization  = ["dep:cognee-visualization"]
 onnx           = ["cognee-embedding/onnx"]
 onnx-dynamic   = ["cognee-embedding/onnx-dynamic"]
@@ -144,7 +143,6 @@ testing = [
 [dependencies]
 cognee-chunking = { path = "../chunking", version = "0.1.3" }
 cognee-utils = { path = "../utils", version = "0.1.3" }
-cognee-http-server = { path = "../http-server", version = "0.1.3", optional = true }
 cognee-cognify = { path = "../cognify", version = "0.1.3" }
 cognee-core = { path = "../core", version = "0.1.3", features = ["pipeline-run-registry"] }
 cognee-delete = { path = "../delete", version = "0.1.3" }

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -141,15 +141,6 @@ pub mod visualization {
 #[cfg(feature = "visualization")]
 pub use cognee_visualization::{VisualizationError, visualize};
 
-#[cfg(feature = "server")]
-pub mod http {
-    //! HTTP server surface. Available only when the `server` feature is enabled.
-    //! Consumers who only need the embedded server inside their own binary should
-    //! prefer this re-export over taking a direct dependency on `cognee-http-server`,
-    //! to keep their dependency closure aligned with the rest of the cognee crates.
-    pub use cognee_http_server::*;
-}
-
 /// Session management.
 pub mod session;
 


### PR DESCRIPTION
## Why
The 0.1.3 publish stalled after **20/21 crates** shipped to crates.io: `cognee-lib` failed with

```
failed to select a version for the requirement `cognee-http-server = "^0.1.3"`
```

`cognee-lib`'s optional `server` feature depends on `cognee-http-server`, which is `publish = false` (only `0.1.0` on crates.io). `cargo set-version --workspace` bumped the req to `^0.1.3` in lockstep — unsatisfiable. The feature only re-exported `cognee_http_server` behind `#[cfg(feature = "server")]`, **can never resolve from crates.io**, and **nothing in the workspace or bindings enables it** (verified).

## Change
Remove the `server` feature, the optional `cognee-http-server` dependency, and the `pub mod http` re-export from `cognee-lib`. Workspace/source consumers depend on `cognee-http-server` directly. This makes `cognee-lib` publishable and removes the http-server req permanently (nothing left for `set-version` to re-break next release).

`cargo check -p cognee-lib` passes; no references to the removed `cognee_lib::http` re-export exist anywhere.

## After merge (release recovery)
Re-dispatch `release-publish.yml -f version=0.1.3` → approve. The publish loop skips the 20 already-published crates (idempotent), publishes `cognee-lib`, pushes `v0.1.3`, and cascades npm + C-API + GitHub Release.

Note: `publish-dry-run` will be red here (0.1.3 isn't fully on crates.io yet) — expected, non-required, self-heals once the release completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsdjmRwm3Xuu3QFCKGGoq2