### PR TITLE
fix(capi): header-sync gate fails on Windows (CRLF allowlist) — blocks C-API tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Keep shell scripts and plain-text data files LF on every platform, so Windows
+# CI (default core.autocrlf=true) doesn't check them out as CRLF and break tools
+# that parse them line-by-line — e.g. capi/scripts/check_header_sync.sh reading
+# capi/scripts/header_sync_allow.txt.
+*.sh  text eol=lf
+*.txt text eol=lf

--- a/capi/scripts/check_header_sync.sh
+++ b/capi/scripts/check_header_sync.sh
@@ -41,7 +41,13 @@ grep -hoE '\b(cg|cognee)_[a-z0-9_]+[[:space:]]*\(' \
 # Each non-blank, non-comment line in the allowlist is removed from EXPORTS_TMP
 # so it is not flagged as undeclared.
 if [[ -f "$ALLOWLIST" ]]; then
-    while IFS= read -r entry; do
+    while IFS= read -r entry || [[ -n "$entry" ]]; do
+        # Strip a trailing CR: on Windows CI (core.autocrlf=true, no .gitattributes
+        # override) the allowlist checks out as CRLF, leaving "\r" on each entry,
+        # which would defeat the `^${entry}$` sed match below and wrongly flag an
+        # allowlisted symbol. The `|| [[ -n "$entry" ]]` also handles a final line
+        # with no trailing newline.
+        entry="${entry%$'\r'}"
         # Skip blank lines and comments.
         [[ -z "$entry" || "$entry" == \#* ]] && continue
         # `sed -i.bak` is portable across GNU and BSD/macOS sed (a bare `sed -i`


### PR DESCRIPTION
## Why
The `v0.1.3` `capi-release` run failed on the **windows-x86_64** leg at the **Header sync gate**, flagging the allowlisted symbol `cg_test_force_panic`. Because the attach job has `needs: build`, the failure **skipped the tarball attach** → the v0.1.3 Release has **zero C-API tarballs**. (crates.io + npm are unaffected.)

## Root cause
No `.gitattributes` + Windows `core.autocrlf=true` → `capi/scripts/header_sync_allow.txt` checks out CRLF. `check_header_sync.sh` read each entry with a trailing `\r`, so `sed "/^${entry}$/d"` didn't match the LF-clean symbol and the allowlist entry was silently ignored. Pre-existing; would fail every Windows capi build.

## Fix
- Strip trailing `\r` when reading the allowlist (`entry="${entry%$'\r'}"`), plus handle a final newline-less line.
- Add a narrow `.gitattributes` (`*.sh`, `*.txt` → `eol=lf`) so scripts/data files can't check out as CRLF anywhere.

Verified: `bash -n` clean; CRLF allowlist entries now strip correctly to LF-clean symbols.

## After merge
Move/re-push the `v0.1.3` tag to the fixed commit → `capi-release` re-fires and attaches all 5 tarballs. (Only re-triggers the tag workflows — capi-release + idempotent ts-prebuild — not crates.io.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsdjmRwm3Xuu3QFCKGGoq2