### PR TITLE
fix(release): npm publish path + capi-release cross/platform fixes (finish 0.1.3 artifacts)

### DIFF
--- a/.github/workflows/capi-release.yml
+++ b/.github/workflows/capi-release.yml
@@ -51,14 +51,18 @@ jobs:
             cross: true
             archive_suffix: linux-aarch64
 
-          # macOS x86_64
-          - os: macos-13
-            target: x86_64-apple-darwin
-            cross: false
-            archive_suffix: macos-x86_64
+          # NOTE: no macos-x86_64 (x86_64-apple-darwin). ort 2.0.0-rc.12 ships no
+          # prebuilt ONNX Runtime for that target (its dist manifest bundles ORT
+          # 1.24.2, which Microsoft no longer builds for x86_64 macOS as of ORT
+          # 1.24.1), so ort-sys errors "does not provide prebuilt binaries for the
+          # target x86_64-apple-darwin". Intel macOS is also EOL and GitHub is
+          # retiring its x86_64 runners. Dropped rather than carry a red leg —
+          # matches ts-prebuild.yml, which dropped darwin-x64 for the same reason.
 
-          # macOS aarch64 (Apple Silicon)
-          - os: macos-14
+          # macOS aarch64 (Apple Silicon). macos-15 (Xcode 16.4): the older
+          # macos-14 default (Xcode 15.4) ships a libc++ whose std::construct_at
+          # trips a C++20 aggregate-init bug compiling lbug's bundled C++.
+          - os: macos-15
             target: aarch64-apple-darwin
             cross: false
             archive_suffix: macos-aarch64
@@ -106,6 +110,16 @@ jobs:
           workspaces: capi -> target
           cache-on-failure: true
 
+      # ort-sys downloads the ONNX Runtime binary into ORT_CACHE_DIR. For the
+      # cross build that dir is /target/ort-cache in-container == capi/target/
+      # ort-cache on the host (cross mounts capi/target at /target).
+      - name: Cache ORT binary (cross)
+        if: matrix.cross
+        uses: actions/cache@v4
+        with:
+          path: capi/target/ort-cache
+          key: capi-ort-${{ matrix.archive_suffix }}-v1
+
       - name: Resolve tag
         id: tag
         shell: bash
@@ -133,8 +147,20 @@ jobs:
 
       - name: Build release library (cross)
         if: matrix.cross
+        working-directory: capi
         shell: bash
-        run: cross build --release --manifest-path capi/Cargo.toml --target ${{ matrix.target }}
+        # Run from capi/ so cross picks up capi/Cross.toml (repo mount via
+        # COGNEE_REPO_ROOT so ../crates path-deps resolve; gcc-11 + libssl image).
+        # cross mounts capi/target at /target. Disable simsimd's advanced ARM SIMD
+        # kernels the cross toolchain can't assemble (basic NEON + serial remain).
+        env:
+          ORT_CACHE_DIR: /target/ort-cache
+          COGNEE_REPO_ROOT: ${{ github.workspace }}
+        run: |
+          SVE="-DSIMSIMD_TARGET_NEON_I8=0 -DSIMSIMD_TARGET_NEON_F16=0 -DSIMSIMD_TARGET_NEON_BF16=0 -DSIMSIMD_TARGET_SVE=0 -DSIMSIMD_TARGET_SVE_I8=0 -DSIMSIMD_TARGET_SVE_F16=0 -DSIMSIMD_TARGET_SVE_BF16=0 -DSIMSIMD_TARGET_SVE2=0"
+          TGT_US=$(echo "${{ matrix.target }}" | tr '-' '_')
+          export CFLAGS_${TGT_US}="$SVE" CXXFLAGS_${TGT_US}="$SVE"
+          cross build --release --target ${{ matrix.target }}
 
       - name: Assemble release tarball
         shell: bash
@@ -153,11 +179,28 @@ jobs:
     name: Attach to GitHub Release
     needs: build
     runs-on: ubuntu-latest
-    # Only auto-attach for real tag pushes; workflow_dispatch is dry-run only.
-    if: github.event_name == 'push'
+    # Attach on a real tag push, or on a manual workflow_dispatch (so a failed
+    # release can be re-cut without force-moving the tag — the dispatch input
+    # supplies the tag to attach to).
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          else
+            TAG="${{ inputs.tag }}"
+          fi
+          if [ -z "$TAG" ]; then
+            echo "::error::Could not resolve a tag to attach to"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Download all platform artifacts
         uses: actions/download-artifact@v4
@@ -171,6 +214,9 @@ jobs:
       - name: Attach tarballs to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          # Explicit tag_name: on workflow_dispatch github.ref is a branch, so
+          # the action can't infer the tag from the ref like it does on push.
+          tag_name: ${{ steps.tag.outputs.tag }}
           files: artifacts/*
           fail_on_unmatched_files: true
         env:

--- a/.github/workflows/ts-prebuild.yml
+++ b/.github/workflows/ts-prebuild.yml
@@ -1,7 +1,7 @@
 name: TS Prebuild
 
 # Build per-platform prebuilt .node binaries and publish per-platform npm
-# packages (@cognee-ts/neon-<platform>) on release tags, then publish the main
+# packages (@cognee/neon-<platform>) on release tags, then publish the main
 # `cognee-ts` npm package once all platform packages are live.
 #
 # The matrix matches the entries in:
@@ -337,7 +337,9 @@ jobs:
               echo "SKIP ${PKG}@${VER}: already on registry"
             else
               echo "--- Publishing ${PKG}@${VER} ---"
-              npm publish "${PLATFORM}" --access public
+              # `./` prefix so npm treats the arg as a directory to pack, not a
+              # package spec to fetch (a bare `linux-x64-gnu` → E404 GET /linux-x64-gnu).
+              npm publish "./${PLATFORM}" --access public
             fi
           done
 

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ cognee.db
 # Generated Locust benchmark artifacts
 e2e-cross-sdk/performance/locust/results/
 results/
+ghlogs/

--- a/capi/Cross.toml
+++ b/capi/Cross.toml
@@ -1,0 +1,25 @@
+# Cross-compilation config for the C-API (cross-rs), mirroring the proven
+# ts/cognee-ts-neon/Cross.toml setup that already builds the aarch64 Neon addon.
+#
+# capi/ is a standalone (nested) workspace, so cross-rs by default mounts only
+# this directory — leaving its path-deps (../crates/*) and the root Cargo.toml
+# outside the container ("failed to find a workspace root"). `volumes` mounts the
+# whole repo (COGNEE_REPO_ROOT) at its host path so those resolve.
+#
+# The stock cross image is a minimal Ubuntu that lacks what the build needs:
+#   - gcc-11 / libstdc++ 11 for the bundled lbug C++ engine (C++20),
+#   - libssl-dev, so ort-sys's ureq/native-tls -> openssl-sys build script links
+#     (the default cross image has no openssl -> the previous capi run failed here).
+# ci/cross/aarch64-gnu.Dockerfile (shared with ts-prebuild) bakes in gcc-11 +
+# cmake + protoc + libssl.
+
+[build.env]
+volumes = ["COGNEE_REPO_ROOT"]
+passthrough = [
+    "CFLAGS_aarch64_unknown_linux_gnu",
+    "CXXFLAGS_aarch64_unknown_linux_gnu",
+    "ORT_CACHE_DIR",
+]
+
+[target.aarch64-unknown-linux-gnu]
+dockerfile = "../ci/cross/aarch64-gnu.Dockerfile"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -50,7 +50,10 @@ Runs behind the **`release` environment** (required reviewers). Order:
    the index between dependents; already-published versions are skipped, so
    re-runs are safe).
 2. **Tag** — push `vX.Y.Z` with `RELEASE_PAT`, which cascades into:
-   - `capi-release.yml` → 5 per-platform C-API tarballs attached to the Release.
+   - `capi-release.yml` → 4 per-platform C-API tarballs (linux-x86_64,
+     linux-aarch64, macos-aarch64, windows-x86_64) attached to the Release.
+     x86_64-apple-darwin is intentionally not built — `ort` ships no prebuilt
+     ONNX Runtime for it (mirrors ts-prebuild dropping darwin-x64).
    - `ts-prebuild.yml` → prebuilt `.node` binaries + `@cognee/neon-*` and
      `@cognee/cognee-ts` npm packages (gated on `NPM_TOKEN`).
 3. **GitHub Release** — created/updated with the changelog section.


### PR DESCRIPTION
Both cascade workflows failed on the `v0.1.3` tag; this fixes them. (crates.io is already complete — this is only the npm + C-API artifacts.)

## npm (`ts-prebuild`)
`npm publish "${PLATFORM}"` treated the bare `linux-x64-gnu` as a *package spec* → `E404 GET /linux-x64-gnu` on the first platform, aborting the publish. Nothing published (verified npm is clean).
- **Fix:** `npm publish "./${PLATFORM}"` so npm packs the directory. Also fixed the stale `@cognee-ts/neon-*` header comment.

## C-API (`capi-release`) — three distinct failures
- **linux-aarch64:** the default `cross` image has no openssl, so `ort-sys`'s `ureq`→`native-tls`→`openssl-sys` build script failed. Added **`capi/Cross.toml`** mirroring the proven `ts-prebuild` setup — mounts the repo (so `../crates` path-deps resolve) and uses the shared `ci/cross/aarch64-gnu.Dockerfile` (gcc-11 + cmake + protoc + **libssl**), with `ORT_CACHE_DIR` + SIMSIMD-disable CFLAGS + an ORT-binary cache.
- **macos-aarch64:** bumped `macos-14` → **`macos-15`** (Xcode 16.4) so `lbug`'s C++20 compiles (the `std::construct_at` libc++ issue).
- **macos-x86_64:** **dropped.** `ort` 2.0.0-rc.12 ships no prebuilt ONNX Runtime for `x86_64-apple-darwin` (MS dropped x64 macOS at ORT 1.24.1) — the leg can't link. Verified against ort's dist manifest + MS release notes. Mirrors `ts-prebuild` dropping darwin-x64.

Also made the capi-release **attach job `workflow_dispatch`-runnable** (explicit `tag_name`) so a failed release can be re-cut without force-moving the tag.

Result: 4 supported C-API platforms (linux-x86_64, linux-aarch64, macos-aarch64, windows-x86_64) + npm.

## After merge
- Re-run npm: `gh workflow run ts-prebuild.yml` (idempotent; publishes all 5 packages).
- Re-cut C-API: `gh workflow run capi-release.yml -f tag=v0.1.3` (builds from main, attaches to the existing Release — no tag move).

⚠️ The `linux-aarch64` cross build and macOS legs can only be validated by the actual CI run; this is the first iteration of the capi cross port and may need follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsdjmRwm3Xuu3QFCKGGoq2