### PR TITLE
chore(perf): re-record stale perf benchmark cassette

### DIFF
--- a/scripts/perf/fixtures/cassette.json
+++ b/scripts/perf/fixtures/cassette.json
@@ -2,3482 +2,3308 @@
   "version": 1,
   "model": "gpt-4o-mini",
   "entries": {
-    "05fb6278db240d295d2fe7f69d2ef9c42ce457583b06800f6cde3f2bf6404458": {
-      "method": "structured_output",
-      "user_input_preview": "Title: First Day at University\n\nI remember my first day at the University of Belgrade. The campus was bustling with new ",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "The author's initial experience at the University of Belgrade was filled with excitement and anxiety as they began their Computer Science studies.",
-        "description": "On the first day at the University of Belgrade, the campus was lively with incoming students, evoking feelings of both anticipation and nervousness. The author started their journey in the Computer Science program, which would influence their next four years, highlighted by an inspiring introductory lecture from a professor about the future of computing."
-      }
-    },
-    "0603c47a0609b2d6e4f8e5ae9ed2aaf5d30633e4ca85e02e97f29493ca530577": {
-      "method": "structured_output",
-      "user_input_preview": "Title: The Importance of Backups\n\nI learned the importance of backups when my laptop's hard drive failed in 2016, taking",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "The significance of backups became clear to me after losing six months of personal projects due to a hard drive failure in 2016. Since then, I have implemented automated backups to both an external drive and cloud storage.",
-        "description": "In 2016, I experienced a hard drive failure on my laptop that resulted in the loss of six months' worth of personal projects, highlighting the critical need for backups. Following this incident, I established a system for automated backups to an external drive and cloud storage, adhering to the principle that data must be stored in multiple locations to ensure its existence."
-      }
-    },
-    "061e4e2a435270d0487a57ff3ffcbb25f560454e383d38652e27e70c66d6f3f6": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Setting Up My First Server\n\nI set up my first Linux server in 2011 — a Debian box running Apache and MySQL. I spe",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Linux",
-            "name": "Linux",
-            "type": "CONCEPT",
-            "description": "Linux is a family of open-source Unix-like operating systems based on the Linux kernel."
-          },
-          {
-            "id": "Debian",
-            "name": "Debian",
-            "type": "CONCEPT",
-            "description": "Debian is a popular Linux distribution known for its stability and extensive software repositories."
-          },
-          {
-            "id": "Apache",
-            "name": "Apache",
-            "type": "CONCEPT",
-            "description": "Apache is a widely-used open-source web server software."
-          },
-          {
-            "id": "MySQL",
-            "name": "MySQL",
-            "type": "CONCEPT",
-            "description": "MySQL is an open-source relational database management system."
-          },
-          {
-            "id": "2011",
-            "name": "2011",
-            "type": "DATE",
-            "description": "The year when the first Linux server was set up."
-          },
-          {
-            "id": "iptables",
-            "name": "iptables",
-            "type": "CONCEPT",
-            "description": "iptables is a user-space utility program that allows a system administrator to configure the IP packet filter rules of the Linux kernel."
-          },
-          {
-            "id": "SSH keys",
-            "name": "SSH keys",
-            "type": "CONCEPT",
-            "description": "SSH keys are a pair of cryptographic keys used for secure access to servers."
-          },
-          {
-            "id": "port 22",
-            "name": "port 22",
-            "type": "CONCEPT",
-            "description": "Port 22 is the default port used for SSH connections."
-          },
-          {
-            "id": "website",
-            "name": "website",
-            "type": "CONCEPT",
-            "description": "A website is a collection of related web pages located under a single domain name."
-          },
-          {
-            "id": "sysadmin",
-            "name": "sysadmin",
-            "type": "CONCEPT",
-            "description": "A sysadmin, or system administrator, is responsible for managing and maintaining computer systems."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "2011",
-            "target_node_id": "Linux",
-            "relationship_name": "set_up"
-          },
-          {
-            "source_node_id": "Linux",
-            "target_node_id": "Debian",
-            "relationship_name": "uses"
-          },
-          {
-            "source_node_id": "Linux",
-            "target_node_id": "Apache",
-            "relationship_name": "runs"
-          },
-          {
-            "source_node_id": "Linux",
-            "target_node_id": "MySQL",
-            "relationship_name": "runs"
-          },
-          {
-            "source_node_id": "Linux",
-            "target_node_id": "iptables",
-            "relationship_name": "configures"
-          },
-          {
-            "source_node_id": "Linux",
-            "target_node_id": "SSH keys",
-            "relationship_name": "configures"
-          },
-          {
-            "source_node_id": "Linux",
-            "target_node_id": "port 22",
-            "relationship_name": "uses"
-          },
-          {
-            "source_node_id": "Linux",
-            "target_node_id": "website",
-            "relationship_name": "hosts"
-          },
-          {
-            "source_node_id": "Linux",
-            "target_node_id": "sysadmin",
-            "relationship_name": "managed_by"
-          }
-        ]
-      }
-    },
-    "0949e1abc0ce108c6eacfb2469953d3bcbeb790b2ea00b0447bfedf897f518b2": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Learning to Ride a Bicycle\n\nMy grandfather taught me to ride a bicycle in the park near our house when I was six ",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "My grandfather taught me to ride a bike when I was six, supporting me until I balanced on my own, leading to a joyful moment despite a subsequent crash into a bush.",
-        "description": "At the age of six, my grandfather guided me in learning to ride a bicycle in a nearby park. He initially held the back of the seat while running beside me until I achieved balance. The exhilarating moment he released me was filled with happiness, even though I soon crashed into a bush."
-      }
-    },
-    "0ae128d23c37c0a5fa49463f1e86ffaec6735e9ea1a037b4a73b6b18d996ec8c": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Visiting a Museum in Florence\n\nSeeing Michelangelo's David at the Galleria dell'Accademia in Florence was overwhe",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Michelangelo",
-            "name": "Michelangelo",
-            "type": "PERSON",
-            "description": "Michelangelo was an Italian sculptor, painter, and architect, renowned for his masterpieces including the statue of David."
-          },
-          {
-            "id": "Florence",
-            "name": "Florence",
-            "type": "LOCATION",
-            "description": "Florence is a city in Italy known for its rich history, art, and architecture, and is home to many famous museums."
-          },
-          {
-            "id": "Galleria dell'Accademia",
-            "name": "Galleria dell'Accademia",
-            "type": "ORGANIZATION",
-            "description": "Galleria dell'Accademia is a prominent art museum in Florence, famous for housing Michelangelo's David."
-          },
-          {
-            "id": "David",
-            "name": "David",
-            "type": "CONCEPT",
-            "description": "David is a renowned marble sculpture created by Michelangelo, representing the biblical hero."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Michelangelo",
-            "target_node_id": "David",
-            "relationship_name": "created"
-          },
-          {
-            "source_node_id": "Galleria dell'Accademia",
-            "target_node_id": "David",
-            "relationship_name": "houses"
-          },
-          {
-            "source_node_id": "Galleria dell'Accademia",
-            "target_node_id": "Florence",
-            "relationship_name": "located_in"
-          }
-        ]
-      }
-    },
-    "0db24cab16935df50334b663536403e8e39d77e73f3b41851eef7cc72e4eda01": {
-      "method": "structured_output",
-      "user_input_preview": "Title: First Programming Language\n\nI wrote my first program in BASIC on a Commodore 64 when I was twelve. It was a simpl",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "BASIC",
-            "name": "BASIC",
-            "type": "CONCEPT",
-            "description": "BASIC is a high-level programming language designed for ease of use, often used for teaching programming."
-          },
-          {
-            "id": "Commodore 64",
-            "name": "Commodore 64",
-            "type": "CONCEPT",
-            "description": "The Commodore 64 is an 8-bit home computer introduced in 1982, known for its popularity in the 1980s."
-          },
-          {
-            "id": "programming",
-            "name": "programming",
-            "type": "CONCEPT",
-            "description": "Programming is the process of designing and building executable computer software to accomplish a specific task."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "BASIC",
-            "target_node_id": "Commodore 64",
-            "relationship_name": "used_on"
-          },
-          {
-            "source_node_id": "programming",
-            "target_node_id": "BASIC",
-            "relationship_name": "involves"
-          }
-        ]
-      }
-    },
-    "148fafc3c329c58b8dba7dcd2d8a20a893cbab3b42167c967ab0bee62f3c8b1a": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Building a Treehouse\n\nMy father and I built a treehouse in the oak tree in our backyard when I was ten. We spent ",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "father",
-            "name": "father",
-            "type": "PERSON",
-            "description": "The narrator's father who helped build a treehouse."
-          },
-          {
-            "id": "oak_tree",
-            "name": "oak tree",
-            "type": "LOCATION",
-            "description": "The type of tree where the treehouse was built."
-          },
-          {
-            "id": "backyard",
-            "name": "backyard",
-            "type": "LOCATION",
-            "description": "The area behind the house where the treehouse was constructed."
-          },
-          {
-            "id": "treehouse",
-            "name": "treehouse",
-            "type": "CONCEPT",
-            "description": "A structure built in a tree, used by the narrator as a reading nook."
-          },
-          {
-            "id": "childhood",
-            "name": "childhood",
-            "type": "CONCEPT",
-            "description": "The period of life when the narrator was ten years old and built the treehouse."
-          },
-          {
-            "id": "DIY",
-            "name": "DIY",
-            "type": "CONCEPT",
-            "description": "Do-it-yourself activities, such as building a treehouse."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "father",
-            "target_node_id": "treehouse",
-            "relationship_name": "helped_build"
-          },
-          {
-            "source_node_id": "treehouse",
-            "target_node_id": "oak_tree",
-            "relationship_name": "built_in"
-          },
-          {
-            "source_node_id": "treehouse",
-            "target_node_id": "backyard",
-            "relationship_name": "located_in"
-          },
-          {
-            "source_node_id": "treehouse",
-            "target_node_id": "childhood",
-            "relationship_name": "associated_with"
-          },
-          {
-            "source_node_id": "treehouse",
-            "target_node_id": "DIY",
-            "relationship_name": "related_to"
-          }
-        ]
-      }
-    },
-    "176f04038710b016afc91908ecd171813ac8a5c166960eb17fa29eff8f4d10f9": {
-      "method": "structured_output",
-      "user_input_preview": "Title: First Open Source Contribution\n\nMy first open source contribution was a bug fix to a Python logging library in 20",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "First Open Source Contribution",
-            "name": "First Open Source Contribution",
-            "type": "CONCEPT",
-            "description": "The initial contribution made to an open source project, specifically a bug fix in this context."
-          },
-          {
-            "id": "Python",
-            "name": "Python",
-            "type": "CONCEPT",
-            "description": "A high-level programming language known for its readability and versatility."
-          },
-          {
-            "id": "2014",
-            "name": "2014",
-            "type": "DATE",
-            "description": "The year when the first open source contribution was made."
-          },
-          {
-            "id": "bug fix",
-            "name": "bug fix",
-            "type": "CONCEPT",
-            "description": "A correction made to a software program to resolve an error or issue."
-          },
-          {
-            "id": "race condition",
-            "name": "race condition",
-            "type": "CONCEPT",
-            "description": "A situation in computing where the behavior of software depends on the sequence or timing of uncontrollable events."
-          },
-          {
-            "id": "file rotation handler",
-            "name": "file rotation handler",
-            "type": "CONCEPT",
-            "description": "A component in logging systems that manages the creation and deletion of log files."
-          },
-          {
-            "id": "pull request",
-            "name": "pull request",
-            "type": "CONCEPT",
-            "description": "A method of submitting contributions to a software project, where changes are proposed for review."
-          },
-          {
-            "id": "changelog",
-            "name": "changelog",
-            "type": "CONCEPT",
-            "description": "A log or record of changes made to a project, often including contributions and bug fixes."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "First Open Source Contribution",
-            "target_node_id": "Python",
-            "relationship_name": "involves"
-          },
-          {
-            "source_node_id": "First Open Source Contribution",
-            "target_node_id": "2014",
-            "relationship_name": "occurred_in"
-          },
-          {
-            "source_node_id": "First Open Source Contribution",
-            "target_node_id": "bug fix",
-            "relationship_name": "is_a"
-          },
-          {
-            "source_node_id": "bug fix",
-            "target_node_id": "race condition",
-            "relationship_name": "addresses"
-          },
-          {
-            "source_node_id": "bug fix",
-            "target_node_id": "file rotation handler",
-            "relationship_name": "related_to"
-          },
-          {
-            "source_node_id": "First Open Source Contribution",
-            "target_node_id": "pull request",
-            "relationship_name": "involves"
-          },
-          {
-            "source_node_id": "pull request",
-            "target_node_id": "changelog",
-            "relationship_name": "updates"
-          }
-        ]
-      }
-    },
-    "17f3f229483cf5775cc08fda9567e2d5944b3b51c07735617ffa1468d35bf669": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Moving to a New City\n\nWhen I moved to Berlin in 2018, I knew nobody in the city. The first month was lonely — I s",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Berlin",
-            "name": "Berlin",
-            "type": "LOCATION",
-            "description": "Berlin is the capital city of Germany, known for its rich history and vibrant culture."
-          },
-          {
-            "id": "Kreuzberg",
-            "name": "Kreuzberg",
-            "type": "LOCATION",
-            "description": "Kreuzberg is a district in Berlin, famous for its diverse community and artistic scene."
-          },
-          {
-            "id": "2018",
-            "name": "2018",
-            "type": "DATE",
-            "description": "The year when the author moved to Berlin."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Berlin",
-            "target_node_id": "Kreuzberg",
-            "relationship_name": "located_in"
-          }
-        ]
-      }
-    },
-    "1c2f3af45b34be6f0616b41d7f83af99ce61308d00b676b834e068be6c4c18af": {
-      "method": "structured_output",
-      "user_input_preview": "Title: First Day at University\n\nI remember my first day at the University of Belgrade. The campus was bustling with new ",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "University of Belgrade",
-            "name": "University of Belgrade",
-            "type": "ORGANIZATION",
-            "description": "A prominent university located in Belgrade, Serbia, known for its diverse academic programs."
-          },
-          {
-            "id": "Computer Science",
-            "name": "Computer Science",
-            "type": "CONCEPT",
-            "description": "An academic discipline that studies the principles and use of computers and computational systems."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "University of Belgrade",
-            "target_node_id": "Computer Science",
-            "relationship_name": "offers"
-          }
-        ]
-      }
-    },
-    "1ce155dbf6159d25bcd20cbed85ad8f880303a2091e28a75c76b277b1b656bf0": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Sunrise Over the Mountains\n\nI woke up at 4 AM to hike to a summit in the Dolomites to watch the sunrise. The tr",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "An early morning hike in the Dolomites led to a breathtaking sunrise at the summit.",
-        "description": "At 4 AM, I embarked on a hike to a peak in the Dolomites, navigating a dark and chilly trail illuminated only by my headlamp. As the sun rose, the mountain faces transformed into hues of orange and pink, and I lingered in solitude for thirty minutes, captivated by the view."
-      }
-    },
-    "22a28a10e4123b4b3230ce531293d43a7217d8deac6b9fc485503914cd7113a5": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Broken Deployment Pipeline\n\nOur CI/CD pipeline broke silently for two weeks in 2021 — tests were passing but no",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "A CI/CD pipeline malfunctioned for two weeks in 2021 due to a misconfiguration in GitHub Actions, leading to passing tests that weren't executed. This issue was identified when a faulty PR was merged, prompting the addition of a failing canary test to verify the execution of the test suite.",
-        "description": "In 2021, a CI/CD pipeline experienced a silent failure for two weeks because of a misconfigured GitHub Actions workflow, resulting in tests that appeared to pass without running. The problem was uncovered when a clearly defective pull request was merged into the main branch. To prevent future occurrences, a canary test that is designed to fail was implemented to confirm that the testing suite is functioning properly."
-      }
-    },
-    "25cb68b3877d213a49e42b34587d9954bbefed3030ad14aae24ace13cb2c1626": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Learning to Ride a Bicycle\n\nMy grandfather taught me to ride a bicycle in the park near our house when I was six ",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "grandfather",
-            "name": "grandfather",
-            "type": "PERSON",
-            "description": "The narrator's grandfather who taught them to ride a bicycle."
-          },
-          {
-            "id": "bicycle",
-            "name": "bicycle",
-            "type": "CONCEPT",
-            "description": "A two-wheeled vehicle that the narrator learned to ride."
-          },
-          {
-            "id": "park",
-            "name": "park",
-            "type": "LOCATION",
-            "description": "The location where the narrator learned to ride a bicycle."
-          },
-          {
-            "id": "house",
-            "name": "house",
-            "type": "LOCATION",
-            "description": "The narrator's home near the park."
-          },
-          {
-            "id": "childhood",
-            "name": "childhood",
-            "type": "CONCEPT",
-            "description": "The period of life when the narrator learned to ride a bicycle."
-          },
-          {
-            "id": "family",
-            "name": "family",
-            "type": "CONCEPT",
-            "description": "The narrator's family, including the grandfather."
-          },
-          {
-            "id": "joy",
-            "name": "joy",
-            "type": "CONCEPT",
-            "description": "The feeling experienced by the narrator when they successfully rode the bicycle."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "grandfather",
-            "target_node_id": "bicycle",
-            "relationship_name": "taught"
-          },
-          {
-            "source_node_id": "grandfather",
-            "target_node_id": "park",
-            "relationship_name": "located_near"
-          },
-          {
-            "source_node_id": "bicycle",
-            "target_node_id": "joy",
-            "relationship_name": "caused"
-          },
-          {
-            "source_node_id": "house",
-            "target_node_id": "park",
-            "relationship_name": "located_near"
-          },
-          {
-            "source_node_id": "childhood",
-            "target_node_id": "bicycle",
-            "relationship_name": "involves"
-          },
-          {
-            "source_node_id": "family",
-            "target_node_id": "grandfather",
-            "relationship_name": "includes"
-          }
-        ]
-      }
-    },
-    "26a7d8374dc4078db0aa35662d042eda845d621d051a281c79f62c025b0b809a": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Winning a Hackathon\n\nOur team won a 48-hour hackathon in 2017 by building a real-time translator for sign languag",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Winning a Hackathon",
-            "name": "Winning a Hackathon",
-            "type": "CONCEPT",
-            "description": "A concept related to achieving success in a competitive programming event."
-          },
-          {
-            "id": "2017",
-            "name": "2017",
-            "type": "DATE",
-            "description": "The year when the hackathon took place."
-          },
-          {
-            "id": "real-time translator for sign language",
-            "name": "real-time translator for sign language",
-            "type": "CONCEPT",
-            "description": "A project developed to translate sign language in real-time using technology."
-          },
-          {
-            "id": "computer vision",
-            "name": "computer vision",
-            "type": "CONCEPT",
-            "description": "A field of computer science that enables computers to interpret and process visual information."
-          },
-          {
-            "id": "CNN model",
-            "name": "CNN model",
-            "type": "CONCEPT",
-            "description": "A type of deep learning model known as Convolutional Neural Network, commonly used in image processing."
-          },
-          {
-            "id": "ASL datasets",
-            "name": "ASL datasets",
-            "type": "CONCEPT",
-            "description": "Datasets containing American Sign Language data used for training models."
-          },
-          {
-            "id": "judges",
-            "name": "judges",
-            "type": "PERSON",
-            "description": "Individuals who evaluated the hackathon projects."
-          },
-          {
-            "id": "prize",
-            "name": "prize",
-            "type": "CONCEPT",
-            "description": "The reward given to the winning team of the hackathon."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "2017",
-            "target_node_id": "Winning a Hackathon",
-            "relationship_name": "took_place_in"
-          },
-          {
-            "source_node_id": "real-time translator for sign language",
-            "target_node_id": "computer vision",
-            "relationship_name": "utilizes"
-          },
-          {
-            "source_node_id": "real-time translator for sign language",
-            "target_node_id": "CNN model",
-            "relationship_name": "built_with"
-          },
-          {
-            "source_node_id": "CNN model",
-            "target_node_id": "ASL datasets",
-            "relationship_name": "trained_on"
-          },
-          {
-            "source_node_id": "judges",
-            "target_node_id": "real-time translator for sign language",
-            "relationship_name": "evaluated"
-          },
-          {
-            "source_node_id": "Winning a Hackathon",
-            "target_node_id": "prize",
-            "relationship_name": "awarded"
-          }
-        ]
-      }
-    },
-    "27bf7f0dd4b4b5cfd64681b89a57a8f137ea9074dc9899fc6949b9ea3db9a94e": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Discovering Podcasts\n\nI discovered podcasts during my daily commute in 2016. The first one I binged was a technol",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "podcasts",
-            "name": "podcasts",
-            "type": "CONCEPT",
-            "description": "Podcasts are digital audio files available for streaming or download, often focusing on various topics."
-          },
-          {
-            "id": "commute",
-            "name": "commute",
-            "type": "CONCEPT",
-            "description": "Commute refers to the travel between one's home and place of work or study."
-          },
-          {
-            "id": "2016",
-            "name": "2016",
-            "type": "DATE",
-            "description": "The year when the author discovered podcasts during their daily commute."
-          },
-          {
-            "id": "technology_history_series",
-            "name": "technology history series",
-            "type": "CONCEPT",
-            "description": "A podcast series that covers the history of technology, including significant inventions like the transistor."
-          },
-          {
-            "id": "transistor",
-            "name": "transistor",
-            "type": "CONCEPT",
-            "description": "A semiconductor device used to amplify or switch electronic signals, pivotal in modern electronics."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "2016",
-            "target_node_id": "podcasts",
-            "relationship_name": "discovered"
-          },
-          {
-            "source_node_id": "podcasts",
-            "target_node_id": "technology_history_series",
-            "relationship_name": "includes"
-          },
-          {
-            "source_node_id": "technology_history_series",
-            "target_node_id": "transistor",
-            "relationship_name": "covers"
-          },
-          {
-            "source_node_id": "commute",
-            "target_node_id": "podcasts",
-            "relationship_name": "transformed_into"
-          }
-        ]
-      }
-    },
-    "2b5a020dfa47059b70bea01a6ed35c846e8fc91593766718d68357fba6950244": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Learning a New Language\n\nI started learning Japanese in 2019 using a combination of apps and textbooks. Hiragana ",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Japanese",
-            "name": "Japanese",
-            "type": "CONCEPT",
-            "description": "Japanese is a language spoken primarily in Japan, known for its unique writing systems including hiragana, katakana, and kanji."
-          },
-          {
-            "id": "Tokyo",
-            "name": "Tokyo",
-            "type": "LOCATION",
-            "description": "Tokyo is the capital city of Japan, known for its vibrant culture, modern architecture, and historical landmarks."
-          },
-          {
-            "id": "2019",
-            "name": "2019",
-            "type": "DATE",
-            "description": "The year when the author started learning Japanese."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "2019",
-            "target_node_id": "Japanese",
-            "relationship_name": "started_learning"
-          },
-          {
-            "source_node_id": "Tokyo",
-            "target_node_id": "Japanese",
-            "relationship_name": "related_to"
-          }
-        ]
-      }
-    },
-    "2c7bfa2b72fad4d22f8bf6d3a47a8440d1e6eb2aa34908b2cd5a92fdfb53f613": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Conversation with a Stranger\n\nOn a delayed train from Prague to Vienna, I sat next to a retired physicist who t",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Prague",
-            "name": "Prague",
-            "type": "LOCATION",
-            "description": "The capital city of the Czech Republic, known for its historic architecture and vibrant culture."
-          },
-          {
-            "id": "Vienna",
-            "name": "Vienna",
-            "type": "LOCATION",
-            "description": "The capital city of Austria, famous for its artistic and intellectual legacy."
-          },
-          {
-            "id": "retired physicist",
-            "name": "retired physicist",
-            "type": "PERSON",
-            "description": "An individual who has retired from a career in physics, specifically known for work on particle accelerators."
-          },
-          {
-            "id": "1980s",
-            "name": "1980s",
-            "type": "DATE",
-            "description": "The decade from 1980 to 1989, notable for significant advancements in various fields including physics."
-          },
-          {
-            "id": "quantum tunneling",
-            "name": "quantum tunneling",
-            "type": "CONCEPT",
-            "description": "A quantum mechanical phenomenon where a particle passes through a potential barrier that it classically could not surmount."
-          },
-          {
-            "id": "coffee cup metaphor",
-            "name": "coffee cup metaphor",
-            "type": "CONCEPT",
-            "description": "A metaphor used to explain complex concepts in a relatable way, in this case, quantum tunneling."
-          },
-          {
-            "id": "three-hour conversation",
-            "name": "three-hour conversation",
-            "type": "CONCEPT",
-            "description": "A lengthy discussion that led to a reconsideration of assumptions about time and randomness."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "retired physicist",
-            "target_node_id": "quantum tunneling",
-            "relationship_name": "explained"
-          },
-          {
-            "source_node_id": "retired physicist",
-            "target_node_id": "1980s",
-            "relationship_name": "worked_in"
-          },
-          {
-            "source_node_id": "three-hour conversation",
-            "target_node_id": "quantum tunneling",
-            "relationship_name": "influenced_by"
-          },
-          {
-            "source_node_id": "three-hour conversation",
-            "target_node_id": "time",
-            "relationship_name": "reconsidered_assumptions_about"
-          },
-          {
-            "source_node_id": "three-hour conversation",
-            "target_node_id": "randomness",
-            "relationship_name": "reconsidered_assumptions_about"
-          },
-          {
-            "source_node_id": "Prague",
-            "target_node_id": "Vienna",
-            "relationship_name": "connected_by_train"
-          }
-        ]
-      }
-    },
-    "30651735d1777e90ccc7ecbbffd4a4501f57fbd53cdeba75623ec7618124ba34": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Cooking Grandmother's Stew\n\nMy grandmother's beef stew recipe has been in the family for three generations. The s",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "grandmother's beef stew recipe",
-            "name": "grandmother's beef stew recipe",
-            "type": "CONCEPT",
-            "description": "A family recipe for beef stew that has been passed down for three generations."
-          },
-          {
-            "id": "red wine vinegar",
-            "name": "red wine vinegar",
-            "type": "CONCEPT",
-            "description": "A type of vinegar made from red wine, used as a secret ingredient in the stew."
-          },
-          {
-            "id": "cast-iron pot",
-            "name": "cast-iron pot",
-            "type": "CONCEPT",
-            "description": "A heavy pot made of cast iron, used for cooking the stew over low heat."
-          },
-          {
-            "id": "four hours",
-            "name": "four hours",
-            "type": "DATE",
-            "description": "The minimum cooking time for the beef stew."
-          },
-          {
-            "id": "winter",
-            "name": "winter",
-            "type": "DATE",
-            "description": "The season when the grandmother's beef stew recipe is typically used."
-          },
-          {
-            "id": "family",
-            "name": "family",
-            "type": "CONCEPT",
-            "description": "The group of relatives who have passed down the beef stew recipe."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "grandmother's beef stew recipe",
-            "target_node_id": "family",
-            "relationship_name": "passed_down"
-          },
-          {
-            "source_node_id": "grandmother's beef stew recipe",
-            "target_node_id": "red wine vinegar",
-            "relationship_name": "contains"
-          },
-          {
-            "source_node_id": "grandmother's beef stew recipe",
-            "target_node_id": "cast-iron pot",
-            "relationship_name": "cooked_in"
-          },
-          {
-            "source_node_id": "grandmother's beef stew recipe",
-            "target_node_id": "four hours",
-            "relationship_name": "requires_cooking_time"
-          },
-          {
-            "source_node_id": "grandmother's beef stew recipe",
-            "target_node_id": "winter",
-            "relationship_name": "used_in_season"
-          }
-        ]
-      }
-    },
-    "3b3883d4b601624d7f37331a71c2d4e1f659c21d3cf7e62a6dcdac7d8339f6ac": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Conversation with a Stranger\n\nOn a delayed train from Prague to Vienna, I sat next to a retired physicist who t",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "A chance encounter on a delayed train led to an enlightening discussion with a retired physicist about his experiences with particle accelerators and quantum tunneling.",
-        "description": "While traveling from Prague to Vienna, I met a retired physicist who shared insights from his work in the 1980s on particle accelerators. He used a coffee cup analogy to clarify quantum tunneling, prompting me to rethink my views on time and randomness during our three-hour dialogue."
-      }
-    },
-    "3e74354941f112acb28efc0a4b37b90f3096c3b91afeddae2f8bc24adc5f9218": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Attending a Live Concert\n\nThe first live concert I attended was Radiohead at a festival in 2006. The band opened ",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Radiohead",
-            "name": "Radiohead",
-            "type": "ORGANIZATION",
-            "description": "Radiohead is a British rock band known for their experimental approach to music and thought-provoking lyrics."
-          },
-          {
-            "id": "2006",
-            "name": "2006",
-            "type": "DATE",
-            "description": "The year when the first live concert attended by the author took place."
-          },
-          {
-            "id": "Karma Police",
-            "name": "Karma Police",
-            "type": "CONCEPT",
-            "description": "A song by Radiohead that became popular and is known for its haunting melody and lyrics."
-          },
-          {
-            "id": "There There",
-            "name": "There There",
-            "type": "CONCEPT",
-            "description": "A song by Radiohead that was performed at the concert."
-          },
-          {
-            "id": "live concert",
-            "name": "live concert",
-            "type": "CONCEPT",
-            "description": "A live performance of music in front of an audience."
-          },
-          {
-            "id": "festival",
-            "name": "festival",
-            "type": "CONCEPT",
-            "description": "A large event featuring performances, often including multiple artists and activities."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Radiohead",
-            "target_node_id": "live concert",
-            "relationship_name": "performed_at"
-          },
-          {
-            "source_node_id": "2006",
-            "target_node_id": "live concert",
-            "relationship_name": "took_place_in"
-          },
-          {
-            "source_node_id": "Karma Police",
-            "target_node_id": "live concert",
-            "relationship_name": "performed_in"
-          },
-          {
-            "source_node_id": "There There",
-            "target_node_id": "live concert",
-            "relationship_name": "performed_in"
-          },
-          {
-            "source_node_id": "festival",
-            "target_node_id": "live concert",
-            "relationship_name": "part_of"
-          }
-        ]
-      }
-    },
-    "40a297191c21e2b66aa5125a7c57f1e36a87dcac908968719c6ed359a5f7d5d3": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Learning to Play Chess\n\nMy uncle taught me chess when I was seven. He never let me win, which frustrated me at fi",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "uncle",
-            "name": "uncle",
-            "type": "PERSON",
-            "description": "The narrator's uncle who taught them how to play chess."
-          },
-          {
-            "id": "chess",
-            "name": "chess",
-            "type": "CONCEPT",
-            "description": "A strategic board game played between two players."
-          },
-          {
-            "id": "school_chess_club",
-            "name": "school chess club",
-            "type": "ORGANIZATION",
-            "description": "A club at the narrator's school where students gather to play chess."
-          },
-          {
-            "id": "regional_tournament",
-            "name": "regional tournament",
-            "type": "CONCEPT",
-            "description": "A competitive event where chess players compete at a regional level."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "uncle",
-            "target_node_id": "chess",
-            "relationship_name": "taught"
-          },
-          {
-            "source_node_id": "school_chess_club",
-            "target_node_id": "chess",
-            "relationship_name": "involved_with"
-          },
-          {
-            "source_node_id": "regional_tournament",
-            "target_node_id": "school_chess_club",
-            "relationship_name": "associated_with"
-          }
-        ]
-      }
-    },
-    "427faa59ce3349c51d2efa1bead7458e905ea10b21d25b5b74fc47728f36e63b": {
+    "039460ea728274e4d46dc2808d1d867a321a6c8bb1fc27d3c7f1eea19b8a5673": {
       "method": "structured_output",
       "user_input_preview": "Title: Adopting a Cat\n\nWe adopted our cat Luna from a local shelter in 2020. She was shy at first and hid under the couc",
       "schema_name": "KnowledgeGraph",
       "response": {
+        "edges": [
+          {
+            "description": "Luna was adopted from a local shelter in 2020.",
+            "relationship_name": "adopted_from",
+            "source_node_id": "Luna",
+            "target_node_id": "local_shelter"
+          },
+          {
+            "description": "Luna has a distinctive orange patch on her left ear.",
+            "relationship_name": "has_feature",
+            "source_node_id": "Luna",
+            "target_node_id": "orange_patch"
+          }
+        ],
         "nodes": [
           {
+            "description": "Luna is a cat who was adopted from a local shelter.",
             "id": "Luna",
             "name": "Luna",
-            "type": "PERSON",
-            "description": "A cat adopted from a local shelter in 2020, known for her distinctive orange patch on her left ear."
+            "type": "ANIMAL"
           },
           {
-            "id": "2020",
-            "name": "2020",
-            "type": "DATE",
-            "description": "The year when Luna was adopted from the local shelter."
-          },
-          {
-            "id": "local shelter",
+            "description": "A local shelter where pets are available for adoption.",
+            "id": "local_shelter",
             "name": "local shelter",
-            "type": "ORGANIZATION",
-            "description": "The shelter from which Luna was adopted."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Luna",
-            "target_node_id": "local shelter",
-            "relationship_name": "adopted_from"
+            "type": "ORGANIZATION"
           },
           {
-            "source_node_id": "Luna",
-            "target_node_id": "2020",
-            "relationship_name": "adopted_in"
+            "description": "An orange patch on Luna's left ear.",
+            "id": "orange_patch",
+            "name": "orange patch",
+            "type": "FEATURE"
           }
         ]
       }
     },
-    "42898f4e1536c8178a338f8aba3fd6775ab9088eb77a6217d63fb8a11fab0376": {
+    "093c05ebff8dc1445b90b59c0140d35adca3b017f86f117f0407d1d4188514fa": {
       "method": "structured_output",
-      "user_input_preview": "Title: First Job Interview\n\nMy first real job interview was at a small software consultancy in 2010. I was so nervous th",
+      "user_input_preview": "Title: Baking Bread During Lockdown\n\nLike many people, I started baking sourdough bread during the 2020 lockdown. My fir",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "First Job Interview",
-            "name": "First Job Interview",
-            "type": "CONCEPT",
-            "description": "A significant event marking the author's initial experience with a job interview."
-          },
-          {
-            "id": "small software consultancy",
-            "name": "small software consultancy",
-            "type": "ORGANIZATION",
-            "description": "A small company that provides software consulting services."
-          },
-          {
-            "id": "2010",
-            "name": "2010",
-            "type": "DATE",
-            "description": "The year when the author's first job interview took place."
-          },
-          {
-            "id": "sorting algorithm",
-            "name": "sorting algorithm",
-            "type": "CONCEPT",
-            "description": "A method for arranging elements in a specific order."
-          },
-          {
-            "id": "quicksort",
-            "name": "quicksort",
-            "type": "CONCEPT",
-            "description": "A popular sorting algorithm that uses a divide-and-conquer approach."
-          },
-          {
-            "id": "merge sort",
-            "name": "merge sort",
-            "type": "CONCEPT",
-            "description": "A sorting algorithm that divides the input array into two halves, sorts them, and then merges them."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "First Job Interview",
-            "target_node_id": "small software consultancy",
-            "relationship_name": "took_place_at"
+            "description": "The starter named Clint Yeastwood was used for baking sourdough bread.",
+            "relationship_name": "used_for",
+            "source_node_id": "Clint Yeastwood",
+            "target_node_id": "sourdough_bread"
           },
           {
-            "source_node_id": "First Job Interview",
-            "target_node_id": "2010",
-            "relationship_name": "occurred_in"
+            "description": "The baking of sourdough bread occurred during the 2020 lockdown.",
+            "relationship_name": "occurred_during",
+            "source_node_id": "sourdough_bread",
+            "target_node_id": "lockdown_2020"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Clint Yeastwood is the name of a sourdough starter used for baking bread.",
+            "id": "Clint Yeastwood",
+            "name": "Clint Yeastwood",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "First Job Interview",
-            "target_node_id": "sorting algorithm",
-            "relationship_name": "involves"
+            "description": "Sourdough bread is a type of bread made using a fermented dough starter.",
+            "id": "sourdough_bread",
+            "name": "Sourdough Bread",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "sorting algorithm",
-            "target_node_id": "quicksort",
-            "relationship_name": "is_a"
-          },
-          {
-            "source_node_id": "sorting algorithm",
-            "target_node_id": "merge sort",
-            "relationship_name": "is_a"
+            "description": "Lockdown refers to the period during which people were restricted to their homes due to the COVID-19 pandemic.",
+            "id": "lockdown_2020",
+            "name": "2020 Lockdown",
+            "type": "CONCEPT"
           }
         ]
       }
     },
-    "4317ee66e2b06d607fbed93f57beb80e676b3dc3087e61926bd1ba3233fabdbb": {
+    "0c572e1cc53fa0821a5bc772a1f38c76aee2efe2547f296c0199d55480ac1a22": {
       "method": "structured_output",
-      "user_input_preview": "Title: Stargazing in the Countryside\n\nOn a camping trip far from city lights, I saw the Milky Way clearly for the first ",
+      "user_input_preview": "Title: Refactoring Legacy Code\n\nI spent three months refactoring a 10,000-line PHP file that had been accumulating featu",
       "schema_name": "SummarizedContent",
       "response": {
-        "summary": "During a camping excursion away from urban light pollution, I experienced the Milky Way and numerous stars for the first time, while identifying constellations with a friend.",
-        "description": "On a camping adventure in a remote area, I witnessed the Milky Way in all its glory, along with countless stars. A companion helped me recognize constellations such as Orion, Cassiopeia, and the Big Dipper. We remained awake until 3 AM, observing satellites and even spotted two shooting stars."
+        "description": "The chunk discusses the process of refactoring legacy code, specifically a large PHP file, over a three-month period. It highlights the importance of characterization tests and the methodical extraction of classes to improve code maintainability.",
+        "summary": "This chunk details a three-month effort to refactor a 10,000-line PHP file, emphasizing the use of characterization tests and gradual class extraction to enhance code safety and organization."
       }
     },
-    "444204d25a324925d0d0eb3ad59ccdcbe6cb20905c676272bfc05d453b83b764": {
+    "0cbc28d3b75c2b8d84e57a170520f7dd469a2ad9d75564a4b4bca93ddbf25305": {
       "method": "structured_output",
-      "user_input_preview": "Title: Hiking in the Alps\n\nIn the summer of 2015, I hiked the Tour du Mont Blanc with two friends. The 170-kilometer tra",
+      "user_input_preview": "Title: Setting Up a Home Network\n\nWhen I set up a mesh Wi-Fi network in my apartment, I learned more about networking th",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the process of setting up a home network, specifically a mesh Wi-Fi network, and the lessons learned during the setup. It highlights the configuration of VLANs for device separation, the implementation of Pi-hole for ad blocking, and the physical installation of Ethernet cables.",
+        "summary": "This chunk is about setting up a home network with a focus on mesh Wi-Fi, VLANs, and Pi-hole. The author shares personal experiences and technical details from the setup process."
+      }
+    },
+    "10ee273f5337fd43ae23fe7ab272253dbb4ee584d38b6d81f24c1e397bdd6502": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Planting a Garden\n\nIn spring 2021, I started a small vegetable garden on my balcony. I planted tomatoes, basil, a",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "Tour du Mont Blanc",
-            "name": "Tour du Mont Blanc",
-            "type": "CONCEPT",
-            "description": "A popular long-distance hiking trail in the Alps, covering approximately 170 kilometers."
-          },
-          {
-            "id": "Alps",
-            "name": "Alps",
-            "type": "LOCATION",
-            "description": "A major mountain range in Europe, stretching across several countries including France, Italy, and Switzerland."
-          },
-          {
-            "id": "2015-01-01",
-            "name": "2015",
-            "type": "DATE",
-            "description": "The year when the hiking trip took place."
-          },
-          {
-            "id": "France",
-            "name": "France",
-            "type": "LOCATION",
-            "description": "A country in Western Europe, known for its rich history and culture."
-          },
-          {
-            "id": "Italy",
-            "name": "Italy",
-            "type": "LOCATION",
-            "description": "A country in Southern Europe, famous for its art, architecture, and cuisine."
-          },
-          {
-            "id": "Switzerland",
-            "name": "Switzerland",
-            "type": "LOCATION",
-            "description": "A landlocked country in Central Europe, known for its mountains and neutrality."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "Tour du Mont Blanc",
-            "target_node_id": "Alps",
-            "relationship_name": "located_in"
+            "description": "The vegetable garden was started in spring 2021 on the balcony.",
+            "relationship_name": "started_on",
+            "source_node_id": "vegetable_garden",
+            "target_node_id": "spring_2021"
           },
           {
-            "source_node_id": "2015-01-01",
-            "target_node_id": "Tour du Mont Blanc",
-            "relationship_name": "hiked"
+            "description": "Tomatoes were planted in the vegetable garden.",
+            "relationship_name": "planted",
+            "source_node_id": "vegetable_garden",
+            "target_node_id": "tomatoes"
           },
           {
-            "source_node_id": "Tour du Mont Blanc",
-            "target_node_id": "France",
-            "relationship_name": "passes_through"
+            "description": "Basil was planted in the vegetable garden.",
+            "relationship_name": "planted",
+            "source_node_id": "vegetable_garden",
+            "target_node_id": "basil"
           },
           {
-            "source_node_id": "Tour du Mont Blanc",
-            "target_node_id": "Italy",
-            "relationship_name": "passes_through"
+            "description": "Peppers were planted in the vegetable garden.",
+            "relationship_name": "planted",
+            "source_node_id": "vegetable_garden",
+            "target_node_id": "peppers"
           },
           {
-            "source_node_id": "Tour du Mont Blanc",
-            "target_node_id": "Switzerland",
-            "relationship_name": "passes_through"
+            "description": "The tomatoes thrived in the vegetable garden.",
+            "relationship_name": "thrived_in",
+            "source_node_id": "tomatoes",
+            "target_node_id": "vegetable_garden"
+          },
+          {
+            "description": "The peppers struggled with insufficient sunlight in the vegetable garden.",
+            "relationship_name": "struggled_in",
+            "source_node_id": "peppers",
+            "target_node_id": "vegetable_garden"
+          },
+          {
+            "description": "Basil was harvested every week to make pesto from the vegetable garden by August.",
+            "relationship_name": "harvested_for",
+            "source_node_id": "basil",
+            "target_node_id": "pesto"
+          },
+          {
+            "description": "The garden became a meditative morning ritual.",
+            "relationship_name": "became",
+            "source_node_id": "vegetable_garden",
+            "target_node_id": "meditative_morning_ritual"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A garden where vegetables are grown, started on a balcony in spring 2021.",
+            "id": "vegetable_garden",
+            "name": "Vegetable Garden",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A type of plant that produces fruit, grown in the vegetable garden.",
+            "id": "tomatoes",
+            "name": "Tomatoes",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A type of herb used in cooking, grown in the vegetable garden.",
+            "id": "basil",
+            "name": "Basil",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A type of vegetable that struggled to grow due to insufficient sunlight in the vegetable garden.",
+            "id": "peppers",
+            "name": "Peppers",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A type of sauce made from basil, harvested from the vegetable garden.",
+            "id": "pesto",
+            "name": "Pesto",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The season in which the vegetable garden was started, in the year 2021.",
+            "id": "spring_2021",
+            "name": "Spring 2021",
+            "type": "DATE"
+          },
+          {
+            "description": "A morning practice that became a ritual due to the vegetable garden.",
+            "id": "meditative_morning_ritual",
+            "name": "Meditative Morning Ritual",
+            "type": "CONCEPT"
           }
         ]
       }
     },
-    "4d4e548047b28d2af22d2f5e992fd4bc1cfb1b92e34f3b1df60913eeed098a63": {
+    "1202d6810ea843ed3228e773b8e26bbc12eb9ae1b7b552b565a36f46c33657c0": {
       "method": "structured_output",
       "user_input_preview": "Title: Teaching Someone to Code\n\nI taught my younger cousin the basics of Python over a summer. We started with variable",
       "schema_name": "SummarizedContent",
       "response": {
-        "summary": "I introduced my younger cousin to Python programming during the summer, covering fundamentals like variables and loops, and we created a text adventure game together.",
-        "description": "Over the summer, I mentored my younger cousin in the essentials of Python, starting with concepts such as variables and loops. Together, we developed a simple text adventure game, and her excitement when her code executed successfully rekindled my passion for programming. She is currently pursuing computer science at university."
+        "description": "The chunk discusses the experience of teaching coding, specifically Python, to a younger cousin, highlighting the progression from basic concepts to creating a game. It reflects on the joy of seeing the cousin's success and notes her current pursuit of computer science studies.",
+        "summary": "The chunk describes a mentorship experience in teaching Python to a younger cousin, culminating in her studying computer science at university."
       }
     },
-    "5310de2a9913001019d3e7b312dfefcc47c3874745fe30b87fee6f621d8c513e": {
+    "1280ea71f5fb2c3fcc03b3b75a8fc0e78cb92a1ebfcff8937e823d89f66e89b7": {
       "method": "structured_output",
-      "user_input_preview": "Title: Power of a Mentor\n\nMy first real mentor was a senior engineer named David who took the time to review my code lin",
+      "user_input_preview": "Title: Setting Up My First Server\n\nI set up my first Linux server in 2011 — a Debian box running Apache and MySQL. I spe",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "David",
-            "name": "David",
-            "type": "PERSON",
-            "description": "A senior engineer who served as a mentor, helping to develop critical thinking skills in his mentee."
-          },
-          {
-            "id": "mentorship",
-            "name": "mentorship",
-            "type": "CONCEPT",
-            "description": "The practice of guiding and supporting someone in their personal or professional development."
-          },
-          {
-            "id": "career",
-            "name": "career",
-            "type": "CONCEPT",
-            "description": "The progression of professional life and work experiences over time."
-          },
-          {
-            "id": "engineering",
-            "name": "engineering",
-            "type": "CONCEPT",
-            "description": "The application of scientific and mathematical principles to design and build structures, machines, and systems."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "David",
-            "target_node_id": "mentorship",
-            "relationship_name": "is_a_mentor_for"
+            "description": "The Linux server is a Debian box running Apache and MySQL.",
+            "relationship_name": "runs_software",
+            "source_node_id": "Linux_server",
+            "target_node_id": "Debian"
           },
           {
-            "source_node_id": "mentorship",
-            "target_node_id": "career",
-            "relationship_name": "supports"
+            "description": "The Linux server is a Debian box running Apache and MySQL.",
+            "relationship_name": "runs_software",
+            "source_node_id": "Linux_server",
+            "target_node_id": "Apache"
           },
           {
-            "source_node_id": "mentorship",
-            "target_node_id": "engineering",
-            "relationship_name": "applies_to"
+            "description": "The Linux server is a Debian box running Apache and MySQL.",
+            "relationship_name": "runs_software",
+            "source_node_id": "Linux_server",
+            "target_node_id": "MySQL"
+          },
+          {
+            "description": "The Linux server was set up in 2011.",
+            "relationship_name": "set_up_in",
+            "source_node_id": "Linux_server",
+            "target_node_id": "2011"
+          },
+          {
+            "description": "The Linux server was hacked within a week due to default port 22 configuration.",
+            "relationship_name": "hacked_due_to",
+            "source_node_id": "Linux_server",
+            "target_node_id": "default_port_22_configuration"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A Linux server set up in 2011, running Debian, Apache, and MySQL.",
+            "id": "Linux_server",
+            "name": "Linux Server",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A Debian operating system used for the Linux server.",
+            "id": "Debian",
+            "name": "Debian",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Apache is a web server software used on the Linux server.",
+            "id": "Apache",
+            "name": "Apache",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "MySQL is a database management system used on the Linux server.",
+            "id": "MySQL",
+            "name": "MySQL",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The year 2011 when the Linux server was set up.",
+            "id": "2011",
+            "name": "2011",
+            "type": "DATE"
+          },
+          {
+            "description": "The default configuration of port 22 which led to the server being hacked.",
+            "id": "default_port_22_configuration",
+            "name": "Default Port 22 Configuration",
+            "type": "CONCEPT"
           }
         ]
       }
     },
-    "56a8bc412eaf3dbf756e3295a17f0d4daac67ee9732e440ff70e89df5a1ca105": {
+    "17cf86c49becfce7708ce8405af82fcf4f4b47908f409d43baabef6f8b7f1c7f": {
       "method": "structured_output",
-      "user_input_preview": "Title: A Broken Deployment Pipeline\n\nOur CI/CD pipeline broke silently for two weeks in 2021 — tests were passing but no",
+      "user_input_preview": "Title: Volunteering at a Food Bank\n\nI volunteered at a local food bank every Saturday for six months in 2019. We sorted ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "CI/CD",
-            "name": "CI/CD",
-            "type": "CONCEPT",
-            "description": "Continuous Integration and Continuous Deployment (CI/CD) is a software development practice that allows for frequent code changes and automated testing."
-          },
-          {
-            "id": "GitHub Actions",
-            "name": "GitHub Actions",
-            "type": "CONCEPT",
-            "description": "GitHub Actions is a CI/CD feature that allows developers to automate workflows directly in their GitHub repositories."
-          },
-          {
-            "id": "2021",
-            "name": "2021",
-            "type": "DATE",
-            "description": "The year when the CI/CD pipeline issue occurred."
-          },
-          {
-            "id": "canary test",
-            "name": "canary test",
-            "type": "CONCEPT",
-            "description": "A canary test is a type of software testing that intentionally fails to verify that the testing suite is executed."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "CI/CD",
-            "target_node_id": "GitHub Actions",
-            "relationship_name": "uses"
+            "description": "The local food bank is where the volunteering took place.",
+            "relationship_name": "volunteered_at",
+            "source_node_id": "Volunteer",
+            "target_node_id": "Local Food Bank"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "An individual who offers their time to help others without payment.",
+            "id": "Volunteer",
+            "name": "Volunteer",
+            "type": "PERSON"
           },
           {
-            "source_node_id": "2021",
-            "target_node_id": "CI/CD",
-            "relationship_name": "occurred_in"
-          },
-          {
-            "source_node_id": "canary test",
-            "target_node_id": "CI/CD",
-            "relationship_name": "improves"
+            "description": "A community organization that provides food assistance to those in need.",
+            "id": "Local Food Bank",
+            "name": "Local Food Bank",
+            "type": "ORGANIZATION"
           }
         ]
       }
     },
-    "5822a4c82ed1755e736d078f5d12926f338d87ec77cb9d940b5b4a486c37c4bf": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Childhood Pet Dog\n\nOur family dog Rex was a German Shepherd who lived with us for thirteen years. He waited at th",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Rex",
-            "name": "Rex",
-            "type": "PERSON",
-            "description": "Rex was a German Shepherd who lived with the family for thirteen years."
-          },
-          {
-            "id": "German Shepherd",
-            "name": "German Shepherd",
-            "type": "CONCEPT",
-            "description": "A breed of dog known for its intelligence and versatility."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Rex",
-            "target_node_id": "German Shepherd",
-            "relationship_name": "is_a"
-          }
-        ]
-      }
-    },
-    "59d16f8cd3e467c0b1c4b96186bb1de5ae6ebe21abc98ce5e3f8eef6261532ce": {
-      "method": "structured_output",
-      "user_input_preview": "Title: The Solar Eclipse of 1999\n\nOn August 11, 1999, a total solar eclipse was visible from parts of Europe. I watched ",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "The total solar eclipse on August 11, 1999, was observable in parts of Europe, creating a memorable experience for viewers.",
-        "description": "On August 11, 1999, a total solar eclipse occurred, visible from various locations in Europe. I experienced it from my rooftop using special glasses purchased by my father. The daytime sky turned dark, and the birds ceased chirping. Although the event lasted just a few minutes, it made a significant impact on me."
-      }
-    },
-    "5ce1eda63ff19943fe8ee02fccf94af7b831295a2cffca422afe7069a3bad542": {
-      "method": "structured_output",
-      "user_input_preview": "Title: First Flight Experience\n\nMy first time on an airplane was a flight from Belgrade to London when I was sixteen. I ",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Belgrade",
-            "name": "Belgrade",
-            "type": "LOCATION",
-            "description": "The capital city of Serbia, known for its historical significance and vibrant culture."
-          },
-          {
-            "id": "London",
-            "name": "London",
-            "type": "LOCATION",
-            "description": "The capital city of England and the United Kingdom, famous for its history, architecture, and cultural landmarks."
-          },
-          {
-            "id": "sixteen",
-            "name": "sixteen",
-            "type": "DATE",
-            "description": "Refers to the age of the narrator during their first flight experience."
-          },
-          {
-            "id": "first_flight_experience",
-            "name": "First Flight Experience",
-            "type": "CONCEPT",
-            "description": "The initial experience of traveling by airplane, often filled with excitement and nervousness."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "sixteen",
-            "target_node_id": "first_flight_experience",
-            "relationship_name": "at_age"
-          },
-          {
-            "source_node_id": "Belgrade",
-            "target_node_id": "London",
-            "relationship_name": "flight_route"
-          }
-        ]
-      }
-    },
-    "5e9715fff9606101224457a3808f07ae762c7fc5c7b770ec3a648f5273eae03d": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Flat Tire on a Road Trip\n\nHalfway through a road trip to the coast, we got a flat tire on a deserted stretch of",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "During a coastal road trip, we experienced a flat tire on an isolated highway but managed to change it with the help of a truck driver, arriving at the beach two hours behind schedule.",
-        "description": "While traveling to the coast, we encountered a flat tire on a remote highway. Despite having no prior experience with tire changes, we consulted the car manual and attempted the repair. A passing truck driver assisted us by correcting our use of the jack. Ultimately, we reached the beach two hours later than planned."
-      }
-    },
-    "5fc58ffa3eb6f85e8067250809b6fe1b18dfabe3fcfd85f713882ad98ded5615": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Coffee Culture Discovery\n\nI discovered specialty coffee when a friend took me to a third-wave coffee shop in 2017",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "specialty coffee",
-            "name": "specialty coffee",
-            "type": "CONCEPT",
-            "description": "A high-quality coffee that is often sourced from specific regions and prepared with care."
-          },
-          {
-            "id": "third-wave coffee shop",
-            "name": "third-wave coffee shop",
-            "type": "CONCEPT",
-            "description": "A type of coffee shop that focuses on high-quality coffee and the artisanal aspects of coffee preparation."
-          },
-          {
-            "id": "Ethiopian Yirgacheffe",
-            "name": "Ethiopian Yirgacheffe",
-            "type": "CONCEPT",
-            "description": "A renowned coffee variety from the Yirgacheffe region of Ethiopia, known for its fruity and floral flavors."
-          },
-          {
-            "id": "2017",
-            "name": "2017",
-            "type": "DATE",
-            "description": "The year when the author discovered specialty coffee."
-          },
-          {
-            "id": "coffee",
-            "name": "coffee",
-            "type": "CONCEPT",
-            "description": "A popular beverage made from roasted coffee beans."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "2017",
-            "target_node_id": "specialty coffee",
-            "relationship_name": "discovered_in"
-          },
-          {
-            "source_node_id": "specialty coffee",
-            "target_node_id": "third-wave coffee shop",
-            "relationship_name": "associated_with"
-          },
-          {
-            "source_node_id": "specialty coffee",
-            "target_node_id": "Ethiopian Yirgacheffe",
-            "relationship_name": "includes"
-          },
-          {
-            "source_node_id": "coffee",
-            "target_node_id": "specialty coffee",
-            "relationship_name": "is_a_type_of"
-          }
-        ]
-      }
-    },
-    "641b7c209bbe8a32cd6ade9d929d8bceac41d4cc845a6166bd14d0401b117741": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Setting Up a Home Network\n\nWhen I set up a mesh Wi-Fi network in my apartment, I learned more about networking th",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "I gained practical networking knowledge while establishing a mesh Wi-Fi network in my apartment, including VLAN configuration and DNS ad blocking.",
-        "description": "While setting up a mesh Wi-Fi network in my apartment, I acquired more networking skills than in any formal education. I implemented VLANs to isolate IoT devices from my work computers, configured Pi-hole for DNS ad blocking, and installed Ethernet cabling within the walls. Although my partner believed I was making it too complex, the network has proven to be extremely reliable."
-      }
-    },
-    "680c5b1a53575da44a8ed92e80f75ccfbd29c9b5a9958deb0453041c08287ef7": {
-      "method": "structured_output",
-      "user_input_preview": "Title: First Programming Language\n\nI wrote my first program in BASIC on a Commodore 64 when I was twelve. It was a simpl",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "At twelve, I created my initial program in BASIC on a Commodore 64, a basic number guessing game that provided feedback on user guesses. The thrill of it running flawlessly ignited my enduring enthusiasm for coding.",
-        "description": "At the age of twelve, I wrote my first program using BASIC on a Commodore 64, which was a straightforward number guessing game that responded with 'Too high' or 'Too low' depending on the user's input. The exhilarating feeling of seeing it execute without any errors was captivating and led to a lasting passion for programming."
-      }
-    },
-    "68ebeba68e784f7fd40cb84b626a5993b69a66d8d408647835110082bc5042d6": {
-      "method": "structured_output",
-      "user_input_preview": "Title: The Blackout of 2003\n\nDuring the Northeast blackout of August 2003, the power went out for nearly two days. Neigh",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "The 2003 Northeast blackout fostered a sense of community as neighbors connected during the prolonged power outage.",
-        "description": "In August 2003, a blackout affected the Northeast for almost two days, prompting residents to come together on the streets, share food from their refrigerators, and enjoy music by candlelight, creating a unique communal experience in a typically isolated urban environment."
-      }
-    },
-    "6dd4b18dc47aec707e943ef424be71fc6d918278ae52b46f620a14ba840c1d70": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Learning to Cook Pasta\n\nAn Italian roommate in college taught me that you must salt the pasta water generously — ",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "An Italian college roommate imparted essential pasta cooking tips, emphasizing the importance of salting the water and not breaking spaghetti.",
-        "description": "During college, an Italian roommate educated me on key pasta cooking techniques, such as generously salting the water to make it taste like the sea, avoiding the breaking of spaghetti, and reserving some pasta water for the sauce. These fundamental guidelines significantly enhanced my culinary skills."
-      }
-    },
-    "6fb04e68b04d9554b591e8da5c16a0e313615955553b1dda847fff1935e7a56a": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Planting a Garden\n\nIn spring 2021, I started a small vegetable garden on my balcony. I planted tomatoes, basil, a",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "In 2021, I initiated a small vegetable garden on my balcony, growing tomatoes, basil, and peppers.",
-        "description": "I planted tomatoes, basil, and peppers in sizable pots during spring 2021. The tomatoes flourished, while the peppers faced challenges due to limited sunlight. By August, I was able to harvest sufficient basil for weekly pesto, turning the gardening experience into a calming morning routine."
-      }
-    },
-    "7422d701ff93a82677b9d98c029380cad33d1c57e655af1f737127e386324d70": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Learning Git the Hard Way\n\nI learned git by accidentally deleting a week's worth of work with git reset --hard in",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "git",
-            "name": "git",
-            "type": "CONCEPT",
-            "description": "Git is a distributed version control system used for tracking changes in source code during software development."
-          },
-          {
-            "id": "Pro Git book",
-            "name": "Pro Git book",
-            "type": "CONCEPT",
-            "description": "Pro Git is a comprehensive book that covers the Git version control system, providing insights and best practices."
-          },
-          {
-            "id": "2013",
-            "name": "2013",
-            "type": "DATE",
-            "description": "The year when the author accidentally deleted a week's worth of work using git reset --hard."
-          },
-          {
-            "id": "junior developers",
-            "name": "junior developers",
-            "type": "PERSON",
-            "description": "Junior developers are individuals who are new to the field of software development and are typically in the early stages of their careers."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "git",
-            "target_node_id": "Pro Git book",
-            "relationship_name": "related_to"
-          },
-          {
-            "source_node_id": "2013",
-            "target_node_id": "git",
-            "relationship_name": "experienced_in"
-          },
-          {
-            "source_node_id": "junior developers",
-            "target_node_id": "git",
-            "relationship_name": "taught_workshops"
-          }
-        ]
-      }
-    },
-    "7a00c4133bb0b0805b5548c26086b6283c42672a18265055bb8e5c9ab42174e2": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Running My First Marathon\n\nI ran my first marathon in 2016 in Vienna. Training took five months with a gradual bu",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "I completed my inaugural marathon in Vienna in 2016, finishing in 4 hours and 12 minutes after five months of training.",
-        "description": "In 2016, I participated in my first marathon in Vienna, where I trained for five months, progressively increasing my distance from 5K to the full 42 kilometers. At kilometer 35, I faced a challenging moment but was motivated by the enthusiastic crowd along the Ringstrasse, enabling me to finish the race in 4 hours and 12 minutes."
-      }
-    },
-    "7c33e44e4cc22ed89458b42c7159d899292f9af7e5b9055452c0dea0e429a428": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Thunderstorm at the Beach\n\nWe were at the beach when a sudden thunderstorm rolled in from the sea. The sky turn",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "A sudden thunderstorm unexpectedly hit the beach, transforming the sky and prompting a hurried retreat to the car.",
-        "description": "While at the beach, a fierce thunderstorm approached rapidly, darkening the sky and increasing the wind. As lightning illuminated the sea, we sought refuge in the car, where the intense rain created a mix of fear and awe."
-      }
-    },
-    "7c6316fb28631db4aa52e6a024f283bc2909a2126889488a4546606bba0e6ece": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Setting Up a Home Network\n\nWhen I set up a mesh Wi-Fi network in my apartment, I learned more about networking th",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "mesh Wi-Fi network",
-            "name": "mesh Wi-Fi network",
-            "type": "CONCEPT",
-            "description": "A type of wireless network that uses multiple devices to provide seamless coverage throughout an area."
-          },
-          {
-            "id": "apartment",
-            "name": "apartment",
-            "type": "LOCATION",
-            "description": "A self-contained housing unit that occupies part of a building."
-          },
-          {
-            "id": "VLANs",
-            "name": "VLANs",
-            "type": "CONCEPT",
-            "description": "Virtual Local Area Networks that segment network traffic for improved performance and security."
-          },
-          {
-            "id": "IoT devices",
-            "name": "IoT devices",
-            "type": "CONCEPT",
-            "description": "Devices connected to the internet that can collect and exchange data."
-          },
-          {
-            "id": "work machines",
-            "name": "work machines",
-            "type": "CONCEPT",
-            "description": "Computers and devices used for professional tasks."
-          },
-          {
-            "id": "Pi-hole",
-            "name": "Pi-hole",
-            "type": "CONCEPT",
-            "description": "A network-wide ad blocker that operates at the DNS level."
-          },
-          {
-            "id": "Ethernet",
-            "name": "Ethernet",
-            "type": "CONCEPT",
-            "description": "A system for connecting computers within a local area network."
-          },
-          {
-            "id": "partner",
-            "name": "partner",
-            "type": "PERSON",
-            "description": "The individual who shares a living space with the narrator."
-          },
-          {
-            "id": "networking",
-            "name": "networking",
-            "type": "CONCEPT",
-            "description": "The practice of connecting computers and other devices to share resources."
-          },
-          {
-            "id": "home lab",
-            "name": "home lab",
-            "type": "CONCEPT",
-            "description": "A personal workspace set up for experimentation and learning in technology."
-          },
-          {
-            "id": "Wi-Fi",
-            "name": "Wi-Fi",
-            "type": "CONCEPT",
-            "description": "A technology that allows electronic devices to connect to a wireless local area network."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "mesh Wi-Fi network",
-            "target_node_id": "apartment",
-            "relationship_name": "located_in"
-          },
-          {
-            "source_node_id": "VLANs",
-            "target_node_id": "IoT devices",
-            "relationship_name": "separate_from"
-          },
-          {
-            "source_node_id": "VLANs",
-            "target_node_id": "work machines",
-            "relationship_name": "separate_from"
-          },
-          {
-            "source_node_id": "Pi-hole",
-            "target_node_id": "networking",
-            "relationship_name": "used_in"
-          },
-          {
-            "source_node_id": "Ethernet",
-            "target_node_id": "apartment",
-            "relationship_name": "installed_in"
-          },
-          {
-            "source_node_id": "partner",
-            "target_node_id": "mesh Wi-Fi network",
-            "relationship_name": "opinion_on"
-          },
-          {
-            "source_node_id": "networking",
-            "target_node_id": "home lab",
-            "relationship_name": "related_to"
-          },
-          {
-            "source_node_id": "Wi-Fi",
-            "target_node_id": "mesh Wi-Fi network",
-            "relationship_name": "type_of"
-          }
-        ]
-      }
-    },
-    "7f82ff293807083f2eb912bb4f1f90db4f36f93e10d9ce2dfbed9c2f88d931dc": {
-      "method": "structured_output",
-      "user_input_preview": "Title: The Solar Eclipse of 1999\n\nOn August 11, 1999, a total solar eclipse was visible from parts of Europe. I watched ",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "The Solar Eclipse of 1999",
-            "name": "The Solar Eclipse of 1999",
-            "type": "CONCEPT",
-            "description": "A total solar eclipse that occurred on August 11, 1999, visible from parts of Europe."
-          },
-          {
-            "id": "August 11, 1999",
-            "name": "August 11, 1999",
-            "type": "DATE",
-            "description": "The date when the total solar eclipse occurred."
-          },
-          {
-            "id": "Europe",
-            "name": "Europe",
-            "type": "LOCATION",
-            "description": "A continent where the total solar eclipse was visible."
-          },
-          {
-            "id": "astronomy",
-            "name": "astronomy",
-            "type": "CONCEPT",
-            "description": "The scientific study of celestial bodies, space, and the universe."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "The Solar Eclipse of 1999",
-            "target_node_id": "August 11, 1999",
-            "relationship_name": "occurred_on"
-          },
-          {
-            "source_node_id": "The Solar Eclipse of 1999",
-            "target_node_id": "Europe",
-            "relationship_name": "visible_from"
-          },
-          {
-            "source_node_id": "The Solar Eclipse of 1999",
-            "target_node_id": "astronomy",
-            "relationship_name": "related_to"
-          }
-        ]
-      }
-    },
-    "8146fe0d20eafaa406e2b1c8a17e6a3f745924479d8a46318571813fab99fb66": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Cooking Grandmother's Stew\n\nMy grandmother's beef stew recipe has been in the family for three generations. The s",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "My grandmother's beef stew recipe, cherished for three generations, features red wine vinegar as a secret ingredient and is traditionally cooked in a cast-iron pot for four hours.",
-        "description": "The beef stew recipe passed down through three generations in my family includes a unique touch of red wine vinegar added at the end. It is prepared in a cast-iron pot on low heat for a minimum of four hours, and I continue to follow her original recipe each winter."
-      }
-    },
-    "8208bd0b247e370999e3a878ddfe7ce0e31f123853d8cd96f5d1cb018495e502": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Moving to a New City\n\nWhen I moved to Berlin in 2018, I knew nobody in the city. The first month was lonely — I s",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "Relocating to Berlin in 2018 was initially isolating, but discovering a co-working space led to friendships and a sense of belonging in the Kreuzberg area.",
-        "description": "Upon moving to Berlin in 2018, I felt lonely as I had no acquaintances in the city. My weekends were spent wandering various neighborhoods. However, I eventually joined a co-working space where I connected with individuals who became good friends, and within six months, the Kreuzberg district began to feel like home."
-      }
-    },
-    "823d7993aec0cdd0c5f94f5a77cff68ff9e237465073f859de2c967a48ce8ea4": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Coffee Culture Discovery\n\nI discovered specialty coffee when a friend took me to a third-wave coffee shop in 2017",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "In 2017, I was introduced to specialty coffee at a third-wave café, where I learned about processing methods and experienced the unique flavors of an Ethiopian Yirgacheffe pour-over.",
-        "description": "My journey into coffee culture began in 2017 when a friend brought me to a third-wave coffee shop. There, a barista detailed the distinctions between washed and natural coffee processing. I sampled a pour-over of Ethiopian Yirgacheffe and was delighted by the blueberry notes, igniting my passion for coffee."
-      }
-    },
-    "8813d06c65537f2e32671564b724dea5cced3cc964e89f6c7192f4e624120164": {
-      "method": "structured_output",
-      "user_input_preview": "Title: First Job Interview\n\nMy first real job interview was at a small software consultancy in 2010. I was so nervous th",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "The author's initial job interview occurred in 2010 at a small software consultancy, where they forgot their portfolio but successfully explained merge sort after struggling with quicksort. They received a job offer two days later.",
-        "description": "In 2010, the author experienced their first significant job interview at a small software consultancy. Overwhelmed with anxiety, they left their portfolio at home. During the interview, they were asked to demonstrate a sorting algorithm on a whiteboard; although they couldn't recall quicksort, they articulated merge sort effectively. Subsequently, they were offered the position two days after the interview."
-      }
-    },
-    "8aa735ef70198f87c9bd0dbb2f2a21e7c653d5287204b51ea88370825af4c5b1": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Understanding Recursion\n\nThe moment recursion clicked for me was during a lecture on the Tower of Hanoi. The prof",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "Recursion became clear to me through a Tower of Hanoi lecture, leading to my first implementation and a recursive maze solver.",
-        "description": "During a lecture on the Tower of Hanoi, the professor illustrated how recursion works by solving the same problem on a reduced scale. This understanding prompted me to implement the concept at home, resulting in the creation of a recursive maze solver, marking the first time I found an abstract idea to be intuitively graspable."
-      }
-    },
-    "8b5563e381c10cc4a67e1714b14d3f6bb829772d5d6461ac507f641b97288f70": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Adopting a Cat\n\nWe adopted our cat Luna from a local shelter in 2020. She was shy at first and hid under the couc",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "In 2020, we adopted Luna, a shy cat from a shelter who initially hid for three days but eventually became affectionate, often sleeping on my keyboard.",
-        "description": "Luna, our cat adopted from a local shelter in 2020, was initially timid and spent three days hiding under the couch. Over time, she became more comfortable and now enjoys sleeping on my keyboard while I work. She is identifiable by a unique orange patch on her left ear."
-      }
-    },
-    "8d0a88bcbb42e67724344adf55e26301ca9f48275ef190e9cc059a182aed873b": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Debugging a Production Outage\n\nIn 2019, our production database went down at 3 AM due to a misconfigured connecti",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "2019",
-            "name": "2019",
-            "type": "DATE",
-            "description": "The year when the production database outage occurred."
-          },
-          {
-            "id": "production_database",
-            "name": "Production Database",
-            "type": "CONCEPT",
-            "description": "The database that experienced an outage due to a misconfigured connection pool."
-          },
-          {
-            "id": "misconfigured_connection_pool",
-            "name": "Misconfigured Connection Pool",
-            "type": "CONCEPT",
-            "description": "The issue that caused the production database to go down."
-          },
-          {
-            "id": "max_connections",
-            "name": "Max Connections",
-            "type": "CONCEPT",
-            "description": "The configuration setting that was changed from 100 to 10, leading to the database outage."
-          },
-          {
-            "id": "config_change",
-            "name": "Config Change",
-            "type": "CONCEPT",
-            "description": "The one-line change made to fix the database connection issue."
-          },
-          {
-            "id": "logs",
-            "name": "Logs",
-            "type": "CONCEPT",
-            "description": "The records that were traced to investigate the database outage."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "production_database",
-            "target_node_id": "misconfigured_connection_pool",
-            "relationship_name": "experienced"
-          },
-          {
-            "source_node_id": "misconfigured_connection_pool",
-            "target_node_id": "max_connections",
-            "relationship_name": "caused"
-          },
-          {
-            "source_node_id": "max_connections",
-            "target_node_id": "config_change",
-            "relationship_name": "fixed_by"
-          },
-          {
-            "source_node_id": "production_database",
-            "target_node_id": "logs",
-            "relationship_name": "traced_through"
-          }
-        ]
-      }
-    },
-    "8eaadd392dd2937f81045a71643933563252d759afd2a886f54400db1190e4bc": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Rainy Day in Kyoto\n\nIt rained the entire day I visited Kyoto's bamboo grove. Most tourists left, but I stayed a",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "A rainy day in Kyoto's bamboo grove provided a unique experience, as fewer tourists remained, allowing for a serene atmosphere.",
-        "description": "During my visit to Kyoto, it rained all day while I explored the bamboo grove. With most visitors gone, I enjoyed a tranquil walk, accompanied by the soothing sound of rain on the bamboo leaves. The rain enhanced the vibrant greenery, proving that inclement weather can create unforgettable moments."
-      }
-    },
-    "8eb64adba248a10bdc21f8508fe416c5e39827758bdb721452e2d6154d7aa09e": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Learning to Play Chess\n\nMy uncle taught me chess when I was seven. He never let me win, which frustrated me at fi",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "I learned chess from my uncle at the age of seven, which helped me enhance my skills despite initial frustration. I later joined the school chess club and secured third place in a regional competition, and I continue to play online regularly to unwind.",
-        "description": "At seven, my uncle introduced me to chess, never allowing me to win, which initially frustrated me but ultimately led to my improvement. I became a member of the school chess club and achieved third place in a regional tournament. Nowadays, I frequently play online in the evenings as a way to relax."
-      }
-    },
-    "989310c9f12dbb66a2fd7570d687f1c389a463c5e2414311467695a2605cc48c": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Baking Bread During Lockdown\n\nLike many people, I started baking sourdough bread during the 2020 lockdown. My fir",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "During the 2020 lockdown, I began baking sourdough bread, initially struggling but eventually mastering the technique.",
-        "description": "I started making sourdough bread in 2020, with my first starter taking two weeks to activate. My initial loaf was heavy and tangy, but by my fifth try, I achieved a loaf with a nice texture and a crunchy crust. I affectionately named my starter 'Clint Yeastwood'."
-      }
-    },
-    "9bba44b978f80466c1e27f7cb7d2b19863ae97e9879b2a5dbf6058cbd065de80": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Understanding Recursion\n\nThe moment recursion clicked for me was during a lecture on the Tower of Hanoi. The prof",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Recursion",
-            "name": "Recursion",
-            "type": "CONCEPT",
-            "description": "Recursion is a method of solving problems where the solution depends on solutions to smaller instances of the same problem."
-          },
-          {
-            "id": "Tower of Hanoi",
-            "name": "Tower of Hanoi",
-            "type": "CONCEPT",
-            "description": "The Tower of Hanoi is a mathematical puzzle that involves moving a stack of disks from one peg to another, following specific rules."
-          },
-          {
-            "id": "Computer Science",
-            "name": "Computer Science",
-            "type": "CONCEPT",
-            "description": "Computer Science is the study of computers and computational systems, encompassing both theoretical and practical aspects."
-          },
-          {
-            "id": "Learning",
-            "name": "Learning",
-            "type": "CONCEPT",
-            "description": "Learning is the process of acquiring knowledge or skills through experience, study, or teaching."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Recursion",
-            "target_node_id": "Tower of Hanoi",
-            "relationship_name": "illustrated_by"
-          },
-          {
-            "source_node_id": "Recursion",
-            "target_node_id": "Computer Science",
-            "relationship_name": "related_to"
-          },
-          {
-            "source_node_id": "Recursion",
-            "target_node_id": "Learning",
-            "relationship_name": "enhances"
-          }
-        ]
-      }
-    },
-    "9c75eeef454da05040d5ff2083fc95f38f036afb43c611185148946cf5ce1c66": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Reading Lord of the Rings\n\nI read the entire Lord of the Rings trilogy in one week during summer break when I was",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "At fourteen, I devoured the entire Lord of the Rings trilogy in a week, losing track of time in Middle-earth. The chapter 'The Bridge of Khazad-dûm' was particularly haunting, and the conclusion at the Grey Havens moved me to tears.",
-        "description": "During my summer break at the age of fourteen, I immersed myself in the Lord of the Rings trilogy, finishing all three books in just one week. I was so engrossed that I neglected sleep and meals. The chapter titled 'The Bridge of Khazad-dûm' sent chills down my spine, and the emotional farewell at the Grey Havens was the first moment in literature that brought me to tears."
-      }
-    },
-    "9dbcef5a4f14efefe76bf46d4fed517f50dd52ec9c53a24112cacf7128152d10": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Attending a Live Concert\n\nThe first live concert I attended was Radiohead at a festival in 2006. The band opened ",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "My inaugural live concert experience was Radiohead at a festival in 2006, where the audience passionately sang along to their hits.",
-        "description": "I attended my first live concert featuring Radiohead at a festival in 2006. The band started with 'There There', igniting excitement among the crowd. Being in a field filled with thousands, all joining in on 'Karma Police', created a euphoric atmosphere. I still possess the wristband from that memorable day."
-      }
-    },
-    "9e3ace982ee0ba2606c11e875d1beb7c8b869ba584749c76abf41504960a5442": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Sunrise Over the Mountains\n\nI woke up at 4 AM to hike to a summit in the Dolomites to watch the sunrise. The tr",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Dolomites",
-            "name": "Dolomites",
-            "type": "LOCATION",
-            "description": "The Dolomites are a mountain range located in northeastern Italy, known for their stunning peaks and natural beauty."
-          },
-          {
-            "id": "sunrise",
-            "name": "sunrise",
-            "type": "CONCEPT",
-            "description": "Sunrise is the time in the morning when the sun appears above the horizon, marking the beginning of the day."
-          },
-          {
-            "id": "hiking",
-            "name": "hiking",
-            "type": "CONCEPT",
-            "description": "Hiking is an outdoor activity that involves walking in natural environments, often on trails or paths."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "hiking",
-            "target_node_id": "Dolomites",
-            "relationship_name": "takes_place_in"
-          },
-          {
-            "source_node_id": "sunrise",
-            "target_node_id": "Dolomites",
-            "relationship_name": "observed_in"
-          }
-        ]
-      }
-    },
-    "9ed15b0318a696ba68fbf2308119e626a6b11147474b4ffb5d706e62ef7cf1c0": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Flat Tire on a Road Trip\n\nHalfway through a road trip to the coast, we got a flat tire on a deserted stretch of",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "road trip",
-            "name": "road trip",
-            "type": "CONCEPT",
-            "description": "A journey taken by car, often for leisure or vacation purposes."
-          },
-          {
-            "id": "car trouble",
-            "name": "car trouble",
-            "type": "CONCEPT",
-            "description": "Issues or problems that occur with a vehicle, such as a flat tire."
-          },
-          {
-            "id": "beach",
-            "name": "beach",
-            "type": "LOCATION",
-            "description": "A sandy or pebbly shore by a body of water, often a destination for relaxation and recreation."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "road trip",
-            "target_node_id": "car trouble",
-            "relationship_name": "involves"
-          },
-          {
-            "source_node_id": "road trip",
-            "target_node_id": "beach",
-            "relationship_name": "leads_to"
-          }
-        ]
-      }
-    },
-    "9f362cbb6cf3092661bbfab0e92808608b9b50c226c35f36dec697b540e0a0c8": {
-      "method": "structured_output",
-      "user_input_preview": "Title: First Time Using Docker\n\nThe first time I used Docker in 2015, it felt like magic. I went from 'it works on my ma",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Docker",
-            "name": "Docker",
-            "type": "CONCEPT",
-            "description": "Docker is a platform that enables developers to automate the deployment of applications inside lightweight containers."
-          },
-          {
-            "id": "2015",
-            "name": "2015",
-            "type": "DATE",
-            "description": "The year when the author first used Docker."
-          },
-          {
-            "id": "Python app",
-            "name": "Python app",
-            "type": "CONCEPT",
-            "description": "A software application developed using the Python programming language."
-          },
-          {
-            "id": "DevOps",
-            "name": "DevOps",
-            "type": "CONCEPT",
-            "description": "A set of practices that combines software development (Dev) and IT operations (Ops) to shorten the systems development life cycle."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "2015",
-            "target_node_id": "Docker",
-            "relationship_name": "first_used"
-          },
-          {
-            "source_node_id": "Docker",
-            "target_node_id": "Python app",
-            "relationship_name": "used_for"
-          },
-          {
-            "source_node_id": "Docker",
-            "target_node_id": "DevOps",
-            "relationship_name": "related_to"
-          }
-        ]
-      }
-    },
-    "9f4931264ac0431a84b18fa6552d060d442e25d0360cb626500c04a64b63b933": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Watching the World Cup Final\n\nThe 2014 World Cup final between Germany and Argentina was one of the most tense ma",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "The 2014 World Cup final was a thrilling match between Germany and Argentina, experienced in a lively gathering with friends.",
-        "description": "During the intense 2014 World Cup final, held between Germany and Argentina, we convened at a friend's place with refreshments. The atmosphere was charged, especially when Götze netted the winning goal in extra time, causing a split reaction among the attendees."
-      }
-    },
-    "a10e0fd60fce7375ece6b1ab391229a8be6493d871bd882724d595b6be326ff1": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Learning to Swim\n\nI learned to swim at the municipal pool when I was eight. The instructor, Mrs. Petrovic, was pa",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "At eight years old, I learned to swim at a local pool under the guidance of a strict yet understanding instructor, Mrs. Petrovic, who emphasized back floating before other techniques. Overcoming my fear of the deep end, I eventually took a leap of faith and dove in spontaneously.",
-        "description": "I began my swimming journey at the municipal pool when I was eight years old, taught by Mrs. Petrovic, who was both patient and authoritative. She prioritized back floating practice, which helped build our confidence. Initially, I was fearful of the deep end, but one day, I unexpectedly took the plunge."
-      }
-    },
-    "a1c77d9f0a933522fb5cd07e8dd36f039e6fd4ac8c40ec9e09d514d9e03140ee": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Childhood Pet Dog\n\nOur family dog Rex was a German Shepherd who lived with us for thirteen years. He waited at th",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "Rex, our family German Shepherd, was a loyal companion for thirteen years, eagerly greeting me after school and having adventurous escapades, like chasing a deer. His passing left a significant void in our home for months.",
-        "description": "Rex, a German Shepherd, was part of our family for thirteen years, always waiting at the door when I returned from school. He had a memorable adventure where he chased a deer and returned three hours later muddy. After his death, the house felt desolate for several months."
-      }
-    },
-    "a1dc499a20fa5f97eaf5c410887ca2297ef658c5a292dfb9ed90fed542936178": {
+    "18b336c39d62ed0a0de529d66e81b72fca7c0ea85606beb2f9e7bce2b6183f14": {
       "method": "structured_output",
       "user_input_preview": "Title: Stargazing in the Countryside\n\nOn a camping trip far from city lights, I saw the Milky Way clearly for the first ",
       "schema_name": "KnowledgeGraph",
       "response": {
+        "edges": [
+          {
+            "description": "The Milky Way is a galaxy that was clearly visible during the stargazing experience.",
+            "relationship_name": "is_visible_in",
+            "source_node_id": "Milky Way",
+            "target_node_id": "Stargazing"
+          },
+          {
+            "description": "Orion is a constellation that was pointed out during the stargazing experience.",
+            "relationship_name": "is_a_constellation",
+            "source_node_id": "Orion",
+            "target_node_id": "Stargazing"
+          },
+          {
+            "description": "Cassiopeia is a constellation that was pointed out during the stargazing experience.",
+            "relationship_name": "is_a_constellation",
+            "source_node_id": "Cassiopeia",
+            "target_node_id": "Stargazing"
+          },
+          {
+            "description": "The Big Dipper is a constellation that was pointed out during the stargazing experience.",
+            "relationship_name": "is_a_constellation",
+            "source_node_id": "Big Dipper",
+            "target_node_id": "Stargazing"
+          },
+          {
+            "description": "Satellites were observed crossing the sky during the stargazing experience.",
+            "relationship_name": "were_observed_in",
+            "source_node_id": "Satellites",
+            "target_node_id": "Stargazing"
+          },
+          {
+            "description": "Shooting stars were seen during the stargazing experience.",
+            "relationship_name": "were_seen_in",
+            "source_node_id": "Shooting Stars",
+            "target_node_id": "Stargazing"
+          }
+        ],
         "nodes": [
           {
+            "description": "The Milky Way is a galaxy that contains billions of stars and is visible from Earth.",
             "id": "Milky Way",
             "name": "Milky Way",
-            "type": "CONCEPT",
-            "description": "The Milky Way is the galaxy that contains our Solar System, characterized by its spiral shape and numerous stars."
+            "type": "CONCEPT"
           },
           {
+            "description": "Orion is a prominent constellation located on the celestial equator and visible throughout the world.",
             "id": "Orion",
             "name": "Orion",
-            "type": "CONCEPT",
-            "description": "Orion is a prominent constellation located on the celestial equator, known for its bright stars and distinctive shape."
+            "type": "CONCEPT"
           },
           {
+            "description": "Cassiopeia is a constellation in the northern sky, easily recognizable by its W shape.",
             "id": "Cassiopeia",
             "name": "Cassiopeia",
-            "type": "CONCEPT",
-            "description": "Cassiopeia is a recognizable constellation in the northern sky, easily identified by its W shape formed by five bright stars."
+            "type": "CONCEPT"
           },
           {
+            "description": "The Big Dipper is an asterism consisting of seven bright stars in the constellation Ursa Major.",
             "id": "Big Dipper",
             "name": "Big Dipper",
-            "type": "CONCEPT",
-            "description": "The Big Dipper is an asterism in the constellation Ursa Major, consisting of seven bright stars that form a distinctive shape."
+            "type": "CONCEPT"
           },
           {
-            "id": "3 AM",
-            "name": "3 AM",
-            "type": "DATE",
-            "description": "3 AM refers to the time in the early morning when the stargazing activity took place."
+            "description": "Satellites are human-made objects placed in orbit around Earth for various purposes.",
+            "id": "Satellites",
+            "name": "Satellites",
+            "type": "CONCEPT"
           },
           {
-            "id": "stargazing",
-            "name": "stargazing",
-            "type": "CONCEPT",
-            "description": "Stargazing is the activity of observing stars and celestial objects in the night sky."
+            "description": "Shooting stars are the visible paths of meteoroids as they enter the Earth's atmosphere and burn up.",
+            "id": "Shooting Stars",
+            "name": "Shooting Stars",
+            "type": "CONCEPT"
           },
           {
-            "id": "astronomy",
-            "name": "astronomy",
-            "type": "CONCEPT",
-            "description": "Astronomy is the scientific study of celestial bodies, space, and the universe as a whole."
+            "description": "Stargazing is the activity of observing the stars and celestial bodies in the night sky.",
+            "id": "Stargazing",
+            "name": "Stargazing",
+            "type": "CONCEPT"
           },
           {
-            "id": "camping",
-            "name": "camping",
-            "type": "CONCEPT",
-            "description": "Camping is an outdoor activity involving overnight stays away from home in a shelter, such as a tent."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "stargazing",
-            "target_node_id": "Milky Way",
-            "relationship_name": "involves"
+            "description": "Camping is an outdoor activity involving overnight stays away from home in a shelter, such as a tent.",
+            "id": "Camping",
+            "name": "Camping",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "stargazing",
-            "target_node_id": "Orion",
-            "relationship_name": "involves"
-          },
-          {
-            "source_node_id": "stargazing",
-            "target_node_id": "Cassiopeia",
-            "relationship_name": "involves"
-          },
-          {
-            "source_node_id": "stargazing",
-            "target_node_id": "Big Dipper",
-            "relationship_name": "involves"
-          },
-          {
-            "source_node_id": "camping",
-            "target_node_id": "stargazing",
-            "relationship_name": "facilitates"
-          },
-          {
-            "source_node_id": "camping",
-            "target_node_id": "3 AM",
-            "relationship_name": "occurs_at"
+            "description": "Astronomy is the scientific study of celestial bodies, space, and the universe as a whole.",
+            "id": "Astronomy",
+            "name": "Astronomy",
+            "type": "CONCEPT"
           }
         ]
       }
     },
-    "a70941627ac37e06b583f393274540a75acc792b29f08a987ce9d2b525f96ad9": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Volunteering at a Food Bank\n\nI volunteered at a local food bank every Saturday for six months in 2019. We sorted ",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "I volunteered at a food bank weekly for six months, gaining insights into supply chain management while assisting families in need.",
-        "description": "During my six-month volunteering stint at a local food bank in 2019, I dedicated my Saturdays to sorting donations and preparing boxes for families requiring assistance. This experience provided me with practical knowledge about managing perishable goods, surpassing what I learned in business classes. The appreciation expressed by those we helped made the early mornings rewarding."
-      }
-    },
-    "a778679e24a25c3ac54fa46a708338b0d305fe39c632dec3baed1fc2f6bd37aa": {
-      "method": "structured_output",
-      "user_input_preview": "Title: First Open Source Contribution\n\nMy first open source contribution was a bug fix to a Python logging library in 20",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "In 2014, I made my initial open source contribution by fixing a bug in a Python logging library related to file rotation.",
-        "description": "My first contribution to open source involved addressing a race condition in a Python logging library's file rotation handler, which resulted in log file truncation. After three rounds of review, my pull request was successfully merged, and I felt immense satisfaction seeing my name in the changelog."
-      }
-    },
-    "a7b6356d8a0526d89bde26c73bca6d04bae7ed6eb48c77d5ad574300b8205232": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Planting a Garden\n\nIn spring 2021, I started a small vegetable garden on my balcony. I planted tomatoes, basil, a",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "spring 2021",
-            "name": "spring 2021",
-            "type": "DATE",
-            "description": "The season in which the vegetable garden was started."
-          },
-          {
-            "id": "vegetable garden",
-            "name": "vegetable garden",
-            "type": "CONCEPT",
-            "description": "A small garden where various vegetables are grown."
-          },
-          {
-            "id": "balcony",
-            "name": "balcony",
-            "type": "LOCATION",
-            "description": "The location where the vegetable garden was planted."
-          },
-          {
-            "id": "tomatoes",
-            "name": "tomatoes",
-            "type": "CONCEPT",
-            "description": "A type of vegetable that thrived in the garden."
-          },
-          {
-            "id": "basil",
-            "name": "basil",
-            "type": "CONCEPT",
-            "description": "An herb that was harvested weekly to make pesto."
-          },
-          {
-            "id": "peppers",
-            "name": "peppers",
-            "type": "CONCEPT",
-            "description": "A type of vegetable that struggled to grow due to insufficient sunlight."
-          },
-          {
-            "id": "pesto",
-            "name": "pesto",
-            "type": "CONCEPT",
-            "description": "A sauce made from basil, commonly prepared in the garden."
-          },
-          {
-            "id": "August",
-            "name": "August",
-            "type": "DATE",
-            "description": "The month when harvesting of basil was sufficient for weekly preparation."
-          },
-          {
-            "id": "gardening",
-            "name": "gardening",
-            "type": "CONCEPT",
-            "description": "The practice of growing and cultivating plants."
-          },
-          {
-            "id": "vegetables",
-            "name": "vegetables",
-            "type": "CONCEPT",
-            "description": "Plants cultivated for food, including tomatoes, basil, and peppers."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "spring 2021",
-            "target_node_id": "vegetable garden",
-            "relationship_name": "started"
-          },
-          {
-            "source_node_id": "vegetable garden",
-            "target_node_id": "balcony",
-            "relationship_name": "located_in"
-          },
-          {
-            "source_node_id": "vegetable garden",
-            "target_node_id": "tomatoes",
-            "relationship_name": "contains"
-          },
-          {
-            "source_node_id": "vegetable garden",
-            "target_node_id": "basil",
-            "relationship_name": "contains"
-          },
-          {
-            "source_node_id": "vegetable garden",
-            "target_node_id": "peppers",
-            "relationship_name": "contains"
-          },
-          {
-            "source_node_id": "basil",
-            "target_node_id": "pesto",
-            "relationship_name": "used_to_make"
-          },
-          {
-            "source_node_id": "August",
-            "target_node_id": "basil",
-            "relationship_name": "harvested_in"
-          },
-          {
-            "source_node_id": "gardening",
-            "target_node_id": "vegetables",
-            "relationship_name": "involves"
-          }
-        ]
-      }
-    },
-    "ab85970d6cd24b1a4c4566f512a545e22bd952caf4cc3cde366a9001bc52372b": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Learning a New Language\n\nI started learning Japanese in 2019 using a combination of apps and textbooks. Hiragana ",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "The author began learning Japanese in 2019, mastering hiragana and katakana quickly, but found kanji challenging. After two years, they achieved conversational skills, culminating in a rewarding experience of ordering food in Tokyo.",
-        "description": "In 2019, the author embarked on the journey of learning Japanese, utilizing various apps and textbooks. They quickly learned hiragana and katakana within a week each, but struggled with kanji, which seemed never-ending. After two years of dedication, they were able to engage in basic conversations. A significant highlight was visiting Tokyo and successfully ordering food in Japanese, validating their efforts."
-      }
-    },
-    "ad65d2a20c8b4535206f80e26551edafc845261a2874b4b4c7e8c6d060ea2ca6": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Snow Day in School\n\nThe heaviest snowfall I remember was in January 1998 when school was canceled for three days.",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "In January 1998, a significant snowfall led to a three-day school closure, allowing for the construction of a large snow fort in the park that lasted until February.",
-        "description": "The most memorable snowfall occurred in January 1998, resulting in a three-day school cancellation. During this time, an impressive snow fort was built in the park, complete with tunnels and a watchtower. Despite freezing hands, I stayed outside to enjoy the fort, which ultimately collapsed in February."
-      }
-    },
-    "b23d20911992aa8542464468fc167fdfa0cbb7e7feafd1184f84a4a8cbaeff66": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Learning to Swim\n\nI learned to swim at the municipal pool when I was eight. The instructor, Mrs. Petrovic, was pa",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Mrs. Petrovic",
-            "name": "Mrs. Petrovic",
-            "type": "PERSON",
-            "description": "The swimming instructor who taught the author to swim, known for being patient but firm."
-          },
-          {
-            "id": "municipal pool",
-            "name": "municipal pool",
-            "type": "LOCATION",
-            "description": "The location where the author learned to swim."
-          },
-          {
-            "id": "swimming",
-            "name": "swimming",
-            "type": "CONCEPT",
-            "description": "The activity of moving through water by using the limbs."
-          },
-          {
-            "id": "childhood",
-            "name": "childhood",
-            "type": "CONCEPT",
-            "description": "The period of life when the author learned to swim, specifically at the age of eight."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "municipal pool",
-            "target_node_id": "Mrs. Petrovic",
-            "relationship_name": "taught_at"
-          },
-          {
-            "source_node_id": "childhood",
-            "target_node_id": "swimming",
-            "relationship_name": "involves"
-          }
-        ]
-      }
-    },
-    "b68450f01644097773b33f503ae1ab87b4042a68e73e056da0762dca22e13723": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Power Outage During a Demo\n\nDuring a client demo in 2018, the office power went out just as I was showing the n",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "A power outage occurred during a client demonstration in 2018, but the presenter quickly adapted by using a phone hotspot and laptop battery, impressing the client.",
-        "description": "During a client demo in 2018, the office experienced a power failure while showcasing a new dashboard. The presenter swiftly switched to a mobile hotspot and continued the presentation using the laptop's battery, which left a positive impression on the client. It was later discovered that a construction crew had accidentally severed a cable outside the building."
-      }
-    },
-    "b9c5729e0c35ca7323ea7b67329030933a8cf2c7447093c17265064203d11616": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Reading Lord of the Rings\n\nI read the entire Lord of the Rings trilogy in one week during summer break when I was",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Lord of the Rings",
-            "name": "Lord of the Rings",
-            "type": "CONCEPT",
-            "description": "A high-fantasy novel series written by J.R.R. Tolkien, set in the fictional world of Middle-earth."
-          },
-          {
-            "id": "J.R.R. Tolkien",
-            "name": "J.R.R. Tolkien",
-            "type": "PERSON",
-            "description": "An English writer, best known for his high-fantasy works including The Hobbit and The Lord of the Rings."
-          },
-          {
-            "id": "Middle-earth",
-            "name": "Middle-earth",
-            "type": "CONCEPT",
-            "description": "The fictional setting for many of J.R.R. Tolkien's works, including The Lord of the Rings."
-          },
-          {
-            "id": "The Bridge of Khazad-dûm",
-            "name": "The Bridge of Khazad-dûm",
-            "type": "CONCEPT",
-            "description": "A significant chapter in The Lord of the Rings, known for its dramatic events and emotional impact."
-          },
-          {
-            "id": "Grey Havens",
-            "name": "Grey Havens",
-            "type": "CONCEPT",
-            "description": "A location in Middle-earth, known for its role in the ending of The Lord of the Rings."
-          },
-          {
-            "id": "summer break",
-            "name": "summer break",
-            "type": "DATE",
-            "description": "A period during the summer when students are typically on vacation from school."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "J.R.R. Tolkien",
-            "target_node_id": "Lord of the Rings",
-            "relationship_name": "wrote"
-          },
-          {
-            "source_node_id": "Lord of the Rings",
-            "target_node_id": "Middle-earth",
-            "relationship_name": "set_in"
-          },
-          {
-            "source_node_id": "Lord of the Rings",
-            "target_node_id": "The Bridge of Khazad-dûm",
-            "relationship_name": "contains_chapter"
-          },
-          {
-            "source_node_id": "Lord of the Rings",
-            "target_node_id": "Grey Havens",
-            "relationship_name": "features_location"
-          },
-          {
-            "source_node_id": "summer break",
-            "target_node_id": "Lord of the Rings",
-            "relationship_name": "read_during"
-          }
-        ]
-      }
-    },
-    "bcdffc7e641ecbfd181fa0289817450686741878c8d3ec8c661645cfafe56482": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Power Outage During a Demo\n\nDuring a client demo in 2018, the office power went out just as I was showing the n",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "client",
-            "name": "client",
-            "type": "CONCEPT",
-            "description": "A person or organization that purchases goods or services from a business."
-          },
-          {
-            "id": "power outage",
-            "name": "power outage",
-            "type": "CONCEPT",
-            "description": "A temporary loss of electrical power."
-          },
-          {
-            "id": "2018",
-            "name": "2018",
-            "type": "DATE",
-            "description": "The year when the power outage occurred during a client demo."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "client",
-            "target_node_id": "power outage",
-            "relationship_name": "experienced"
-          },
-          {
-            "source_node_id": "power outage",
-            "target_node_id": "2018",
-            "relationship_name": "occurred_in"
-          }
-        ]
-      }
-    },
-    "bf103490feb048f7b81a3a30688bda7d265e5c5d4b8f12f8227c0bade99f101f": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Refactoring Legacy Code\n\nI spent three months refactoring a 10,000-line PHP file that had been accumulating featu",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Refactoring Legacy Code",
-            "name": "Refactoring Legacy Code",
-            "type": "CONCEPT",
-            "description": "A process of restructuring existing computer code without changing its external behavior."
-          },
-          {
-            "id": "PHP",
-            "name": "PHP",
-            "type": "CONCEPT",
-            "description": "A popular general-purpose scripting language that is especially suited to web development."
-          },
-          {
-            "id": "characterization tests",
-            "name": "characterization tests",
-            "type": "CONCEPT",
-            "description": "Tests that capture the existing behavior of a system to ensure that refactoring does not change its functionality."
-          },
-          {
-            "id": "legacy code",
-            "name": "legacy code",
-            "type": "CONCEPT",
-            "description": "Old code that is still in use but may be difficult to maintain or extend."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Refactoring Legacy Code",
-            "target_node_id": "legacy code",
-            "relationship_name": "related_to"
-          },
-          {
-            "source_node_id": "Refactoring Legacy Code",
-            "target_node_id": "PHP",
-            "relationship_name": "uses"
-          },
-          {
-            "source_node_id": "Refactoring Legacy Code",
-            "target_node_id": "characterization tests",
-            "relationship_name": "involves"
-          }
-        ]
-      }
-    },
-    "bfb6af8dc3a4b20112482a7b05c6e71b333472d28862a898d9f4696795a46da2": {
+    "19620fe2bb2bd418f22cae2d0f96f4df1efc7dcde4a29cb66d2c45b03445e639": {
       "method": "structured_output",
       "user_input_preview": "Title: The Neighborhood Bookstore\n\nThere was a tiny bookstore on my street run by an elderly couple. They knew every boo",
       "schema_name": "KnowledgeGraph",
       "response": {
+        "edges": [
+          {
+            "description": "The tiny bookstore was run by an elderly couple.",
+            "relationship_name": "run_by",
+            "source_node_id": "tiny_bookstore",
+            "target_node_id": "elderly_couple"
+          },
+          {
+            "description": "The tiny bookstore was located in the neighborhood.",
+            "relationship_name": "located_in",
+            "source_node_id": "tiny_bookstore",
+            "target_node_id": "neighborhood"
+          },
+          {
+            "description": "The neighborhood felt the loss when the tiny bookstore closed.",
+            "relationship_name": "felt_loss",
+            "source_node_id": "neighborhood",
+            "target_node_id": "tiny_bookstore"
+          }
+        ],
         "nodes": [
           {
-            "id": "The Neighborhood Bookstore",
-            "name": "The Neighborhood Bookstore",
-            "type": "CONCEPT",
-            "description": "A tiny bookstore run by an elderly couple, known for their extensive knowledge of books."
+            "description": "A small bookstore that was run by an elderly couple and closed in 2019.",
+            "id": "tiny_bookstore",
+            "name": "tiny bookstore",
+            "type": "CONCEPT"
           },
           {
-            "id": "2019",
-            "name": "2019",
-            "type": "DATE",
-            "description": "The year when the elderly couple retired and closed the bookstore."
+            "description": "An elderly couple who ran the tiny bookstore.",
+            "id": "elderly_couple",
+            "name": "elderly couple",
+            "type": "PERSON"
           },
           {
+            "description": "A community area where the tiny bookstore was located.",
             "id": "neighborhood",
             "name": "neighborhood",
-            "type": "CONCEPT",
-            "description": "The local community that felt the loss of the bookstore when it closed."
+            "type": "CONCEPT"
           },
           {
+            "description": "A group of people living in the same area, connected by shared interests and experiences.",
             "id": "community",
             "name": "community",
-            "type": "CONCEPT",
-            "description": "A group of people living in the same area, in this case, the neighborhood around the bookstore."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "The Neighborhood Bookstore",
-            "target_node_id": "2019",
-            "relationship_name": "closed_in"
-          },
-          {
-            "source_node_id": "neighborhood",
-            "target_node_id": "The Neighborhood Bookstore",
-            "relationship_name": "felt_loss_for"
-          },
-          {
-            "source_node_id": "community",
-            "target_node_id": "neighborhood",
-            "relationship_name": "comprises"
+            "type": "CONCEPT"
           }
         ]
       }
     },
-    "bfc656cd74568aff7a45977a5349a2563fe6a254d87115fc075a700a1a6ed89d": {
+    "1accdd6cb7bb225ba356d5b45f039ff034fdcac1e2cc2fe2719c6704db9fa581": {
       "method": "structured_output",
-      "user_input_preview": "Title: Setting Up My First Server\n\nI set up my first Linux server in 2011 — a Debian box running Apache and MySQL. I spe",
+      "user_input_preview": "Title: A Conversation with a Stranger\n\nOn a delayed train from Prague to Vienna, I sat next to a retired physicist who t",
       "schema_name": "SummarizedContent",
       "response": {
-        "summary": "In 2011, I configured my initial Linux server, a Debian system with Apache and MySQL, and experienced the excitement of launching my website online, only to have it compromised shortly after due to default port settings.",
-        "description": "In 2011, I established my first Linux server, specifically a Debian machine that operated with Apache and MySQL. I dedicated an entire weekend to setting up iptables rules and SSH keys. The exhilaration of making my website available on the internet was unparalleled, but it was hacked within a week because I neglected to change the default configuration of port 22."
+        "description": "The chunk discusses a conversation with a retired physicist on a train journey from Prague to Vienna, focusing on his work in particle physics and the concept of quantum tunneling. The conversation led to a personal reflection on time and randomness.",
+        "summary": "The content describes a train conversation with a retired physicist about particle accelerators and quantum tunneling, which prompted a reevaluation of the author's views on time and randomness."
       }
     },
-    "c1fcf08ef8505bbfb2e9c98f9d062deafc0b7028c8ffca40ad6da1255a4e65d7": {
+    "1c7cd226b1fb9c88d3beb53f44c9460cb1b47d36a4d9920a5606fcb5dc2cc6f7": {
       "method": "structured_output",
-      "user_input_preview": "Title: Baking Bread During Lockdown\n\nLike many people, I started baking sourdough bread during the 2020 lockdown. My fir",
+      "user_input_preview": "Title: A Power Outage During a Demo\n\nDuring a client demo in 2018, the office power went out just as I was showing the n",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "In 2018, during a client demo, the office experienced a power outage while showcasing a new dashboard. The presenter quickly switched to a phone's hotspot and continued the demo on a laptop battery, impressing the client. The outage was later attributed to a construction crew cutting a cable outside the building.",
+        "summary": "In 2018, a power outage occurred during a client demo, but the presenter successfully continued using a phone's hotspot, impressing the client."
+      }
+    },
+    "1ddea159cda9052fa130e385c410d1d6dc94da60ee69d95b3e89b00f30ac9ef0": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Learning Git the Hard Way\n\nI learned git by accidentally deleting a week's worth of work with git reset --hard in",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The content discusses a personal experience of learning Git after a significant mistake in 2013. The author emphasizes the importance of understanding Git's reflog and mentions teaching Git workshops to junior developers.",
+        "summary": "The author learned Git the hard way in 2013 after losing work due to a command error. They now teach Git workshops and highlight the importance of understanding the reflog."
+      }
+    },
+    "1f295e24576cf2edd547258a710a471b3074caf871b0e22b9c80919e02eb3a62": {
+      "method": "structured_output",
+      "user_input_preview": "Title: First Flight Experience\n\nMy first time on an airplane was a flight from Belgrade to London when I was sixteen. I ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "Clint Yeastwood",
-            "name": "Clint Yeastwood",
-            "type": "CONCEPT",
-            "description": "A sourdough starter named during the baking process."
-          },
-          {
-            "id": "sourdough bread",
-            "name": "sourdough bread",
-            "type": "CONCEPT",
-            "description": "A type of bread made using a sourdough starter."
-          },
-          {
-            "id": "lockdown",
-            "name": "lockdown",
-            "type": "CONCEPT",
-            "description": "A period during which people were restricted to their homes due to health concerns."
-          },
-          {
-            "id": "2020",
-            "name": "2020",
-            "type": "DATE",
-            "description": "The year during which the lockdown occurred."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "Clint Yeastwood",
-            "target_node_id": "sourdough bread",
-            "relationship_name": "used_to_make"
+            "description": "The flight from Belgrade to London was the first flight experience for the person.",
+            "relationship_name": "experienced",
+            "source_node_id": "first_flight_experience",
+            "target_node_id": "flight_from_belgrade_to_london"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The first flight experience of the person, which involved flying from Belgrade to London.",
+            "id": "first_flight_experience",
+            "name": "First Flight Experience",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "lockdown",
-            "target_node_id": "2020",
-            "relationship_name": "occurred_in"
+            "description": "A flight that took place from Belgrade to London, marking the person's first time on an airplane.",
+            "id": "flight_from_belgrade_to_london",
+            "name": "Flight from Belgrade to London",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The person who experienced their first flight at the age of sixteen.",
+            "id": "person",
+            "name": "Person",
+            "type": "PERSON"
           }
         ]
       }
     },
-    "c2e2a7dc5554b9d1b225e58db9bf91eadfc4cbf9e776c02cedb354cc747c9d3f": {
+    "2e685c4e8e67a8aa3f1e00e59a64128b0901f438022c0ab1b1a0d27260c96ec8": {
       "method": "structured_output",
-      "user_input_preview": "Title: Running My First Marathon\n\nI ran my first marathon in 2016 in Vienna. Training took five months with a gradual bu",
+      "user_input_preview": "Title: Building a Treehouse\n\nMy father and I built a treehouse in the oak tree in our backyard when I was ten. We spent ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "2016",
-            "name": "2016",
-            "type": "DATE",
-            "description": "The year when the first marathon was run."
-          },
-          {
-            "id": "Vienna",
-            "name": "Vienna",
-            "type": "LOCATION",
-            "description": "The capital city of Austria, where the marathon took place."
-          },
-          {
-            "id": "marathon",
-            "name": "marathon",
-            "type": "CONCEPT",
-            "description": "A long-distance running race with an official distance of 42.195 kilometers."
-          },
-          {
-            "id": "running",
-            "name": "running",
-            "type": "CONCEPT",
-            "description": "A method of terrestrial locomotion allowing humans and other animals to move rapidly on foot."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "2016",
-            "target_node_id": "Vienna",
-            "relationship_name": "took_place_in"
+            "description": "The treehouse was built by the father and the child in the oak tree in the backyard.",
+            "relationship_name": "built",
+            "source_node_id": "father",
+            "target_node_id": "treehouse"
           },
           {
-            "source_node_id": "marathon",
-            "target_node_id": "running",
-            "relationship_name": "is_a"
+            "description": "The treehouse is located in the oak tree in the backyard.",
+            "relationship_name": "located_in",
+            "source_node_id": "treehouse",
+            "target_node_id": "oak_tree"
+          },
+          {
+            "description": "The treehouse had a rope ladder and a small window facing west.",
+            "relationship_name": "has_feature",
+            "source_node_id": "treehouse",
+            "target_node_id": "rope_ladder"
+          },
+          {
+            "description": "The treehouse had a rope ladder and a small window facing west.",
+            "relationship_name": "has_feature",
+            "source_node_id": "treehouse",
+            "target_node_id": "small_window"
+          },
+          {
+            "description": "The child used the treehouse as a reading nook every summer until moving.",
+            "relationship_name": "used_as",
+            "source_node_id": "treehouse",
+            "target_node_id": "reading_nook"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The father is a parent who participated in building the treehouse.",
+            "id": "father",
+            "name": "Father",
+            "type": "PERSON"
+          },
+          {
+            "description": "The treehouse is a structure built in an oak tree for recreational use.",
+            "id": "treehouse",
+            "name": "Treehouse",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The oak tree is a type of tree where the treehouse was built.",
+            "id": "oak_tree",
+            "name": "Oak Tree",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The rope ladder is a feature of the treehouse.",
+            "id": "rope_ladder",
+            "name": "Rope Ladder",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The small window is a feature of the treehouse that faces west.",
+            "id": "small_window",
+            "name": "Small Window",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The reading nook is a purpose for which the treehouse was used.",
+            "id": "reading_nook",
+            "name": "Reading Nook",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Childhood refers to the period of life when the treehouse was built and used.",
+            "id": "childhood",
+            "name": "Childhood",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "DIY refers to the activity of building the treehouse by oneself.",
+            "id": "DIY",
+            "name": "DIY",
+            "type": "CONCEPT"
           }
         ]
       }
     },
-    "c3a80231b71489309e272da143289c5097940b1be2f1ef5a71114b8a87bd7c25": {
+    "3070e10fc2275c3fd2424818f4f12d3de12f4f5be5c7f2066bee4f984af7152e": {
       "method": "structured_output",
-      "user_input_preview": "Title: The Blackout of 2003\n\nDuring the Northeast blackout of August 2003, the power went out for nearly two days. Neigh",
-      "schema_name": "KnowledgeGraph",
+      "user_input_preview": "Title: First Day at University\n\nI remember my first day at the University of Belgrade. The campus was bustling with new ",
+      "schema_name": "SummarizedContent",
       "response": {
-        "nodes": [
-          {
-            "id": "Northeast blackout",
-            "name": "Northeast blackout",
-            "type": "CONCEPT",
-            "description": "The Northeast blackout of August 2003 was a major power outage that affected several states in the northeastern United States."
-          },
-          {
-            "id": "August 2003",
-            "name": "August 2003",
-            "type": "DATE",
-            "description": "The month and year when the Northeast blackout occurred."
-          },
-          {
-            "id": "community",
-            "name": "community",
-            "type": "CONCEPT",
-            "description": "A group of people living in the same place or having a particular characteristic in common."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Northeast blackout",
-            "target_node_id": "August 2003",
-            "relationship_name": "occurred_in"
-          },
-          {
-            "source_node_id": "Northeast blackout",
-            "target_node_id": "community",
-            "relationship_name": "influenced"
-          }
-        ]
+        "description": "The chunk describes the author's first day at the University of Belgrade, highlighting their feelings of excitement and nervousness as they began their Computer Science program. An inspiring lecture by a professor is also mentioned.",
+        "summary": "The author recalls their first day at the University of Belgrade, where they enrolled in the Computer Science program and attended an inspiring lecture by a professor."
       }
     },
-    "c57864bb285a23ad5a3a9c6b4004f83cecf67482f974d08a87bd84638b5f3e9e": {
+    "3488d16e6acc1b4124945f7132f2f3969b074bbbc3bab7a95fad2405a51d83c1": {
       "method": "structured_output",
       "user_input_preview": "Title: Visiting a Museum in Florence\n\nSeeing Michelangelo's David at the Galleria dell'Accademia in Florence was overwhe",
       "schema_name": "SummarizedContent",
       "response": {
-        "summary": "Experiencing Michelangelo's David at the Galleria dell'Accademia in Florence is a breathtaking encounter that surpasses any photograph.",
-        "description": "The visit to the Galleria dell'Accademia in Florence, where Michelangelo's David is housed, was profoundly impactful. The sheer size and intricate details of the sculpture are unmatched by images, leading to a moment of deep appreciation as I focused on its hands for twenty minutes, despite the crowded museum."
+        "description": "This chunk discusses a visit to the Galleria dell'Accademia in Florence where the author experienced Michelangelo's David. The author describes the overwhelming scale and detail of the sculpture, particularly focusing on its hands, and notes the crowded atmosphere of the museum.",
+        "summary": "The author describes an overwhelming experience viewing Michelangelo's David at the Galleria dell'Accademia in Florence, emphasizing the sculpture's scale and detail."
       }
     },
-    "c7a38b7cbc90b0ce0331fe184dbd4861bc05c40494147784b3b730eea9bd3731": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Building a Treehouse\n\nMy father and I built a treehouse in the oak tree in our backyard when I was ten. We spent ",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "At the age of ten, I collaborated with my father to construct a treehouse in our backyard's oak tree, which served as my summer reading spot until we relocated.",
-        "description": "When I was ten years old, my father and I dedicated three weekends to building a treehouse in the oak tree in our backyard. We measured, cut, and nailed boards together, creating a structure that featured a rope ladder and a small west-facing window. This treehouse became my favorite reading nook during the summers until we moved away."
-      }
-    },
-    "c8e792af0b7b079728611d7e679691f215282adaacb9f4ecf985d10b50548c4e": {
+    "3513954a50bc2591afce322236ffe558372109824bc325d3d66ef14d19048629": {
       "method": "structured_output",
       "user_input_preview": "Title: The Importance of Backups\n\nI learned the importance of backups when my laptop's hard drive failed in 2016, taking",
       "schema_name": "KnowledgeGraph",
       "response": {
+        "edges": [
+          {
+            "description": "The importance of backups was learned after the laptop's hard drive failure in 2016.",
+            "relationship_name": "learned_importance_of",
+            "source_node_id": "2016",
+            "target_node_id": "backups"
+          },
+          {
+            "description": "Automated backups were set up to an external drive and cloud storage after the hard drive failure.",
+            "relationship_name": "set_up",
+            "source_node_id": "automated_backups",
+            "target_node_id": "external_drive"
+          },
+          {
+            "description": "Automated backups were set up to an external drive and cloud storage after the hard drive failure.",
+            "relationship_name": "set_up",
+            "source_node_id": "automated_backups",
+            "target_node_id": "cloud_storage"
+          }
+        ],
         "nodes": [
           {
-            "id": "backups",
-            "name": "backups",
-            "type": "CONCEPT",
-            "description": "Backups refer to copies of data stored separately to prevent loss in case of hardware failure or other issues."
-          },
-          {
-            "id": "data_loss",
-            "name": "data_loss",
-            "type": "CONCEPT",
-            "description": "Data loss is the loss of data due to various reasons, including hardware failure, accidental deletion, or corruption."
-          },
-          {
-            "id": "hard_drive_failure",
-            "name": "hard drive failure",
-            "type": "CONCEPT",
-            "description": "Hard drive failure occurs when a hard drive malfunctions, leading to the loss of data stored on it."
-          },
-          {
+            "description": "The year when the laptop's hard drive failed, leading to a significant lesson about backups.",
             "id": "2016",
             "name": "2016",
-            "type": "DATE",
-            "description": "The year when the author experienced a hard drive failure, resulting in the loss of personal projects."
+            "type": "DATE"
           },
           {
-            "id": "automated_backups",
-            "name": "automated backups",
-            "type": "CONCEPT",
-            "description": "Automated backups are scheduled processes that create copies of data without manual intervention."
+            "description": "A method of storing data to prevent loss, highlighted as crucial after a hard drive failure.",
+            "id": "backups",
+            "name": "backups",
+            "type": "CONCEPT"
           },
           {
+            "description": "A storage device used for keeping copies of data, mentioned as part of the backup solution.",
             "id": "external_drive",
             "name": "external drive",
-            "type": "CONCEPT",
-            "description": "An external drive is a storage device that connects to a computer externally, used for backup and data storage."
+            "type": "CONCEPT"
           },
           {
+            "description": "A storage solution that allows data to be saved online, mentioned as part of the backup solution.",
             "id": "cloud_storage",
             "name": "cloud storage",
-            "type": "CONCEPT",
-            "description": "Cloud storage is a service that allows users to store data on remote servers accessed via the internet."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "2016",
-            "target_node_id": "hard_drive_failure",
-            "relationship_name": "experienced"
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "hard_drive_failure",
-            "target_node_id": "data_loss",
-            "relationship_name": "caused"
-          },
-          {
-            "source_node_id": "data_loss",
-            "target_node_id": "backups",
-            "relationship_name": "highlighted_importance_of"
-          },
-          {
-            "source_node_id": "backups",
-            "target_node_id": "automated_backups",
-            "relationship_name": "led_to"
-          },
-          {
-            "source_node_id": "automated_backups",
-            "target_node_id": "external_drive",
-            "relationship_name": "utilized_for"
-          },
-          {
-            "source_node_id": "automated_backups",
-            "target_node_id": "cloud_storage",
-            "relationship_name": "utilized_for"
+            "description": "A process established to regularly save data automatically, implemented after experiencing data loss.",
+            "id": "automated_backups",
+            "name": "automated backups",
+            "type": "CONCEPT"
           }
         ]
       }
     },
-    "cd20e0f478ebc69fe4e627a563a366dccaf7aa015a7972795e16c25e0e3fef48": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Volunteering at a Food Bank\n\nI volunteered at a local food bank every Saturday for six months in 2019. We sorted ",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "local food bank",
-            "name": "local food bank",
-            "type": "ORGANIZATION",
-            "description": "A community organization that provides food assistance to families in need."
-          },
-          {
-            "id": "2019",
-            "name": "2019",
-            "type": "DATE",
-            "description": "The year during which the volunteering took place."
-          },
-          {
-            "id": "volunteering",
-            "name": "volunteering",
-            "type": "CONCEPT",
-            "description": "The act of offering services or time to help others without financial gain."
-          },
-          {
-            "id": "supply chain management",
-            "name": "supply chain management",
-            "type": "CONCEPT",
-            "description": "The management of the flow of goods and services, including all processes that transform raw materials into final products."
-          },
-          {
-            "id": "community",
-            "name": "community",
-            "type": "CONCEPT",
-            "description": "A group of people living in the same place or having a particular characteristic in common."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "local food bank",
-            "target_node_id": "volunteering",
-            "relationship_name": "involves"
-          },
-          {
-            "source_node_id": "2019",
-            "target_node_id": "volunteering",
-            "relationship_name": "took_place_in"
-          },
-          {
-            "source_node_id": "volunteering",
-            "target_node_id": "supply chain management",
-            "relationship_name": "related_to"
-          },
-          {
-            "source_node_id": "local food bank",
-            "target_node_id": "community",
-            "relationship_name": "serves"
-          }
-        ]
-      }
-    },
-    "cebdf3c5a7f610c84fdc0d0aaa76d2b7db5af50fd8278e0b9fc4f3fe8ab6d2b1": {
+    "3caae2b39d271ee1484134e06496ca73c7eee50fd72e13245de4ff145f45358c": {
       "method": "structured_output",
       "user_input_preview": "Title: First Time Using Docker\n\nThe first time I used Docker in 2015, it felt like magic. I went from 'it works on my ma",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "My initial experience with Docker in 2015 was transformative, enabling quick creation of reproducible environments and simplifying deployment for our Python app.",
-        "description": "In 2015, my first encounter with Docker felt revolutionary, as it transitioned me from the common issue of 'it works on my machine' to establishing reproducible environments within a single afternoon. The Dockerfile for our Python application was just fifteen lines long, effectively addressing months of deployment challenges. Consequently, I became the team's Docker advocate for the following year."
-      }
-    },
-    "d3d3c4be2475b5d2f4bb70171302dc1abe81c5afb0bb1eacc3c8199b10ae70ca": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Power of a Mentor\n\nMy first real mentor was a senior engineer named David who took the time to review my code lin",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "David, a senior engineer, exemplified effective mentorship by guiding me through my code, encouraging self-discovery rather than simply providing solutions.",
-        "description": "My initial significant mentor, David, a senior engineer, dedicated time to meticulously examine my code. Instead of merely pointing out errors, he posed questions that prompted me to identify the problems independently. This experience highlighted that effective mentorship focuses on fostering critical thinking rather than just giving answers."
-      }
-    },
-    "d493d4576c0bcc0c5d9973801fbe3081b949ca900271a9852ba0dc83b7602472": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Refactoring Legacy Code\n\nI spent three months refactoring a 10,000-line PHP file that had been accumulating featu",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "Over three months, I refactored a 10,000-line PHP file that had grown over eight years, starting with characterization tests to ensure existing functionality.",
-        "description": "The process involved extracting classes individually and executing the test suite after each modification. Ultimately, the code was reorganized into twenty clearly named files, allowing the team to make changes safely."
-      }
-    },
-    "d6e803b66ff13b036eda3230fe2fe951aac30ba6c476fd1bbac0d3ef707f094d": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Watching the World Cup Final\n\nThe 2014 World Cup final between Germany and Argentina was one of the most tense ma",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "2014 World Cup",
-            "name": "2014 World Cup",
-            "type": "CONCEPT",
-            "description": "The 2014 World Cup was an international football tournament held in Brazil, featuring teams from around the world."
-          },
-          {
-            "id": "Germany",
-            "name": "Germany",
-            "type": "LOCATION",
-            "description": "Germany is a country in Central Europe known for its rich history and strong football tradition."
-          },
-          {
-            "id": "Argentina",
-            "name": "Argentina",
-            "type": "LOCATION",
-            "description": "Argentina is a country in South America known for its passionate football culture and history of success in international tournaments."
-          },
-          {
-            "id": "Götze",
-            "name": "Götze",
-            "type": "PERSON",
-            "description": "Mario Götze is a German professional footballer who scored the winning goal in the 2014 World Cup final."
-          },
-          {
-            "id": "friend's apartment",
-            "name": "friend's apartment",
-            "type": "LOCATION",
-            "description": "A private residence where friends gathered to watch the World Cup final."
-          },
-          {
-            "id": "snacks and drinks",
-            "name": "snacks and drinks",
-            "type": "CONCEPT",
-            "description": "Food and beverages typically enjoyed during social gatherings, such as watching sports."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "2014 World Cup",
-            "target_node_id": "Germany",
-            "relationship_name": "featured_team"
+            "description": "The Dockerfile for the Python app solved months of deployment headaches.",
+            "relationship_name": "solved",
+            "source_node_id": "Dockerfile",
+            "target_node_id": "deployment_headaches"
           },
           {
-            "source_node_id": "2014 World Cup",
-            "target_node_id": "Argentina",
-            "relationship_name": "featured_team"
+            "description": "The author became the Docker evangelist on the team for the next year.",
+            "relationship_name": "became",
+            "source_node_id": "author",
+            "target_node_id": "Docker_evangelist"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Docker is a platform for developing, shipping, and running applications in containers.",
+            "id": "Docker",
+            "name": "Docker",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "Götze",
-            "target_node_id": "2014 World Cup",
-            "relationship_name": "scored_goal"
+            "description": "A Dockerfile is a text document that contains all the commands to assemble an image.",
+            "id": "Dockerfile",
+            "name": "Dockerfile",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "friend's apartment",
-            "target_node_id": "2014 World Cup",
-            "relationship_name": "location_of_event"
+            "description": "Deployment headaches refer to the challenges and issues faced during the deployment of applications.",
+            "id": "deployment_headaches",
+            "name": "deployment headaches",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "snacks and drinks",
-            "target_node_id": "friend's apartment",
-            "relationship_name": "served_at"
+            "description": "The author refers to the person recounting their experience with Docker.",
+            "id": "author",
+            "name": "author",
+            "type": "PERSON"
+          },
+          {
+            "description": "A Docker evangelist is someone who promotes the use of Docker within their organization or community.",
+            "id": "Docker_evangelist",
+            "name": "Docker evangelist",
+            "type": "PERSON"
+          },
+          {
+            "description": "Containers are a standard unit of software that package up code and all its dependencies so the application runs quickly and reliably from one computing environment to another.",
+            "id": "containers",
+            "name": "containers",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "DevOps is a set of practices that combines software development (Dev) and IT operations (Ops).",
+            "id": "DevOps",
+            "name": "DevOps",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Python is a high-level programming language that is widely used for web development, data analysis, artificial intelligence, and more.",
+            "id": "Python",
+            "name": "Python",
+            "type": "CONCEPT"
           }
         ]
       }
     },
-    "d8edf14621c8e51de9aa53ca66e4cfdf92468952db9ffe311bbba0d5b0e23d3d": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Snow Day in School\n\nThe heaviest snowfall I remember was in January 1998 when school was canceled for three days.",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "January 1998",
-            "name": "January 1998",
-            "type": "DATE",
-            "description": "The month and year when the heaviest snowfall occurred, leading to school cancellation."
-          },
-          {
-            "id": "February",
-            "name": "February",
-            "type": "DATE",
-            "description": "The month when the snow fort collapsed."
-          },
-          {
-            "id": "snow_fort",
-            "name": "snow fort",
-            "type": "CONCEPT",
-            "description": "An enormous snow fort built in the park during the heavy snowfall."
-          },
-          {
-            "id": "school",
-            "name": "school",
-            "type": "CONCEPT",
-            "description": "The educational institution that was closed for three days due to heavy snowfall."
-          },
-          {
-            "id": "park",
-            "name": "park",
-            "type": "LOCATION",
-            "description": "The location where the snow fort was built."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "January 1998",
-            "target_node_id": "school",
-            "relationship_name": "canceled"
-          },
-          {
-            "source_node_id": "January 1998",
-            "target_node_id": "snow_fort",
-            "relationship_name": "built"
-          },
-          {
-            "source_node_id": "snow_fort",
-            "target_node_id": "park",
-            "relationship_name": "located_in"
-          },
-          {
-            "source_node_id": "snow_fort",
-            "target_node_id": "February",
-            "relationship_name": "collapsed"
-          }
-        ]
-      }
-    },
-    "deef9b0e83eb8d734f820282626e99ccd863a5aeab90cfc17baceea38f23a147": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Learning Git the Hard Way\n\nI learned git by accidentally deleting a week's worth of work with git reset --hard in",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "The author learned Git through a painful experience of losing work, which led to a comprehensive study of the Pro Git book and subsequent teaching of Git workshops.",
-        "description": "In 2013, the author accidentally deleted a week's worth of work using 'git reset --hard', prompting a weekend of thorough reading of the Pro Git book. Mastering the reflog proved invaluable in recovering from mistakes, and the author now conducts Git workshops for junior developers."
-      }
-    },
-    "df952b27a7553ce983d03b969dc958b7fee58ff4ead3e124ff8024ab66661c74": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Migrating a Monolith to Microservices\n\nOur team spent eight months in 2020 migrating a monolithic Python applicat",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "In 2020, our team transitioned a monolithic Python application to microservices over eight months, utilizing the strangler fig pattern for gradual traffic rerouting.",
-        "description": "The migration involved significant challenges, particularly in separating the shared database. Ultimately, the process resulted in a 40% reduction in latency, although it also led to a threefold increase in operational complexity."
-      }
-    },
-    "e18a5789466807d8951fa8243d33a6fedb013f3cb804257ee6c9b653fc194f68": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Winning a Hackathon\n\nOur team won a 48-hour hackathon in 2017 by building a real-time translator for sign languag",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "In 2017, our team triumphed in a 48-hour hackathon by developing a real-time sign language translator utilizing computer vision, achieving 85% accuracy.",
-        "description": "Our team secured victory at a 48-hour hackathon in 2017 by creating a real-time translator for sign language through computer vision techniques. We employed a pre-trained CNN model, which we refined using ASL datasets. The judges were impressed with our demonstration, which successfully translated basic signs with an accuracy of 85%. The prize was divided among the four team members."
-      }
-    },
-    "e33846d5333f429b649858bd1f16d35bf1c20e64acb4cf252bd8da1145161864": {
-      "method": "structured_output",
-      "user_input_preview": "Title: A Rainy Day in Kyoto\n\nIt rained the entire day I visited Kyoto's bamboo grove. Most tourists left, but I stayed a",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Kyoto",
-            "name": "Kyoto",
-            "type": "LOCATION",
-            "description": "Kyoto is a city in Japan known for its classical Buddhist temples, as well as gardens, imperial palaces, Shinto shrines, and traditional wooden houses."
-          },
-          {
-            "id": "Japan",
-            "name": "Japan",
-            "type": "LOCATION",
-            "description": "Japan is an island country in East Asia, located in the Pacific Ocean, known for its rich culture, history, and technological advancements."
-          },
-          {
-            "id": "bamboo",
-            "name": "bamboo",
-            "type": "CONCEPT",
-            "description": "Bamboo is a group of woody perennial grasses known for their fast growth and versatility, often found in various ecosystems."
-          },
-          {
-            "id": "travel",
-            "name": "travel",
-            "type": "CONCEPT",
-            "description": "Travel refers to the movement of people between distant geographical locations, often for leisure or exploration."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Kyoto",
-            "target_node_id": "Japan",
-            "relationship_name": "located_in"
-          },
-          {
-            "source_node_id": "Kyoto",
-            "target_node_id": "bamboo",
-            "relationship_name": "features"
-          },
-          {
-            "source_node_id": "Kyoto",
-            "target_node_id": "travel",
-            "relationship_name": "associated_with"
-          }
-        ]
-      }
-    },
-    "e3cd6843af76ad615a9af626225e63a5fdc59a52c19abddc9e0ff79445ca6215": {
+    "3f44f67c34f4a28fc189beda23c175c8c24f00f8309a1ed50aa900a20afd558b": {
       "method": "structured_output",
       "user_input_preview": "Title: Learning to Cook Pasta\n\nAn Italian roommate in college taught me that you must salt the pasta water generously — ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "Italian roommate",
-            "name": "Italian roommate",
-            "type": "PERSON",
-            "description": "A college roommate who taught the author how to cook pasta."
-          },
-          {
-            "id": "pasta",
-            "name": "pasta",
-            "type": "CONCEPT",
-            "description": "A staple Italian dish made from wheat and water, often served with various sauces."
-          },
-          {
-            "id": "cooking",
-            "name": "cooking",
-            "type": "CONCEPT",
-            "description": "The practice of preparing food for consumption."
-          },
-          {
-            "id": "college",
-            "name": "college",
-            "type": "CONCEPT",
-            "description": "An educational institution where students pursue higher education."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "Italian roommate",
-            "target_node_id": "cooking",
-            "relationship_name": "teaches"
+            "description": "The Italian roommate taught the author how to cook pasta.",
+            "relationship_name": "taught",
+            "source_node_id": "Italian_roommate",
+            "target_node_id": "Cooking_rules"
           },
           {
-            "source_node_id": "pasta",
-            "target_node_id": "cooking",
-            "relationship_name": "is_prepared_in"
+            "description": "The author learned cooking rules from the Italian roommate in college.",
+            "relationship_name": "learned_from",
+            "source_node_id": "Author",
+            "target_node_id": "Italian_roommate"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A person who taught cooking rules to the author.",
+            "id": "Italian_roommate",
+            "name": "Italian roommate",
+            "type": "PERSON"
           },
           {
-            "source_node_id": "college",
-            "target_node_id": "Italian roommate",
-            "relationship_name": "shares_room_with"
+            "description": "The author who learned cooking rules.",
+            "id": "Author",
+            "name": "Author",
+            "type": "PERSON"
+          },
+          {
+            "description": "Simple rules for cooking pasta, including salting water and saving pasta water.",
+            "id": "Cooking_rules",
+            "name": "Cooking rules",
+            "type": "CONCEPT"
           }
         ]
       }
     },
-    "e62f0911a661bc353da8d4a530741118d31e27d02c305c7808839437083f6991": {
+    "4178fa8c71e05b31446fc7f8185fa1e72560dbfe290d5310831ce4ab2fa37b01": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Running My First Marathon\n\nI ran my first marathon in 2016 in Vienna. Training took five months with a gradual bu",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The marathon took place in Vienna.",
+            "relationship_name": "took_place_in",
+            "source_node_id": "marathon",
+            "target_node_id": "Vienna"
+          },
+          {
+            "description": "The marathon is a running event.",
+            "relationship_name": "is_a",
+            "source_node_id": "marathon",
+            "target_node_id": "running"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A long-distance running race with an official distance of 42.195 kilometers.",
+            "id": "marathon",
+            "name": "Marathon",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A city in Austria known for its cultural and historical significance.",
+            "id": "Vienna",
+            "name": "Vienna",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The activity of running, often for exercise or competition.",
+            "id": "running",
+            "name": "Running",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The year when the first marathon was run by the author.",
+            "id": "2016",
+            "name": "2016",
+            "type": "DATE"
+          }
+        ]
+      }
+    },
+    "4884a40367c7aa096f5bc1d16468b1060b7232b3778ba949f4a56328c375b15a": {
       "method": "structured_output",
       "user_input_preview": "Title: Discovering Podcasts\n\nI discovered podcasts during my daily commute in 2016. The first one I binged was a technol",
       "schema_name": "SummarizedContent",
       "response": {
-        "summary": "I found podcasts in 2016 during my daily travel, which turned my commute into a productive learning experience.",
-        "description": "In 2016, I stumbled upon podcasts while commuting, starting with a technology history series about the transistor's invention. This shift allowed me to utilize my time in traffic for educational purposes, and I now dedicate approximately ten hours weekly to listening to various podcasts."
+        "description": "The chunk discusses the author's experience with podcasts, highlighting their discovery during a commute in 2016 and the impact it had on their daily routine. The author now dedicates significant time to listening to podcasts as a means of learning.",
+        "summary": "The author discovered podcasts in 2016 during their commute, starting with a technology history series. They now listen to about ten hours of podcasts each week, turning their commute into a valuable learning experience."
       }
     },
-    "e8c9beb40082e851e96d12c26219e97285ae19eefc8bc0d9b98a13bb30d45f57": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Teaching Someone to Code\n\nI taught my younger cousin the basics of Python over a summer. We started with variable",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "younger cousin",
-            "name": "younger cousin",
-            "type": "PERSON",
-            "description": "The speaker's younger cousin who learned the basics of Python programming."
-          },
-          {
-            "id": "Python",
-            "name": "Python",
-            "type": "CONCEPT",
-            "description": "A high-level programming language known for its readability and versatility."
-          },
-          {
-            "id": "computer science",
-            "name": "computer science",
-            "type": "CONCEPT",
-            "description": "The study of computers and computational systems, encompassing both theoretical and practical aspects."
-          },
-          {
-            "id": "university",
-            "name": "university",
-            "type": "LOCATION",
-            "description": "An institution of higher education where students study various subjects, including computer science."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "younger cousin",
-            "target_node_id": "Python",
-            "relationship_name": "learned"
-          },
-          {
-            "source_node_id": "younger cousin",
-            "target_node_id": "computer science",
-            "relationship_name": "studying"
-          },
-          {
-            "source_node_id": "younger cousin",
-            "target_node_id": "university",
-            "relationship_name": "attending"
-          }
-        ]
-      }
-    },
-    "e92cf54f52267440ca214876ce4f2502f420e2ff8a230e8193bf3c04b74366b3": {
+    "4a813f9e4a2c4cf619b0d269e18753429d5d2f37e20ad266941c23eb2aa236c6": {
       "method": "structured_output",
       "user_input_preview": "Title: Migrating a Monolith to Microservices\n\nOur team spent eight months in 2020 migrating a monolithic Python applicat",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "Migrating a Monolith to Microservices",
-            "name": "Migrating a Monolith to Microservices",
-            "type": "CONCEPT",
-            "description": "A process of transitioning from a monolithic application architecture to a microservices architecture."
-          },
-          {
-            "id": "Python",
-            "name": "Python",
-            "type": "CONCEPT",
-            "description": "A high-level programming language known for its readability and versatility."
-          },
-          {
-            "id": "2020",
-            "name": "2020",
-            "type": "DATE",
-            "description": "The year during which the migration of the application took place."
-          },
-          {
-            "id": "strangler fig pattern",
-            "name": "strangler fig pattern",
-            "type": "CONCEPT",
-            "description": "A pattern used in software development to gradually replace a monolithic application with microservices."
-          },
-          {
-            "id": "shared database",
-            "name": "shared database",
-            "type": "CONCEPT",
-            "description": "A database that is used by multiple services or applications."
-          },
-          {
-            "id": "latency",
-            "name": "latency",
-            "type": "CONCEPT",
-            "description": "The time delay experienced in a system, often measured in milliseconds."
-          },
-          {
-            "id": "operational complexity",
-            "name": "operational complexity",
-            "type": "CONCEPT",
-            "description": "The level of difficulty in managing and operating a system or application."
-          },
-          {
-            "id": "microservices",
-            "name": "microservices",
-            "type": "CONCEPT",
-            "description": "An architectural style that structures an application as a collection of loosely coupled services."
-          },
-          {
-            "id": "architecture",
-            "name": "architecture",
-            "type": "CONCEPT",
-            "description": "The conceptual model that defines the structure, behavior, and more views of a system."
-          },
-          {
-            "id": "migration",
-            "name": "migration",
-            "type": "CONCEPT",
-            "description": "The process of moving from one system or architecture to another."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "Migrating a Monolith to Microservices",
-            "target_node_id": "Python",
-            "relationship_name": "uses"
+            "description": "The team migrated a monolithic Python application to microservices using the strangler fig pattern.",
+            "relationship_name": "migrated",
+            "source_node_id": "Team",
+            "target_node_id": "Monolithic Python Application"
           },
           {
-            "source_node_id": "Migrating a Monolith to Microservices",
-            "target_node_id": "2020",
-            "relationship_name": "took_place_in"
+            "description": "The team used the strangler fig pattern to gradually route traffic to new services during the migration.",
+            "relationship_name": "used",
+            "source_node_id": "Team",
+            "target_node_id": "Strangler Fig Pattern"
           },
           {
-            "source_node_id": "Migrating a Monolith to Microservices",
-            "target_node_id": "strangler fig pattern",
-            "relationship_name": "employs"
+            "description": "The hardest part of the migration was splitting the shared database.",
+            "relationship_name": "faced_challenge",
+            "source_node_id": "Team",
+            "target_node_id": "Shared Database"
           },
           {
-            "source_node_id": "Migrating a Monolith to Microservices",
-            "target_node_id": "shared database",
-            "relationship_name": "involves"
+            "description": "Latency improved by 40% after migrating to microservices.",
+            "relationship_name": "resulted_in",
+            "source_node_id": "Migration",
+            "target_node_id": "Latency Improvement"
           },
           {
-            "source_node_id": "Migrating a Monolith to Microservices",
-            "target_node_id": "latency",
-            "relationship_name": "improves"
+            "description": "Operational complexity tripled as a result of the migration to microservices.",
+            "relationship_name": "resulted_in",
+            "source_node_id": "Migration",
+            "target_node_id": "Operational Complexity"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A group of individuals working together on a project.",
+            "id": "Team",
+            "name": "Team",
+            "type": "PERSON"
           },
           {
-            "source_node_id": "Migrating a Monolith to Microservices",
-            "target_node_id": "operational complexity",
-            "relationship_name": "increases"
+            "description": "A software application that was originally built as a single unit.",
+            "id": "Monolithic Python Application",
+            "name": "Monolithic Python Application",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "Migrating a Monolith to Microservices",
-            "target_node_id": "microservices",
-            "relationship_name": "transitions_to"
+            "description": "A design pattern used to gradually replace a monolithic application with microservices.",
+            "id": "Strangler Fig Pattern",
+            "name": "Strangler Fig Pattern",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "Migrating a Monolith to Microservices",
-            "target_node_id": "architecture",
-            "relationship_name": "relates_to"
+            "description": "A database that is shared among multiple services or components.",
+            "id": "Shared Database",
+            "name": "Shared Database",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "Migrating a Monolith to Microservices",
-            "target_node_id": "migration",
-            "relationship_name": "is_a"
+            "description": "The reduction in time taken to process requests after the migration.",
+            "id": "Latency Improvement",
+            "name": "Latency Improvement",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The increase in complexity of operations after the migration to microservices.",
+            "id": "Operational Complexity",
+            "name": "Operational Complexity",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The process of transitioning from a monolithic architecture to a microservices architecture.",
+            "id": "Migration",
+            "name": "Migration",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A software architectural style that structures an application as a collection of loosely coupled services.",
+            "id": "Microservices",
+            "name": "Microservices",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The overall structure and design of a software system.",
+            "id": "Architecture",
+            "name": "Architecture",
+            "type": "CONCEPT"
           }
         ]
       }
     },
-    "ed9369f34f3b968836d641ef85773fe0705fcce5e292d648f8b0ec78ae7b266e": {
+    "4bf66d0c77192bde4ea1867dfa7b2abea2a4fb32a5996c92486f1a058dc8ee4b": {
       "method": "structured_output",
-      "user_input_preview": "Title: A Thunderstorm at the Beach\n\nWe were at the beach when a sudden thunderstorm rolled in from the sea. The sky turn",
+      "user_input_preview": "Title: A Sunrise Over the Mountains\n\nI woke up at 4 AM to hike to a summit in the Dolomites to watch the sunrise. The tr",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "beach",
-            "name": "beach",
-            "type": "LOCATION",
-            "description": "A sandy area by the sea, often used for recreation and leisure activities."
-          },
-          {
-            "id": "thunderstorm",
-            "name": "thunderstorm",
-            "type": "CONCEPT",
-            "description": "A weather phenomenon characterized by the presence of thunder and lightning, often accompanied by heavy rain."
-          },
-          {
-            "id": "weather",
-            "name": "weather",
-            "type": "CONCEPT",
-            "description": "The state of the atmosphere at a specific place and time, including factors like temperature, humidity, and precipitation."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "thunderstorm",
-            "target_node_id": "weather",
-            "relationship_name": "is_a_type_of"
+            "description": "The sunrise occurs over the Dolomites, illuminating the rock faces with orange and pink hues.",
+            "relationship_name": "occurs_over",
+            "source_node_id": "sunrise",
+            "target_node_id": "Dolomites"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The Dolomites are a mountain range located in northeastern Italy, known for their stunning landscapes and hiking trails.",
+            "id": "Dolomites",
+            "name": "Dolomites",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "beach",
-            "target_node_id": "thunderstorm",
-            "relationship_name": "located_near"
+            "description": "The sunrise is the moment when the sun appears above the horizon, often associated with beautiful colors in the sky.",
+            "id": "sunrise",
+            "name": "sunrise",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Hiking is an outdoor activity that involves walking in natural environments, often on trails or paths.",
+            "id": "hiking",
+            "name": "hiking",
+            "type": "CONCEPT"
           }
         ]
       }
     },
-    "ee17227cc6320a02be44049e406202075a598e4c57b6dc3cc5c6cce605eb6f6c": {
+    "4c91353131ad4a517be3ef2bd8bb67e915f2d8c9bb8915cca1670ace5b57b53f": {
       "method": "structured_output",
-      "user_input_preview": "Title: Debugging a Production Outage\n\nIn 2019, our production database went down at 3 AM due to a misconfigured connecti",
-      "schema_name": "SummarizedContent",
+      "user_input_preview": "Title: Learning to Ride a Bicycle\n\nMy grandfather taught me to ride a bicycle in the park near our house when I was six ",
+      "schema_name": "KnowledgeGraph",
       "response": {
-        "summary": "In 2019, a production database outage occurred at 3 AM due to a misconfigured connection pool, which took four hours to diagnose.",
-        "description": "The issue was traced through logs, revealing that a recent deployment had reduced the maximum connections from 100 to 10. Although the resolution required only a simple one-line configuration adjustment, the investigation process was arduous."
+        "edges": [
+          {
+            "description": "My grandfather taught me to ride a bicycle.",
+            "relationship_name": "taught",
+            "source_node_id": "Grandfather",
+            "target_node_id": "Bicycle"
+          },
+          {
+            "description": "The park is located near our house.",
+            "relationship_name": "located_near",
+            "source_node_id": "Park",
+            "target_node_id": "House"
+          },
+          {
+            "description": "The park is where I learned to ride a bicycle.",
+            "relationship_name": "learned_in",
+            "source_node_id": "Bicycle",
+            "target_node_id": "Park"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A person who taught the narrator to ride a bicycle.",
+            "id": "Grandfather",
+            "name": "Grandfather",
+            "type": "PERSON"
+          },
+          {
+            "description": "A two-wheeled vehicle that is powered by pedaling.",
+            "id": "Bicycle",
+            "name": "Bicycle",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A public area with grass and trees, where the narrator learned to ride a bicycle.",
+            "id": "Park",
+            "name": "Park",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A physical structure where the narrator lives.",
+            "id": "House",
+            "name": "House",
+            "type": "CONCEPT"
+          }
+        ]
       }
     },
-    "f5c90a74b27d026250a8e83c0c19a6de0cdd08ec16f07d42d4892df99548a34a": {
-      "method": "structured_output",
-      "user_input_preview": "Title: Hiking in the Alps\n\nIn the summer of 2015, I hiked the Tour du Mont Blanc with two friends. The 170-kilometer tra",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "In 2015, I trekked the Tour du Mont Blanc with friends, covering 170 kilometers across France, Italy, and Switzerland in eleven days.",
-        "description": "During the summer of 2015, I embarked on the Tour du Mont Blanc hike with two companions. This 170-kilometer route spanned France, Italy, and Switzerland over the course of eleven days. The scenery from Col de la Seigne was stunning, and we transported all our equipment while camping throughout the journey."
-      }
-    },
-    "f730a2ab4127fd5466909d0b078fbc834488f078e866b6eb6a847895a7297089": {
-      "method": "structured_output",
-      "user_input_preview": "Title: First Flight Experience\n\nMy first time on an airplane was a flight from Belgrade to London when I was sixteen. I ",
-      "schema_name": "SummarizedContent",
-      "response": {
-        "summary": "My inaugural airplane journey was at sixteen from Belgrade to London, where I enjoyed a window seat and breathtaking views.",
-        "description": "At the age of sixteen, I embarked on my first flight from Belgrade to London. Seated by the window, I marveled at the clouds from above. The initial takeoff caused a stomach drop, but once we stabilized, the scenery was tranquil. I remained glued to the window throughout the two-hour trip."
-      }
-    },
-    "fa78bd7efe66c8b2a3c5f2266fd769254282b2400768ad3971f87b815dd37cb9": {
+    "4ce5be98f14e0b0b696b296b08416b738536ba97c3466329ced4e643032aaa22": {
       "method": "structured_output",
       "user_input_preview": "Title: The Neighborhood Bookstore\n\nThere was a tiny bookstore on my street run by an elderly couple. They knew every boo",
       "schema_name": "SummarizedContent",
       "response": {
-        "summary": "A small neighborhood bookstore, managed by a knowledgeable elderly couple, closed in 2019, leaving the community mourning its loss.",
-        "description": "The quaint bookstore on my street, operated by an elderly pair who had an intimate knowledge of their inventory, could suggest books based on minimal descriptions. Its closure in 2019 due to their retirement left a significant void in the local community."
+        "description": "The chunk discusses a small neighborhood bookstore run by an elderly couple who had a deep knowledge of their inventory. The store closed in 2019 upon their retirement, leading to a sense of loss in the community.",
+        "summary": "The chunk describes a beloved neighborhood bookstore run by an elderly couple, which closed in 2019 after their retirement, leaving the community feeling a significant loss."
+      }
+    },
+    "4e6e122804a4c589b33c8f06dd6910d4861050817a9e6cda7885edb8b2512db8": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Learning to Cook Pasta\n\nAn Italian roommate in college taught me that you must salt the pasta water generously — ",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses essential tips for cooking pasta, emphasizing the importance of salting the water, not breaking spaghetti, and saving pasta water for sauce. These lessons were taught by an Italian roommate during college and significantly improved the author's cooking skills.",
+        "summary": "The chunk provides key tips for cooking pasta learned from an Italian roommate in college, highlighting the importance of salting water, not breaking spaghetti, and saving pasta water."
+      }
+    },
+    "4ef25a5d622566c03c32c0dcdaf70457cf23ad32204bbd6e359fe3cdf2ac7741": {
+      "method": "structured_output",
+      "user_input_preview": "Title: The Blackout of 2003\n\nDuring the Northeast blackout of August 2003, the power went out for nearly two days. Neigh",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The Northeast blackout of August 2003 caused a power outage lasting nearly two days, leading to a sense of community as neighbors gathered, shared food, and sang songs by candlelight.",
+        "summary": "The 2003 blackout resulted in a two-day power outage that fostered community bonding among neighbors in an isolating city."
+      }
+    },
+    "508c0c856bb82ffc578ef43c449210ed6207722113370e2d0a3b2c018e7d1ddb": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Winning a Hackathon\n\nOur team won a 48-hour hackathon in 2017 by building a real-time translator for sign languag",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The team won the hackathon by building a real-time translator for sign language using computer vision.",
+            "relationship_name": "won",
+            "source_node_id": "team",
+            "target_node_id": "hackathon"
+          },
+          {
+            "description": "The real-time translator for sign language was built using computer vision.",
+            "relationship_name": "built_using",
+            "source_node_id": "real_time_translator",
+            "target_node_id": "computer_vision"
+          },
+          {
+            "description": "The real-time translator for sign language was fine-tuned on ASL datasets.",
+            "relationship_name": "fine_tuned_on",
+            "source_node_id": "real_time_translator",
+            "target_node_id": "asl_datasets"
+          },
+          {
+            "description": "The judges were impressed by the demo of the real-time translator for sign language.",
+            "relationship_name": "impressed_by",
+            "source_node_id": "judges",
+            "target_node_id": "real_time_translator"
+          },
+          {
+            "description": "The demo of the real-time translator for sign language translated basic signs with 85% accuracy.",
+            "relationship_name": "translated_with_accuracy",
+            "source_node_id": "demo",
+            "target_node_id": "accuracy"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A group of individuals who collaborated to win a hackathon.",
+            "id": "team",
+            "name": "team",
+            "type": "GROUP"
+          },
+          {
+            "description": "An event where participants compete to create a project within a limited time.",
+            "id": "hackathon",
+            "name": "hackathon",
+            "type": "EVENT"
+          },
+          {
+            "description": "A system designed to translate sign language in real-time using technology.",
+            "id": "real_time_translator",
+            "name": "real-time translator for sign language",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A field of study that enables computers to interpret and understand visual information from the world.",
+            "id": "computer_vision",
+            "name": "computer vision",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A type of machine learning model that is trained on labeled data to perform specific tasks.",
+            "id": "cnn_model",
+            "name": "CNN model",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Datasets containing examples of American Sign Language used for training models.",
+            "id": "asl_datasets",
+            "name": "ASL datasets",
+            "type": "DATASET"
+          },
+          {
+            "description": "Individuals who evaluate and judge the projects presented in the hackathon.",
+            "id": "judges",
+            "name": "judges",
+            "type": "GROUP"
+          },
+          {
+            "description": "A demonstration of the real-time translator for sign language.",
+            "id": "demo",
+            "name": "demo",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A measure of how accurately the demo translated basic signs.",
+            "id": "accuracy",
+            "name": "85% accuracy",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "514aa1189559f39780f974592f577cc262b148a1e5642b1afb746cfb2246abd9": {
+      "method": "structured_output",
+      "user_input_preview": "Title: The Solar Eclipse of 1999\n\nOn August 11, 1999, a total solar eclipse was visible from parts of Europe. I watched ",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the total solar eclipse that occurred on August 11, 1999, and the personal experience of watching it. The event is noted for its impact on the observer, highlighting the silence of birds and the darkness during the day.",
+        "summary": "This chunk describes the total solar eclipse of August 11, 1999, and a personal experience of witnessing it. The event was significant due to its dramatic effects on the environment."
+      }
+    },
+    "53634df0ceb67576005fbde94f1780db2902f60e4e4238d9d51f529e42a29471": {
+      "method": "structured_output",
+      "user_input_preview": "Title: First Job Interview\n\nMy first real job interview was at a small software consultancy in 2010. I was so nervous th",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The small software consultancy offered the job to the person after the interview.",
+            "relationship_name": "offered_job",
+            "source_node_id": "small_software_consultancy",
+            "target_node_id": "person"
+          },
+          {
+            "description": "The person had their first job interview at the small software consultancy in 2010.",
+            "relationship_name": "had_interview_at",
+            "source_node_id": "person",
+            "target_node_id": "small_software_consultancy"
+          },
+          {
+            "description": "The person explained merge sort during the job interview at the small software consultancy.",
+            "relationship_name": "explained_algorithm",
+            "source_node_id": "person",
+            "target_node_id": "merge_sort"
+          },
+          {
+            "description": "The person forgot their portfolio at home before the job interview at the small software consultancy.",
+            "relationship_name": "forgot_item",
+            "source_node_id": "person",
+            "target_node_id": "portfolio"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A person who had their first job interview.",
+            "id": "person",
+            "name": "Person",
+            "type": "PERSON"
+          },
+          {
+            "description": "A small software consultancy where the person had their first job interview.",
+            "id": "small_software_consultancy",
+            "name": "Small Software Consultancy",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "A sorting algorithm that the person managed to explain during the interview.",
+            "id": "merge_sort",
+            "name": "Merge Sort",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A portfolio that the person forgot at home before the interview.",
+            "id": "portfolio",
+            "name": "Portfolio",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The year when the person had their first job interview.",
+            "id": "2010",
+            "name": "2010",
+            "type": "DATE"
+          }
+        ]
+      }
+    },
+    "58128b996433bd8da7d09718ce674c67a9f90f3bea737cd9542b0d38e3226568": {
+      "method": "structured_output",
+      "user_input_preview": "Title: A Sunrise Over the Mountains\n\nI woke up at 4 AM to hike to a summit in the Dolomites to watch the sunrise. The tr",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "This chunk describes a personal experience of hiking in the Dolomites to watch the sunrise. The author details the early morning hike, the conditions of the trail, and the beauty of the sunrise over the mountain peaks.",
+        "summary": "The chunk recounts a 4 AM hike to a summit in the Dolomites to witness a stunning sunrise, highlighting the dark and cold trail and the vibrant colors of the rock faces."
+      }
+    },
+    "597b5e3f9d9d0da4a7ffc2aabfb48db7c2ee774d6ca34305722e62e4a370ea97": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Planting a Garden\n\nIn spring 2021, I started a small vegetable garden on my balcony. I planted tomatoes, basil, a",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "In spring 2021, a small vegetable garden was started on a balcony, featuring tomatoes, basil, and peppers. By August, enough basil was harvested weekly to make pesto, while tomatoes thrived and peppers struggled due to insufficient sunlight, turning the gardening experience into a meditative morning ritual.",
+        "summary": "The chunk describes the experience of starting a vegetable garden on a balcony in spring 2021, highlighting the success of tomatoes and basil, and the challenges faced by peppers."
+      }
+    },
+    "5a136d39f9b9ee836ae5ed400eb1b07402fc10ed68b60940b556d03b6beaa272": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Learning a New Language\n\nI started learning Japanese in 2019 using a combination of apps and textbooks. Hiragana ",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "This chunk discusses the process of learning Japanese, including the methods used and personal experiences related to language acquisition and travel.",
+        "summary": "The content describes the author's journey of learning Japanese, starting in 2019, and highlights the challenges and achievements encountered along the way."
+      }
+    },
+    "5ad736934381f61cdec23804e560323bcfeacd337d5176fab3a755969ae62652": {
+      "method": "structured_output",
+      "user_input_preview": "Title: First Job Interview\n\nMy first real job interview was at a small software consultancy in 2010. I was so nervous th",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses a personal experience regarding a job interview at a software consultancy in 2010, highlighting the nervousness of forgetting a portfolio and the performance during a technical question.",
+        "summary": "The content recounts a first job interview experience at a software consultancy in 2010, where the author forgot their portfolio but successfully explained merge sort during a technical question."
+      }
+    },
+    "5b18f22d9268ef2b6bf2d2ceae602339154848aa16a45a4c8f988eb35607f58d": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Hiking in the Alps\n\nIn the summer of 2015, I hiked the Tour du Mont Blanc with two friends. The 170-kilometer tra",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The Tour du Mont Blanc is a hiking trail located in the Alps.",
+            "relationship_name": "located_in",
+            "source_node_id": "Tour du Mont Blanc",
+            "target_node_id": "Alps"
+          },
+          {
+            "description": "The hiking trail Tour du Mont Blanc spans 170 kilometers.",
+            "relationship_name": "has_length",
+            "source_node_id": "Tour du Mont Blanc",
+            "target_node_id": "170 kilometers"
+          },
+          {
+            "description": "The hiking trail Tour du Mont Blanc passes through France, Italy, and Switzerland.",
+            "relationship_name": "passes_through",
+            "source_node_id": "Tour du Mont Blanc",
+            "target_node_id": "France"
+          },
+          {
+            "description": "The hiking trail Tour du Mont Blanc passes through France, Italy, and Switzerland.",
+            "relationship_name": "passes_through",
+            "source_node_id": "Tour du Mont Blanc",
+            "target_node_id": "Italy"
+          },
+          {
+            "description": "The hiking trail Tour du Mont Blanc passes through France, Italy, and Switzerland.",
+            "relationship_name": "passes_through",
+            "source_node_id": "Tour du Mont Blanc",
+            "target_node_id": "Switzerland"
+          },
+          {
+            "description": "The hike on the Tour du Mont Blanc took eleven days.",
+            "relationship_name": "took_duration",
+            "source_node_id": "Tour du Mont Blanc",
+            "target_node_id": "11 days"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The Tour du Mont Blanc is a famous hiking trail in the Alps, known for its scenic views.",
+            "id": "Tour du Mont Blanc",
+            "name": "Tour du Mont Blanc",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The Alps is a major mountain range in Europe, known for its stunning landscapes and outdoor activities.",
+            "id": "Alps",
+            "name": "Alps",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "France is a country in Western Europe, known for its rich history and culture.",
+            "id": "France",
+            "name": "France",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Italy is a country in Southern Europe, famous for its art, history, and cuisine.",
+            "id": "Italy",
+            "name": "Italy",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Switzerland is a landlocked country in Central Europe, known for its mountains and neutrality.",
+            "id": "Switzerland",
+            "name": "Switzerland",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "170 kilometers is the length of the Tour du Mont Blanc hiking trail.",
+            "id": "170 kilometers",
+            "name": "170 kilometers",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "11 days is the duration it took to hike the Tour du Mont Blanc.",
+            "id": "11 days",
+            "name": "11 days",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "5bef0b8e04bcbe319c0f34f3fdf3f1ee85dad105d5f74f50590089d79e9ae41e": {
+      "method": "structured_output",
+      "user_input_preview": "Title: A Power Outage During a Demo\n\nDuring a client demo in 2018, the office power went out just as I was showing the n",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The client was impressed by the quick recovery during the demo.",
+            "relationship_name": "impressed_by",
+            "source_node_id": "client",
+            "target_node_id": "demo"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A demonstration of a product or service to a client.",
+            "id": "demo",
+            "name": "demo",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A person or organization that receives a service or product.",
+            "id": "client",
+            "name": "client",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "An interruption of electrical power supply.",
+            "id": "power_outage",
+            "name": "power outage",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "5d21f7dcdecc882cf5550ddb57f89055cc7840223801ffc8786cc05d3d4923e5": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Teaching Someone to Code\n\nI taught my younger cousin the basics of Python over a summer. We started with variable",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The younger cousin is taught the basics of Python by the mentor.",
+            "relationship_name": "taught",
+            "source_node_id": "Mentor",
+            "target_node_id": "Younger Cousin"
+          },
+          {
+            "description": "The younger cousin is studying computer science at university.",
+            "relationship_name": "studies_at",
+            "source_node_id": "Younger Cousin",
+            "target_node_id": "University"
+          },
+          {
+            "description": "The mentor has a passion for programming, which was rekindled by teaching the younger cousin.",
+            "relationship_name": "has_passion_for",
+            "source_node_id": "Mentor",
+            "target_node_id": "Programming"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The mentor taught programming basics to their younger cousin and has a passion for programming.",
+            "id": "Mentor",
+            "name": "Mentor",
+            "type": "PERSON"
+          },
+          {
+            "description": "The younger cousin learned Python and is now pursuing computer science at university.",
+            "id": "Younger Cousin",
+            "name": "Younger Cousin",
+            "type": "PERSON"
+          },
+          {
+            "description": "Python is a programming language that was taught to the younger cousin.",
+            "id": "Python",
+            "name": "Python",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Programming is the field that the mentor is passionate about.",
+            "id": "Programming",
+            "name": "Programming",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "University is where the younger cousin is studying computer science.",
+            "id": "University",
+            "name": "University",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "5d94d1728d9d26989b3acb625884839009822a2fe8ac43e1d1710cada6293126": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Building a Treehouse\n\nMy father and I built a treehouse in the oak tree in our backyard when I was ten. We spent ",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk describes the experience of building a treehouse with a father during childhood, highlighting the activities involved and the personal significance of the treehouse as a reading nook.",
+        "summary": "The content recounts the author's experience of building a treehouse with their father at the age of ten, which served as a cherished reading nook during summers."
+      }
+    },
+    "607a599d316bd16cacb81932043135b8553257e7c2ae058e418af43f1e40d75f": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Understanding Recursion\n\nThe moment recursion clicked for me was during a lecture on the Tower of Hanoi. The prof",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The concept of recursion is illustrated through the Tower of Hanoi problem.",
+            "relationship_name": "illustrates",
+            "source_node_id": "recursion",
+            "target_node_id": "Tower of Hanoi"
+          },
+          {
+            "description": "The author implemented a recursive maze solver after understanding recursion.",
+            "relationship_name": "implemented",
+            "source_node_id": "author",
+            "target_node_id": "recursive maze solver"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Recursion is a concept in computer science where a function calls itself to solve a problem.",
+            "id": "recursion",
+            "name": "recursion",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The Tower of Hanoi is a mathematical puzzle that demonstrates the principles of recursion.",
+            "id": "Tower of Hanoi",
+            "name": "Tower of Hanoi",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The author is a learner who experienced a breakthrough in understanding recursion.",
+            "id": "author",
+            "name": "author",
+            "type": "PERSON"
+          },
+          {
+            "description": "A recursive maze solver is a program that uses recursion to find a path through a maze.",
+            "id": "recursive maze solver",
+            "name": "recursive maze solver",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "614453092c7d938ff1943cd1c17b6b88cd407278a26d29b08053488cbfaa06be": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Power of a Mentor\n\nMy first real mentor was a senior engineer named David who took the time to review my code lin",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "This chunk discusses the importance of mentorship in career development, particularly in engineering. It highlights the mentoring style of a senior engineer named David, who focused on guiding rather than simply providing answers.",
+        "summary": "The chunk emphasizes the value of mentorship in engineering, showcasing how David, a senior engineer, guided the author through questioning rather than direct answers."
+      }
+    },
+    "63d5ccc4315d5ca0e435c1c5ba5bf51f6b31ee27df1d29ccf580777244cd5d6e": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Power of a Mentor\n\nMy first real mentor was a senior engineer named David who took the time to review my code lin",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "David is a mentor to the author, providing guidance and support in their engineering career.",
+            "relationship_name": "is_mentor_of",
+            "source_node_id": "David",
+            "target_node_id": "author"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "David is a senior engineer who provided mentorship to the author by reviewing code and encouraging independent thinking.",
+            "id": "David",
+            "name": "David",
+            "type": "PERSON"
+          },
+          {
+            "description": "The author is a person who received mentorship from David in their engineering career.",
+            "id": "author",
+            "name": "author",
+            "type": "PERSON"
+          }
+        ]
+      }
+    },
+    "651c8423cb9ad1ebae4178ddf01f14da9f0cfe6f0881a62ed7390119305776ce": {
+      "method": "structured_output",
+      "user_input_preview": "Title: A Thunderstorm at the Beach\n\nWe were at the beach when a sudden thunderstorm rolled in from the sea. The sky turn",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk describes a sudden thunderstorm that occurred at the beach, highlighting the dramatic changes in weather and the experience of seeking shelter in a car while observing the storm.",
+        "summary": "A sudden thunderstorm hit the beach, causing dark skies and strong winds, prompting a quick retreat to the car where the storm was both terrifying and beautiful."
+      }
+    },
+    "677cb6f7a54ea9a5c2e6d181d583ee413402dd1e98c733a723daa46a50ea02e6": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Discovering Podcasts\n\nI discovered podcasts during my daily commute in 2016. The first one I binged was a technol",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The technology history series covers the invention of the transistor.",
+            "relationship_name": "covers",
+            "source_node_id": "technology_history_series",
+            "target_node_id": "transistor"
+          },
+          {
+            "description": "Listening to podcasts transformed the commute into a learning opportunity.",
+            "relationship_name": "transformed",
+            "source_node_id": "podcasts",
+            "target_node_id": "commute"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Podcasts are digital audio files available for streaming or download, often focusing on various topics.",
+            "id": "podcasts",
+            "name": "Podcasts",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The technology history series is a podcast that discusses the history of technology, including significant inventions.",
+            "id": "technology_history_series",
+            "name": "Technology History Series",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The transistor is a semiconductor device used to amplify or switch electronic signals and electrical power.",
+            "id": "transistor",
+            "name": "Transistor",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Commute refers to the travel between one's home and place of work or study, often involving significant time spent in transit.",
+            "id": "commute",
+            "name": "Commute",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "69d842a2b716709a774bde6913dcec6b78852dd59ed915c4e92eace7ea2b2f2f": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Debugging a Production Outage\n\nIn 2019, our production database went down at 3 AM due to a misconfigured connecti",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "In 2019, a production database outage occurred at 3 AM due to a misconfigured connection pool. The issue was traced through logs for four hours, revealing that a recent deployment had reduced the maximum connections from 100 to 10, which was fixed with a one-line configuration change.",
+        "summary": "The chunk discusses a production database outage in 2019 caused by a misconfigured connection pool, which was resolved after a four-hour investigation."
+      }
+    },
+    "6ce321e138b816b55bbef3e857198979bf7a568c3f922714066e773b3294108c": {
+      "method": "structured_output",
+      "user_input_preview": "Title: First Programming Language\n\nI wrote my first program in BASIC on a Commodore 64 when I was twelve. It was a simpl",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the author's experience of writing their first program in BASIC on a Commodore 64, which was a number guessing game. This experience ignited their passion for programming.",
+        "summary": "The author wrote their first program in BASIC on a Commodore 64 at age twelve, which sparked a lifelong passion for programming."
+      }
+    },
+    "7036a0460ae87899318a9ba1eef412438511c1f4923df8a19e052bd896129397": {
+      "method": "structured_output",
+      "user_input_preview": "Title: A Flat Tire on a Road Trip\n\nHalfway through a road trip to the coast, we got a flat tire on a deserted stretch of",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The road trip involved car trouble due to a flat tire.",
+            "relationship_name": "involved",
+            "source_node_id": "road_trip",
+            "target_node_id": "car_trouble"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A journey taken by car, typically for leisure or vacation purposes.",
+            "id": "road_trip",
+            "name": "road trip",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "An issue with a vehicle that affects its operation, in this case, a flat tire.",
+            "id": "car_trouble",
+            "name": "car trouble",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "71ea7be29afc4aeb632fcab430fe5e7fc85d91e63aba72bec9cd6010fbcb4a2e": {
+      "method": "structured_output",
+      "user_input_preview": "Title: The Solar Eclipse of 1999\n\nOn August 11, 1999, a total solar eclipse was visible from parts of Europe. I watched ",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The solar eclipse occurred on August 11, 1999.",
+            "relationship_name": "occurred_on",
+            "source_node_id": "solar_eclipse",
+            "target_node_id": "1999"
+          },
+          {
+            "description": "The solar eclipse is a phenomenon studied in astronomy.",
+            "relationship_name": "related_to",
+            "source_node_id": "solar_eclipse",
+            "target_node_id": "astronomy"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A total solar eclipse that was visible from parts of Europe on August 11, 1999.",
+            "id": "solar_eclipse",
+            "name": "Solar Eclipse",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The year when the solar eclipse occurred.",
+            "id": "1999",
+            "name": "1999",
+            "type": "DATE"
+          },
+          {
+            "description": "The scientific study of celestial bodies and phenomena.",
+            "id": "astronomy",
+            "name": "Astronomy",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "748bad3f5344c2bd60091fb5d547be7bedef1aca7762b92146e811170c80e7ab": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Adopting a Cat\n\nWe adopted our cat Luna from a local shelter in 2020. She was shy at first and hid under the couc",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "This chunk discusses the adoption of a cat named Luna from a local shelter in 2020. It describes her initial shyness, her eventual acclimatization to her new home, and a distinctive feature of her appearance.",
+        "summary": "The content details the adoption of a cat named Luna in 2020, highlighting her initial shyness and her later affectionate behavior."
+      }
+    },
+    "7520f9b4f5564a7fec9c8345552d24a19423d8a3695a8cfb2cb125acaa580527": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Moving to a New City\n\nWhen I moved to Berlin in 2018, I knew nobody in the city. The first month was lonely — I s",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The person moved to Berlin in 2018.",
+            "relationship_name": "moved_to",
+            "source_node_id": "Person",
+            "target_node_id": "Berlin"
+          },
+          {
+            "description": "The person explored neighborhoods in Berlin.",
+            "relationship_name": "explored",
+            "source_node_id": "Person",
+            "target_node_id": "Berlin"
+          },
+          {
+            "description": "The person found a co-working space in Berlin.",
+            "relationship_name": "found",
+            "source_node_id": "Person",
+            "target_node_id": "Co-working Space"
+          },
+          {
+            "description": "The person met people who became close friends in the co-working space.",
+            "relationship_name": "met",
+            "source_node_id": "Person",
+            "target_node_id": "Friends"
+          },
+          {
+            "description": "The Kreuzberg district felt like home to the person within six months of moving to Berlin.",
+            "relationship_name": "felt_like_home",
+            "source_node_id": "Person",
+            "target_node_id": "Kreuzberg"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A city in Germany known for its culture and history.",
+            "id": "Berlin",
+            "name": "Berlin",
+            "type": "CITY"
+          },
+          {
+            "description": "A district in Berlin known for its vibrant culture and community.",
+            "id": "Kreuzberg",
+            "name": "Kreuzberg",
+            "type": "DISTRICT"
+          },
+          {
+            "description": "A person who relocated to Berlin.",
+            "id": "Person",
+            "name": "Person",
+            "type": "PERSON"
+          },
+          {
+            "description": "A space where individuals work independently or collaboratively, often in a shared environment.",
+            "id": "Co-working Space",
+            "name": "Co-working Space",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Individuals who share a close bond with the person.",
+            "id": "Friends",
+            "name": "Friends",
+            "type": "PERSON"
+          }
+        ]
+      }
+    },
+    "7540dc613acfaaf6207aff235830f06bf3eb5b677589503f21bb02f3927a6d65": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Watching the World Cup Final\n\nThe 2014 World Cup final between Germany and Argentina was one of the most tense ma",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the 2014 World Cup final match between Germany and Argentina, highlighting the atmosphere during the game and the moment when Götze scored.",
+        "summary": "The chunk describes the intense experience of watching the 2014 World Cup final between Germany and Argentina, focusing on the moment Götze scored in extra time."
+      }
+    },
+    "79bca1fc3d87642ec44c16b7ff8d62ab31746334539fd4d295ce0a64dcd64845": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Reading Lord of the Rings\n\nI read the entire Lord of the Rings trilogy in one week during summer break when I was",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The chapter 'The Bridge of Khazad-dûm' from 'Lord of the Rings' gave the reader chills.",
+            "relationship_name": "contains_chapter",
+            "source_node_id": "Lord of the Rings",
+            "target_node_id": "The Bridge of Khazad-dûm"
+          },
+          {
+            "description": "The ending of 'Lord of the Rings' at the Grey Havens made the reader cry.",
+            "relationship_name": "has_impact_on",
+            "source_node_id": "Lord of the Rings",
+            "target_node_id": "Grey Havens"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "'Lord of the Rings' is a high-fantasy novel written by J.R.R. Tolkien, consisting of three volumes.",
+            "id": "Lord of the Rings",
+            "name": "Lord of the Rings",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "'The Bridge of Khazad-dûm' is a chapter in 'Lord of the Rings' that is notable for its emotional impact.",
+            "id": "The Bridge of Khazad-dûm",
+            "name": "The Bridge of Khazad-dûm",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The Grey Havens is a significant location in 'Lord of the Rings' associated with the ending of the story.",
+            "id": "Grey Havens",
+            "name": "Grey Havens",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "7a054ea0618cd214553d301a8a031464b0189ed5c5da20131a16cfd789133614": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Attending a Live Concert\n\nThe first live concert I attended was Radiohead at a festival in 2006. The band opened ",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "Radiohead performed at a festival in 2006.",
+            "relationship_name": "performed_at",
+            "source_node_id": "Radiohead",
+            "target_node_id": "2006"
+          },
+          {
+            "description": "The crowd sang along to Karma Police during the concert by Radiohead.",
+            "relationship_name": "sang_along_to",
+            "source_node_id": "crowd",
+            "target_node_id": "Karma Police"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Radiohead is a British rock band formed in 1985, known for their experimental approach to music.",
+            "id": "Radiohead",
+            "name": "Radiohead",
+            "type": "BAND"
+          },
+          {
+            "description": "Karma Police is a song by Radiohead from their album OK Computer, released in 1997.",
+            "id": "Karma Police",
+            "name": "Karma Police",
+            "type": "SONG"
+          },
+          {
+            "description": "The year 2006 is noted for various events, including the live concert attended by the narrator.",
+            "id": "2006",
+            "name": "2006",
+            "type": "DATE"
+          },
+          {
+            "description": "The crowd refers to the audience present at the concert, participating in the live performance.",
+            "id": "crowd",
+            "name": "crowd",
+            "type": "GROUP"
+          }
+        ]
+      }
+    },
+    "7cba679aaf97ef467ea8af21133800f2ea0dc534a447645b3d5d0a5944a85c8a": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Coffee Culture Discovery\n\nI discovered specialty coffee when a friend took me to a third-wave coffee shop in 2017",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the author's journey into specialty coffee, starting in 2017 when they visited a third-wave coffee shop. They learned about coffee processing methods and experienced tasting unique flavors in coffee for the first time.",
+        "summary": "The author discovered specialty coffee in 2017 at a third-wave coffee shop, where they learned about coffee processing and tasted blueberries in coffee for the first time."
+      }
+    },
+    "7d07054d19fea273fb5908a486c028deb505e0d387c9e18a06e2c5a809b26c59": {
+      "method": "structured_output",
+      "user_input_preview": "Title: First Flight Experience\n\nMy first time on an airplane was a flight from Belgrade to London when I was sixteen. I ",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk describes a personal experience of flying for the first time on a flight from Belgrade to London at the age of sixteen. The author enjoyed the view from the window seat and felt a mix of excitement and nervousness during takeoff, ultimately finding the flight serene.",
+        "summary": "The author recounts their first airplane flight from Belgrade to London at sixteen, highlighting the excitement of the window seat and the serene views during the journey."
+      }
+    },
+    "805012acd819997f9c74a9bac11349e172158e282e44046d65d84ba496025be0": {
+      "method": "structured_output",
+      "user_input_preview": "Title: A Conversation with a Stranger\n\nOn a delayed train from Prague to Vienna, I sat next to a retired physicist who t",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The retired physicist explained quantum tunneling using a coffee cup metaphor during a conversation with the narrator.",
+            "relationship_name": "explained",
+            "source_node_id": "retired_physicist",
+            "target_node_id": "quantum_tunneling"
+          },
+          {
+            "description": "The narrator had a three-hour conversation with the retired physicist on a delayed train from Prague to Vienna.",
+            "relationship_name": "had_conversation_with",
+            "source_node_id": "narrator",
+            "target_node_id": "retired_physicist"
+          },
+          {
+            "description": "The retired physicist worked on particle accelerators in the 1980s.",
+            "relationship_name": "worked_on",
+            "source_node_id": "retired_physicist",
+            "target_node_id": "particle_accelerators"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The narrator is a person who sat next to a retired physicist on a train and had a significant conversation about physics.",
+            "id": "narrator",
+            "name": "Narrator",
+            "type": "PERSON"
+          },
+          {
+            "description": "The retired physicist is a person who worked on particle accelerators in the 1980s and explained quantum tunneling.",
+            "id": "retired_physicist",
+            "name": "Retired Physicist",
+            "type": "PERSON"
+          },
+          {
+            "description": "Quantum tunneling is a concept in physics that describes the phenomenon where particles pass through a barrier that they classically shouldn't be able to cross.",
+            "id": "quantum_tunneling",
+            "name": "Quantum Tunneling",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Particle accelerators are devices that use electromagnetic fields to propel charged particles to high speeds and contain them in well-defined beams.",
+            "id": "particle_accelerators",
+            "name": "Particle Accelerators",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The train journey from Prague to Vienna is a travel route that the narrator took while conversing with the retired physicist.",
+            "id": "train_prague_to_vienna",
+            "name": "Train from Prague to Vienna",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "81f721f6367e54171a1a555eeb6c9c0ddbc37907fa7b5c1493b4cc3ddee3f28c": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Learning to Swim\n\nI learned to swim at the municipal pool when I was eight. The instructor, Mrs. Petrovic, was pa",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the author's experience learning to swim at a municipal pool during childhood. The instructor, Mrs. Petrovic, played a significant role in teaching the author by emphasizing floating techniques and helping them overcome their fear of the deep end.",
+        "summary": "The author learned to swim at eight years old with instructor Mrs. Petrovic at a municipal pool, overcoming a fear of the deep end."
+      }
+    },
+    "85bb1fc4cdf4bbcc6e5f5bd1698e983f533f618bb1927e4a87e6b18e79824e3c": {
+      "method": "structured_output",
+      "user_input_preview": "Title: The Importance of Backups\n\nI learned the importance of backups when my laptop's hard drive failed in 2016, taking",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the significance of backups in preventing data loss, illustrated by a personal experience of losing six months of projects due to a hard drive failure in 2016. It emphasizes the necessity of having multiple backups, both on external drives and in cloud storage.",
+        "summary": "The content highlights the critical nature of backups to avoid data loss, based on a personal experience of losing important projects due to a hard drive failure."
+      }
+    },
+    "8d19df0b0cfed9fbf02624617c9df6553d9c5717499e227a6e418c8d8c0f03fa": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Visiting a Museum in Florence\n\nSeeing Michelangelo's David at the Galleria dell'Accademia in Florence was overwhe",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "Michelangelo's David is located at Galleria dell'Accademia in Florence.",
+            "relationship_name": "located_in",
+            "source_node_id": "Michelangelo's David",
+            "target_node_id": "Galleria dell'Accademia"
+          },
+          {
+            "description": "Galleria dell'Accademia is located in Florence.",
+            "relationship_name": "located_in",
+            "source_node_id": "Galleria dell'Accademia",
+            "target_node_id": "Florence"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Michelangelo's David is a renowned sculpture created by Michelangelo.",
+            "id": "Michelangelo's David",
+            "name": "Michelangelo's David",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Galleria dell'Accademia is a museum in Florence known for housing Michelangelo's David.",
+            "id": "Galleria dell'Accademia",
+            "name": "Galleria dell'Accademia",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Florence is a city in Italy known for its art and history.",
+            "id": "Florence",
+            "name": "Florence",
+            "type": "LOCATION"
+          },
+          {
+            "description": "Michelangelo was an Italian sculptor, painter, and architect of the High Renaissance.",
+            "id": "Michelangelo",
+            "name": "Michelangelo",
+            "type": "PERSON"
+          },
+          {
+            "description": "Art refers to the diverse range of human activities that involve the creation of visual, auditory, or performance artifacts.",
+            "id": "art",
+            "name": "art",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Travel refers to the movement of people between distant geographical locations.",
+            "id": "travel",
+            "name": "travel",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "8d80fce0603e33e502d7379daad750d7f64936a5ed203ffb63639d16601b8d8a": {
+      "method": "structured_output",
+      "user_input_preview": "Title: A Broken Deployment Pipeline\n\nOur CI/CD pipeline broke silently for two weeks in 2021 — tests were passing but no",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The CI/CD pipeline is associated with GitHub Actions.",
+            "relationship_name": "uses",
+            "source_node_id": "CI/CD",
+            "target_node_id": "GitHub Actions"
+          },
+          {
+            "description": "The CI/CD pipeline includes testing as a component.",
+            "relationship_name": "includes",
+            "source_node_id": "CI/CD",
+            "target_node_id": "testing"
+          },
+          {
+            "description": "The broken PR was merged to the main branch of the CI/CD pipeline.",
+            "relationship_name": "merged_to",
+            "source_node_id": "broken PR",
+            "target_node_id": "main"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "CI/CD is a software development practice that enables frequent code changes and automated testing.",
+            "id": "CI/CD",
+            "name": "CI/CD",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "GitHub Actions is a CI/CD tool that automates workflows for software development.",
+            "id": "GitHub Actions",
+            "name": "GitHub Actions",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Testing is the process of evaluating software to ensure it meets requirements and functions correctly.",
+            "id": "testing",
+            "name": "testing",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A broken PR is a pull request that contains errors or issues that prevent it from being successfully merged.",
+            "id": "broken PR",
+            "name": "broken PR",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Main is the primary branch in a version control system where the stable code resides.",
+            "id": "main",
+            "name": "main",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "900d0e50cb0c21c455df123dfbfea7e50a809fd909d909d606d587f8f830ff5e": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Learning a New Language\n\nI started learning Japanese in 2019 using a combination of apps and textbooks. Hiragana ",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The person started learning Japanese in 2019 using apps and textbooks.",
+            "relationship_name": "started_learning",
+            "source_node_id": "Person",
+            "target_node_id": "Japanese"
+          },
+          {
+            "description": "The person visited Tokyo and ordered food in Japanese for the first time.",
+            "relationship_name": "visited",
+            "source_node_id": "Person",
+            "target_node_id": "Tokyo"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A language spoken primarily in Japan, known for its three writing systems: hiragana, katakana, and kanji.",
+            "id": "Japanese",
+            "name": "Japanese",
+            "type": "LANGUAGE"
+          },
+          {
+            "description": "A city in Japan, known for its modern architecture, shopping, and cultural landmarks.",
+            "id": "Tokyo",
+            "name": "Tokyo",
+            "type": "CITY"
+          },
+          {
+            "description": "An individual who is learning a new language.",
+            "id": "Person",
+            "name": "Person",
+            "type": "PERSON"
+          }
+        ]
+      }
+    },
+    "90c0090b33afc8345b9817198a6daf9ee72bffaab5a758462e73763952b78ad8": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Attending a Live Concert\n\nThe first live concert I attended was Radiohead at a festival in 2006. The band opened ",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the author's experience attending a live concert by Radiohead in 2006, highlighting the band's performance and the emotional impact of the event.",
+        "summary": "The author attended a Radiohead concert in 2006, where the band opened with 'There There' and the crowd sang along to 'Karma Police.' They still have the wristband from the concert."
+      }
+    },
+    "931e2ca00e4bc636ca7eeeb860cea6b86a78605516ca793d5034a6f6677df123": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Refactoring Legacy Code\n\nI spent three months refactoring a 10,000-line PHP file that had been accumulating featu",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The process of refactoring involves improving legacy code.",
+            "relationship_name": "involves",
+            "source_node_id": "refactoring",
+            "target_node_id": "legacy_code"
+          },
+          {
+            "description": "Refactoring was done on a PHP file.",
+            "relationship_name": "refactored",
+            "source_node_id": "refactoring",
+            "target_node_id": "PHP_file"
+          },
+          {
+            "description": "Characterization tests were written to ensure existing behavior during refactoring.",
+            "relationship_name": "used",
+            "source_node_id": "characterization_tests",
+            "target_node_id": "refactoring"
+          },
+          {
+            "description": "The refactoring process resulted in the code being organized into well-named files.",
+            "relationship_name": "resulted_in",
+            "source_node_id": "refactoring",
+            "target_node_id": "well_named_files"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Refactoring is the process of restructuring existing computer code without changing its external behavior.",
+            "id": "refactoring",
+            "name": "Refactoring",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Legacy code refers to outdated code that is still in use, often difficult to maintain or modify.",
+            "id": "legacy_code",
+            "name": "Legacy Code",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "PHP is a popular general-purpose scripting language that is especially suited to web development.",
+            "id": "PHP",
+            "name": "PHP",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Characterization tests are tests that capture the current behavior of a system to ensure that future changes do not alter that behavior.",
+            "id": "characterization_tests",
+            "name": "Characterization Tests",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Well-named files refer to files that are organized and named in a way that clearly indicates their purpose and functionality.",
+            "id": "well_named_files",
+            "name": "Well-Named Files",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A PHP file is a file that contains PHP code, which can be executed on a server to generate dynamic web content.",
+            "id": "PHP_file",
+            "name": "PHP File",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "951b7b890491af76ce4081cfc71f7e0aae5d4a2fe3432fbdc3d405d61a33d9ee": {
+      "method": "structured_output",
+      "user_input_preview": "Title: A Broken Deployment Pipeline\n\nOur CI/CD pipeline broke silently for two weeks in 2021 — tests were passing but no",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses a broken CI/CD pipeline due to a misconfigured GitHub Actions workflow in 2021, which went unnoticed for two weeks. It highlights the importance of testing and mentions the addition of a canary test to ensure proper execution of the test suite.",
+        "summary": "The CI/CD pipeline was broken for two weeks in 2021 due to a misconfigured GitHub Actions workflow, leading to the merging of a broken PR. A canary test was later added to ensure the test suite executes properly."
+      }
+    },
+    "9aad9ad2fc976a17875be157a0438e974718adde951c2d19d64ed77ef34e73c7": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Learning to Play Chess\n\nMy uncle taught me chess when I was seven. He never let me win, which frustrated me at fi",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The uncle taught the person chess.",
+            "relationship_name": "taught",
+            "source_node_id": "uncle",
+            "target_node_id": "Person"
+          },
+          {
+            "description": "The person joined the school chess club.",
+            "relationship_name": "joined",
+            "source_node_id": "Person",
+            "target_node_id": "school_chess_club"
+          },
+          {
+            "description": "The person placed third in a regional tournament.",
+            "relationship_name": "placed_in",
+            "source_node_id": "Person",
+            "target_node_id": "regional_tournament"
+          },
+          {
+            "description": "The person plays chess online most evenings.",
+            "relationship_name": "plays",
+            "source_node_id": "Person",
+            "target_node_id": "online_chess"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The person who learned chess from their uncle.",
+            "id": "Person",
+            "name": "Person",
+            "type": "PERSON"
+          },
+          {
+            "description": "The uncle who taught chess.",
+            "id": "uncle",
+            "name": "Uncle",
+            "type": "PERSON"
+          },
+          {
+            "description": "A club at school for students interested in chess.",
+            "id": "school_chess_club",
+            "name": "School Chess Club",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "A tournament where the person placed third.",
+            "id": "regional_tournament",
+            "name": "Regional Tournament",
+            "type": "EVENT"
+          },
+          {
+            "description": "A platform where the person plays chess online.",
+            "id": "online_chess",
+            "name": "Online Chess",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "9aae2421a6c41adfbdf7895992b337d0481e905e16c5cc8ef4d3dc37773172d2": {
+      "method": "structured_output",
+      "user_input_preview": "Title: First Open Source Contribution\n\nMy first open source contribution was a bug fix to a Python logging library in 20",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The bug fix was a contribution to the Python logging library.",
+            "relationship_name": "contributed_to",
+            "source_node_id": "My first open source contribution",
+            "target_node_id": "Python logging library"
+          },
+          {
+            "description": "The contribution was made in the context of open source software.",
+            "relationship_name": "related_to",
+            "source_node_id": "My first open source contribution",
+            "target_node_id": "open source"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A personal account of an individual's first contribution to open source software.",
+            "id": "My first open source contribution",
+            "name": "My first open source contribution",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A programming language known for its readability and versatility, used in the contribution.",
+            "id": "Python",
+            "name": "Python",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A library in Python used for logging messages, which was the target of the bug fix.",
+            "id": "Python logging library",
+            "name": "Python logging library",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A software development model that encourages collaboration and sharing of code.",
+            "id": "open source",
+            "name": "open source",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "9ae25a83bad2c89667fa6df7ac3b4b9133b39821969663c17666e37563dc78c9": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Coffee Culture Discovery\n\nI discovered specialty coffee when a friend took me to a third-wave coffee shop in 2017",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The third-wave coffee shop introduced specialty coffee to the coffee enthusiast.",
+            "relationship_name": "introduced_to",
+            "source_node_id": "third_wave_coffee_shop",
+            "target_node_id": "specialty_coffee"
+          },
+          {
+            "description": "The barista explained the difference between washed and natural processing to the coffee enthusiast.",
+            "relationship_name": "explained",
+            "source_node_id": "barista",
+            "target_node_id": "washed_processing"
+          },
+          {
+            "description": "The barista explained the difference between washed and natural processing to the coffee enthusiast.",
+            "relationship_name": "explained",
+            "source_node_id": "barista",
+            "target_node_id": "natural_processing"
+          },
+          {
+            "description": "The coffee enthusiast tasted blueberries in coffee for the first time with Ethiopian Yirgacheffe.",
+            "relationship_name": "tasted",
+            "source_node_id": "coffee_enthusiast",
+            "target_node_id": "Ethiopian_Yirgacheffe"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A coffee shop that is part of the third wave of coffee movement, focusing on high-quality coffee and artisanal preparation.",
+            "id": "third_wave_coffee_shop",
+            "name": "Third-Wave Coffee Shop",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A type of coffee that emphasizes quality and unique flavors, often sourced from specific regions and prepared with care.",
+            "id": "specialty_coffee",
+            "name": "Specialty Coffee",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A method of processing coffee beans that involves washing them to remove the mucilage before drying.",
+            "id": "washed_processing",
+            "name": "Washed Processing",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A method of processing coffee beans where the fruit is dried on the bean, allowing for a different flavor profile.",
+            "id": "natural_processing",
+            "name": "Natural Processing",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A person who has a strong interest in coffee and its various forms and preparations.",
+            "id": "coffee_enthusiast",
+            "name": "Coffee Enthusiast",
+            "type": "PERSON"
+          },
+          {
+            "description": "A coffee variety known for its bright acidity and fruity flavors, often associated with the Yirgacheffe region in Ethiopia.",
+            "id": "Ethiopian_Yirgacheffe",
+            "name": "Ethiopian Yirgacheffe",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "9cf89be2639d661a90361498957c0b9fa88015e583f9b79bfcaaec5585541a74": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Snow Day in School\n\nThe heaviest snowfall I remember was in January 1998 when school was canceled for three days.",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The heaviest snowfall occurred in January 1998.",
+            "relationship_name": "occurred_in",
+            "source_node_id": "heaviest_snowfall",
+            "target_node_id": "January_1998"
+          },
+          {
+            "description": "School was canceled for three days due to the heaviest snowfall.",
+            "relationship_name": "canceled_due_to",
+            "source_node_id": "school",
+            "target_node_id": "heaviest_snowfall"
+          },
+          {
+            "description": "An enormous snow fort was built in the park during the heavy snowfall.",
+            "relationship_name": "built_in",
+            "source_node_id": "snow_fort",
+            "target_node_id": "heaviest_snowfall"
+          },
+          {
+            "description": "The snow fort survived until February before it collapsed.",
+            "relationship_name": "survived_until",
+            "source_node_id": "snow_fort",
+            "target_node_id": "February"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The heaviest snowfall remembered by the narrator, occurring in January 1998.",
+            "id": "heaviest_snowfall",
+            "name": "Heaviest Snowfall",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The month and year when the heaviest snowfall occurred.",
+            "id": "January_1998",
+            "name": "January 1998",
+            "type": "DATE"
+          },
+          {
+            "description": "The educational institution that was closed for three days due to heavy snowfall.",
+            "id": "school",
+            "name": "School",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "An enormous structure made of snow built by the narrator and others in the park.",
+            "id": "snow_fort",
+            "name": "Snow Fort",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The month when the snow fort collapsed after surviving the heavy snowfall.",
+            "id": "February",
+            "name": "February",
+            "type": "DATE"
+          }
+        ]
+      }
+    },
+    "9f9532caf1e91badaa0d74167c88f572d64b3b0d443e2add4979b3c90889934a": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Learning Git the Hard Way\n\nI learned git by accidentally deleting a week's worth of work with git reset --hard in",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The author learned git after accidentally deleting work with git reset --hard.",
+            "relationship_name": "learned",
+            "source_node_id": "author",
+            "target_node_id": "git"
+          },
+          {
+            "description": "The author teaches git workshops to junior developers.",
+            "relationship_name": "teaches",
+            "source_node_id": "author",
+            "target_node_id": "junior_developers"
+          },
+          {
+            "description": "The author read the Pro Git book cover to cover after a painful lesson.",
+            "relationship_name": "read",
+            "source_node_id": "author",
+            "target_node_id": "Pro_Git_book"
+          },
+          {
+            "description": "Understanding the reflog saved the author multiple times after learning git.",
+            "relationship_name": "saved",
+            "source_node_id": "reflog",
+            "target_node_id": "author"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The author learned git through a painful experience and now teaches it.",
+            "id": "author",
+            "name": "author",
+            "type": "PERSON"
+          },
+          {
+            "description": "Git is a version control system used for tracking changes in source code.",
+            "id": "git",
+            "name": "git",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The Pro Git book is a comprehensive guide to using git.",
+            "id": "Pro_Git_book",
+            "name": "Pro Git book",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Junior developers are individuals who are new to the field and are learning skills.",
+            "id": "junior_developers",
+            "name": "junior developers",
+            "type": "PERSON"
+          },
+          {
+            "description": "The reflog is a mechanism in git that records updates to the tip of branches.",
+            "id": "reflog",
+            "name": "reflog",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Version control is a system that records changes to files over time.",
+            "id": "version_control",
+            "name": "version control",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Learning is the process of acquiring knowledge or skills through experience or education.",
+            "id": "learning",
+            "name": "learning",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "a350da7775dfeb687a27f7a8a4928b076fcfd3bcb522e0bbd5c12ec246ed49d4": {
+      "method": "structured_output",
+      "user_input_preview": "Title: First Open Source Contribution\n\nMy first open source contribution was a bug fix to a Python logging library in 20",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses an individual's first experience with open source contributions, specifically a bug fix made to a Python logging library in 2014. The contribution involved addressing a race condition in the file rotation handler, which resulted in log files being truncated. The pull request underwent three rounds of review before it was successfully merged, leading to personal satisfaction upon seeing the contributor's name in the changelog.",
+        "summary": "The chunk details a person's first open source contribution, a bug fix to a Python logging library in 2014, which involved a race condition issue. The contributor experienced satisfaction after their pull request was merged following three rounds of review."
+      }
+    },
+    "a7560325f582204029acf4fff7179a297cb480898d6a6fe31947791241189e30": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Setting Up a Home Network\n\nWhen I set up a mesh Wi-Fi network in my apartment, I learned more about networking th",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The person configured VLANs to separate IoT devices from work machines in the home network setup.",
+            "relationship_name": "configured",
+            "source_node_id": "Person",
+            "target_node_id": "VLANs"
+          },
+          {
+            "description": "The person set up Pi-hole for DNS-level ad blocking in the home network setup.",
+            "relationship_name": "set_up",
+            "source_node_id": "Person",
+            "target_node_id": "Pi-hole"
+          },
+          {
+            "description": "The person ran Ethernet through the walls as part of the home network setup.",
+            "relationship_name": "ran",
+            "source_node_id": "Person",
+            "target_node_id": "Ethernet"
+          },
+          {
+            "description": "The person set up a mesh Wi-Fi network in their apartment.",
+            "relationship_name": "set_up",
+            "source_node_id": "Person",
+            "target_node_id": "mesh_Wi-Fi_network"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A person who set up a home network and learned about networking in the process.",
+            "id": "Person",
+            "name": "Person",
+            "type": "PERSON"
+          },
+          {
+            "description": "A technology used to separate different types of network traffic, such as IoT devices and work machines.",
+            "id": "VLANs",
+            "name": "VLANs",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A network-wide ad blocker that operates at the DNS level.",
+            "id": "Pi-hole",
+            "name": "Pi-hole",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A type of wired network connection that transmits data through cables.",
+            "id": "Ethernet",
+            "name": "Ethernet",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A type of wireless network that uses multiple access points to provide coverage over a large area.",
+            "id": "mesh_Wi-Fi_network",
+            "name": "mesh Wi-Fi network",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "a8ffcf9a3b1b7d9b45361702be5e15617434b2792cb6b086a3cb6f77919e7fa4": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Migrating a Monolith to Microservices\n\nOur team spent eight months in 2020 migrating a monolithic Python applicat",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the process of migrating a monolithic Python application to microservices, highlighting the challenges and outcomes of the migration effort.",
+        "summary": "The team migrated a monolithic Python application to microservices over eight months in 2020, improving latency by 40% but increasing operational complexity."
+      }
+    },
+    "a9522091351c31a28ea90fa0bc553ec5a7b52b160cea85a4214fe8a996ea6794": {
+      "method": "structured_output",
+      "user_input_preview": "Title: First Time Using Docker\n\nThe first time I used Docker in 2015, it felt like magic. I went from 'it works on my ma",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "This chunk discusses the author's initial experience with Docker, highlighting its impact on software deployment and the author's role in promoting its use within their team.",
+        "summary": "The author first used Docker in 2015, transforming deployment processes and becoming a team advocate for the technology."
+      }
+    },
+    "aadb3f9cf1afaeb4d862102f5cedf893b619c1eab45aca81a9f40e95ae065c66": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Reading Lord of the Rings\n\nI read the entire Lord of the Rings trilogy in one week during summer break when I was",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses a personal experience of reading the Lord of the Rings trilogy by J.R.R. Tolkien during summer break at the age of fourteen. It highlights the emotional impact of specific chapters, particularly 'The Bridge of Khazad-dûm' and the ending at the Grey Havens.",
+        "summary": "The chunk details a personal account of reading the Lord of the Rings trilogy in one week at age fourteen, emphasizing its emotional impact."
+      }
+    },
+    "ac8898f811aef73b906f41f5873f1f336d6534b5f28de712103d65e34732ab5f": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Childhood Pet Dog\n\nOur family dog Rex was a German Shepherd who lived with us for thirteen years. He waited at th",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses a childhood pet dog named Rex, a German Shepherd who lived for thirteen years and had memorable experiences with the family, including waiting at the door for the owner and chasing a deer.",
+        "summary": "The content reflects on the author's childhood pet dog, Rex, a German Shepherd who had a significant impact on the family during his thirteen years of life."
+      }
+    },
+    "b59e24e510fd5b55d43bbae1b2edab9e8bd6f1fc9c3b783d309b159931474b34": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Stargazing in the Countryside\n\nOn a camping trip far from city lights, I saw the Milky Way clearly for the first ",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk describes a camping trip where the author experienced stargazing in the countryside, highlighting the visibility of the Milky Way and various constellations. The author and a friend observed satellites and shooting stars during their night out.",
+        "summary": "The chunk recounts a memorable camping trip focused on stargazing, where the author saw the Milky Way and identified constellations with a friend."
+      }
+    },
+    "bbe45600a6ebe7fdfb91eebbcd7fdf76ca86ff902a59155354c6e0d19144ec00": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Moving to a New City\n\nWhen I moved to Berlin in 2018, I knew nobody in the city. The first month was lonely — I s",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the experience of relocating to Berlin in 2018, the initial loneliness, and the eventual connection with friends through a co-working space in the Kreuzberg district.",
+        "summary": "The content describes a person's move to Berlin in 2018, highlighting feelings of loneliness and the eventual establishment of friendships in the Kreuzberg district."
+      }
+    },
+    "bce698fef681f68f230ea37d2dd3a57bccc47116d618df9204a0f8aa746c464c": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Baking Bread During Lockdown\n\nLike many people, I started baking sourdough bread during the 2020 lockdown. My fir",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the experience of baking sourdough bread during the 2020 lockdown, including the process of creating a starter and improving the bread quality over time. The starter was humorously named 'Clint Yeastwood'.",
+        "summary": "The content describes the journey of baking sourdough bread during the 2020 lockdown, highlighting the development of a starter and the improvement of bread quality."
+      }
+    },
+    "bdfdd49bf5bed90f02da2c3e4e75bd3ce6a458885e7f93888d0838248dafbbce": {
+      "method": "structured_output",
+      "user_input_preview": "Title: A Thunderstorm at the Beach\n\nWe were at the beach when a sudden thunderstorm rolled in from the sea. The sky turn",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The thunderstorm occurred at the beach.",
+            "relationship_name": "occurred_at",
+            "source_node_id": "Thunderstorm",
+            "target_node_id": "Beach"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A thunderstorm is a weather phenomenon characterized by the presence of lightning and thunder, often accompanied by heavy rain and strong winds.",
+            "id": "Thunderstorm",
+            "name": "Thunderstorm",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A beach is a landform along the shoreline of an ocean, sea, lake, or river, characterized by loose particles such as sand, gravel, or cobblestones.",
+            "id": "Beach",
+            "name": "Beach",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Weather refers to the state of the atmosphere at a specific place and time, including factors such as temperature, humidity, precipitation, and wind.",
+            "id": "Weather",
+            "name": "Weather",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "c2bc8cfeffa56e4dccbb1f8b928969f5cf49479031216a779c3ad710bc0ba19b": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Running My First Marathon\n\nI ran my first marathon in 2016 in Vienna. Training took five months with a gradual bu",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the author's experience running their first marathon, including the training process, challenges faced during the race, and the final completion time.",
+        "summary": "The author completed their first marathon in Vienna in 2016, finishing in 4 hours and 12 minutes after five months of training."
+      }
+    },
+    "c41b4441f97ce2496cfe97d8bfb9de5aa7f7f952c85e0c15638969d344ad04b1": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Watching the World Cup Final\n\nThe 2014 World Cup final between Germany and Argentina was one of the most tense ma",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The 2014 World Cup final was a football match between Germany and Argentina.",
+            "relationship_name": "featured_teams",
+            "source_node_id": "2014_World_Cup_Final",
+            "target_node_id": "Germany"
+          },
+          {
+            "description": "The 2014 World Cup final was a football match between Germany and Argentina.",
+            "relationship_name": "featured_teams",
+            "source_node_id": "2014_World_Cup_Final",
+            "target_node_id": "Argentina"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The 2014 World Cup final was a football match held in 2014, featuring Germany and Argentina.",
+            "id": "2014_World_Cup_Final",
+            "name": "2014 World Cup Final",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Germany is a national football team that competed in the 2014 World Cup final.",
+            "id": "Germany",
+            "name": "Germany",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Argentina is a national football team that competed in the 2014 World Cup final.",
+            "id": "Argentina",
+            "name": "Argentina",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Football is a team sport played between two teams of eleven players with a spherical ball.",
+            "id": "football",
+            "name": "Football",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "c63cc3f3754c3b8570b3ba588f6b28495e6a0343238d27006f3c82a7ab94adac": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Childhood Pet Dog\n\nOur family dog Rex was a German Shepherd who lived with us for thirteen years. He waited at th",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "Rex was a German Shepherd who lived with the family for thirteen years.",
+            "relationship_name": "was",
+            "source_node_id": "Rex",
+            "target_node_id": "German Shepherd"
+          },
+          {
+            "description": "Rex was the family dog.",
+            "relationship_name": "was",
+            "source_node_id": "Rex",
+            "target_node_id": "family dog"
+          },
+          {
+            "description": "Rex waited at the door every day when the owner came home from school.",
+            "relationship_name": "waited_for",
+            "source_node_id": "Rex",
+            "target_node_id": "owner"
+          },
+          {
+            "description": "Rex chased a deer through the woods and came back covered in mud.",
+            "relationship_name": "chased",
+            "source_node_id": "Rex",
+            "target_node_id": "deer"
+          },
+          {
+            "description": "Rex passed away, leaving the house feeling empty for months.",
+            "relationship_name": "passed_away",
+            "source_node_id": "Rex",
+            "target_node_id": "house"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Rex was a German Shepherd and the family dog, known for his loyalty and playful nature.",
+            "id": "Rex",
+            "name": "Rex",
+            "type": "PERSON"
+          },
+          {
+            "description": "A German Shepherd is a breed of dog known for its intelligence and versatility.",
+            "id": "German Shepherd",
+            "name": "German Shepherd",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The family dog is a pet that is part of the family, providing companionship and loyalty.",
+            "id": "family dog",
+            "name": "family dog",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The owner is the person who had Rex as a pet and experienced his companionship.",
+            "id": "owner",
+            "name": "owner",
+            "type": "PERSON"
+          },
+          {
+            "description": "The house is the place where Rex lived and where the family felt emptiness after his passing.",
+            "id": "house",
+            "name": "house",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A deer is a wild animal that Rex chased through the woods.",
+            "id": "deer",
+            "name": "deer",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "d8899446d40b840885ebfa4c479550f21d401c3035b6b532ed9f064cf4ede0e9": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Learning to Ride a Bicycle\n\nMy grandfather taught me to ride a bicycle in the park near our house when I was six ",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses a personal experience of learning to ride a bicycle, highlighting the role of the grandfather in this childhood memory.",
+        "summary": "The content recounts a childhood memory of learning to ride a bicycle with the help of a grandfather, emphasizing the joy of achieving balance despite a minor crash."
+      }
+    },
+    "dc27207bf90b3438ac48f8817806dbefa83ba5bf54cf94ff74354285ab2233bf": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Learning to Swim\n\nI learned to swim at the municipal pool when I was eight. The instructor, Mrs. Petrovic, was pa",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "Mrs. Petrovic taught swimming to the narrator.",
+            "relationship_name": "taught",
+            "source_node_id": "Mrs. Petrovic",
+            "target_node_id": "Swimming"
+          },
+          {
+            "description": "The narrator learned to swim at the municipal pool.",
+            "relationship_name": "learned_at",
+            "source_node_id": "Narrator",
+            "target_node_id": "Municipal Pool"
+          },
+          {
+            "description": "The narrator experienced childhood swimming lessons.",
+            "relationship_name": "related_to",
+            "source_node_id": "Narrator",
+            "target_node_id": "Childhood"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The narrator is the person recounting their experience of learning to swim.",
+            "id": "Narrator",
+            "name": "Narrator",
+            "type": "PERSON"
+          },
+          {
+            "description": "Mrs. Petrovic was the swimming instructor who taught the narrator.",
+            "id": "Mrs. Petrovic",
+            "name": "Mrs. Petrovic",
+            "type": "PERSON"
+          },
+          {
+            "description": "The municipal pool is where the narrator learned to swim.",
+            "id": "Municipal Pool",
+            "name": "Municipal Pool",
+            "type": "LOCATION"
+          },
+          {
+            "description": "Swimming is the activity that the narrator learned at the municipal pool.",
+            "id": "Swimming",
+            "name": "Swimming",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Childhood refers to the period of the narrator's early life when they learned to swim.",
+            "id": "Childhood",
+            "name": "Childhood",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "dd6fff4780772b1cfefe881645502b7f5599ead02310ee893865db87498cd721": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Understanding Recursion\n\nThe moment recursion clicked for me was during a lecture on the Tower of Hanoi. The prof",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "This chunk discusses the concept of recursion, particularly through the example of the Tower of Hanoi. The author shares a personal experience of understanding recursion during a lecture and successfully implementing it in a maze solver.",
+        "summary": "The chunk highlights the author's realization of recursion through the Tower of Hanoi example, leading to a successful implementation of a recursive maze solver."
+      }
+    },
+    "ddaaf6a9bdbfd32fba445509b18c4f32f24fce57829cda75c34e84ba89ba5ae8": {
+      "method": "structured_output",
+      "user_input_preview": "Title: A Rainy Day in Kyoto\n\nIt rained the entire day I visited Kyoto's bamboo grove. Most tourists left, but I stayed a",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "This chunk describes a personal experience visiting Kyoto's bamboo grove on a rainy day, highlighting the beauty and tranquility of the scene despite the weather. It reflects on how bad weather can enhance memorable experiences during travel.",
+        "summary": "The content recounts a visit to Kyoto's bamboo grove on a rainy day, emphasizing the serene atmosphere and vivid colors created by the rain."
+      }
+    },
+    "ddd58705f3c35d0783cb63663f236865634d42723ada6b1ec9680e13794898df": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Snow Day in School\n\nThe heaviest snowfall I remember was in January 1998 when school was canceled for three days.",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "This chunk discusses a memorable snow day during childhood in January 1998, when school was canceled for three days due to heavy snowfall. It describes the construction of a large snow fort in the park, which included tunnels and a watchtower, and mentions the fort's eventual collapse in February.",
+        "summary": "The chunk recounts a snow day in January 1998 when school was canceled for three days, leading to the construction of a large snow fort that lasted until February."
+      }
+    },
+    "ddf67fde42a98ab82658972b7d52e49b9e90a71441345b75c38f2788097ffc85": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Cooking Grandmother's Stew\n\nMy grandmother's beef stew recipe has been in the family for three generations. The s",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The beef stew recipe has been in the family for three generations.",
+            "relationship_name": "has_been_in",
+            "source_node_id": "beef_stew_recipe",
+            "target_node_id": "family"
+          },
+          {
+            "description": "The secret ingredient of the beef stew recipe is red wine vinegar.",
+            "relationship_name": "contains_ingredient",
+            "source_node_id": "beef_stew_recipe",
+            "target_node_id": "red_wine_vinegar"
+          },
+          {
+            "description": "The beef stew recipe is cooked in a cast-iron pot.",
+            "relationship_name": "cooked_in",
+            "source_node_id": "beef_stew_recipe",
+            "target_node_id": "cast_iron_pot"
+          },
+          {
+            "description": "The beef stew recipe is cooked over low heat for at least four hours.",
+            "relationship_name": "cooked_over",
+            "source_node_id": "beef_stew_recipe",
+            "target_node_id": "low_heat"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A recipe for beef stew that has been passed down through generations.",
+            "id": "beef_stew_recipe",
+            "name": "Beef Stew Recipe",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A type of vinegar made from red wine, used as a secret ingredient in the stew.",
+            "id": "red_wine_vinegar",
+            "name": "Red Wine Vinegar",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A heavy cooking pot made of cast iron, used for cooking the stew.",
+            "id": "cast_iron_pot",
+            "name": "Cast Iron Pot",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The family that has passed down the beef stew recipe for generations.",
+            "id": "family",
+            "name": "Family",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A method of cooking that involves low temperatures for extended periods.",
+            "id": "low_heat",
+            "name": "Low Heat",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "df03d121c90731b065581cea9aa7035b7017f714376979dd427dd2d19efc43dd": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Cooking Grandmother's Stew\n\nMy grandmother's beef stew recipe has been in the family for three generations. The s",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses a family recipe for beef stew that has been passed down through three generations. The recipe includes a secret ingredient of red wine vinegar and specifies cooking in a cast-iron pot for at least four hours.",
+        "summary": "This chunk details a three-generation family recipe for beef stew, highlighting the use of red wine vinegar and cooking methods."
+      }
+    },
+    "e504a210bdc7b46485fd8b3fdbb9a0e8229bf3981b6cf6606babca0fa81ffd4d": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Hiking in the Alps\n\nIn the summer of 2015, I hiked the Tour du Mont Blanc with two friends. The 170-kilometer tra",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The content describes a hiking experience on the Tour du Mont Blanc in the Alps during the summer of 2015. The hike covered 170 kilometers through France, Italy, and Switzerland over eleven days, featuring stunning views and camping along the trail.",
+        "summary": "The chunk recounts a hiking trip on the Tour du Mont Blanc in the Alps in 2015, covering 170 kilometers over eleven days with breathtaking views."
+      }
+    },
+    "e5b7e824ae72368b7e9afcd349bcf7ddd3b4aa309d5ddb9d19069770a5ef3a9e": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Winning a Hackathon\n\nOur team won a 48-hour hackathon in 2017 by building a real-time translator for sign languag",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "In 2017, a team won a hackathon by developing a real-time translator for sign language using computer vision and a pre-trained CNN model. The judges were impressed with the demo that achieved 85% accuracy in translating basic signs, and the prize was divided among the four team members.",
+        "summary": "A team won a 2017 hackathon by creating a real-time sign language translator with computer vision, achieving 85% accuracy in their demo."
+      }
+    },
+    "e6c8069e7632f9c20abcff0828101b3b0dc040366d693ac72fcfcb06a34dbbe9": {
+      "method": "structured_output",
+      "user_input_preview": "Title: First Day at University\n\nI remember my first day at the University of Belgrade. The campus was bustling with new ",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The University of Belgrade offers the Computer Science program.",
+            "relationship_name": "offers",
+            "source_node_id": "University of Belgrade",
+            "target_node_id": "Computer Science"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The University of Belgrade is a prominent educational institution located in Serbia.",
+            "id": "University of Belgrade",
+            "name": "University of Belgrade",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "The Computer Science program is an academic course of study focusing on computing and technology.",
+            "id": "Computer Science",
+            "name": "Computer Science",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "e7ee3f0bb0f8dc327fdda34034bd54b7e81f0ce8492e4e1f67f1fd33e2b685f3": {
+      "method": "structured_output",
+      "user_input_preview": "Title: First Programming Language\n\nI wrote my first program in BASIC on a Commodore 64 when I was twelve. It was a simpl",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "BASIC is the programming language used on the Commodore 64.",
+            "relationship_name": "used_on",
+            "source_node_id": "BASIC",
+            "target_node_id": "Commodore 64"
+          },
+          {
+            "description": "The author wrote their first program in BASIC.",
+            "relationship_name": "wrote_first_program_in",
+            "source_node_id": "Author",
+            "target_node_id": "BASIC"
+          },
+          {
+            "description": "The author's first program was a number guessing game.",
+            "relationship_name": "was_a",
+            "source_node_id": "Number Guessing Game",
+            "target_node_id": "Author"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "BASIC is a high-level programming language known for its simplicity and ease of use.",
+            "id": "BASIC",
+            "name": "BASIC",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The Commodore 64 is an 8-bit home computer introduced in 1982, known for its versatility and large library of software.",
+            "id": "Commodore 64",
+            "name": "Commodore 64",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The author is a person who wrote their first program at the age of twelve.",
+            "id": "Author",
+            "name": "Author",
+            "type": "PERSON"
+          },
+          {
+            "description": "The number guessing game is a simple program that prompts the user to guess a number and provides feedback on their guesses.",
+            "id": "Number Guessing Game",
+            "name": "Number Guessing Game",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "eb5d9e726e7abc71df6a03ba6e21133321fe8f767438ee1213a36db4bef1c4e9": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Volunteering at a Food Bank\n\nI volunteered at a local food bank every Saturday for six months in 2019. We sorted ",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the experience of volunteering at a food bank, focusing on the activities involved and the lessons learned about supply chain management.",
+        "summary": "The content describes a six-month volunteering experience at a food bank in 2019, highlighting the sorting of donations and the impact of gratitude from recipients."
+      }
+    },
+    "f43f9f5b5f5ebff50c184ebdee85cff6290a120abd3319dd063286851c9b703f": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Debugging a Production Outage\n\nIn 2019, our production database went down at 3 AM due to a misconfigured connecti",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The production database experienced an outage due to a misconfigured connection pool.",
+            "relationship_name": "experienced_outage",
+            "source_node_id": "production_database",
+            "target_node_id": "production_outage"
+          },
+          {
+            "description": "The issue was traced through logs during the debugging process.",
+            "relationship_name": "involved_in",
+            "source_node_id": "debugging",
+            "target_node_id": "production_outage"
+          },
+          {
+            "description": "The max connections for the production database were changed from 100 to 10 in a recent deployment.",
+            "relationship_name": "changed_in",
+            "source_node_id": "recent_deployment",
+            "target_node_id": "production_database"
+          },
+          {
+            "description": "The fix for the production database outage was a one-line config change.",
+            "relationship_name": "resolved_by",
+            "source_node_id": "production_outage",
+            "target_node_id": "config_change"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A database that is used in a production environment.",
+            "id": "production_database",
+            "name": "Production Database",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "An event where the production database was unavailable due to a configuration issue.",
+            "id": "production_outage",
+            "name": "Production Outage",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The process of identifying and resolving issues in software or systems.",
+            "id": "debugging",
+            "name": "Debugging",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A deployment that recently altered the configuration of the production database.",
+            "id": "recent_deployment",
+            "name": "Recent Deployment",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A configuration change made to resolve the production database outage.",
+            "id": "config_change",
+            "name": "Config Change",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "f5d73123e63cdf34ac58bd684966396ecc3c9ca34a18cd95c401aaa0c8d74a96": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Learning to Play Chess\n\nMy uncle taught me chess when I was seven. He never let me win, which frustrated me at fi",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The content discusses the author's experience learning chess from their uncle, joining a school chess club, and participating in a regional tournament. It highlights the author's ongoing enjoyment of playing chess online as a way to relax.",
+        "summary": "The author learned chess from their uncle at age seven, joined a school chess club, and placed third in a regional tournament. They continue to play online regularly for relaxation."
+      }
+    },
+    "f6b519ba987da0c86e2b8aad92016ff328dc1dc6ca9c4fc06667a29a24959a7a": {
+      "method": "structured_output",
+      "user_input_preview": "Title: The Blackout of 2003\n\nDuring the Northeast blackout of August 2003, the power went out for nearly two days. Neigh",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The 2003 blackout caused a power outage in the Northeast for nearly two days.",
+            "relationship_name": "caused",
+            "source_node_id": "2003_blackout",
+            "target_node_id": "Northeast_power_outage"
+          },
+          {
+            "description": "The community gathered during the 2003 blackout to share food and sing songs.",
+            "relationship_name": "involved",
+            "source_node_id": "community",
+            "target_node_id": "2003_blackout"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "The 2003 blackout refers to a significant power outage that occurred in August 2003 affecting the Northeast region.",
+            "id": "2003_blackout",
+            "name": "2003 Blackout",
+            "type": "EVENT"
+          },
+          {
+            "description": "The community refers to the group of neighbors who came together during the blackout.",
+            "id": "community",
+            "name": "Community",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The Northeast power outage refers to the widespread loss of electrical power in the Northeast region during the blackout.",
+            "id": "Northeast_power_outage",
+            "name": "Northeast Power Outage",
+            "type": "EVENT"
+          }
+        ]
+      }
+    },
+    "f80bb11bb6428437d6f74cc581ae413e7fc7c1c5df8bf54451fcc106a3d95efc": {
+      "method": "structured_output",
+      "user_input_preview": "Title: A Flat Tire on a Road Trip\n\nHalfway through a road trip to the coast, we got a flat tire on a deserted stretch of",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk describes an experience during a road trip where the travelers encountered a flat tire. They had no prior experience changing a tire but managed to do so with the help of a truck driver who corrected their mistake with the jack. Ultimately, they reached their destination two hours later than planned.",
+        "summary": "The chunk narrates a road trip incident involving a flat tire and the assistance of a truck driver. The travelers learned to change the tire using the car manual and arrived at the beach two hours late."
+      }
+    },
+    "fa344dc34188869948486d2836dfd1c5d4b3b7bca21156035b75d388fc9e599c": {
+      "method": "structured_output",
+      "user_input_preview": "Title: Setting Up My First Server\n\nI set up my first Linux server in 2011 — a Debian box running Apache and MySQL. I spe",
+      "schema_name": "SummarizedContent",
+      "response": {
+        "description": "The chunk discusses the author's experience of setting up their first Linux server in 2011, detailing the configuration process and the subsequent hacking incident due to a security oversight.",
+        "summary": "The author set up their first Linux server in 2011, configuring it with Apache and MySQL. The server was hacked within a week due to leaving port 22 on the default configuration."
+      }
+    },
+    "fcbbb8b07f6a9923aa93654be41435dbde5e38af68ba3b3ca4e5485b9850f13b": {
+      "method": "structured_output",
+      "user_input_preview": "Title: A Rainy Day in Kyoto\n\nIt rained the entire day I visited Kyoto's bamboo grove. Most tourists left, but I stayed a",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "description": "The bamboo grove is located in Kyoto, Japan.",
+            "relationship_name": "located_in",
+            "source_node_id": "bamboo_grove",
+            "target_node_id": "Kyoto"
+          },
+          {
+            "description": "Kyoto is a city in Japan.",
+            "relationship_name": "is_a",
+            "source_node_id": "Kyoto",
+            "target_node_id": "Japan"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A city known for its classical Buddhist temples, as well as gardens, imperial palaces, Shinto shrines, and traditional wooden houses.",
+            "id": "Kyoto",
+            "name": "Kyoto",
+            "type": "CITY"
+          },
+          {
+            "description": "A type of plant characterized by its tall, slender stems and often found in groves.",
+            "id": "bamboo_grove",
+            "name": "bamboo grove",
+            "type": "NATURAL_FEATURE"
+          },
+          {
+            "description": "A country in East Asia, known for its rich culture and history.",
+            "id": "Japan",
+            "name": "Japan",
+            "type": "COUNTRY"
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
## What

Re-records `scripts/perf/fixtures/cassette.json` (the offline mock-LLM benchmark cassette for `cognee-cli bench`) against current `main`.

## Why

The committed cassette had drifted against the current cognify prompts/schemas. Replaying it produced only `EmptyGraph` fallbacks — **zero entity-type nodes** — so the offline perf benchmark's `add`/`cognify` timings were not representative of a real graph build, while still reporting `success`.

## Verification

Recorded against `main`'s `cognee-cli` over the committed 50-doc corpus (`gpt-4o-mini`, deterministic mock embeddings). Offline replay now reconstructs the full graph:

- record: **221 entity types / 542 structural edges** over the corpus
- replay (fresh config home): entity-type nodes created (was 0) → guard passes
- `scripts/perf/run_mock_bench.sh` via the shared Python orchestrator: **3/3 runs succeed**, cognify p50 ≈ 0.47s

100 entries (50 `KnowledgeGraph` + 50 `SummarizedContent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)