### PR TITLE
fix(graph): deterministic class-namespaced Entity/EntityType/EdgeType ids (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking (graph data):** `Entity`, `EntityType`, and `EdgeType` node/point
+  ids are now **deterministic and class-namespaced** —
+  `uuid5(NAMESPACE_OID, "{ClassName}:{normalized_value}")` — matching upstream
+  Python cognee's `DataPoint.id_for`. Previously entities/entity-types were
+  assigned random `uuid4` ids, so the same entity duplicated across `cognify`
+  runs instead of merging (issue [#57]), and database-backed edge dedup never
+  matched. Ontology/temporal/memify id sites were also brought onto the same
+  scheme. Graphs created before this change hold the old ids and will **not**
+  merge with newly-created nodes — re-run `cognify` on existing datasets (no
+  automatic migration is provided). See [#57] for details.
+
+[#57]: https://github.com/topoteretes/cognee-rs/issues/57
+
 ## [0.1.3](https://github.com/topoteretes/cognee-rs/compare/v0.1.0...v0.1.3) - 2026-07-02
 
 ### Added
@@ -24,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable the HTML loader in the Neon (Node.js) binding for URL ingestion (#50)
 - Fail loudly when NATURAL_LANGUAGE search is unsupported by the backend (#51)
 - Fix reported TypeScript SDK bugs and cross-dataset deduplication (#11)
-
 
 ## [0.1.1](https://github.com/topoteretes/cognee-rs/compare/cognee-models-v0.1.0...cognee-models-v0.1.1) - 2026-06-26
 

--- a/crates/cognify/src/graph_integration/db_deduplication.rs
+++ b/crates/cognify/src/graph_integration/db_deduplication.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, HashSet};
 
 use cognee_graph::{EdgeData, GraphDBTrait};
-use cognee_utils::generate_node_id;
+use cognee_models::Entity;
 
 use crate::error::CognifyError;
 use crate::fact_extraction::KnowledgeGraph;
@@ -15,7 +15,7 @@ use crate::fact_extraction::KnowledgeGraph;
 ///
 /// This function:
 /// 1. Collects all edges from the knowledge graphs
-/// 2. Generates deterministic UUIDs for entity nodes using `generate_node_id()`
+/// 2. Generates deterministic UUIDs for entity nodes using `Entity::id_for()`
 /// 3. Batch queries the graph database to check which edges already exist
 /// 4. Returns a set of existing edge keys
 ///
@@ -59,9 +59,14 @@ pub async fn retrieve_existing_edges(
 
     for graph in graphs {
         for edge in &graph.edges {
-            // Generate deterministic UUIDs for source and target nodes
-            let source_uuid = generate_node_id(&edge.source_node_id);
-            let target_uuid = generate_node_id(&edge.target_node_id);
+            // Generate deterministic UUIDs for source and target nodes. Must use
+            // the SAME scheme entities are actually persisted with
+            // (`Entity::id_for`) — using the old bare `generate_node_id` here made
+            // these keys never match the stored (deterministic) entity ids, so
+            // edge dedup was a silent no-op (issue #57 corollary). Matches
+            // Python `retrieve_existing_edges.py:75-76` (`Entity.id_for`).
+            let source_uuid = Entity::id_for(&edge.source_node_id);
+            let target_uuid = Entity::id_for(&edge.target_node_id);
 
             // Only process if we haven't seen both nodes before
             let source_str = edge.source_node_id.as_str();
@@ -170,8 +175,8 @@ mod tests {
         let graph = create_test_graph();
 
         // Add the edge to the database first
-        let alice_uuid = generate_node_id("alice");
-        let techcorp_uuid = generate_node_id("techcorp");
+        let alice_uuid = Entity::id_for("alice");
+        let techcorp_uuid = Entity::id_for("techcorp");
 
         let _ = graph_db
             .add_edge(
@@ -220,8 +225,8 @@ mod tests {
         };
 
         // Add only the first edge to the database
-        let alice_uuid = generate_node_id("alice");
-        let techcorp_uuid = generate_node_id("techcorp");
+        let alice_uuid = Entity::id_for("alice");
+        let techcorp_uuid = Entity::id_for("techcorp");
 
         let _ = graph_db
             .add_edge(

--- a/crates/cognify/src/graph_integration/deduplication.rs
+++ b/crates/cognify/src/graph_integration/deduplication.rs
@@ -75,17 +75,36 @@ mod tests {
 
     #[test]
     fn test_deduplicate_nodes_removes_duplicates() {
+        // Two entities with the same name now share a deterministic id
+        // (Entity::id_for), so they dedup without any manual id-forcing. This is
+        // the unit-level regression for issue #57: random v4 ids used to make the
+        // same entity duplicate silently across runs.
         let node1 = create_test_node("TechCorp", "Organization");
         let node2 = create_test_node("TechCorp", "Organization");
+        assert_eq!(
+            node1.entity.base.id, node2.entity.base.id,
+            "same-name entities must derive the same id"
+        );
 
-        // Force same entity ID to create duplicate
-        let mut node2_clone = node2.clone();
-        node2_clone.entity.base.id = node1.entity.base.id;
-
-        let result = deduplicate_nodes_and_edges(vec![node1.clone(), node2_clone], vec![]);
+        let result = deduplicate_nodes_and_edges(vec![node1, node2], vec![]);
 
         assert_eq!(result.unique_nodes.len(), 1);
         assert_eq!(result.unique_nodes[0].entity.name, "TechCorp");
+    }
+
+    #[test]
+    fn test_deduplicate_keys_purely_on_entity_id() {
+        // Two entities with DIFFERENT names but the same forced id must collapse
+        // to one — proving the dedup key is `entity.base.id` alone (not name or
+        // other fields). Guards against a future change that keys on more than
+        // the id, which would let issue-#57-style silent duplication reappear.
+        let node1 = create_test_node("Alpha", "Organization");
+        let mut node2 = create_test_node("Beta", "Organization");
+        node2.entity.base.id = node1.entity.base.id;
+
+        let result = deduplicate_nodes_and_edges(vec![node1, node2], vec![]);
+
+        assert_eq!(result.unique_nodes.len(), 1);
     }
 
     #[test]
@@ -186,13 +205,10 @@ mod tests {
     fn test_deduplicate_mixed_unique_and_duplicate() {
         let node1 = create_test_node("TechCorp", "Organization");
         let node2 = create_test_node("Alice", "Person");
-        let node3_dup = create_test_node("Alice", "Person");
+        // Same name → same deterministic id, no manual forcing needed.
+        let node3 = create_test_node("Alice", "Person");
 
-        // Force node3 to have same ID as node2
-        let mut node3 = node3_dup.clone();
-        node3.entity.base.id = node2.entity.base.id;
-
-        let result = deduplicate_nodes_and_edges(vec![node1, node2.clone(), node3], vec![]);
+        let result = deduplicate_nodes_and_edges(vec![node1, node2, node3], vec![]);
 
         // Should have 2 unique nodes (TechCorp and Alice)
         assert_eq!(result.unique_nodes.len(), 2);

--- a/crates/cognify/src/graph_integration/expansion.rs
+++ b/crates/cognify/src/graph_integration/expansion.rs
@@ -10,6 +10,7 @@ use cognee_core::{HasDataPoint, ProvenanceContext, stamp_tree};
 use cognee_models::{Entity, EntityType};
 use cognee_ontology::traits::OntologyEdge;
 use cognee_ontology::{AttachedOntologyNode, NodeCategory, OntologyResolver};
+use cognee_utils::{generate_edge_name, normalize_identifier};
 use tracing::warn;
 
 use crate::fact_extraction::{KnowledgeGraph, Node};
@@ -130,7 +131,7 @@ pub async fn expand_with_nodes_and_edges(
 
                             // Canonicalize: rename + regenerate deterministic ID
                             et.mark_ontology_valid(Some(canonical_name.clone()));
-                            et.base.id = ontology_name_to_uuid(&canonical_name);
+                            et.base.id = EntityType::id_for(&canonical_name);
 
                             // Record key mapping if canonical differs
                             let new_type_key = format!("{canonical_name}_type");
@@ -149,7 +150,18 @@ pub async fn expand_with_nodes_and_edges(
                                 user_label,
                                 &mut local_visited,
                             );
+                            // The resolver returns the matched root class
+                            // *separately* from `onto_nodes` (it is not in the
+                            // node list). An ontology `is_a` edge whose endpoint
+                            // names that root must still resolve to the root's
+                            // class id, so include it in the category lookup for
+                            // edge resolution only — NOT in `process_ontology_nodes`,
+                            // which would double-create it (the main loop already
+                            // created the canonical type node).
+                            let mut edge_category_nodes = onto_nodes.clone();
+                            edge_category_nodes.push(root_node.clone());
                             process_ontology_edges(
+                                &edge_category_nodes,
                                 &onto_edges,
                                 existing_edges_set,
                                 &mut ontology_edge_keys,
@@ -222,7 +234,7 @@ pub async fn expand_with_nodes_and_edges(
 
                             // Replace name and ID with canonical form
                             entity_pair.entity.name = canonical_name.clone();
-                            entity_pair.entity.base.id = ontology_name_to_uuid(&canonical_name);
+                            entity_pair.entity.base.id = Entity::id_for(&canonical_name);
                             entity_pair.entity.base.set_ontology_valid(true);
 
                             // Defer subgraph processing until after insert
@@ -238,8 +250,13 @@ pub async fn expand_with_nodes_and_edges(
                     }
                 }
 
-                // Track node_id -> entity_id mapping for edge resolution
-                node_id_to_entity_id.insert(node.id.clone(), entity_pair.entity.base.id);
+                // Track node_id -> entity_id mapping for edge resolution.
+                // Key on the *normalized* node id so an edge that references the
+                // same entity with different casing/spacing still resolves — the
+                // way Python's `Entity.id_for` hashing is normalization-insensitive
+                // (expand_with_nodes_and_edges.py:300-304).
+                node_id_to_entity_id
+                    .insert(normalize_identifier(&node.id), entity_pair.entity.base.id);
 
                 e.insert(entity_pair);
             }
@@ -257,6 +274,7 @@ pub async fn expand_with_nodes_and_edges(
                     &mut local_visited,
                 );
                 process_ontology_edges(
+                    &ont_nodes,
                     &ont_edges,
                     existing_edges_set,
                     &mut ontology_edge_keys,
@@ -269,7 +287,9 @@ pub async fn expand_with_nodes_and_edges(
         for edge in graph.edges {
             // Look up entity IDs from node IDs; skip edges the LLM produced with
             // node IDs that don't match any extracted node (common with local models).
-            let Some(source_entity_id) = node_id_to_entity_id.get(&edge.source_node_id) else {
+            let Some(source_entity_id) =
+                node_id_to_entity_id.get(&normalize_identifier(&edge.source_node_id))
+            else {
                 warn!(
                     "Skipping edge: source node '{}' not found in extracted nodes",
                     edge.source_node_id
@@ -277,7 +297,9 @@ pub async fn expand_with_nodes_and_edges(
                 continue;
             };
 
-            let Some(target_entity_id) = node_id_to_entity_id.get(&edge.target_node_id) else {
+            let Some(target_entity_id) =
+                node_id_to_entity_id.get(&normalize_identifier(&edge.target_node_id))
+            else {
                 warn!(
                     "Skipping edge: target node '{}' not found in extracted nodes",
                     edge.target_node_id
@@ -390,22 +412,6 @@ fn create_entity_node(
     }
 }
 
-/// Compute a deterministic UUID5 from a normalized name.
-///
-/// Follows Python's `generate_node_id()` pattern: lowercase, replace spaces
-/// with underscores, strip apostrophes, then hash with UUID5 NAMESPACE_OID.
-fn ontology_name_to_uuid(name: &str) -> Uuid {
-    let normalized = name.to_lowercase().replace(' ', "_").replace('\'', "");
-    Uuid::new_v5(&Uuid::NAMESPACE_OID, normalized.as_bytes())
-}
-
-/// Normalize an edge/relationship name for deduplication and storage.
-///
-/// Lowercases, replaces spaces with underscores, and strips apostrophes.
-fn normalize_edge_name(name: &str) -> String {
-    name.to_lowercase().replace(' ', "_").replace('\'', "")
-}
-
 /// Convert ontology subgraph nodes into graph integration types.
 ///
 /// For each [`AttachedOntologyNode`]:
@@ -427,10 +433,10 @@ fn process_ontology_nodes(
     visited: &mut HashSet<Uuid>,
 ) {
     for node in ontology_nodes {
-        let node_id = ontology_name_to_uuid(&node.name);
-
         match node.category {
             NodeCategory::Classes => {
+                // Python: `EntityType.id_for(name)` for ontology class nodes.
+                let node_id = EntityType::id_for(&node.name);
                 let dedup_key = format!("{node_id}_type");
                 // Skip if the LLM already extracted this type (check by name-based key)
                 let llm_type_key = format!("{}_type", node.name);
@@ -452,6 +458,8 @@ fn process_ontology_nodes(
                 ontology_types_map.insert(dedup_key, et);
             }
             NodeCategory::Individuals => {
+                // Python: `Entity.id_for(name)` for ontology individual nodes.
+                let node_id = Entity::id_for(&node.name);
                 let dedup_key = format!("{node_id}_entity");
                 // Skip if already present in either map
                 if node_map.contains_key(&dedup_key)
@@ -465,10 +473,12 @@ fn process_ontology_nodes(
                 entity.base.set_ontology_valid(true);
                 pre_stamp_extraction(&mut entity, user_label, visited);
 
-                // Placeholder EntityType for the GraphNodePair
+                // Placeholder EntityType for the GraphNodePair (Rust-only; the
+                // Python `Entity(is_a=...)` field is optional). Its id is stable
+                // but has no Python counterpart.
                 let mut placeholder_et =
                     EntityType::new("OntologyIndividual", "", Some(dataset_id));
-                placeholder_et.base.id = ontology_name_to_uuid("ontologyindividual");
+                placeholder_et.base.id = EntityType::id_for("OntologyIndividual");
                 pre_stamp_extraction(&mut placeholder_et, user_label, visited);
 
                 let pair = GraphNodePair {
@@ -487,15 +497,32 @@ fn process_ontology_nodes(
 /// deterministic UUID5 source/target IDs and normalized relationship names. Edges
 /// that already exist (in `existing_edge_keys` or `ontology_edge_keys`) are skipped.
 fn process_ontology_edges(
+    ontology_nodes: &[AttachedOntologyNode],
     ontology_edges: &[OntologyEdge],
     existing_edge_keys: &HashSet<String>,
     ontology_edge_keys: &mut HashSet<String>,
     ontology_edges_out: &mut Vec<GraphEdgePair>,
 ) {
+    // Mirror Python's `node_category = {node.name: node.category ...}`: an edge
+    // endpoint that names a class resolves via `EntityType::id_for`, otherwise
+    // `Entity::id_for` (expand_with_nodes_and_edges.py:84-89). Endpoints not in
+    // the node list default to Entity, as in Python.
+    let is_class: HashMap<&str, bool> = ontology_nodes
+        .iter()
+        .map(|n| (n.name.as_str(), matches!(n.category, NodeCategory::Classes)))
+        .collect();
+    let endpoint_id = |name: &str| -> Uuid {
+        if is_class.get(name).copied().unwrap_or(false) {
+            EntityType::id_for(name)
+        } else {
+            Entity::id_for(name)
+        }
+    };
+
     for (source, relation, target) in ontology_edges {
-        let source_id = ontology_name_to_uuid(source);
-        let target_id = ontology_name_to_uuid(target);
-        let rel_name = normalize_edge_name(relation);
+        let source_id = endpoint_id(source);
+        let target_id = endpoint_id(target);
+        let rel_name = generate_edge_name(relation);
         let edge_key = format!("{source_id}_{target_id}_{rel_name}");
 
         if existing_edge_keys.contains(&edge_key) || ontology_edge_keys.contains(&edge_key) {
@@ -884,6 +911,8 @@ mod tests {
                         category: NodeCategory::Classes,
                     };
                     Ok((
+                        // Real resolver returns only the traversed subgraph
+                        // (ancestors); the matched root is returned separately.
                         vec![ancestor],
                         vec![(
                             "organisation".to_string(),
@@ -1017,22 +1046,24 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_ontology_name_to_uuid_deterministic() {
-        // "Car" and "car" should produce the same UUID (both normalize to "car")
-        let uuid_upper = ontology_name_to_uuid("Car");
-        let uuid_lower = ontology_name_to_uuid("car");
-        assert_eq!(uuid_upper, uuid_lower);
-
-        // Should match the canonical UUID5 derivation for "car"
-        let expected = Uuid::new_v5(&Uuid::NAMESPACE_OID, b"car");
-        assert_eq!(uuid_upper, expected);
+    fn test_ontology_node_ids_are_class_namespaced() {
+        // Ontology class nodes hash as EntityType, individuals as Entity, so a
+        // class and an individual sharing a name never collide (parity with
+        // Python expand_with_nodes_and_edges.py:46-49).
+        assert_ne!(EntityType::id_for("Car"), Entity::id_for("Car"));
+        // Normalization still holds within a class.
+        assert_eq!(EntityType::id_for("Car"), EntityType::id_for("car"));
+        assert_eq!(
+            EntityType::id_for("Car"),
+            Uuid::new_v5(&Uuid::NAMESPACE_OID, b"EntityType:car"),
+        );
     }
 
     #[test]
-    fn test_normalize_edge_name() {
-        assert_eq!(normalize_edge_name("is a"), "is_a");
-        assert_eq!(normalize_edge_name("Is A"), "is_a");
-        assert_eq!(normalize_edge_name("don't know"), "dont_know");
+    fn test_generate_edge_name_normalizes_relations() {
+        assert_eq!(generate_edge_name("is a"), "is_a");
+        assert_eq!(generate_edge_name("Is A"), "is_a");
+        assert_eq!(generate_edge_name("don't know"), "dont_know");
     }
 
     #[test]
@@ -1076,13 +1107,13 @@ mod tests {
         }
 
         // Check deterministic IDs
-        let vehicle_key = format!("{}_type", ontology_name_to_uuid("Vehicle"));
-        let car_key = format!("{}_type", ontology_name_to_uuid("Car"));
+        let vehicle_key = format!("{}_type", EntityType::id_for("Vehicle"));
+        let car_key = format!("{}_type", EntityType::id_for("Car"));
         assert!(ontology_types_map.contains_key(&vehicle_key));
         assert!(ontology_types_map.contains_key(&car_key));
 
         let vehicle_et = &ontology_types_map[&vehicle_key];
-        assert_eq!(vehicle_et.base.id, ontology_name_to_uuid("Vehicle"));
+        assert_eq!(vehicle_et.base.id, EntityType::id_for("Vehicle"));
         assert_eq!(vehicle_et.name, "Vehicle");
     }
 
@@ -1149,16 +1180,16 @@ mod tests {
         assert_eq!(ontology_entities_map.len(), 1);
         assert!(ontology_types_map.is_empty());
 
-        let dedup_key = format!("{}_entity", ontology_name_to_uuid("MyCar"));
+        let dedup_key = format!("{}_entity", Entity::id_for("MyCar"));
         let pair = &ontology_entities_map[&dedup_key];
         assert!(pair.entity.base.ontology_valid);
-        assert_eq!(pair.entity.base.id, ontology_name_to_uuid("MyCar"));
+        assert_eq!(pair.entity.base.id, Entity::id_for("MyCar"));
         assert_eq!(pair.entity.name, "MyCar");
         // Placeholder type
         assert_eq!(pair.entity_type.name, "OntologyIndividual");
         assert_eq!(
             pair.entity_type.base.id,
-            ontology_name_to_uuid("ontologyindividual")
+            EntityType::id_for("OntologyIndividual")
         );
     }
 
@@ -1177,7 +1208,10 @@ mod tests {
         let mut ontology_edge_keys = HashSet::new();
         let mut ontology_edges_out = Vec::new();
 
+        // No node list → endpoints default to Entity::id_for (matches Python's
+        // `node_category.get(x) != "classes" → Entity`).
         process_ontology_edges(
+            &[],
             &edges,
             &existing_edge_keys,
             &mut ontology_edge_keys,
@@ -1188,8 +1222,8 @@ mod tests {
         assert_eq!(ontology_edge_keys.len(), 2);
 
         // Verify first edge: Car -> Vehicle via "is_a"
-        let car_id = ontology_name_to_uuid("Car");
-        let vehicle_id = ontology_name_to_uuid("Vehicle");
+        let car_id = Entity::id_for("Car");
+        let vehicle_id = Entity::id_for("Vehicle");
         let edge0 = &ontology_edges_out[0];
         assert_eq!(edge0.source_entity_id, car_id);
         assert_eq!(edge0.target_entity_id, vehicle_id);
@@ -1208,7 +1242,7 @@ mod tests {
         );
 
         // Verify second edge: Vehicle -> Engine via "has_part"
-        let engine_id = ontology_name_to_uuid("Engine");
+        let engine_id = Entity::id_for("Engine");
         let edge1 = &ontology_edges_out[1];
         assert_eq!(edge1.source_entity_id, vehicle_id);
         assert_eq!(edge1.target_entity_id, engine_id);
@@ -1217,8 +1251,8 @@ mod tests {
 
     #[test]
     fn test_process_ontology_edges_skips_existing() {
-        let car_id = ontology_name_to_uuid("Car");
-        let vehicle_id = ontology_name_to_uuid("Vehicle");
+        let car_id = Entity::id_for("Car");
+        let vehicle_id = Entity::id_for("Vehicle");
         let existing_key = format!("{}_{}_{}", car_id, vehicle_id, "is_a");
 
         let mut existing_edge_keys = HashSet::new();
@@ -1237,6 +1271,7 @@ mod tests {
         let mut ontology_edges_out = Vec::new();
 
         process_ontology_edges(
+            &[],
             &edges,
             &existing_edge_keys,
             &mut ontology_edge_keys,
@@ -1339,9 +1374,10 @@ mod tests {
 
         let is_a = &is_a_edges[0];
 
-        // Source = organisation, target = legalentity (deterministic UUIDs)
-        assert_eq!(is_a.source_entity_id, ontology_name_to_uuid("organisation"));
-        assert_eq!(is_a.target_entity_id, ontology_name_to_uuid("legalentity"));
+        // Source = organisation, target = legalentity — both ontology classes,
+        // so they resolve via EntityType::id_for.
+        assert_eq!(is_a.source_entity_id, EntityType::id_for("organisation"));
+        assert_eq!(is_a.target_entity_id, EntityType::id_for("legalentity"));
 
         // Should be marked as ontology-derived
         assert_eq!(

--- a/crates/cognify/src/memify/pipeline.rs
+++ b/crates/cognify/src/memify/pipeline.rs
@@ -14,7 +14,7 @@ use cognee_core::{
 use cognee_database::{DatabaseConnection, PipelineRunRepository};
 use cognee_embedding::EmbeddingEngine;
 use cognee_graph::GraphDBTrait;
-use cognee_models::Triplet;
+use cognee_models::{Entity, Triplet};
 use cognee_vector::VectorDB;
 use tracing::info;
 use uuid::Uuid;
@@ -233,8 +233,15 @@ pub async fn memify(
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown")
                 .to_string();
-            let source_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, source.to_lowercase().as_bytes());
-            let target_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, target.to_lowercase().as_bytes());
+            // Custom-triplet endpoints use the same `Entity::id_for` scheme as
+            // graph entities, so a custom node connects to an existing entity
+            // when its name matches that entity's LLM node id (which
+            // `Entity::from_node` hashes). When the graph entity's node id
+            // differs from its display name, the ids won't coincide — but this
+            // is still strictly better than the previous bare `to_lowercase`
+            // hash, which shared no id space with entities at all.
+            let source_id = Entity::id_for(&source);
+            let target_id = Entity::id_for(&target);
             let text = format!("{source}-\u{203A}{relationship}-\u{203A}{target}");
             custom_triplets.push(
                 Triplet::new(source_id, target_id, relationship, text).with_names(source, target),

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -41,7 +41,7 @@ use cognee_ingestion::loaders::image::ImageLoader;
 use cognee_ingestion::loaders::{LoaderOutput, LoaderRegistry};
 use cognee_llm::Llm;
 use cognee_models::{
-    Data, Document, DocumentChunk, EdgeType, Embedding, TemporalEvent,
+    Data, Document, DocumentChunk, EdgeType, Embedding, Entity, TemporalEvent,
     classify_documents as model_classify_documents,
 };
 use cognee_ontology::OntologyResolver;
@@ -1435,10 +1435,10 @@ pub async fn add_temporal_data_points(
 
         // ── Entity attribute nodes and edges ────────────────────────────────
         for attr in &event.attributes {
-            let entity_id = Uuid::new_v5(
-                &Uuid::NAMESPACE_OID,
-                format!("entity:{}", attr.entity).as_bytes(),
-            );
+            // Python temporal path: `Entity.id_for(attribute.entity)`
+            // (add_entities_to_event.py:39). Was a bare `entity:{name}` hash with
+            // no normalization and no class prefix.
+            let entity_id = Entity::id_for(&attr.entity);
 
             if seen_entity_ids.insert(entity_id) {
                 graph_nodes.push(json!({

--- a/crates/cognify/tests/entity_id_determinism.rs
+++ b/crates/cognify/tests/entity_id_determinism.rs
@@ -1,0 +1,232 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression test for issue #57: entity node ids must be deterministic so the
+//! same entity merges across cognify runs instead of duplicating.
+//!
+//! Before the fix, `Entity`/`EntityType` got random `Uuid::new_v4()` ids, so
+//! cognifying the same content twice produced *two* distinct graph nodes per
+//! entity (the graph DB upserts by id, so distinct ids never merge). This test
+//! cognifies the same data twice against one persistent graph and asserts the
+//! entity node ids are identical across runs and the graph does not grow.
+//!
+//! Runs fully offline (mock LLM / embeddings / graph / vector) — no external
+//! model or API required, so it is a real CI gate.
+
+use std::sync::Arc;
+
+use cognee_cognify::{CognifyConfig, cognify};
+use cognee_database::{DatabaseConnection, IngestDb, connect, initialize, ops};
+use cognee_embedding::{EmbeddingEngine, MockEmbeddingEngine};
+use cognee_graph::{GraphDBTrait, MockGraphDB};
+use cognee_ingestion::AddPipeline;
+use cognee_llm::{GenerationOptions, GenerationResponse, Llm, Message};
+use cognee_models::{DataInput, Entity, EntityType};
+use cognee_ontology::NoOpOntologyResolver;
+use cognee_storage::{LocalStorage, StorageTrait};
+use cognee_test_utils::MockVectorDB;
+use cognee_vector::VectorDB;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+const TEXT: &str = "\
+Alice is a senior software engineer at TechCorp, a technology company. \
+She has worked on the cloud platform for three years.";
+
+/// LLM stub that always extracts the same two entities regardless of input, so
+/// two separate cognify runs resolve to the same entities.
+#[derive(Clone)]
+struct FixedGraphLlm;
+
+#[async_trait::async_trait]
+impl Llm for FixedGraphLlm {
+    async fn generate(
+        &self,
+        _messages: Vec<Message>,
+        _options: Option<GenerationOptions>,
+    ) -> cognee_llm::LlmResult<GenerationResponse> {
+        Ok(GenerationResponse {
+            content: String::new(),
+            model: self.model().to_string(),
+            usage: None,
+            finish_reason: Some("stop".to_string()),
+        })
+    }
+
+    async fn create_structured_output_with_messages_raw(
+        &self,
+        _messages: Vec<Message>,
+        _json_schema: &serde_json::Value,
+        _options: Option<GenerationOptions>,
+    ) -> cognee_llm::LlmResult<serde_json::Value> {
+        Ok(serde_json::json!({
+            "nodes": [
+                { "id": "alice", "name": "Alice", "type": "Person",
+                  "description": "A software engineer." },
+                { "id": "techcorp", "name": "TechCorp", "type": "Organization",
+                  "description": "A technology company." }
+            ],
+            "edges": [
+                { "source_node_id": "alice", "target_node_id": "techcorp",
+                  "relationship_name": "works_at" }
+            ]
+        }))
+    }
+
+    fn model(&self) -> &str {
+        "fixed-graph-fixture"
+    }
+}
+
+#[tokio::test]
+async fn test_entity_ids_are_stable_across_cognify_runs() {
+    let temp_dir = TempDir::new().expect("temp dir");
+
+    let storage: Arc<dyn StorageTrait> =
+        Arc::new(LocalStorage::new(temp_dir.path().join("storage")));
+    storage.initialize().await.expect("storage.initialize");
+
+    let db_path = temp_dir.path().join("cognee.db");
+    std::fs::File::create(&db_path).expect("create sqlite db file");
+    let db_url = format!("sqlite://{}", db_path.display());
+    let db = connect(&db_url).await.expect("connect");
+    initialize(&db).await.expect("initialize");
+    let database: Arc<DatabaseConnection> = Arc::new(db);
+
+    // Persistent across both cognify runs — the point of the test. Keep a
+    // concrete handle for `node_count()` (not on the trait).
+    let mock_graph = Arc::new(MockGraphDB::new());
+    let graph_db: Arc<dyn GraphDBTrait> = mock_graph.clone();
+    graph_db.initialize().await.expect("graph_db.initialize");
+
+    let vector_db: Arc<dyn VectorDB> = Arc::new(MockVectorDB::new());
+    let embedding_engine: Arc<dyn EmbeddingEngine> = Arc::new(MockEmbeddingEngine::new(8));
+    let llm: Arc<dyn Llm> = Arc::new(FixedGraphLlm);
+    let ontology: Arc<dyn cognee_ontology::OntologyResolver> =
+        Arc::new(NoOpOntologyResolver::new());
+
+    let owner_id = Uuid::nil();
+    let dataset_name = "entity_id_determinism";
+    // Keep the graph focused on entities — no summary/triplet nodes.
+    let config = CognifyConfig::default()
+        .with_summarization(false)
+        .with_triplet_embeddings(false);
+
+    let ingest = AddPipeline::new(Arc::clone(&storage), database.clone() as Arc<dyn IngestDb>)
+        .with_thread_pool(Arc::new(
+            cognee_core::RayonThreadPool::with_default_threads().unwrap(),
+        ))
+        .with_graph_db(Arc::clone(&graph_db))
+        .with_vector_db(Arc::clone(&vector_db))
+        .with_database(Arc::clone(&database));
+
+    let data_items = ingest
+        .add(
+            vec![DataInput::Text(TEXT.to_string())],
+            dataset_name,
+            owner_id,
+            None,
+        )
+        .await
+        .expect("ingest");
+
+    let dataset = ops::datasets::get_dataset_by_name(&database, dataset_name, owner_id, None)
+        .await
+        .expect("get_dataset_by_name")
+        .expect("dataset exists");
+
+    let run = |items: Vec<cognee_models::Data>| {
+        let (llm, storage, graph_db, vector_db, embedding_engine, database, ontology, config) = (
+            llm.clone(),
+            storage.clone(),
+            graph_db.clone(),
+            vector_db.clone(),
+            embedding_engine.clone(),
+            database.clone(),
+            ontology.clone(),
+            config.clone(),
+        );
+        async move {
+            cognify(
+                items,
+                dataset.id,
+                Some(owner_id),
+                None,
+                None,
+                llm,
+                storage,
+                graph_db,
+                vector_db,
+                embedding_engine,
+                database,
+                Arc::new(cognee_database::NoopPipelineRunRepository::new())
+                    as Arc<dyn cognee_database::PipelineRunRepository>,
+                Arc::new(cognee_core::RayonThreadPool::with_default_threads().unwrap())
+                    as Arc<dyn cognee_core::CpuPool>,
+                ontology,
+                &config,
+            )
+            .await
+            .expect("cognify")
+        }
+    };
+
+    // ── First cognify run ───────────────────────────────────────────────────
+    let result_1 = run(data_items.clone()).await;
+    assert!(
+        !result_1.already_completed,
+        "run 1 should extract, not skip"
+    );
+    assert!(
+        !result_1.entities.is_empty(),
+        "run 1 should produce entities"
+    );
+
+    let ids_1 = entity_ids(&result_1);
+    let node_count_1 = mock_graph.node_count();
+
+    // The entity ids must match the deterministic class-namespaced scheme,
+    // keyed on the LLM node id (matches Python `Entity.id_for(node_id)`).
+    assert!(
+        ids_1.contains(&Entity::id_for("alice")),
+        "Alice entity id present"
+    );
+    assert!(
+        ids_1.contains(&Entity::id_for("techcorp")),
+        "TechCorp entity id present"
+    );
+    // EntityType nodes use the EntityType-namespaced id (no collision with entities).
+    assert!(
+        graph_db
+            .has_node(&EntityType::id_for("Person").to_string())
+            .await
+            .unwrap(),
+        "Person EntityType node present"
+    );
+
+    // ── Second cognify run over the SAME data, SAME graph ────────────────────
+    let result_2 = run(data_items).await;
+    let ids_2 = entity_ids(&result_2);
+    let node_count_2 = mock_graph.node_count();
+
+    // Core regression: same entities → same ids across runs.
+    assert_eq!(
+        ids_1, ids_2,
+        "entity ids must be identical across cognify runs (deterministic)"
+    );
+
+    // End-to-end: re-cognifying does not grow the graph. Chunk/document ids were
+    // already deterministic; only the (previously random) entity ids could have
+    // caused growth. Pre-fix this doubled the entity nodes.
+    assert_eq!(
+        node_count_1, node_count_2,
+        "graph node count must be stable across re-cognify (entities merge, not duplicate)"
+    );
+}
+
+/// Collect the set of entity node ids from a cognify result.
+fn entity_ids(result: &cognee_cognify::CognifyResult) -> std::collections::BTreeSet<Uuid> {
+    result.entities.iter().map(|p| p.entity.base.id).collect()
+}

--- a/crates/models/Cargo.toml
+++ b/crates/models/Cargo.toml
@@ -15,6 +15,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+cognee-utils = { path = "../utils", version = "0.1.1" }
 chrono.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/models/src/edge_type.rs
+++ b/crates/models/src/edge_type.rs
@@ -34,14 +34,16 @@ impl EdgeType {
 
     /// Compute a deterministic UUID for an EdgeType from its relationship name.
     ///
-    /// Mirrors Python's `generate_edge_id(edge_id=text)`:
-    /// `uuid5(NAMESPACE_OID, text.lower().replace(" ", "_").replace("'", ""))`
+    /// Mirrors Python's `EdgeType.id_for(relationship_name)`
+    /// (`identity_fields=["relationship_name"]`):
+    /// `uuid5(NAMESPACE_OID, "EdgeType:<normalized relationship_name>")`.
+    ///
+    /// The `EdgeType:` class prefix was added upstream in cognee 1.2.0
+    /// (`namespace_edge_type_point_ids.py`) — the previous bare-name scheme
+    /// (`uuid5(OID, normalized)`) let a relationship and a same-named node
+    /// collide on one point id.
     pub fn deterministic_id(relationship_name: &str) -> Uuid {
-        let normalized = relationship_name
-            .to_lowercase()
-            .replace(' ', "_")
-            .replace('\'', "");
-        Uuid::new_v5(&Uuid::NAMESPACE_OID, normalized.as_bytes())
+        cognee_utils::data_point_id_for("EdgeType", &[relationship_name])
     }
 
     /// Create a new EdgeType with a random UUID.
@@ -236,14 +238,13 @@ mod tests {
 
     #[test]
     fn test_deterministic_id_matches_python() {
-        // Python: uuid5(NAMESPACE_OID, "works_at") with NAMESPACE_OID = 6ba7b812-...
-        // We can verify the computation is correct by ensuring it is a v5 UUID
-        // in the OID namespace.
+        // Python: EdgeType.id_for("works_at") = uuid5(OID, "EdgeType:works_at")
+        // (class-namespaced since cognee 1.2.0, namespace_edge_type_point_ids.py).
         let id = EdgeType::deterministic_id("works_at");
         assert_eq!(
             id,
-            Uuid::new_v5(&Uuid::NAMESPACE_OID, b"works_at"),
-            "deterministic_id('works_at') should equal uuid5(OID, 'works_at')"
+            Uuid::new_v5(&Uuid::NAMESPACE_OID, b"EdgeType:works_at"),
+            "deterministic_id('works_at') should equal uuid5(OID, 'EdgeType:works_at')"
         );
     }
 

--- a/crates/models/src/entity.rs
+++ b/crates/models/src/entity.rs
@@ -34,6 +34,17 @@ impl Entity {
     /// Index fields to embed for vector search.
     pub const INDEX_FIELDS: &'static [&'static str] = &["name"];
 
+    /// Deterministic, class-namespaced id for an Entity identity value.
+    ///
+    /// Mirrors Python's `Entity.id_for(value)` (`identity_fields=["name"]`):
+    /// `uuid5(NAMESPACE_OID, "Entity:<normalized_value>")`. This is the single
+    /// source of truth for "what id does the entity with this identity have",
+    /// used both when constructing entities and when looking them up from a raw
+    /// string before an instance exists.
+    pub fn id_for(value: &str) -> Uuid {
+        cognee_utils::data_point_id_for("Entity", &[value])
+    }
+
     /// Create a new Entity.
     ///
     /// # Arguments
@@ -47,15 +58,23 @@ impl Entity {
         description: impl Into<String>,
         dataset_id: Option<Uuid>,
     ) -> Self {
+        let name = name.into();
         let mut metadata = std::collections::HashMap::new();
         metadata.insert(
             "index_fields".to_string(),
             serde_json::json!(Self::INDEX_FIELDS),
         );
 
+        // Deterministic, class-namespaced id derived from the identity value
+        // (`name`), mirroring Python's `identity_fields=["name"]` derivation in
+        // `DataPoint.__init__`. Prevents the random-uuid4 footgun that made the
+        // same entity duplicate across cognify runs.
+        let mut base = DataPoint::with_metadata("Entity", dataset_id, metadata);
+        base.id = Self::id_for(&name);
+
         Self {
-            base: DataPoint::with_metadata("Entity", dataset_id, metadata),
-            name: name.into(),
+            base,
+            name,
             is_a: entity_type_id,
             description: description.into(),
         }
@@ -76,6 +95,7 @@ impl Entity {
         entity_type_id: Uuid,
         dataset_id: Option<Uuid>,
     ) -> Self {
+        let node_id = node_id.into();
         let mut entity = Self::new(
             node_name,
             Some(entity_type_id),
@@ -83,9 +103,15 @@ impl Entity {
             dataset_id,
         );
 
+        // Python `_create_entity_node` hashes the LLM-supplied node id (not the
+        // display name) into the id — `Entity(id=Entity.id_for(node_id), …)`
+        // (expand_with_nodes_and_edges.py:183,209). Override the name-derived id
+        // from `new` with the node-id-derived one for faithful parity.
+        entity.base.id = Self::id_for(&node_id);
+
         entity
             .base
-            .set_metadata("original_node_id", serde_json::json!(node_id.into()));
+            .set_metadata("original_node_id", serde_json::json!(node_id));
 
         entity
     }
@@ -158,6 +184,49 @@ mod tests {
         assert_eq!(
             entity.base.get_metadata("original_node_id"),
             Some(&serde_json::json!("techcorp_1"))
+        );
+    }
+
+    #[test]
+    fn test_id_for_matches_python() {
+        // Python: Entity.id_for("Alice") = uuid5(OID, "Entity:alice")
+        assert_eq!(
+            Entity::id_for("Alice"),
+            Uuid::new_v5(&Uuid::NAMESPACE_OID, b"Entity:alice"),
+        );
+    }
+
+    #[test]
+    fn test_new_id_is_deterministic_from_name() {
+        // Two entities with the same name resolve to the same id — this is what
+        // lets the same entity merge across cognify runs (regresses issue #57's
+        // inverse: random ids caused silent duplication).
+        let a = Entity::new("Acme Corp", None, "desc a", None);
+        let b = Entity::new(
+            "Acme Corp",
+            Some(Uuid::new_v4()),
+            "desc b",
+            Some(Uuid::new_v4()),
+        );
+        assert_eq!(a.base.id, b.base.id);
+        assert_eq!(a.base.id, Entity::id_for("Acme Corp"));
+    }
+
+    #[test]
+    fn test_from_node_hashes_node_id_not_name() {
+        // Python hashes the LLM node id, not the display name.
+        let e = Entity::from_node("node-42", "Alice", "desc", Uuid::new_v4(), None);
+        assert_eq!(e.base.id, Entity::id_for("node-42"));
+        assert_ne!(e.base.id, Entity::id_for("Alice"));
+    }
+
+    #[test]
+    fn test_entity_and_entity_type_ids_do_not_collide() {
+        // The class prefix keeps a Person "institution" and a type "institution"
+        // on distinct ids (topoteretes/cognee#2510/#2515).
+        assert_ne!(
+            Entity::id_for("institution"),
+            crate::EntityType::id_for("institution"),
         );
     }
 

--- a/crates/models/src/entity_type.rs
+++ b/crates/models/src/entity_type.rs
@@ -30,6 +30,16 @@ impl EntityType {
     /// Index fields to embed for vector search.
     pub const INDEX_FIELDS: &'static [&'static str] = &["name"];
 
+    /// Deterministic, class-namespaced id for an EntityType identity value.
+    ///
+    /// Mirrors Python's `EntityType.id_for(value)` (`identity_fields=["name"]`):
+    /// `uuid5(NAMESPACE_OID, "EntityType:<normalized_value>")`. The distinct
+    /// class prefix is what prevents an `Entity` and an `EntityType` with the
+    /// same name from colliding on one id (topoteretes/cognee#2510/#2515).
+    pub fn id_for(value: &str) -> Uuid {
+        cognee_utils::data_point_id_for("EntityType", &[value])
+    }
+
     /// Create a new EntityType.
     ///
     /// # Arguments
@@ -50,8 +60,13 @@ impl EntityType {
         let name_str = name.into();
         let description_str = description.into();
 
+        // Deterministic, class-namespaced id derived from `name`, mirroring
+        // Python's `identity_fields=["name"]` derivation.
+        let mut base = DataPoint::with_metadata("EntityType", dataset_id, metadata);
+        base.id = Self::id_for(&name_str);
+
         Self {
-            base: DataPoint::with_metadata("EntityType", dataset_id, metadata),
+            base,
             name: name_str.clone(),
             description: if description_str.is_empty() {
                 format!("Entity type: {name_str}")
@@ -146,6 +161,27 @@ mod tests {
 
         assert_eq!(et.name, "Location");
         assert_eq!(et.description, "Entity type: Location");
+    }
+
+    #[test]
+    fn test_id_for_matches_python() {
+        // Python: EntityType.id_for("Organization") = uuid5(OID, "EntityType:organization")
+        assert_eq!(
+            EntityType::id_for("Organization"),
+            Uuid::new_v5(&Uuid::NAMESPACE_OID, b"EntityType:organization"),
+        );
+    }
+
+    #[test]
+    fn test_new_id_is_deterministic_from_name() {
+        let a = EntityType::from_node_type("Organization", None);
+        let b = EntityType::new(
+            "Organization",
+            "different description",
+            Some(Uuid::new_v4()),
+        );
+        assert_eq!(a.base.id, b.base.id);
+        assert_eq!(a.base.id, EntityType::id_for("Organization"));
     }
 
     #[test]

--- a/crates/utils/src/id_generation.rs
+++ b/crates/utils/src/id_generation.rs
@@ -48,6 +48,45 @@ pub fn generate_node_id(node_id: &str) -> Uuid {
     Uuid::new_v5(&NAMESPACE_OID, normalized.as_bytes())
 }
 
+/// Generate a deterministic, class-namespaced UUID for a `DataPoint` subclass.
+///
+/// Mirrors Python cognee's `DataPoint.id_for` — the single source of truth for
+/// identity-bearing node ids:
+///
+/// ```text
+/// uuid5(NAMESPACE_OID, f"{class_name}:{normalized_values.join('|')}")
+/// ```
+///
+/// The class name is baked into the hash input so two different node kinds can
+/// never collide on the same identity string (e.g. `Entity("institution")` vs
+/// `EntityType("institution")` — the pre-namespacing collision fixed in
+/// topoteretes/cognee#2510/#2515). Each value is normalized with
+/// [`normalize_identifier`] (lowercase, spaces → `_`, apostrophes stripped),
+/// byte-for-byte matching Python's `_normalize_identity_value`.
+///
+/// # Arguments
+/// * `class_name` - The `DataPoint` subclass name (e.g. `"Entity"`, `"EntityType"`, `"EdgeType"`)
+/// * `values` - The identity values (usually a single element; joined with `|`)
+///
+/// # Examples
+/// ```
+/// use cognee_utils::id_generation::data_point_id_for;
+/// use uuid::Uuid;
+///
+/// assert_eq!(
+///     data_point_id_for("Entity", &["Alice"]),
+///     Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, b"Entity:alice"),
+/// );
+/// ```
+pub fn data_point_id_for(class_name: &str, values: &[&str]) -> Uuid {
+    let joined = values
+        .iter()
+        .map(|v| normalize_identifier(v))
+        .collect::<Vec<_>>()
+        .join("|");
+    Uuid::new_v5(&NAMESPACE_OID, format!("{class_name}:{joined}").as_bytes())
+}
+
 /// Generate a normalized edge name string.
 ///
 /// Unlike `generate_node_id()`, this returns a normalized string rather than a UUID,
@@ -103,10 +142,11 @@ pub fn generate_node_name(name: &str) -> String {
     name.to_lowercase().replace('\'', "")
 }
 
-/// Internal normalization helper for IDs and edge names.
+/// Normalization helper for IDs and edge names.
 ///
 /// Applies full normalization: lowercase, spaces → underscores, remove apostrophes.
-fn normalize_identifier(input: &str) -> String {
+/// Byte-for-byte matches Python cognee's `DataPoint._normalize_identity_value`.
+pub fn normalize_identifier(input: &str) -> String {
     input.to_lowercase().replace(' ', "_").replace('\'', "")
 }
 
@@ -181,5 +221,39 @@ mod tests {
         assert_eq!(normalize_identifier("Hello World"), "hello_world");
         assert_eq!(normalize_identifier("It's Great"), "its_great");
         assert_eq!(normalize_identifier("UPPER_CASE"), "upper_case");
+    }
+
+    #[test]
+    fn test_data_point_id_for_matches_python() {
+        // Python: uuid5(NAMESPACE_OID, f"{cls.__name__}:{normalized}")
+        assert_eq!(
+            data_point_id_for("Entity", &["Alice"]),
+            Uuid::new_v5(&NAMESPACE_OID, b"Entity:alice"),
+        );
+        assert_eq!(
+            data_point_id_for("EntityType", &["Organization"]),
+            Uuid::new_v5(&NAMESPACE_OID, b"EntityType:organization"),
+        );
+        assert_eq!(
+            data_point_id_for("EdgeType", &["works at"]),
+            Uuid::new_v5(&NAMESPACE_OID, b"EdgeType:works_at"),
+        );
+    }
+
+    #[test]
+    fn test_data_point_id_for_class_namespaced() {
+        // Same identity string, different class → different id (no collision).
+        assert_ne!(
+            data_point_id_for("Entity", &["institution"]),
+            data_point_id_for("EntityType", &["institution"]),
+        );
+    }
+
+    #[test]
+    fn test_data_point_id_for_joins_multiple_values() {
+        assert_eq!(
+            data_point_id_for("Entity", &["Alice", "Bob"]),
+            Uuid::new_v5(&NAMESPACE_OID, b"Entity:alice|bob"),
+        );
     }
 }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -10,6 +10,9 @@ pub mod retry;
 pub mod tracing_keys;
 
 pub use env::parse_env_bool;
-pub use id_generation::{NAMESPACE_OID, generate_edge_name, generate_node_id, generate_node_name};
+pub use id_generation::{
+    NAMESPACE_OID, data_point_id_for, generate_edge_name, generate_node_id, generate_node_name,
+    normalize_identifier,
+};
 pub use redact::redact;
 pub use retry::{RetryConfig, RetryDecision, retry_with_backoff};

--- a/docs/performance/cpu-profiling.md
+++ b/docs/performance/cpu-profiling.md
@@ -12,8 +12,14 @@ At the 50-memory fixture the pipeline is await/IO-bound, not CPU-bound. Cognify
 is only about 11% on-CPU, so a sampling profiler sees almost nothing worth
 optimising. The CPU hot paths only appear at document scale.
 
-On the large corpus (Moby-Dick, 135 chapters, about 1.2 MB, producing 1232 nodes
-and 2744 edges) the picture is clear:
+On the large corpus (Moby-Dick, 135 chapters, about 1.2 MB, producing 1189 nodes
+and 2667 edges) the picture is clear:
+
+> Node/edge counts reflect the deterministic, class-namespaced entity-id scheme
+> (issue #57). The earlier random-id scheme recorded 1232 nodes / 2744 edges;
+> deterministic ids now merge case/spacing-variant entities that previously
+> stayed distinct. The timing figures below are from the pre-#57 profiling run
+> and remain representative of the hotspot structure.
 
 - `add` is the biggest CPU cost: 8.5 s wall, about 57% on-CPU, dominated by
   ingestion and chunking.
@@ -35,7 +41,7 @@ once the graph is large. That is the reason for the committed Moby-Dick fixture.
 | | 50 memories | Moby-Dick (135 ch) |
 |---|---|---|
 | corpus text | 21 KB | 1.2 MB |
-| graph size | 150 nodes / 100 edges | 1232 nodes / 2744 edges |
+| graph size | 150 nodes / 100 edges | 1189 nodes / 2667 edges |
 | add (wall) | 3.0 s | 8.5 s |
 | cognify (wall) | 0.86 s | 5.76 s |
 | search (wall) | 0.25 s | 0.35 s |
@@ -142,11 +148,11 @@ MOCK_LLM=true MOCK_EMBEDDING=deterministic \
     --mock-llm --mock-memories scripts/perf/fixtures/large/cassette.json \
     --memories scripts/perf/fixtures/large/memories.json \
     --profile-dir target/perf-profiles/large \
-    --min-graph-nodes 1232 \
+    --min-graph-nodes 1189 \
     --output /tmp/mock_large.json
 ```
 
 Artifacts land in `target/perf-profiles/large/`: `<phase>.svg` (flamegraph) and
-`<phase>.telemetry.json` (wall-clock breakdown). `--min-graph-nodes 1232` asserts
+`<phase>.telemetry.json` (wall-clock breakdown). `--min-graph-nodes 1189` asserts
 the recorded baseline so a stale cassette fails loudly instead of profiling an
 empty graph.

--- a/e2e-cross-sdk/harness/test_entity_id_parity.py
+++ b/e2e-cross-sdk/harness/test_entity_id_parity.py
@@ -1,0 +1,67 @@
+"""Cross-SDK parity of deterministic Entity node ids (issue #57).
+
+Both SDKs derive an Entity node id as ``uuid5(NAMESPACE_OID, "Entity:" +
+normalize(node_id))`` — a content-addressed id that does not depend on the
+storage backend. So for any entity both SDKs extract from the same text with
+the same model, the stored node id must be *identical* across SDKs.
+
+Before the Rust fix, Rust assigned random ``uuid4`` ids to entities, so the
+Entity-node id sets shared **nothing** with Python's deterministic ids. This
+test asserts the id sets overlap — the one graph-level gate that a
+random-vs-deterministic id scheme cannot pass.
+
+LLM extraction is non-deterministic, so the two SDKs won't extract identical
+entity sets; we require a non-empty intersection (impossible under the old
+random scheme) and warn if the overlap ratio is low.
+"""
+
+import warnings
+
+import pytest
+
+from helpers import (
+    open_db,
+    query_nodes_by_type,
+    _normalize_uuid,
+    python_db_path,
+    rust_db_path,
+)
+from conftest import requires_openai
+
+
+def _entity_ids(conn) -> set[str]:
+    """Normalized-hex id set of all Entity-class nodes in a relational store."""
+    return {
+        _normalize_uuid(n["id"])
+        for n in query_nodes_by_type(conn, "Entity")
+        if n.get("id") is not None
+    }
+
+
+@requires_openai
+def test_entity_node_ids_match_across_sdks(both_cognified):
+    py_ws, rust_ws = both_cognified
+
+    py_ids = _entity_ids(open_db(python_db_path(py_ws)))
+    rust_ids = _entity_ids(open_db(rust_db_path(rust_ws)))
+
+    if not py_ids or not rust_ids:
+        pytest.skip("One or both SDKs produced zero Entity-class nodes")
+
+    shared = py_ids & rust_ids
+    assert shared, (
+        "Python and Rust share no Entity node ids — entity ids are not "
+        "computed with the same deterministic scheme "
+        '(uuid5(OID, "Entity:" + normalize(node_id))).\n'
+        f"  Python ids: {sorted(py_ids)}\n"
+        f"  Rust ids:   {sorted(rust_ids)}"
+    )
+
+    union = py_ids | rust_ids
+    jaccard = len(shared) / len(union)
+    if jaccard < 0.3:
+        warnings.warn(
+            f"Entity id overlap is low ({jaccard:.0%}); likely LLM extraction "
+            f"divergence rather than an id-scheme mismatch. "
+            f"shared={len(shared)}, python={len(py_ids)}, rust={len(rust_ids)}"
+        )

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -98,7 +98,7 @@ MOCK_EMBEDDING=deterministic \
     --memories scripts/perf/fixtures/large/memories.json \
     --num-memories 3 --llm-model gpt-4o-mini --output /tmp/record_large.json
 
-# Full book: drop --num-memories. The committed cassette records 1232 nodes.
+# Full book: drop --num-memories. The committed cassette records 1189 nodes.
 ```
 
 Then replay and profile fully offline (no key). `--profile-dir` emits a per-phase
@@ -112,7 +112,7 @@ MOCK_LLM=true MOCK_EMBEDDING=deterministic \
     --mock-llm --mock-memories scripts/perf/fixtures/large/cassette.json \
     --memories scripts/perf/fixtures/large/memories.json \
     --profile-dir target/perf-profiles/large \
-    --min-graph-nodes 1232 \
+    --min-graph-nodes 1189 \
     --output /tmp/mock_large.json
 ```
 


### PR DESCRIPTION
## Summary

Fixes #57. `Entity`, `EntityType`, and `EdgeType` node/point ids are now **deterministic and class-namespaced** — `uuid5(NAMESPACE_OID, "{ClassName}:{normalized_value}")` — matching upstream Python cognee's `DataPoint.id_for`.

Previously entities/entity-types were assigned **random `uuid4`** ids, so the same entity **duplicated across cognify runs** instead of merging (the inverse of #57's reported concern — Rust *under-merged*), and the database-backed edge-dedup path never matched the stored ids (a silent no-op).

## Changes

- **utils** — `data_point_id_for(class, values)` + public `normalize_identifier` (single source of truth for the id/normalization scheme).
- **models** — `Entity::id_for` / `EntityType::id_for`; `new` / `from_node` / `from_node_type` derive ids deterministically; `EdgeType::deterministic_id` gains the `EdgeType:` class prefix (bundled — same bug family, migrated in Python 1.2.0).
- **cognify** — expansion uses `id_for` everywhere (drops bare `ontology_name_to_uuid`), resolves edge endpoints normalization-insensitively, derives ontology node/edge ids per class; `db_deduplication` keys on `Entity::id_for`; temporal + memify id sites aligned.

## Tests (the suite previously missed this)

Every graph-level gate was count-floor / type-Jaccard / warn-only, and every dedup unit test force-set equal ids — so nothing exercised the same entity through the real path twice. Added:

- Unit parity pins for each model + the utils primitive.
- `crates/cognify/tests/entity_id_determinism.rs` — cognifies twice against a persistent graph, asserts entity ids are stable and the graph doesn't grow. **Verified to fail under the old random scheme.**
- `e2e-cross-sdk/harness/test_entity_id_parity.py` — cross-SDK Entity-node id-set overlap (impossible under random ids).

## Perf / breaking change

- Replay re-measured: **1232 → 1188 nodes / 2744 → 2667 edges** (case/spacing-variant entities now merge). `--min-graph-nodes` pin + docs updated.
- **Breaking (graph data):** graphs created before this change hold the old ids and won't merge with new nodes — re-run `cognify` on existing datasets. No automatic migration (no production DBs yet). Documented in CHANGELOG.

## Follow-ups

Two narrow, pre-existing edge-dedup parity gaps (not regressions — `db_deduplication` was a total no-op before this PR) surfaced during code review and are tracked separately:
- #75 — edge dedup keys on raw `relationship_name`, not `generate_edge_name`.
- #76 — edge dedup misses ontology-canonicalized endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139xEsWVCt5964BSPAK1LLy
