### PR TITLE
fix(llm): litellm-parity for OpenAI-compatible adapter (custom endpoints)

### DIFF
--- a/crates/cognify/tests/provenance_e2e.rs
+++ b/crates/cognify/tests/provenance_e2e.rs
@@ -31,7 +31,7 @@ use cognee_database::{DatabaseConnection, IngestDb, connect, initialize, ops};
 use cognee_embedding::EmbeddingEngine;
 use cognee_graph::{GraphDBTrait, LadybugAdapter};
 use cognee_ingestion::AddPipeline;
-use cognee_llm::{Llm, OpenAIAdapter};
+use cognee_llm::{Llm, build_openai_compatible_adapter};
 use cognee_models::DataInput;
 use cognee_ontology::NoOpOntologyResolver;
 use cognee_storage::{LocalStorage, StorageTrait};
@@ -109,8 +109,13 @@ async fn cognify_e2e_stamps_with_expected_task_names() {
     // In-memory mock vector DB (qdrant extracted to closed cognee-vector-qdrant).
     let vector_db: Arc<dyn VectorDB> = Arc::new(MockVectorDB::new());
 
-    let llm: Arc<dyn Llm> =
-        Arc::new(OpenAIAdapter::new(model, token, Some(url)).expect("OpenAIAdapter::new"));
+    // Route through the production factory (provider from env, default `openai`)
+    // so litellm-style model prefixes are stripped exactly as in a real run.
+    let provider = std::env::var("LLM_PROVIDER").unwrap_or_else(|_| "openai".to_string());
+    let llm: Arc<dyn Llm> = Arc::new(
+        build_openai_compatible_adapter(&provider, &model, &token, &url, 3)
+            .expect("build_openai_compatible_adapter"),
+    );
 
     let owner_id = Uuid::new_v4();
 

--- a/crates/components/Cargo.toml
+++ b/crates/components/Cargo.toml
@@ -41,6 +41,7 @@ cognee-llm = { path = "../llm", version = "0.1.3" }
 cognee-storage = { path = "../storage", version = "0.1.3" }
 cognee-vector = { path = "../vector", version = "0.1.3" }
 async-trait.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 url = { workspace = true, optional = true }

--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -135,6 +135,7 @@ mod tests {
                 api_key: "sk-test".to_string(),
                 endpoint: String::new(),
                 max_retries: 3,
+                llm_args: serde_json::Map::new(),
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),

--- a/crates/components/src/builtins/llm.rs
+++ b/crates/components/src/builtins/llm.rs
@@ -48,7 +48,8 @@ impl LlmFactory for OpenAiCompatibleLlmFactory {
             &ctx.llm.endpoint,
             ctx.llm.max_retries,
         )
-        .map_err(|e| ComponentError::Llm(e.to_string()))?;
+        .map_err(|e| ComponentError::Llm(e.to_string()))?
+        .with_extra_args(ctx.llm.llm_args.clone());
         Ok(Arc::new(adapter))
     }
 

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -102,6 +102,11 @@ pub struct LlmInputs {
     pub api_key: String,
     pub endpoint: String,
     pub max_retries: u32,
+    /// Extra request parameters merged into every chat-completion request body,
+    /// lowered from `LLM_ARGS` (Python `llm_config.llm_args`). Empty = no-op.
+    /// Applied by the OpenAI-compatible factory via
+    /// `OpenAIAdapter::with_extra_args`. See that field's docs for semantics.
+    pub llm_args: serde_json::Map<String, serde_json::Value>,
     /// Replaces the provider adapter with a cassette replay mock.
     pub mock: bool,
     /// Cassette path for the replay mock (consumed only under `mock-llm`).

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -404,6 +404,7 @@ mod tests {
                 api_key: "sk-test".to_string(),
                 endpoint: String::new(),
                 max_retries: 3,
+                llm_args: serde_json::Map::new(),
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),

--- a/crates/delete/tests/hard_mode_orphan_sweep.rs
+++ b/crates/delete/tests/hard_mode_orphan_sweep.rs
@@ -26,7 +26,7 @@ use cognee_embedding::{EmbeddingEngine, MockEmbeddingEngine};
 use cognee_graph::{GraphDBTrait, LadybugAdapter};
 use cognee_ingestion::AddPipeline;
 use cognee_llm::mock::{MissPolicy, RecordingLlm, ReplayLlm};
-use cognee_llm::{Llm, OpenAIAdapter};
+use cognee_llm::{Llm, build_openai_compatible_adapter};
 use cognee_models::DataInput;
 use cognee_ontology::NoOpOntologyResolver;
 use cognee_storage::{LocalStorage, StorageTrait};
@@ -90,13 +90,18 @@ fn create_llm_from_env(cassette_name: &str) -> Arc<dyn Llm> {
                 .with_miss_policy(MissPolicy::Error),
         );
     }
+    // Route through the production factory (provider from env, default `openai`)
+    // so litellm-style model prefixes are stripped exactly as in a real run.
+    let provider = std::env::var("LLM_PROVIDER").unwrap_or_else(|_| "openai".to_string());
     let adapter: Arc<dyn Llm> = Arc::new(
-        OpenAIAdapter::new(
-            require_env("OPENAI_MODEL"),
-            require_env("OPENAI_TOKEN"),
-            Some(require_env("OPENAI_URL")),
+        build_openai_compatible_adapter(
+            &provider,
+            &require_env("OPENAI_MODEL"),
+            &require_env("OPENAI_TOKEN"),
+            &require_env("OPENAI_URL"),
+            3,
         )
-        .expect("OpenAIAdapter::new"),
+        .expect("build_openai_compatible_adapter"),
     );
     if std::env::var("COGNEE_RECORD_LLM").is_ok_and(|v| !v.is_empty()) {
         return Arc::new(RecordingLlm::new(adapter, cassette));

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -664,6 +664,11 @@ impl HttpServerConfig {
                 api_key: self.llm_api_key.expose_secret().to_string(),
                 endpoint: self.llm_endpoint.clone(),
                 max_retries: self.llm_max_retries,
+                // The HTTP server config does not yet expose an `LLM_ARGS`
+                // equivalent; default to no extra request params (a no-op).
+                // The CLI/ComponentManager path wires `LLM_ARGS` via
+                // `cognee_lib::Settings`.
+                llm_args: serde_json::Map::new(),
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),

--- a/crates/http-server/tests/test_cognify_blocking.rs
+++ b/crates/http-server/tests/test_cognify_blocking.rs
@@ -43,7 +43,7 @@ use cognee_graph::{GraphDBTrait, LadybugAdapter};
 use cognee_http_server::components::ComponentHandles;
 use cognee_http_server::{AppState, HttpServerConfig, build_router};
 use cognee_ingestion::AddPipeline;
-use cognee_llm::{Llm, OpenAIAdapter};
+use cognee_llm::{Llm, build_openai_compatible_adapter};
 use cognee_models::DataInput;
 use cognee_storage::{LocalStorage, StorageTrait};
 use cognee_test_utils::MockVectorDB;
@@ -114,9 +114,12 @@ async fn post_cognify_blocking_executes_real_pipeline() {
     // In-memory mock vector DB (qdrant extracted to closed cognee-vector-qdrant).
     let vector_db: Arc<dyn VectorDB> = Arc::new(MockVectorDB::new());
 
+    // Route through the production factory (provider from env, default `openai`)
+    // so litellm-style model prefixes are stripped exactly as in a real run.
+    let provider = std::env::var("LLM_PROVIDER").unwrap_or_else(|_| "openai".to_string());
     let llm: Arc<dyn Llm> = Arc::new(
-        OpenAIAdapter::new(openai_model, openai_token, Some(openai_url))
-            .expect("OpenAIAdapter::new"),
+        build_openai_compatible_adapter(&provider, &openai_model, &openai_token, &openai_url, 3)
+            .expect("build_openai_compatible_adapter"),
     );
 
     let thread_pool: Arc<dyn cognee_core::CpuPool> = Arc::new(

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -72,6 +72,18 @@ pub struct Settings {
     pub llm_max_retries: u32,
     pub llm_max_parallel_requests: u32,
 
+    /// Extra parameters merged into every LLM chat-completion request, parsed
+    /// from the `LLM_ARGS` env var (a JSON object), mirroring Python cognee's
+    /// `llm_config.llm_args`. Python's litellm adapter merges these into each
+    /// call as `{**self.llm_args, **kwargs}`; explicitly-set request parameters
+    /// always win. The canonical use is `LLM_ARGS={"max_tokens": 16384}` to
+    /// lift a provider's small default output cap that would otherwise truncate
+    /// a dense graph-extraction tool call mid-JSON. Empty by default (Python
+    /// default `llm_args = {}`). `#[serde(skip)]` (like `summarization_schema`)
+    /// keeps persisted config snapshots stable — it is env-driven only.
+    #[serde(skip)]
+    pub llm_args: serde_json::Map<String, serde_json::Value>,
+
     /// Select the record/replay mock LLM instead of the real provider
     /// (`MOCK_LLM`). Parallels `MOCK_EMBEDDING`. Requires the `mock-llm` feature.
     pub llm_mock: bool,
@@ -292,6 +304,22 @@ impl Settings {
             && let Ok(n) = v.parse::<u32>()
         {
             self.llm_max_completion_tokens = n;
+        }
+        // `LLM_ARGS` — a JSON object of extra request parameters merged into every
+        // LLM chat-completion call, mirroring Python cognee's `llm_config.llm_args`
+        // (e.g. `LLM_ARGS={"max_tokens": 16384}`). A malformed value or a non-object
+        // JSON is ignored (left at the default empty map) rather than aborting
+        // startup, matching the lenient handling of the other optional LLM knobs.
+        if let Some(v) = str_var("LLM_ARGS") {
+            match serde_json::from_str::<serde_json::Value>(&v) {
+                Ok(serde_json::Value::Object(map)) => self.llm_args = map,
+                _ => {
+                    tracing::warn!(
+                        "LLM_ARGS is set but is not a JSON object; ignoring it. \
+                         Expected e.g. LLM_ARGS='{{\"max_tokens\": 16384}}'"
+                    );
+                }
+            }
         }
         if let Some(v) = str_var("LLM_STREAMING") {
             self.llm_streaming = cognee_utils::parse_env_bool(&v);
@@ -725,6 +753,7 @@ impl Settings {
                 api_key: self.llm_api_key.clone(),
                 endpoint: self.llm_endpoint.clone(),
                 max_retries: self.llm_max_retries,
+                llm_args: self.llm_args.clone(),
                 mock: self.llm_mock,
                 cassette: self.llm_cassette.clone(),
                 record_path: self.llm_record_path.clone(),
@@ -906,6 +935,7 @@ impl Default for Settings {
             llm_max_completion_tokens: 16384,
             llm_max_retries: 2,
             llm_max_parallel_requests: 20,
+            llm_args: serde_json::Map::new(),
             llm_mock: false,
             llm_cassette: String::new(),
             llm_record_path: String::new(),
@@ -2760,8 +2790,44 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
+    fn overlay_parses_llm_args_json_object() {
+        // SAFETY: test is serial — no other thread reads/writes env concurrently.
+        unsafe { std::env::set_var("LLM_ARGS", r#"{"max_tokens": 16384, "top_p": 0.9}"#) };
+        let mut s = Settings::default();
+        s.overlay_from_env();
+        unsafe { std::env::remove_var("LLM_ARGS") };
+
+        assert_eq!(
+            s.llm_args.get("max_tokens"),
+            Some(&serde_json::json!(16384))
+        );
+        assert_eq!(s.llm_args.get("top_p"), Some(&serde_json::json!(0.9)));
+        // The lowered backend context carries the same map through to the factory.
+        assert_eq!(s.backend_context().llm.llm_args, s.llm_args);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn overlay_ignores_malformed_llm_args() {
+        // A non-object / malformed value is ignored (left empty), not fatal.
+        unsafe { std::env::set_var("LLM_ARGS", "not json") };
+        let mut s = Settings::default();
+        s.overlay_from_env();
+        unsafe { std::env::remove_var("LLM_ARGS") };
+        assert!(s.llm_args.is_empty());
+
+        unsafe { std::env::set_var("LLM_ARGS", "[1, 2, 3]") };
+        let mut s = Settings::default();
+        s.overlay_from_env();
+        unsafe { std::env::remove_var("LLM_ARGS") };
+        assert!(s.llm_args.is_empty());
+    }
+
+    #[test]
     fn default_values_are_correct() {
         let s = Settings::default();
+        assert!(s.llm_args.is_empty());
         assert_eq!(s.cache_backend, "fs");
         assert_eq!(s.cache_host, "localhost");
         assert_eq!(s.cache_port, 6379);

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -147,8 +147,21 @@ impl OpenAIAdapter {
         if self.extra_args.is_empty() {
             return;
         }
+        // Reasoning models (`gpt-5*`/`o1*`/`o3*`/`o4*` on api.openai.com) reject
+        // `max_tokens` and require `max_completion_tokens`. The request body's
+        // output cap is written by `write_max_tokens` as `max_completion_tokens`,
+        // so a bare `max_tokens` coming from `LLM_ARGS` here would land alongside
+        // it and OpenAI rejects a request carrying *both* keys with a 400. Fold a
+        // `LLM_ARGS` `max_tokens` into `max_completion_tokens` (only filling the
+        // gap) so exactly one of the two keys is ever emitted.
+        let reasoning = self.is_reasoning_model();
         if let Some(obj) = body.as_object_mut() {
             for (key, value) in &self.extra_args {
+                if reasoning && key == "max_tokens" {
+                    obj.entry("max_completion_tokens")
+                        .or_insert_with(|| value.clone());
+                    continue;
+                }
                 obj.entry(key.clone()).or_insert_with(|| value.clone());
             }
         }
@@ -224,6 +237,21 @@ impl OpenAIAdapter {
     /// - HTTP 5xx (server errors)
     ///
     /// Errors on HTTP 400 and 401 are returned immediately without retrying.
+    async fn call_api(&self, mut request_body: Value) -> LlmResult<OpenAIResponse> {
+        // Merge configured `LLM_ARGS` (Python `llm_config.llm_args`) into every
+        // chat-completion / structured-output request. Only fills keys the request
+        // does not already set, so explicit parameters win — Python's
+        // `{**self.llm_args, **kwargs}`. Scoped to the chat/structured paths: the
+        // transcription (vision) path calls `send_chat_request` directly so a
+        // graph-extraction `LLM_ARGS` (e.g. a large `max_tokens`) never leaks into
+        // an image-description request.
+        self.apply_extra_args(&mut request_body);
+        self.send_chat_request(request_body).await
+    }
+
+    /// Perform the actual chat-completions HTTP POST, retrying on transient
+    /// network/server errors. Does *not* merge [`extra_args`](Self::extra_args) —
+    /// callers that want the `LLM_ARGS` merge go through [`call_api`](Self::call_api).
     #[instrument(
         name = "llm.api_call",
         level = "info",
@@ -234,12 +262,7 @@ impl OpenAIAdapter {
             cognee.llm.provider = "openai",
         ),
     )]
-    async fn call_api(&self, mut request_body: Value) -> LlmResult<OpenAIResponse> {
-        // Merge configured `LLM_ARGS` (Python `llm_config.llm_args`) into every
-        // chat-completion request. Only fills keys the request does not already
-        // set, so explicit parameters win — Python's `{**self.llm_args, **kwargs}`.
-        self.apply_extra_args(&mut request_body);
-
+    async fn send_chat_request(&self, request_body: Value) -> LlmResult<OpenAIResponse> {
         let url = format!("{}/chat/completions", self.base_url);
         tracing::Span::current().record("url", url.as_str());
         let debug_enabled = std::env::var("COGNEE_DEBUG_LLM_REQUEST")
@@ -434,6 +457,38 @@ impl OpenAIAdapter {
     /// required field or structural constraint the previous response violated —
     /// this threads `T`'s typed validation into the repair prompt, matching how
     /// instructor feeds the validation error back to the model.
+    /// Build a schema-aware validator for the type-erased raw path (which has no
+    /// Rust type to deserialize into).
+    ///
+    /// Enforces that every property named in the schema's top-level `required`
+    /// array is present and non-null. This gives the raw path the same
+    /// required-field guarantee instructor provides for a typed model, *without*
+    /// strict/grammar-constrained decoding (`response_format: json_schema`, which
+    /// 501s on Baseten): a response omitting a required field is fed back into the
+    /// existing corrective-retry loop instead of being accepted or hard-failing.
+    fn schema_required_validator(schema: &Value) -> impl Fn(&Value) -> Result<(), String> + '_ {
+        move |value: &Value| {
+            let Some(required) = schema.get("required").and_then(Value::as_array) else {
+                return Ok(());
+            };
+            let Some(obj) = value.as_object() else {
+                return Err("expected a JSON object".to_string());
+            };
+            for field in required {
+                if let Some(name) = field.as_str() {
+                    match obj.get(name) {
+                        None => return Err(format!("missing required field `{name}`")),
+                        Some(Value::Null) => {
+                            return Err(format!("required field `{name}` is null"));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
     fn append_corrective_instruction(request: &mut Value, reason: Option<&str>) {
         if let Some(messages) = request["messages"].as_array_mut()
             && let Some(last_msg) = messages.last_mut()
@@ -522,7 +577,14 @@ impl Llm for OpenAIAdapter {
         json_schema: &Value,
         options: Option<GenerationOptions>,
     ) -> LlmResult<Value> {
-        self.structured_output_impl(messages, json_schema, options, None)
+        // The type-erased raw path has no Rust type to deserialize into, but it
+        // must still enforce the schema's required fields (summarization's
+        // custom-schema path and the HTTP structured endpoints rely on this — e.g.
+        // `summarize_one` needs the `summary` field present). Synthesise a
+        // schema-aware validator so an omitted required field drives the same
+        // corrective retry a typed caller gets, matching instructor.
+        let validator = Self::schema_required_validator(json_schema);
+        self.structured_output_impl(messages, json_schema, options, Some(&validator))
             .await
     }
 
@@ -597,7 +659,10 @@ impl Llm for OpenAIAdapter {
         });
         self.write_max_tokens(&mut request_body, Some(max_tokens));
 
-        let response = self.call_api(request_body).await?;
+        // Deliberately use `send_chat_request` (not `call_api`): `LLM_ARGS`
+        // (`extra_args`) are scoped to chat/structured extraction and must not
+        // bleed into the image-description request.
+        let response = self.send_chat_request(request_body).await?;
 
         let choice = response.choices.first().ok_or_else(|| {
             LlmError::InvalidResponse("No choices in vision response".to_string())
@@ -714,12 +779,26 @@ impl OpenAIAdapter {
         // tool call retries and, once exhausted, falls through to the legacy
         // function-calling / JSON-mode paths below (so servers that do not
         // support tool calling still work).
-        let mut last_invalid: Option<(String, String)> = None;
+        // Last outcome of the tool-calling loop, used to decide how to proceed
+        // once retries are exhausted. We distinguish a *validation miss* (the
+        // server clearly speaks tool calling and returns JSON, it merely omits a
+        // required field) from a *parse failure* / empty output / API error,
+        // because the two want different post-loop handling (see below).
+        enum ToolOutcome {
+            /// No usable output yet, or the request itself errored — fall through.
+            NoUsableOutput,
+            /// Valid JSON that failed the caller's typed/schema validation.
+            ValidationMiss { reason: String, raw: String },
+            /// A non-empty payload that did not parse as JSON.
+            ParseFailure,
+        }
+        let mut outcome = ToolOutcome::NoUsableOutput;
+        // Most recent failure reason, threaded into the next corrective retry.
+        let mut last_reason: Option<String> = None;
         for attempt in 0..self.structured_output_retries {
             let mut request_for_attempt = tools_request.clone();
             if attempt > 0 {
-                let reason = last_invalid.as_ref().map(|(r, _)| r.as_str());
-                Self::append_corrective_instruction(&mut request_for_attempt, reason);
+                Self::append_corrective_instruction(&mut request_for_attempt, last_reason.as_deref());
                 if !self.is_reasoning_model() {
                     request_for_attempt["temperature"] = json!(0.0);
                 }
@@ -734,18 +813,26 @@ impl OpenAIAdapter {
                     // Prefer a modern `tool_calls[0]`, then a legacy
                     // `function_call`, then raw `content` (some servers echo the
                     // JSON directly).
+                    // An empty/whitespace `arguments` string must be treated as
+                    // *absent* so the `.or(content)` fallback engages — some
+                    // servers emit a `tool_calls[0]` with empty arguments but put
+                    // the JSON in `message.content`. Without the `filter`, the
+                    // `Some("")` would shadow the real payload.
+                    let non_blank = |s: &str| !s.trim().is_empty();
                     let arguments = choice
                         .message
                         .tool_calls
                         .as_ref()
                         .and_then(|calls| calls.first())
                         .map(|c| c.function.arguments.as_str())
+                        .filter(|s| non_blank(s))
                         .or_else(|| {
                             choice
                                 .message
                                 .function_call
                                 .as_ref()
                                 .map(|f| f.arguments.as_str())
+                                .filter(|s| non_blank(s))
                         })
                         .or(choice.message.content.as_deref())
                         .unwrap_or("");
@@ -753,6 +840,8 @@ impl OpenAIAdapter {
                     if is_blank(arguments) {
                         // No usable output this attempt: retry until exhausted,
                         // then fall through to the legacy paths.
+                        outcome = ToolOutcome::NoUsableOutput;
+                        last_reason = None;
                         continue;
                     }
 
@@ -770,37 +859,50 @@ impl OpenAIAdapter {
                                     "tool-call response parsed but failed typed validation; \
                                      retrying with corrective instruction",
                                 );
-                                last_invalid = Some((reason, arguments.to_string()));
+                                last_reason = Some(reason.clone());
+                                outcome = ToolOutcome::ValidationMiss {
+                                    reason,
+                                    raw: arguments.to_string(),
+                                };
                                 continue;
                             }
                             return Ok(parsed);
                         }
                         Err(e) => {
-                            // Non-empty but invalid: remember it so we can surface
-                            // a clear error if every attempt fails, then retry.
-                            last_invalid = Some((e.to_string(), arguments.to_string()));
+                            // Non-empty but invalid JSON: retry, and remember that
+                            // the failure was a *parse* failure so we fall through
+                            // to the legacy/JSON-mode fallbacks once exhausted.
+                            last_reason = Some(e.to_string());
+                            outcome = ToolOutcome::ParseFailure;
                             continue;
                         }
                     }
                 }
                 Err(e) => {
-                    // Tool calling is unsupported by this model/endpoint (or the
-                    // schema was rejected). Fall back to legacy function calling
-                    // / JSON mode below, but make the reason visible — a silent
-                    // fallback is how required fields end up missing.
+                    // The tool-calling request itself errored (tool calling
+                    // unsupported, schema rejected, transient API/network error).
+                    // Fall through to the legacy/JSON-mode fallbacks — a server
+                    // may reject tool calling yet answer one of those, and those
+                    // loops re-issue the request and surface any real API error
+                    // via `?`. Crucially we do NOT return a stale validation/parse
+                    // error here [#5]; we discard the prior miss and fall through.
                     warn!(error = %e, "tool-call request failed; falling back to legacy function/JSON mode");
+                    outcome = ToolOutcome::NoUsableOutput;
                     break;
                 }
             }
         }
 
-        // Every tool-calling attempt returned a non-empty payload that was
-        // either unparseable or failed validation: surface it rather than
-        // silently swallowing it (the legacy fallbacks would only re-ask a
-        // server that clearly *does* speak tool calling).
-        if let Some((err, raw)) = last_invalid {
+        // Every tool-calling attempt returned valid JSON that failed the caller's
+        // typed/schema validation (e.g. persistently omits a required field). The
+        // server clearly speaks tool calling and returns well-formed JSON, so the
+        // legacy/JSON-mode fallbacks would only re-ask the same model; surface the
+        // validation error instead (instructor parity), naming the field. This is
+        // deliberately NOT done for a *parse* failure or empty output [#4], which
+        // fall through below in case a different request mode succeeds.
+        if let ToolOutcome::ValidationMiss { reason, raw } = outcome {
             return Err(LlmError::DeserializationError(format!(
-                "Failed to deserialize tool-call arguments after {} attempt(s): {err}. Raw: {raw}",
+                "Tool-call arguments failed schema validation after {} attempt(s): {reason}. Raw: {raw}",
                 self.structured_output_retries
             )));
         }
@@ -828,8 +930,24 @@ impl OpenAIAdapter {
             request_body["reasoning"] = json!({"effort": "none"});
         }
 
+        // Reason carried into the next attempt's corrective instruction so a
+        // legacy retry is not a byte-identical re-send (which just reproduces the
+        // same bad output) — it appends the failure detail and drops temperature
+        // to 0, exactly like the tool-calling and JSON-mode loops.
+        let mut legacy_last_reason: Option<String> = None;
         for attempt in 0..self.structured_output_retries {
-            let response = self.call_api(request_body.clone()).await?;
+            let mut request_for_attempt = request_body.clone();
+            if attempt > 0 {
+                Self::append_corrective_instruction(
+                    &mut request_for_attempt,
+                    legacy_last_reason.as_deref(),
+                );
+                if !self.is_reasoning_model() {
+                    request_for_attempt["temperature"] = json!(0.0);
+                }
+            }
+
+            let response = self.call_api(request_for_attempt).await?;
 
             let choice = response
                 .choices
@@ -850,6 +968,7 @@ impl OpenAIAdapter {
                                     function_call.arguments
                                 )));
                             }
+                            legacy_last_reason = Some(reason);
                             continue;
                         }
                         return Ok(parsed);
@@ -861,6 +980,7 @@ impl OpenAIAdapter {
                             if last_attempt {
                                 break;
                             }
+                            legacy_last_reason = None;
                             continue;
                         }
                         // Non-empty but invalid: surface it on the last attempt,
@@ -871,6 +991,7 @@ impl OpenAIAdapter {
                                 e, function_call.arguments
                             )));
                         }
+                        legacy_last_reason = Some(e.to_string());
                         continue;
                     }
                 }
@@ -960,7 +1081,14 @@ impl OpenAIAdapter {
                     return Ok(parsed);
                 }
                 Err(e) => {
-                    if !last_attempt && is_blank(content) {
+                    // Retry on *any* parse failure while attempts remain — an
+                    // empty response OR a non-empty-but-invalid one (e.g. JSON
+                    // wrapped in prose/markdown). The retry above appends a
+                    // "return ONLY one valid JSON object" instruction and drops
+                    // temperature to 0, so a re-ask can recover; narrowing this to
+                    // blank-only [#8] would give up on a malformed-but-present
+                    // payload after a single attempt.
+                    if !last_attempt {
                         continue;
                     }
                     return Err(LlmError::DeserializationError(format!(
@@ -1434,6 +1562,70 @@ mod tests {
         let mut body = json!({"model": "gpt-4o-mini", "max_tokens": 512});
         adapter.apply_extra_args(&mut body);
         assert_eq!(body["max_tokens"], 512);
+    }
+
+    #[test]
+    fn test_apply_extra_args_translates_max_tokens_for_reasoning_models() {
+        // #1: `write_max_tokens` emits `max_completion_tokens` for a reasoning
+        // model; a bare `LLM_ARGS` `max_tokens` must be folded into
+        // `max_completion_tokens` (never sent alongside it), or OpenAI 400s on
+        // both keys.
+        let args = json!({"max_tokens": 16384})
+            .as_object()
+            .unwrap()
+            .clone();
+        let reasoning = OpenAIAdapter::new("gpt-5-mini", "test-key", None)
+            .unwrap()
+            .with_extra_args(args.clone());
+
+        // Body already carries `max_completion_tokens` (from write_max_tokens):
+        // the extra `max_tokens` must NOT be added, and no bare `max_tokens` key.
+        let mut body = json!({"model": "gpt-5-mini", "max_completion_tokens": 2048});
+        reasoning.apply_extra_args(&mut body);
+        assert!(
+            body.get("max_tokens").is_none(),
+            "reasoning model must never carry a bare max_tokens"
+        );
+        assert_eq!(
+            body["max_completion_tokens"], 2048,
+            "explicit max_completion_tokens must win over LLM_ARGS"
+        );
+
+        // Body has no output cap yet: the LLM_ARGS max_tokens fills
+        // max_completion_tokens (translated), still no bare max_tokens.
+        let mut body = json!({"model": "gpt-5-mini"});
+        reasoning.apply_extra_args(&mut body);
+        assert!(body.get("max_tokens").is_none());
+        assert_eq!(body["max_completion_tokens"], 16384);
+
+        // A classic (non-reasoning) model keeps the bare max_tokens.
+        let classic = OpenAIAdapter::new("gpt-4o-mini", "test-key", None)
+            .unwrap()
+            .with_extra_args(args);
+        let mut body = json!({"model": "gpt-4o-mini"});
+        classic.apply_extra_args(&mut body);
+        assert_eq!(body["max_tokens"], 16384);
+        assert!(body.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn test_schema_required_validator_enforces_required_fields() {
+        // #3: the raw path synthesises a schema-aware validator so an omitted
+        // required field is a retryable miss (not silently accepted).
+        let schema = json!({
+            "type": "object",
+            "required": ["summary"],
+            "properties": {"summary": {"type": "string"}}
+        });
+        let validate = OpenAIAdapter::schema_required_validator(&schema);
+        assert!(validate(&json!({"summary": "hello"})).is_ok());
+        assert!(validate(&json!({"other": "x"})).is_err());
+        assert!(validate(&json!({"summary": null})).is_err());
+
+        // No `required` array → nothing to enforce.
+        let loose = json!({"type": "object"});
+        let validate = OpenAIAdapter::schema_required_validator(&loose);
+        assert!(validate(&json!({})).is_ok());
     }
 
     #[test]

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -798,7 +798,10 @@ impl OpenAIAdapter {
         for attempt in 0..self.structured_output_retries {
             let mut request_for_attempt = tools_request.clone();
             if attempt > 0 {
-                Self::append_corrective_instruction(&mut request_for_attempt, last_reason.as_deref());
+                Self::append_corrective_instruction(
+                    &mut request_for_attempt,
+                    last_reason.as_deref(),
+                );
                 if !self.is_reasoning_model() {
                     request_for_attempt["temperature"] = json!(0.0);
                 }
@@ -1570,10 +1573,7 @@ mod tests {
         // model; a bare `LLM_ARGS` `max_tokens` must be folded into
         // `max_completion_tokens` (never sent alongside it), or OpenAI 400s on
         // both keys.
-        let args = json!({"max_tokens": 16384})
-            .as_object()
-            .unwrap()
-            .clone();
+        let args = json!({"max_tokens": 16384}).as_object().unwrap().clone();
         let reasoning = OpenAIAdapter::new("gpt-5-mini", "test-key", None)
             .unwrap()
             .with_extra_args(args.clone());

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -55,6 +55,16 @@ pub struct OpenAIAdapter {
     network_retries: usize,
     /// Model name for audio transcription (e.g. `"whisper-1"`).
     transcription_model: String,
+    /// Extra request parameters merged into every chat-completion request body,
+    /// mirroring Python cognee's `LLM_ARGS` / `llm_config.llm_args`, which the
+    /// litellm adapter merges into each call as `{**self.llm_args, **kwargs}`
+    /// (see `openai/adapter.py`). Keys already present on the built request body
+    /// (the explicit "kwargs", e.g. `model`, `messages`, an options-supplied
+    /// `max_tokens`) win, so these only ever *fill gaps*. The canonical use is
+    /// `{"max_tokens": 16384}` to lift a provider's small default output cap that
+    /// would otherwise truncate a dense graph-extraction tool call mid-JSON.
+    /// Empty by default (Python default `llm_args = {}`) — a no-op.
+    extra_args: serde_json::Map<String, Value>,
 }
 
 impl OpenAIAdapter {
@@ -114,7 +124,34 @@ impl OpenAIAdapter {
             structured_output_retries: Self::DEFAULT_STRUCTURED_OUTPUT_RETRIES,
             network_retries: Self::DEFAULT_NETWORK_RETRIES,
             transcription_model,
+            extra_args: serde_json::Map::new(),
         })
+    }
+
+    /// Set extra request parameters merged into every chat-completion request,
+    /// mirroring Python cognee's `LLM_ARGS` / `llm_config.llm_args`.
+    ///
+    /// Merge semantics match Python's `{**self.llm_args, **kwargs}`: an entry is
+    /// only applied when the request body does not already carry that key, so
+    /// explicitly-set parameters (model, messages, an options-supplied
+    /// `max_tokens`, …) always win. See the [`extra_args`](Self::extra_args)
+    /// field docs for the primary use case (lifting a provider output cap).
+    pub fn with_extra_args(mut self, args: serde_json::Map<String, Value>) -> Self {
+        self.extra_args = args;
+        self
+    }
+
+    /// Merge [`extra_args`](Self::extra_args) into a request body, filling only
+    /// keys that are not already present (explicit params win — Python parity).
+    fn apply_extra_args(&self, body: &mut Value) {
+        if self.extra_args.is_empty() {
+            return;
+        }
+        if let Some(obj) = body.as_object_mut() {
+            for (key, value) in &self.extra_args {
+                obj.entry(key.clone()).or_insert_with(|| value.clone());
+            }
+        }
     }
 
     /// Configure retry attempts for structured output extraction.
@@ -197,7 +234,12 @@ impl OpenAIAdapter {
             cognee.llm.provider = "openai",
         ),
     )]
-    async fn call_api(&self, request_body: Value) -> LlmResult<OpenAIResponse> {
+    async fn call_api(&self, mut request_body: Value) -> LlmResult<OpenAIResponse> {
+        // Merge configured `LLM_ARGS` (Python `llm_config.llm_args`) into every
+        // chat-completion request. Only fills keys the request does not already
+        // set, so explicit parameters win — Python's `{**self.llm_args, **kwargs}`.
+        self.apply_extra_args(&mut request_body);
+
         let url = format!("{}/chat/completions", self.base_url);
         tracing::Span::current().record("url", url.as_str());
         let debug_enabled = std::env::var("COGNEE_DEBUG_LLM_REQUEST")
@@ -1366,6 +1408,41 @@ mod tests {
         reasoning.write_max_tokens(&mut body, None);
         assert!(body.get("max_tokens").is_none());
         assert!(body.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn test_apply_extra_args_fills_missing_keys_only() {
+        // Mirrors Python's `{**self.llm_args, **kwargs}`: llm_args fill gaps,
+        // explicitly-set request params win.
+        let args = json!({"max_tokens": 16384, "top_p": 0.9})
+            .as_object()
+            .unwrap()
+            .clone();
+        let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", None)
+            .unwrap()
+            .with_extra_args(args);
+
+        // `max_tokens` absent → filled from extra_args; existing `temperature`
+        // untouched (not in extra_args); `top_p` filled.
+        let mut body = json!({"model": "gpt-4o-mini", "temperature": 0.0});
+        adapter.apply_extra_args(&mut body);
+        assert_eq!(body["max_tokens"], 16384);
+        assert_eq!(body["top_p"], 0.9);
+        assert_eq!(body["temperature"], 0.0);
+
+        // An explicitly-set key is NOT overwritten by extra_args.
+        let mut body = json!({"model": "gpt-4o-mini", "max_tokens": 512});
+        adapter.apply_extra_args(&mut body);
+        assert_eq!(body["max_tokens"], 512);
+    }
+
+    #[test]
+    fn test_apply_extra_args_empty_is_noop() {
+        let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", None).unwrap();
+        let mut body = json!({"model": "gpt-4o-mini"});
+        let before = body.clone();
+        adapter.apply_extra_args(&mut body);
+        assert_eq!(body, before);
     }
 
     #[test]

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -1,7 +1,9 @@
-//! OpenAI API adapter with JSON schema support for structured outputs.
+//! OpenAI API adapter with structured-output support.
 //!
-//! This adapter uses OpenAI's function calling or JSON mode to generate
-//! structured outputs based on JSON schemas derived from Rust types.
+//! This adapter uses OpenAI's tool calling (`tools` + `tool_choice`) — the same
+//! shape Python cognee sends via instructor/litellm — to generate structured
+//! outputs based on JSON schemas derived from Rust types, falling back to legacy
+//! function calling and JSON mode for older OpenAI-compatible servers.
 
 use async_trait::async_trait;
 use reqwest::Client;
@@ -19,11 +21,11 @@ use crate::types::{GenerationOptions, GenerationResponse, Message, MessageRole, 
 
 /// OpenAI API adapter.
 ///
-/// Supports structured output generation via:
-/// - Strict JSON schema mode (response_format with type: "json_schema")
-/// - Function calling (for GPT-4 and GPT-3.5-turbo)
+/// Supports structured output generation via (in fallback order):
+/// - Tool calling (`tools` + forced `tool_choice`) — the primary path, matching
+///   Python cognee's instructor/litellm `Mode.TOOLS`
+/// - Legacy function calling (`functions` + `function_call`)
 /// - JSON mode (response_format with type: "json_object")
-/// - JSON schema validation (via function parameters)
 ///
 /// # Example
 /// ```ignore
@@ -90,16 +92,13 @@ impl OpenAIAdapter {
         let transcription_model =
             std::env::var("TRANSCRIPTION_MODEL").unwrap_or_else(|_| "whisper-1".to_string());
 
-        // Strip a leading litellm-style "openai/" provider prefix. Python's
-        // litellm accepts provider-qualified names (e.g. "openai/gpt-5-mini")
-        // and strips the provider before calling the OpenAI-native API, which
-        // itself rejects the prefix. Strip it here for parity so a
-        // provider-qualified config value works against real OpenAI.
+        // The model is used verbatim on the wire. litellm-style provider prefix
+        // stripping (`openai/`, `baseten/`, …) is owned by
+        // `build_openai_compatible_adapter`, which has the provider/endpoint
+        // context needed to strip correctly (and to leave `custom` slugs
+        // untouched). Stripping here as well would wrongly mangle real slugs
+        // that legitimately contain a slash (e.g. Baseten's `openai/gpt-oss-120b`).
         let model: String = model.into();
-        let model = model
-            .strip_prefix("openai/")
-            .map(str::to_string)
-            .unwrap_or(model);
 
         Ok(Self {
             model,
@@ -383,52 +382,23 @@ impl OpenAIAdapter {
 
         serde_json::to_string_pretty(&example).unwrap_or_else(|_| "{}".to_string())
     }
-}
 
-/// Rewrite a `schemars`-generated JSON schema so it satisfies OpenAI's
-/// **strict** structured-output requirements.
-///
-/// OpenAI's `response_format: {type: "json_schema", strict: true}` rejects any
-/// schema where an object lacks `"additionalProperties": false` or whose
-/// `"required"` array does not list *every* declared property. `schemars`
-/// (0.8, draft-07) emits neither guarantee — optional (`Option<T>`) fields are
-/// omitted from `required` and `additionalProperties` is left unset. When the
-/// strict request 400s, [`OpenAIAdapter::create_structured_output_with_messages_raw`]
-/// silently falls back to lenient JSON mode, where the model is free to drop
-/// required fields (e.g. a `Node` without its `type`), causing downstream
-/// deserialization failures.
-///
-/// This walks the schema (including `definitions`/`$defs`, `properties`,
-/// `items`, and the `anyOf`/`allOf`/`oneOf` combinators) and, for every object
-/// that declares `properties`, forces `additionalProperties: false` and sets
-/// `required` to the full set of property keys. The `Value` is cloned and
-/// returned unchanged for non-object schemas.
-fn to_strict_schema(schema: &Value) -> Value {
-    fn walk(value: &mut Value) {
-        match value {
-            Value::Object(obj) => {
-                if let Some(Value::Object(props)) = obj.get("properties") {
-                    // Every declared property must be required under strict mode.
-                    let keys: Vec<Value> = props.keys().map(|k| Value::String(k.clone())).collect();
-                    obj.insert("required".to_string(), Value::Array(keys));
-                    obj.insert("additionalProperties".to_string(), Value::Bool(false));
-                }
-                for (_k, v) in obj.iter_mut() {
-                    walk(v);
-                }
-            }
-            Value::Array(items) => {
-                for v in items.iter_mut() {
-                    walk(v);
-                }
-            }
-            _ => {}
+    /// Append a corrective instruction to the last user message of `request`,
+    /// nudging the model to return a single valid object on a retry attempt.
+    /// Mirrors instructor's repair prompt on a validation/parse failure.
+    fn append_corrective_instruction(request: &mut Value) {
+        if let Some(messages) = request["messages"].as_array_mut()
+            && let Some(last_msg) = messages.last_mut()
+            && last_msg["role"] == "user"
+        {
+            let original = last_msg["content"].as_str().unwrap_or("");
+            last_msg["content"] = json!(format!(
+                "{original}\n\nYour previous response could not be parsed into the required \
+                 structure. Call the `extract_structured_data` function again and return ONE \
+                 valid object that fills in every required field. No extra text."
+            ));
         }
     }
-
-    let mut out = schema.clone();
-    walk(&mut out);
-    out
 }
 
 #[async_trait]
@@ -499,10 +469,11 @@ impl Llm for OpenAIAdapter {
         json_schema: &Value,
         options: Option<GenerationOptions>,
     ) -> LlmResult<Value> {
-        let is_empty_or_non_json = |raw: &str| {
-            let trimmed = raw.trim();
-            trimmed.is_empty() || serde_json::from_str::<Value>(trimmed).is_err()
-        };
+        // Blank = empty or whitespace-only. Kept separate from JSON *validity*
+        // so a non-empty-but-invalid payload can surface a clear error instead
+        // of being lumped together with "no output" (which should retry / fall
+        // back to a different mode).
+        let is_blank = |raw: &str| raw.trim().is_empty();
 
         let parse_json =
             |raw: &str| -> Result<Value, serde_json::Error> { serde_json::from_str(raw) };
@@ -510,98 +481,131 @@ impl Llm for OpenAIAdapter {
         let opts = options.unwrap_or_default();
         let schema = json_schema;
 
-        // OpenAI strict mode requires `additionalProperties: false` and that
-        // every property appear in `required` on every object; the raw
-        // schemars schema satisfies neither, which would 400 and silently
-        // drop us into lenient mode (where required fields can go missing).
-        let strict_schema = to_strict_schema(schema);
-
-        // Try strict JSON schema mode first (new OpenAI API behavior).
-        let mut strict_schema_request = json!({
+        // Primary path: OpenAI tool calling (`tools` + forced `tool_choice`).
+        //
+        // This mirrors Python cognee's request: instructor's default `Mode.TOOLS`
+        // (used by `LLMGateway.acreate_structured_output`) sends the response
+        // model as a single function tool and forces the model to call it,
+        // passing the schema *as-is*.
+        //
+        // We deliberately do NOT use `response_format: {type: json_schema,
+        // strict: true}` here, and we do NOT rewrite the schema to be
+        // all-required / `additionalProperties:false`. Both drive
+        // grammar-constrained decoding on OpenAI-compatible backends; Baseten's
+        // gpt-oss-120b returns HTTP 501 "Error making prediction" on such
+        // requests (verified: even the all-required rewrite *without*
+        // `strict:true` reproduces the 501). Passing the schema unmodified — the
+        // exact shape litellm sends — is what keeps Baseten working. The
+        // required-field guarantee is instead approximated by retrying on a
+        // malformed/incomplete response with a corrective instruction below.
+        let mut tools_request = json!({
             "model": self.model,
             "messages": Self::convert_messages(&messages),
-            "response_format": {
-                "type": "json_schema",
-                "json_schema": {
+            "tools": [{
+                "type": "function",
+                "function": {
                     "name": "extract_structured_data",
-                    "schema": strict_schema,
-                    "strict": true
+                    "description": "Extract structured data from the input",
+                    "parameters": schema
                 }
+            }],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "extract_structured_data"}
             }
         });
 
         if !self.is_reasoning_model()
             && let Some(temp) = opts.temperature
         {
-            strict_schema_request["temperature"] = json!(temp);
+            tools_request["temperature"] = json!(temp);
         }
-        self.write_max_tokens(&mut strict_schema_request, opts.max_tokens);
+        self.write_max_tokens(&mut tools_request, opts.max_tokens);
         if self.should_disable_thinking() {
-            strict_schema_request["think"] = json!(false);
-            strict_schema_request["reasoning"] = json!({"effort": "none"});
+            tools_request["think"] = json!(false);
+            tools_request["reasoning"] = json!({"effort": "none"});
         }
 
+        // Retry loop. A parseable object returns immediately. A non-empty but
+        // invalid payload retries with a corrective instruction (instructor
+        // parity) and, once retries are exhausted, surfaces a `DeserializationError`
+        // carrying the raw payload. An empty / missing tool call retries and, once
+        // exhausted, falls through to the legacy function-calling / JSON-mode
+        // paths below (so servers that do not support tool calling still work).
+        let mut last_invalid: Option<(String, String)> = None;
         for attempt in 0..self.structured_output_retries {
-            match self.call_api(strict_schema_request.clone()).await {
-                Ok(strict_response) => {
-                    let strict_choice = strict_response.choices.first().ok_or_else(|| {
-                        LlmError::InvalidResponse(
-                            "No choices in strict schema response".to_string(),
-                        )
+            let mut request_for_attempt = tools_request.clone();
+            if attempt > 0 {
+                Self::append_corrective_instruction(&mut request_for_attempt);
+                if !self.is_reasoning_model() {
+                    request_for_attempt["temperature"] = json!(0.0);
+                }
+            }
+
+            match self.call_api(request_for_attempt).await {
+                Ok(tools_response) => {
+                    let choice = tools_response.choices.first().ok_or_else(|| {
+                        LlmError::InvalidResponse("No choices in tool-call response".to_string())
                     })?;
 
-                    if let Some(function_call) = &strict_choice.message.function_call {
-                        match parse_json(&function_call.arguments) {
-                            Ok(parsed) => return Ok(parsed),
-                            Err(e) => {
-                                if attempt + 1 < self.structured_output_retries
-                                    && is_empty_or_non_json(&function_call.arguments)
-                                {
-                                    continue;
-                                }
-                                if !is_empty_or_non_json(&function_call.arguments) {
-                                    return Err(LlmError::DeserializationError(format!(
-                                        "Failed to deserialize strict function call arguments: {}. Raw: {}",
-                                        e, function_call.arguments
-                                    )));
-                                }
-                                break;
-                            }
-                        }
+                    // Prefer a modern `tool_calls[0]`, then a legacy
+                    // `function_call`, then raw `content` (some servers echo the
+                    // JSON directly).
+                    let arguments = choice
+                        .message
+                        .tool_calls
+                        .as_ref()
+                        .and_then(|calls| calls.first())
+                        .map(|c| c.function.arguments.as_str())
+                        .or_else(|| {
+                            choice
+                                .message
+                                .function_call
+                                .as_ref()
+                                .map(|f| f.arguments.as_str())
+                        })
+                        .or(choice.message.content.as_deref())
+                        .unwrap_or("");
+
+                    if is_blank(arguments) {
+                        // No usable output this attempt: retry until exhausted,
+                        // then fall through to the legacy paths.
+                        continue;
                     }
 
-                    if let Some(content) = strict_choice.message.content.as_ref() {
-                        match parse_json(content) {
-                            Ok(parsed) => return Ok(parsed),
-                            Err(e) => {
-                                if attempt + 1 < self.structured_output_retries
-                                    && is_empty_or_non_json(content)
-                                {
-                                    continue;
-                                }
-                                if !is_empty_or_non_json(content) {
-                                    return Err(LlmError::DeserializationError(format!(
-                                        "Failed to deserialize strict JSON content: {e}. Raw: {content}"
-                                    )));
-                                }
-                                break;
-                            }
+                    match parse_json(arguments) {
+                        Ok(parsed) => return Ok(parsed),
+                        Err(e) => {
+                            // Non-empty but invalid: remember it so we can surface
+                            // a clear error if every attempt fails, then retry.
+                            last_invalid = Some((e.to_string(), arguments.to_string()));
+                            continue;
                         }
                     }
                 }
                 Err(e) => {
-                    // Strict json_schema mode is unsupported by this
-                    // model/endpoint (or the schema was rejected). Fall back to
-                    // function calling / JSON mode below, but make the reason
-                    // visible — a silent fallback is how required fields end up
-                    // missing from the model's output.
-                    warn!(error = %e, "strict json_schema request failed; falling back to function/JSON mode");
+                    // Tool calling is unsupported by this model/endpoint (or the
+                    // schema was rejected). Fall back to legacy function calling
+                    // / JSON mode below, but make the reason visible — a silent
+                    // fallback is how required fields end up missing.
+                    warn!(error = %e, "tool-call request failed; falling back to legacy function/JSON mode");
                     break;
                 }
             }
         }
 
-        // Try function calling first (works with OpenAI)
+        // Every tool-calling attempt returned a non-empty but unparseable
+        // payload: surface it rather than silently swallowing it (the legacy
+        // fallbacks would only re-ask a server that clearly *does* speak tool
+        // calling).
+        if let Some((err, raw)) = last_invalid {
+            return Err(LlmError::DeserializationError(format!(
+                "Failed to deserialize tool-call arguments after {} attempt(s): {err}. Raw: {raw}",
+                self.structured_output_retries
+            )));
+        }
+
+        // Try legacy function calling next (older OpenAI-compatible servers)
         let mut request_body = json!({
             "model": self.model,
             "messages": Self::convert_messages(&messages),
@@ -636,18 +640,24 @@ impl Llm for OpenAIAdapter {
                 match parse_json(&function_call.arguments) {
                     Ok(parsed) => return Ok(parsed),
                     Err(e) => {
-                        if attempt + 1 < self.structured_output_retries
-                            && is_empty_or_non_json(&function_call.arguments)
-                        {
+                        let last_attempt = attempt + 1 >= self.structured_output_retries;
+                        if is_blank(&function_call.arguments) {
+                            // Empty output: retry until exhausted, then fall
+                            // through to JSON mode.
+                            if last_attempt {
+                                break;
+                            }
                             continue;
                         }
-                        if !is_empty_or_non_json(&function_call.arguments) {
+                        // Non-empty but invalid: surface it on the last attempt,
+                        // otherwise retry.
+                        if last_attempt {
                             return Err(LlmError::DeserializationError(format!(
                                 "Failed to deserialize function call arguments: {}. Raw: {}",
                                 e, function_call.arguments
                             )));
                         }
-                        break;
+                        continue;
                     }
                 }
             }
@@ -723,8 +733,7 @@ impl Llm for OpenAIAdapter {
             match parse_json(content) {
                 Ok(parsed) => return Ok(parsed),
                 Err(e) => {
-                    if attempt + 1 < self.structured_output_retries && is_empty_or_non_json(content)
-                    {
+                    if attempt + 1 < self.structured_output_retries && is_blank(content) {
                         continue;
                     }
                     return Err(LlmError::DeserializationError(format!(
@@ -1046,13 +1055,36 @@ struct OpenAIMessage {
     role: String,
     content: Option<String>,
     reasoning: Option<String>,
+    /// Modern tool-calling response (`tool_choice`/`tools`); the structured
+    /// output is the first call's `function.arguments` JSON string.
+    tool_calls: Option<Vec<OpenAIToolCall>>,
+    /// Legacy `function_call` response (older OpenAI-compatible servers).
     function_call: Option<OpenAIFunctionCall>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
+#[allow(dead_code)]
+struct OpenAIToolCall {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default, rename = "type")]
+    call_type: Option<String>,
+    /// Defaulted so a `tool_calls` entry missing its `function` object (seen on
+    /// some OpenAI-compatible servers) does not fail deserialization of the whole
+    /// response — the fallback chain then engages instead of erroring out.
+    #[serde(default)]
+    function: OpenAIFunctionCall,
+}
+
+#[derive(Debug, Deserialize, Default)]
 #[allow(dead_code)]
 struct OpenAIFunctionCall {
+    #[serde(default)]
     name: String,
+    /// Defaulted to `""` so a `function` object without `arguments` deserializes
+    /// (treated as empty → drives a retry / fallback) rather than erroring the
+    /// entire `ApiResponse`.
+    #[serde(default)]
     arguments: String,
 }
 
@@ -1073,13 +1105,49 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_openai_provider_prefix_is_stripped() {
-        // litellm-style "openai/<model>" must be sent as bare "<model>".
-        let adapter = OpenAIAdapter::new("openai/gpt-5-mini", "test-key", None).unwrap();
+    fn test_model_is_used_verbatim() {
+        // The adapter no longer strips provider prefixes — that is owned by
+        // `build_openai_compatible_adapter`. The model must reach the wire
+        // exactly as constructed so real slugs containing a slash (e.g.
+        // Baseten's `openai/gpt-oss-120b`) are preserved.
+        let adapter = OpenAIAdapter::new("openai/gpt-oss-120b", "test-key", None).unwrap();
+        assert_eq!(adapter.model(), "openai/gpt-oss-120b");
+        let adapter = OpenAIAdapter::new("gpt-5-mini", "test-key", None).unwrap();
         assert_eq!(adapter.model(), "gpt-5-mini");
-        // Non-openai provider prefixes (custom endpoints) are left intact.
-        let adapter = OpenAIAdapter::new("ollama/llama3", "test-key", None).unwrap();
-        assert_eq!(adapter.model(), "ollama/llama3");
+    }
+
+    #[test]
+    fn test_tool_call_missing_arguments_deserializes_to_empty() {
+        // #7: a `tool_calls` entry whose `function` lacks `arguments` must not
+        // fail deserialization of the whole response — it defaults to "" so the
+        // fallback chain engages.
+        let raw = r#"{
+            "id":"x","object":"chat.completion","created":1,"model":"m",
+            "choices":[{"index":0,"message":{"role":"assistant","tool_calls":[
+                {"id":"c1","type":"function","function":{"name":"extract_structured_data"}}
+            ]},"finish_reason":"tool_calls"}]
+        }"#;
+        let resp: OpenAIResponse =
+            serde_json::from_str(raw).expect("missing arguments should default, not error");
+        let call = &resp.choices[0].message.tool_calls.as_ref().unwrap()[0];
+        assert_eq!(call.function.arguments, "");
+    }
+
+    #[test]
+    fn test_tool_call_missing_function_deserializes() {
+        // #7: a `tool_calls` entry with no `function` object at all must also
+        // deserialize (defaulted) rather than erroring the whole `ApiResponse`.
+        let raw = r#"{
+            "id":"x","object":"chat.completion","created":1,"model":"m",
+            "choices":[{"index":0,"message":{"role":"assistant","tool_calls":[
+                {"id":"c1","type":"function"}
+            ]},"finish_reason":"tool_calls"}]
+        }"#;
+        let resp: OpenAIResponse =
+            serde_json::from_str(raw).expect("missing function should default, not error");
+        let call = &resp.choices[0].message.tool_calls.as_ref().unwrap()[0];
+        assert_eq!(call.function.name, "");
+        assert_eq!(call.function.arguments, "");
     }
 
     #[test]
@@ -1315,49 +1383,5 @@ mod tests {
         assert_eq!(audio_mime_type("m4a"), "audio/mp4");
         assert_eq!(audio_mime_type("wav"), "audio/wav");
         assert_eq!(audio_mime_type("webm"), "audio/webm");
-    }
-
-    #[test]
-    fn test_to_strict_schema_marks_all_required_and_closes_objects() {
-        // Mirrors the schemars-0.8 shape: an optional field omitted from
-        // `required`, nested object behind `definitions`/`$ref`, and no
-        // `additionalProperties` set anywhere.
-        let schema = json!({
-            "type": "object",
-            "properties": {
-                "nodes": { "type": "array", "items": { "$ref": "#/definitions/Node" } }
-            },
-            "required": ["nodes"],
-            "definitions": {
-                "Node": {
-                    "type": "object",
-                    "properties": {
-                        "name": { "type": "string" },
-                        "type": { "type": "string" },
-                        "description": { "type": ["string", "null"] }
-                    },
-                    "required": ["name", "type"]
-                }
-            }
-        });
-
-        let strict = to_strict_schema(&schema);
-
-        // Root object closed + all props required.
-        assert_eq!(strict["additionalProperties"], json!(false));
-        assert_eq!(strict["required"], json!(["nodes"]));
-
-        // Nested object inside definitions: every property now required
-        // (including the previously-optional `description`) and closed.
-        let node = &strict["definitions"]["Node"];
-        assert_eq!(node["additionalProperties"], json!(false));
-        let mut req: Vec<String> = node["required"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|v| v.as_str().unwrap().to_string())
-            .collect();
-        req.sort();
-        assert_eq!(req, vec!["description", "name", "type"]);
     }
 }

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -15,7 +15,7 @@ use tracing::{debug, instrument, warn};
 use cognee_utils::tracing_keys::{COGNEE_LLM_MODEL, COGNEE_LLM_PROVIDER};
 
 use crate::error::{LlmError, LlmResult};
-use crate::llm_trait::Llm;
+use crate::llm_trait::{Llm, StructuredOutputValidator};
 use crate::transcriber::{Transcriber, TranscriptionOutput, validate_audio_format};
 use crate::types::{GenerationOptions, GenerationResponse, Message, MessageRole, TokenUsage};
 
@@ -386,16 +386,27 @@ impl OpenAIAdapter {
     /// Append a corrective instruction to the last user message of `request`,
     /// nudging the model to return a single valid object on a retry attempt.
     /// Mirrors instructor's repair prompt on a validation/parse failure.
-    fn append_corrective_instruction(request: &mut Value) {
+    ///
+    /// When `reason` is `Some`, it is surfaced verbatim (e.g. a serde
+    /// `missing field \`type\`` message) so the model knows precisely which
+    /// required field or structural constraint the previous response violated —
+    /// this threads `T`'s typed validation into the repair prompt, matching how
+    /// instructor feeds the validation error back to the model.
+    fn append_corrective_instruction(request: &mut Value, reason: Option<&str>) {
         if let Some(messages) = request["messages"].as_array_mut()
             && let Some(last_msg) = messages.last_mut()
             && last_msg["role"] == "user"
         {
             let original = last_msg["content"].as_str().unwrap_or("");
+            let detail = match reason {
+                Some(r) => format!("Your previous response failed validation: {r}. "),
+                None => "Your previous response could not be parsed into the required structure. "
+                    .to_string(),
+            };
             last_msg["content"] = json!(format!(
-                "{original}\n\nYour previous response could not be parsed into the required \
-                 structure. Call the `extract_structured_data` function again and return ONE \
-                 valid object that fills in every required field. No extra text."
+                "{original}\n\n{detail}Call the `extract_structured_data` function again and \
+                 return ONE valid object that fills in every required field, strictly matching \
+                 the schema. No extra text."
             ));
         }
     }
@@ -469,6 +480,126 @@ impl Llm for OpenAIAdapter {
         json_schema: &Value,
         options: Option<GenerationOptions>,
     ) -> LlmResult<Value> {
+        self.structured_output_impl(messages, json_schema, options, None)
+            .await
+    }
+
+    async fn create_structured_output_with_messages_raw_validated(
+        &self,
+        messages: Vec<Message>,
+        json_schema: &Value,
+        options: Option<GenerationOptions>,
+        validator: StructuredOutputValidator<'_>,
+    ) -> LlmResult<Value> {
+        self.structured_output_impl(messages, json_schema, options, Some(validator))
+            .await
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn supports_function_calling(&self) -> bool {
+        true
+    }
+
+    fn max_context_length(&self) -> u32 {
+        // Context lengths for common OpenAI models
+        match self.model.as_str() {
+            m if m.starts_with("gpt-4-turbo") => 128_000,
+            m if m.starts_with("gpt-4-32k") => 32_768,
+            m if m.starts_with("gpt-4") => 8_192,
+            m if m.starts_with("gpt-3.5-turbo-16k") => 16_384,
+            m if m.starts_with("gpt-3.5-turbo") => 4_096,
+            _ => 4_096, // Conservative default
+        }
+    }
+
+    async fn transcribe_image(
+        &self,
+        image_bytes: &[u8],
+        mime_type: &str,
+        options: Option<GenerationOptions>,
+    ) -> LlmResult<String> {
+        use base64::Engine as _;
+
+        if !mime_type.starts_with("image/") {
+            return Err(LlmError::InvalidResponse(format!(
+                "Expected image/* MIME type, got: {mime_type}"
+            )));
+        }
+
+        let b64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
+        let data_uri = format!("data:{mime_type};base64,{b64}");
+
+        let vision_model = std::env::var("LLM_VISION_MODEL")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| self.model.clone());
+
+        let max_tokens = options.as_ref().and_then(|o| o.max_tokens).unwrap_or(300);
+
+        let mut request_body = json!({
+            "model": vision_model,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": "What's in this image?" },
+                    { "type": "image_url", "image_url": { "url": data_uri } }
+                ]
+            }],
+        });
+        self.write_max_tokens(&mut request_body, Some(max_tokens));
+
+        let response = self.call_api(request_body).await?;
+
+        let choice = response.choices.first().ok_or_else(|| {
+            LlmError::InvalidResponse("No choices in vision response".to_string())
+        })?;
+
+        choice.message.content.clone().ok_or_else(|| {
+            LlmError::InvalidResponse("Vision response contained no content".to_string())
+        })
+    }
+
+    fn supports_vision(&self) -> bool {
+        let m = self.model.to_lowercase();
+        m.contains("gpt-4")
+            || m.contains("gpt-5")
+            || m.contains("vision")
+            || m.contains("o1")
+            || m.contains("o3")
+            || m.contains("o4")
+            || m.contains("llava")
+            || m.contains("moondream")
+            || m.contains("llama-3.2-vision")
+            || m.contains("gemma3")
+    }
+}
+
+impl OpenAIAdapter {
+    /// Shared implementation backing both the plain and the validated
+    /// structured-output trait methods.
+    ///
+    /// When `validator` is `Some`, a response that parses as JSON but fails it
+    /// (e.g. the model returned a well-formed object that omits a required
+    /// field) is treated as a *retryable miss* — exactly like a malformed or
+    /// empty payload — and re-asked with a corrective instruction carrying the
+    /// validation error. This threads the caller's typed validation into the
+    /// existing repair loop (the mechanism instructor uses for parity) without
+    /// introducing a second, multiplying retry loop: total attempts stay bounded
+    /// by `structured_output_retries` because validation reuses the same loop.
+    async fn structured_output_impl(
+        &self,
+        messages: Vec<Message>,
+        json_schema: &Value,
+        options: Option<GenerationOptions>,
+        validator: Option<StructuredOutputValidator<'_>>,
+    ) -> LlmResult<Value> {
         // Blank = empty or whitespace-only. Kept separate from JSON *validity*
         // so a non-empty-but-invalid payload can surface a clear error instead
         // of being lumped together with "no output" (which should retry / fall
@@ -477,6 +608,12 @@ impl Llm for OpenAIAdapter {
 
         let parse_json =
             |raw: &str| -> Result<Value, serde_json::Error> { serde_json::from_str(raw) };
+
+        // Returns `Some(reason)` when a parsed value fails the caller's typed
+        // validation (missing required field, wrong type, …), `None` otherwise
+        // (including when no validator was supplied).
+        let validation_error =
+            |parsed: &Value| -> Option<String> { validator.and_then(|v| v(parsed).err()) };
 
         let opts = options.unwrap_or_default();
         let schema = json_schema;
@@ -496,8 +633,9 @@ impl Llm for OpenAIAdapter {
         // requests (verified: even the all-required rewrite *without*
         // `strict:true` reproduces the 501). Passing the schema unmodified — the
         // exact shape litellm sends — is what keeps Baseten working. The
-        // required-field guarantee is instead approximated by retrying on a
-        // malformed/incomplete response with a corrective instruction below.
+        // required-field guarantee is instead enforced by retrying on a
+        // malformed/incomplete/validation-failing response with a corrective
+        // instruction below.
         let mut tools_request = json!({
             "model": self.model,
             "messages": Self::convert_messages(&messages),
@@ -526,17 +664,20 @@ impl Llm for OpenAIAdapter {
             tools_request["reasoning"] = json!({"effort": "none"});
         }
 
-        // Retry loop. A parseable object returns immediately. A non-empty but
-        // invalid payload retries with a corrective instruction (instructor
-        // parity) and, once retries are exhausted, surfaces a `DeserializationError`
-        // carrying the raw payload. An empty / missing tool call retries and, once
-        // exhausted, falls through to the legacy function-calling / JSON-mode
-        // paths below (so servers that do not support tool calling still work).
+        // Retry loop. A parseable object that also satisfies the validator
+        // returns immediately. A non-empty but invalid *or* validation-failing
+        // payload retries with a corrective instruction carrying the failure
+        // reason (instructor parity) and, once retries are exhausted, surfaces a
+        // `DeserializationError` carrying the raw payload. An empty / missing
+        // tool call retries and, once exhausted, falls through to the legacy
+        // function-calling / JSON-mode paths below (so servers that do not
+        // support tool calling still work).
         let mut last_invalid: Option<(String, String)> = None;
         for attempt in 0..self.structured_output_retries {
             let mut request_for_attempt = tools_request.clone();
             if attempt > 0 {
-                Self::append_corrective_instruction(&mut request_for_attempt);
+                let reason = last_invalid.as_ref().map(|(r, _)| r.as_str());
+                Self::append_corrective_instruction(&mut request_for_attempt, reason);
                 if !self.is_reasoning_model() {
                     request_for_attempt["temperature"] = json!(0.0);
                 }
@@ -574,7 +715,24 @@ impl Llm for OpenAIAdapter {
                     }
 
                     match parse_json(arguments) {
-                        Ok(parsed) => return Ok(parsed),
+                        Ok(parsed) => {
+                            // Valid JSON — but does it satisfy the caller's type?
+                            // A missing required field is caught here and fed
+                            // into the next corrective retry (instructor parity),
+                            // rather than surfacing as an un-retried failure.
+                            if let Some(reason) = validation_error(&parsed) {
+                                debug!(
+                                    attempt,
+                                    structured_output_retries = self.structured_output_retries,
+                                    %reason,
+                                    "tool-call response parsed but failed typed validation; \
+                                     retrying with corrective instruction",
+                                );
+                                last_invalid = Some((reason, arguments.to_string()));
+                                continue;
+                            }
+                            return Ok(parsed);
+                        }
                         Err(e) => {
                             // Non-empty but invalid: remember it so we can surface
                             // a clear error if every attempt fails, then retry.
@@ -594,10 +752,10 @@ impl Llm for OpenAIAdapter {
             }
         }
 
-        // Every tool-calling attempt returned a non-empty but unparseable
-        // payload: surface it rather than silently swallowing it (the legacy
-        // fallbacks would only re-ask a server that clearly *does* speak tool
-        // calling).
+        // Every tool-calling attempt returned a non-empty payload that was
+        // either unparseable or failed validation: surface it rather than
+        // silently swallowing it (the legacy fallbacks would only re-ask a
+        // server that clearly *does* speak tool calling).
         if let Some((err, raw)) = last_invalid {
             return Err(LlmError::DeserializationError(format!(
                 "Failed to deserialize tool-call arguments after {} attempt(s): {err}. Raw: {raw}",
@@ -637,10 +795,24 @@ impl Llm for OpenAIAdapter {
                 .ok_or_else(|| LlmError::InvalidResponse("No choices in response".to_string()))?;
 
             if let Some(function_call) = &choice.message.function_call {
+                let last_attempt = attempt + 1 >= self.structured_output_retries;
                 match parse_json(&function_call.arguments) {
-                    Ok(parsed) => return Ok(parsed),
+                    Ok(parsed) => {
+                        if let Some(reason) = validation_error(&parsed) {
+                            // Valid JSON but fails the caller's type: retry, and
+                            // surface the validation error once exhausted.
+                            if last_attempt {
+                                return Err(LlmError::DeserializationError(format!(
+                                    "Function call arguments failed schema validation: {reason}. \
+                                     Raw: {}",
+                                    function_call.arguments
+                                )));
+                            }
+                            continue;
+                        }
+                        return Ok(parsed);
+                    }
                     Err(e) => {
-                        let last_attempt = attempt + 1 >= self.structured_output_retries;
                         if is_blank(&function_call.arguments) {
                             // Empty output: retry until exhausted, then fall
                             // through to JSON mode.
@@ -730,10 +902,23 @@ impl Llm for OpenAIAdapter {
                 LlmError::InvalidResponse("No content in JSON mode response".to_string())
             })?;
 
+            let last_attempt = attempt + 1 >= self.structured_output_retries;
             match parse_json(content) {
-                Ok(parsed) => return Ok(parsed),
+                Ok(parsed) => {
+                    if let Some(reason) = validation_error(&parsed) {
+                        // Valid JSON but fails the caller's type: retry, and
+                        // surface the validation error once exhausted.
+                        if last_attempt {
+                            return Err(LlmError::DeserializationError(format!(
+                                "JSON content failed schema validation: {reason}. Raw: {content}"
+                            )));
+                        }
+                        continue;
+                    }
+                    return Ok(parsed);
+                }
                 Err(e) => {
-                    if attempt + 1 < self.structured_output_retries && is_blank(content) {
+                    if !last_attempt && is_blank(content) {
                         continue;
                     }
                     return Err(LlmError::DeserializationError(format!(
@@ -746,91 +931,6 @@ impl Llm for OpenAIAdapter {
         Err(LlmError::InvalidResponse(
             "Structured output retries exhausted without a parseable response".to_string(),
         ))
-    }
-
-    fn model(&self) -> &str {
-        &self.model
-    }
-
-    fn supports_streaming(&self) -> bool {
-        true
-    }
-
-    fn supports_function_calling(&self) -> bool {
-        true
-    }
-
-    fn max_context_length(&self) -> u32 {
-        // Context lengths for common OpenAI models
-        match self.model.as_str() {
-            m if m.starts_with("gpt-4-turbo") => 128_000,
-            m if m.starts_with("gpt-4-32k") => 32_768,
-            m if m.starts_with("gpt-4") => 8_192,
-            m if m.starts_with("gpt-3.5-turbo-16k") => 16_384,
-            m if m.starts_with("gpt-3.5-turbo") => 4_096,
-            _ => 4_096, // Conservative default
-        }
-    }
-
-    async fn transcribe_image(
-        &self,
-        image_bytes: &[u8],
-        mime_type: &str,
-        options: Option<GenerationOptions>,
-    ) -> LlmResult<String> {
-        use base64::Engine as _;
-
-        if !mime_type.starts_with("image/") {
-            return Err(LlmError::InvalidResponse(format!(
-                "Expected image/* MIME type, got: {mime_type}"
-            )));
-        }
-
-        let b64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
-        let data_uri = format!("data:{mime_type};base64,{b64}");
-
-        let vision_model = std::env::var("LLM_VISION_MODEL")
-            .ok()
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| self.model.clone());
-
-        let max_tokens = options.as_ref().and_then(|o| o.max_tokens).unwrap_or(300);
-
-        let mut request_body = json!({
-            "model": vision_model,
-            "messages": [{
-                "role": "user",
-                "content": [
-                    { "type": "text", "text": "What's in this image?" },
-                    { "type": "image_url", "image_url": { "url": data_uri } }
-                ]
-            }],
-        });
-        self.write_max_tokens(&mut request_body, Some(max_tokens));
-
-        let response = self.call_api(request_body).await?;
-
-        let choice = response.choices.first().ok_or_else(|| {
-            LlmError::InvalidResponse("No choices in vision response".to_string())
-        })?;
-
-        choice.message.content.clone().ok_or_else(|| {
-            LlmError::InvalidResponse("Vision response contained no content".to_string())
-        })
-    }
-
-    fn supports_vision(&self) -> bool {
-        let m = self.model.to_lowercase();
-        m.contains("gpt-4")
-            || m.contains("gpt-5")
-            || m.contains("vision")
-            || m.contains("o1")
-            || m.contains("o3")
-            || m.contains("o4")
-            || m.contains("llava")
-            || m.contains("moondream")
-            || m.contains("llama-3.2-vision")
-            || m.contains("gemma3")
     }
 }
 

--- a/crates/llm/src/factory.rs
+++ b/crates/llm/src/factory.rs
@@ -15,6 +15,8 @@
 //! `api.openai.com` host, so pointing it at another compatible endpoint does not
 //! trigger any OpenAI-specific behaviour.
 
+use tracing::warn;
+
 use crate::{LlmError, LlmResult, OpenAIAdapter};
 
 /// Default OpenAI-compatible base URL for a local Ollama server.
@@ -23,6 +25,71 @@ const OLLAMA_DEFAULT_ENDPOINT: &str = "http://localhost:11434/v1";
 const MISTRAL_DEFAULT_ENDPOINT: &str = "https://api.mistral.ai/v1";
 /// Default Gemini OpenAI-compatible base URL.
 const GEMINI_DEFAULT_ENDPOINT: &str = "https://generativelanguage.googleapis.com/v1beta/openai/";
+
+/// Known litellm *provider* prefixes that may appear as the leading
+/// `<provider>/` segment of a configured model name.
+///
+/// Python cognee routes every LLM call through litellm, whose model strings are
+/// provider-qualified (e.g. `openai/gpt-4o-mini`, `baseten/openai/gpt-oss-120b`).
+/// litellm strips the leading provider segment and sends the remainder to that
+/// provider's endpoint. We mirror that: [`strip_litellm_provider_prefix`] removes
+/// exactly one leading provider segment so the slug sent on the wire matches what
+/// litellm would send. Crucially only the *first* segment is stripped — for
+/// `baseten/openai/gpt-oss-120b` we strip `baseten/` and keep `openai/gpt-oss-120b`,
+/// because `openai/` is part of Baseten's real model slug (org "openai"), exactly
+/// as litellm does.
+///
+/// This is a hand-maintained *subset* of litellm's full provider registry —
+/// enough to cover the providers users actually configure here. An unrecognised
+/// prefix is simply left in place (the model is sent verbatim), so the worst case
+/// for a missing entry is a provider-qualified slug reaching the wire unchanged,
+/// not a wrong strip. Add entries as needed.
+const LITELLM_PROVIDER_PREFIXES: &[&str] = &[
+    "openai",
+    "azure",
+    "azure_ai",
+    "anthropic",
+    "baseten",
+    "ollama",
+    "mistral",
+    "gemini",
+    "vertex_ai",
+    "bedrock",
+    "cohere",
+    "groq",
+    "together_ai",
+    "fireworks_ai",
+    "deepinfra",
+    "deepseek",
+    "anyscale",
+    "perplexity",
+    "xai",
+    "openrouter",
+    "cerebras",
+    "sambanova",
+    "nvidia_nim",
+    "watsonx",
+    "replicate",
+    "huggingface",
+];
+
+/// Strip a single leading litellm provider segment (`<provider>/`) from `model`
+/// when `<provider>` is a recognised litellm provider (see
+/// [`LITELLM_PROVIDER_PREFIXES`]). Only the first segment is removed, matching
+/// litellm's routing: `baseten/openai/gpt-oss-120b` → `openai/gpt-oss-120b`,
+/// `openai/gpt-4o-mini` → `gpt-4o-mini`, `gpt-4o-mini` (no prefix) → unchanged.
+///
+/// Returns the remaining slug and, when a prefix was removed, the recognised
+/// prefix itself so the caller can flag a provider mismatch.
+fn strip_litellm_provider_prefix(model: &str) -> (&str, Option<&str>) {
+    if let Some((head, rest)) = model.split_once('/')
+        && !rest.is_empty()
+        && LITELLM_PROVIDER_PREFIXES.contains(&head)
+    {
+        return (rest, Some(head));
+    }
+    (model, None)
+}
 
 /// Providers this factory routes onto [`OpenAIAdapter`]. Single source of truth so
 /// the "unsupported provider" message can never drift from the match arms below.
@@ -48,9 +115,13 @@ const SUPPORTED_PROVIDERS: &[&str] = &[
 /// `max_retries` is floored at 1 and applied to both the structured-output and
 /// network retry loops, matching the previous inline wiring.
 ///
-/// litellm-style provider prefixes on the model (`ollama/`, `mistral/`,
-/// `gemini/`) are stripped so provider-qualified config values keep working
-/// (the adapter itself only strips `openai/`).
+/// litellm-style provider prefixes on the model (`openai/`, `baseten/`,
+/// `ollama/`, `mistral/`, `gemini/`, `groq/`, …) are stripped so
+/// provider-qualified config values work exactly as they do under Python's
+/// litellm. Only the first `<provider>/` segment is removed, so a real slug that
+/// itself contains a slash survives — e.g. `baseten/openai/gpt-oss-120b` becomes
+/// `openai/gpt-oss-120b` (Baseten's org is literally "openai"). `custom` /
+/// `openai_compatible` pass the model verbatim.
 ///
 /// Returns [`LlmError::ConfigError`] when a required API key or endpoint is
 /// missing, or the provider is unsupported, so each caller can decide whether to
@@ -66,29 +137,24 @@ pub fn build_openai_compatible_adapter(
     let provider = provider.to_ascii_lowercase();
     let endpoint = endpoint.trim();
 
-    // Per provider: resolved base URL and the litellm-style model prefix to strip.
-    let (base_url, strip_prefix): (Option<String>, Option<&str>) = match provider.as_str() {
+    // Per provider: resolved base URL and whether to strip a leading litellm
+    // provider prefix from the model. `custom` / `openai_compatible` pass the
+    // model verbatim (the user supplied the exact slug their endpoint expects);
+    // every other provider strips one litellm provider segment for parity with
+    // Python's litellm routing.
+    let (base_url, strip): (Option<String>, bool) = match provider.as_str() {
         // Empty endpoint → None so the adapter uses its OpenAI default.
-        "openai" => (non_empty(endpoint), None),
-        "ollama" => (
-            Some(endpoint_or(endpoint, OLLAMA_DEFAULT_ENDPOINT)),
-            Some("ollama/"),
-        ),
-        "mistral" => (
-            Some(endpoint_or(endpoint, MISTRAL_DEFAULT_ENDPOINT)),
-            Some("mistral/"),
-        ),
-        "gemini" => (
-            Some(endpoint_or(endpoint, GEMINI_DEFAULT_ENDPOINT)),
-            Some("gemini/"),
-        ),
+        "openai" => (non_empty(endpoint), true),
+        "ollama" => (Some(endpoint_or(endpoint, OLLAMA_DEFAULT_ENDPOINT)), true),
+        "mistral" => (Some(endpoint_or(endpoint, MISTRAL_DEFAULT_ENDPOINT)), true),
+        "gemini" => (Some(endpoint_or(endpoint, GEMINI_DEFAULT_ENDPOINT)), true),
         "custom" | "openai_compatible" => {
             if endpoint.is_empty() {
                 return Err(LlmError::ConfigError(format!(
                     "llm_endpoint must be configured for provider '{provider}'"
                 )));
             }
-            (Some(endpoint.to_string()), None)
+            (Some(endpoint.to_string()), false)
         }
         other => {
             return Err(LlmError::ConfigError(format!(
@@ -106,9 +172,31 @@ pub fn build_openai_compatible_adapter(
         ));
     }
 
-    let model = match strip_prefix {
-        Some(prefix) => model.strip_prefix(prefix).unwrap_or(model),
-        None => model,
+    let model = if strip {
+        let (stripped, prefix) = strip_litellm_provider_prefix(model);
+        // A stripped prefix that differs from the configured provider is a
+        // configuration smell: e.g. `provider=openai` + `model=anthropic/claude-3`
+        // would send `claude-3` to the OpenAI endpoint and 404. We still strip
+        // (this is exactly how the legitimate Baseten config
+        // `provider=openai` + `model=baseten/openai/gpt-oss-120b` works — the
+        // `baseten/` prefix is litellm routing metadata, not the OpenAI provider),
+        // but warn so a genuine mismatch is visible rather than silently mangled.
+        if let Some(prefix) = prefix
+            && prefix != provider
+        {
+            warn!(
+                configured_provider = %provider,
+                stripped_prefix = %prefix,
+                original_model = %model,
+                wire_model = %stripped,
+                "litellm model prefix does not match configured llm_provider; stripping it \
+                 and sending the remainder to the configured endpoint. If this is a real \
+                 mismatch, drop the prefix from llm_model or set llm_provider=custom.",
+            );
+        }
+        stripped
+    } else {
+        model
     };
 
     let adapter = OpenAIAdapter::new(model.to_string(), api_key.to_string(), base_url)?
@@ -152,6 +240,78 @@ mod tests {
                 .expect("adapter should build");
         // OpenAIAdapter strips the leading `openai/` litellm-style prefix.
         assert_eq!(adapter.model(), "gpt-4o-mini");
+    }
+
+    #[test]
+    fn openai_strips_only_first_litellm_provider_segment() {
+        // litellm-style Baseten config: provider=openai, model carries the
+        // litellm provider prefix `baseten/`. We must strip only `baseten/` and
+        // keep `openai/gpt-oss-120b` (Baseten's real slug — org "openai").
+        let adapter = build_openai_compatible_adapter(
+            "openai",
+            "baseten/openai/gpt-oss-120b",
+            "sk-test",
+            "https://inference.baseten.co/v1",
+            3,
+        )
+        .expect("adapter should build");
+        assert_eq!(adapter.model(), "openai/gpt-oss-120b");
+
+        // A bare `openai/` prefix against real OpenAI is stripped to the slug.
+        let adapter =
+            build_openai_compatible_adapter("openai", "openai/gpt-4o-mini", "sk-test", "", 3)
+                .expect("adapter should build");
+        assert_eq!(adapter.model(), "gpt-4o-mini");
+    }
+
+    #[test]
+    fn strip_reports_the_removed_prefix_for_mismatch_detection() {
+        // #3: the stripper surfaces which recognised prefix it removed so the
+        // builder can warn on a provider mismatch.
+        assert_eq!(
+            strip_litellm_provider_prefix("anthropic/claude-3"),
+            ("claude-3", Some("anthropic"))
+        );
+        assert_eq!(
+            strip_litellm_provider_prefix("baseten/openai/gpt-oss-120b"),
+            ("openai/gpt-oss-120b", Some("baseten"))
+        );
+        assert_eq!(
+            strip_litellm_provider_prefix("gpt-4o-mini"),
+            ("gpt-4o-mini", None)
+        );
+        // An unrecognised prefix is left in place (sent verbatim).
+        assert_eq!(
+            strip_litellm_provider_prefix("acme/model"),
+            ("acme/model", None)
+        );
+    }
+
+    #[test]
+    fn provider_mismatch_still_strips_and_builds() {
+        // #3: `provider=openai` + a non-openai litellm prefix still strips (the
+        // legitimate Baseten config relies on this) and builds; the mismatch is
+        // surfaced via a `warn!`, not by mangling silently or failing.
+        let adapter =
+            build_openai_compatible_adapter("openai", "anthropic/claude-3", "sk-test", "", 3)
+                .expect("adapter should build");
+        assert_eq!(adapter.model(), "claude-3");
+    }
+
+    #[test]
+    fn custom_provider_never_strips_prefix() {
+        // A `custom`/`openai_compatible` endpoint gets the model verbatim, even
+        // when it looks like a litellm provider prefix — the user gave the exact
+        // slug their endpoint expects.
+        let adapter = build_openai_compatible_adapter(
+            "custom",
+            "openai/gpt-oss-120b",
+            "sk-test",
+            "https://inference.baseten.co/v1",
+            3,
+        )
+        .expect("adapter should build");
+        assert_eq!(adapter.model(), "openai/gpt-oss-120b");
     }
 
     #[test]

--- a/crates/llm/src/llm_trait.rs
+++ b/crates/llm/src/llm_trait.rs
@@ -9,6 +9,17 @@ use crate::error::{LlmError, LlmResult};
 use crate::schema::generate_json_schema;
 use crate::types::{GenerationOptions, GenerationResponse, Message, MessageRole};
 
+/// A borrowed validator closure that checks whether a parsed structured-output
+/// [`Value`] satisfies the caller's target type.
+///
+/// Returns `Err(reason)` describing *why* validation failed (e.g. a serde
+/// `missing field \`type\`` message). Adapters that own a repair loop (the
+/// OpenAI adapter) feed that reason into a corrective retry, so a well-formed
+/// JSON response that omits a required field is repaired within the existing
+/// retry budget instead of aborting the pipeline. This is the Rust analogue of
+/// instructor threading the response model's validation into its retry loop.
+pub type StructuredOutputValidator<'a> = &'a (dyn Fn(&Value) -> Result<(), String> + Send + Sync);
+
 /// Object-safe base trait for LLM implementations.
 ///
 /// Provides type-erased methods that work with `serde_json::Value` for JSON schemas
@@ -57,6 +68,34 @@ pub trait Llm: Send + Sync {
         json_schema: &Value,
         options: Option<GenerationOptions>,
     ) -> LlmResult<Value>;
+
+    /// Generate structured output from messages, threading a typed `validator`
+    /// into the adapter's retry loop (type-erased).
+    ///
+    /// Behaves like [`Llm::create_structured_output_with_messages_raw`], but
+    /// `validator` reports whether a parsed [`Value`] satisfies the caller's
+    /// target type. Adapters with a repair loop (OpenAI) treat a response that
+    /// parses as JSON but fails the validator (e.g. omits a required field) as a
+    /// retryable miss and re-ask with a corrective instruction carrying the
+    /// validation error — bounded by the same `structured_output_retries`
+    /// budget as malformed/empty responses.
+    ///
+    /// The default implementation ignores `validator` and delegates to
+    /// [`Llm::create_structured_output_with_messages_raw`]; the caller's typed
+    /// wrapper ([`LlmExt::create_structured_output_with_messages`]) still
+    /// deserializes the result and surfaces any validation error. Adapters that
+    /// can benefit from validation-retry override this method.
+    async fn create_structured_output_with_messages_raw_validated(
+        &self,
+        messages: Vec<Message>,
+        json_schema: &Value,
+        options: Option<GenerationOptions>,
+        validator: StructuredOutputValidator<'_>,
+    ) -> LlmResult<Value> {
+        let _ = validator;
+        self.create_structured_output_with_messages_raw(messages, json_schema, options)
+            .await
+    }
 
     /// Get the model identifier.
     fn model(&self) -> &str;
@@ -130,13 +169,20 @@ pub trait LlmExt: Llm {
     where
         T: Serialize + DeserializeOwned + JsonSchema + Send,
     {
-        let schema = generate_json_schema::<T>();
-        let value = self
-            .create_structured_output_raw(text_input, system_prompt, &schema, options)
-            .await?;
-        serde_json::from_value(value).map_err(|e| {
-            LlmError::DeserializationError(format!("Failed to deserialize structured output: {e}"))
-        })
+        // Route through the messages path so `T`'s validation is threaded into
+        // the adapter's retry loop (instructor parity).
+        let messages = vec![
+            Message {
+                role: MessageRole::System,
+                content: system_prompt.to_string(),
+            },
+            Message {
+                role: MessageRole::User,
+                content: text_input.to_string(),
+            },
+        ];
+        self.create_structured_output_with_messages::<T>(messages, options)
+            .await
     }
 
     /// Generate structured output from custom messages.
@@ -152,8 +198,18 @@ pub trait LlmExt: Llm {
         T: Serialize + DeserializeOwned + JsonSchema + Send,
     {
         let schema = generate_json_schema::<T>();
+        // Trial-deserialize into `T` so the adapter can retry a well-formed but
+        // incomplete response (e.g. one missing a required field) with a
+        // corrective instruction, rather than failing the whole pipeline.
+        let validator = |value: &Value| -> Result<(), String> {
+            serde_json::from_value::<T>(value.clone())
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        };
         let value = self
-            .create_structured_output_with_messages_raw(messages, &schema, options)
+            .create_structured_output_with_messages_raw_validated(
+                messages, &schema, options, &validator,
+            )
             .await?;
         serde_json::from_value(value).map_err(|e| {
             LlmError::DeserializationError(format!("Failed to deserialize structured output: {e}"))

--- a/crates/llm/src/llm_trait.rs
+++ b/crates/llm/src/llm_trait.rs
@@ -1,5 +1,7 @@
 //! LLM trait definition for structured output generation.
 
+use std::sync::Mutex;
+
 use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::{Serialize, de::DeserializeOwned};
@@ -201,16 +203,41 @@ pub trait LlmExt: Llm {
         // Trial-deserialize into `T` so the adapter can retry a well-formed but
         // incomplete response (e.g. one missing a required field) with a
         // corrective instruction, rather than failing the whole pipeline.
+        //
+        // The successfully-deserialized `T` is captured here and reused below,
+        // avoiding a second full `from_value` (and the `value.clone()` a
+        // borrow-only validator would need): the adapter returns the exact
+        // `Value` that last passed the validator, so the captured `T` corresponds
+        // to it. `Mutex<Option<T>>` keeps the borrowed closure `Send + Sync` as
+        // the trait's validator type requires.
+        let captured: Mutex<Option<T>> = Mutex::new(None);
         let validator = |value: &Value| -> Result<(), String> {
-            serde_json::from_value::<T>(value.clone())
-                .map(|_| ())
-                .map_err(|e| e.to_string())
+            match serde_json::from_value::<T>(value.clone()) {
+                Ok(typed) => {
+                    // A poisoned lock (a prior panic) just means we skip the
+                    // reuse optimisation and re-deserialize below — never panic.
+                    if let Ok(mut guard) = captured.lock() {
+                        *guard = Some(typed);
+                    }
+                    Ok(())
+                }
+                Err(e) => Err(e.to_string()),
+            }
         };
         let value = self
             .create_structured_output_with_messages_raw_validated(
                 messages, &schema, options, &validator,
             )
             .await?;
+        // Reuse the `T` produced by the validator when the adapter actually ran
+        // it (the normal path). Adapters whose `_validated` default impl ignores
+        // the validator leave `captured` empty, so fall back to deserializing the
+        // returned `Value` once.
+        if let Ok(mut guard) = captured.lock()
+            && let Some(typed) = guard.take()
+        {
+            return Ok(typed);
+        }
         serde_json::from_value(value).map_err(|e| {
             LlmError::DeserializationError(format!("Failed to deserialize structured output: {e}"))
         })

--- a/crates/llm/src/mock/recording.rs
+++ b/crates/llm/src/mock/recording.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 
 use super::cassette::{CassetteEntry, CassetteMethod, LlmCassette, input_hash, vision_hash};
 use crate::error::LlmResult;
-use crate::llm_trait::Llm;
+use crate::llm_trait::{Llm, StructuredOutputValidator};
 use crate::types::{GenerationOptions, GenerationResponse, Message, MessageRole};
 
 /// Maximum length (in characters) of the recorded user-input preview.
@@ -139,6 +139,44 @@ impl Llm for RecordingLlm {
         let response = self
             .inner
             .create_structured_output_with_messages_raw(messages, json_schema, options)
+            .await?;
+        self.record(
+            hash,
+            CassetteEntry {
+                method: CassetteMethod::StructuredOutput,
+                user_input_preview: preview,
+                schema_name,
+                response: response.clone(),
+            },
+        );
+        Ok(response)
+    }
+
+    /// Must be overridden (not left to the trait default) so the caller's typed
+    /// `validator` reaches the wrapped real adapter's repair loop. The default
+    /// impl drops the validator and delegates to
+    /// `create_structured_output_with_messages_raw`, which would bypass
+    /// validation-retry (a well-formed response omitting a required field would
+    /// fail the pipeline instead of being re-asked). We forward the validator to
+    /// the inner adapter and record the (repaired) response.
+    async fn create_structured_output_with_messages_raw_validated(
+        &self,
+        messages: Vec<Message>,
+        json_schema: &Value,
+        options: Option<GenerationOptions>,
+        validator: StructuredOutputValidator<'_>,
+    ) -> LlmResult<Value> {
+        let hash = input_hash(&messages, Some(json_schema));
+        let preview = user_input_preview(&messages);
+        let schema_name = schema_name(json_schema);
+        let response = self
+            .inner
+            .create_structured_output_with_messages_raw_validated(
+                messages,
+                json_schema,
+                options,
+                validator,
+            )
             .await?;
         self.record(
             hash,
@@ -366,6 +404,77 @@ mod tests {
             .expect("one recorded entry");
         assert_eq!(entry.method, CassetteMethod::Generate);
         assert_eq!(entry.response, Value::String("\"hello\"".to_string()));
+    }
+
+    // Distinguishes which inner trait method a wrapper delegates to: `_raw`
+    // returns `{"marker":"raw"}`, `_validated` returns `{"marker":"validated"}`.
+    struct MarkerLlm;
+
+    #[async_trait]
+    impl Llm for MarkerLlm {
+        async fn generate(
+            &self,
+            _messages: Vec<Message>,
+            _options: Option<GenerationOptions>,
+        ) -> LlmResult<GenerationResponse> {
+            unimplemented!()
+        }
+
+        async fn create_structured_output_with_messages_raw(
+            &self,
+            _messages: Vec<Message>,
+            _json_schema: &Value,
+            _options: Option<GenerationOptions>,
+        ) -> LlmResult<Value> {
+            Ok(json!({"marker": "raw"}))
+        }
+
+        async fn create_structured_output_with_messages_raw_validated(
+            &self,
+            _messages: Vec<Message>,
+            _json_schema: &Value,
+            _options: Option<GenerationOptions>,
+            _validator: crate::llm_trait::StructuredOutputValidator<'_>,
+        ) -> LlmResult<Value> {
+            Ok(json!({"marker": "validated"}))
+        }
+
+        fn model(&self) -> &str {
+            "marker"
+        }
+    }
+
+    #[tokio::test]
+    async fn validated_path_delegates_to_inner_validated() {
+        // #2: RecordingLlm must forward the typed validator to the inner
+        // adapter's `_validated` method. If it fell back to the trait default it
+        // would call `_with_messages_raw` (returning the "raw" marker) and bypass
+        // validation-retry.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("cassette.json");
+        let recorder = RecordingLlm::new(Arc::new(MarkerLlm), &path);
+
+        let schema = json!({"title": "KnowledgeGraph", "type": "object"});
+        let validate = |_: &Value| Ok(());
+        let value = recorder
+            .create_structured_output_with_messages_raw_validated(
+                graph_msgs(),
+                &schema,
+                None,
+                &validate,
+            )
+            .await
+            .expect("validated delegation");
+
+        assert_eq!(
+            value,
+            json!({"marker": "validated"}),
+            "must delegate to inner `_validated`, not `_with_messages_raw`"
+        );
+        // The delegated response is still recorded.
+        recorder.flush().expect("flush");
+        let cassette = LlmCassette::load(&path).expect("load");
+        assert_eq!(cassette.entries.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/llm/src/mock/throttle.rs
+++ b/crates/llm/src/mock/throttle.rs
@@ -33,7 +33,7 @@ use serde_json::Value;
 use tokio::time::Instant;
 
 use crate::error::{LlmError, LlmResult};
-use crate::llm_trait::Llm;
+use crate::llm_trait::{Llm, StructuredOutputValidator};
 use crate::types::{GenerationOptions, GenerationResponse, Message};
 
 /// Rolling window over which [`ThrottleConfig::rpm_limit`] is enforced.
@@ -166,6 +166,28 @@ impl Llm for ThrottleLlm {
             .await
     }
 
+    /// Overridden so the caller's typed `validator` reaches the wrapped real
+    /// adapter's repair loop (the trait default would drop it and delegate to the
+    /// non-validated method, bypassing validation-retry). The gate still counts
+    /// and throttles exactly one call per structured-output request.
+    async fn create_structured_output_with_messages_raw_validated(
+        &self,
+        messages: Vec<Message>,
+        json_schema: &Value,
+        options: Option<GenerationOptions>,
+        validator: StructuredOutputValidator<'_>,
+    ) -> LlmResult<Value> {
+        self.gate().await?;
+        self.inner
+            .create_structured_output_with_messages_raw_validated(
+                messages,
+                json_schema,
+                options,
+                validator,
+            )
+            .await
+    }
+
     async fn transcribe_image(
         &self,
         image_bytes: &[u8],
@@ -282,6 +304,61 @@ mod tests {
             .expect("structured");
         assert_eq!(t.metrics().total_calls, 2);
         assert_eq!(t.metrics().allowed, 2);
+    }
+
+    // Returns different markers per method so a test can tell which inner method
+    // a wrapper delegated to.
+    struct MarkerLlm;
+
+    #[async_trait]
+    impl Llm for MarkerLlm {
+        async fn generate(
+            &self,
+            _messages: Vec<Message>,
+            _options: Option<GenerationOptions>,
+        ) -> LlmResult<GenerationResponse> {
+            unimplemented!()
+        }
+
+        async fn create_structured_output_with_messages_raw(
+            &self,
+            _messages: Vec<Message>,
+            _json_schema: &Value,
+            _options: Option<GenerationOptions>,
+        ) -> LlmResult<Value> {
+            Ok(json!({"marker": "raw"}))
+        }
+
+        async fn create_structured_output_with_messages_raw_validated(
+            &self,
+            _messages: Vec<Message>,
+            _json_schema: &Value,
+            _options: Option<GenerationOptions>,
+            _validator: crate::llm_trait::StructuredOutputValidator<'_>,
+        ) -> LlmResult<Value> {
+            Ok(json!({"marker": "validated"}))
+        }
+
+        fn model(&self) -> &str {
+            "marker"
+        }
+    }
+
+    #[tokio::test]
+    async fn validated_path_delegates_to_inner_validated_and_counts_once() {
+        // #2: ThrottleLlm must forward the validator to the inner adapter's
+        // `_validated` (not the trait default, which would call `_raw` and bypass
+        // validation-retry), while still counting exactly one gated call.
+        let t = ThrottleLlm::new(Arc::new(MarkerLlm), ThrottleConfig::default());
+        let schema = json!({"type": "object"});
+        let validate = |_: &Value| Ok(());
+        let value = t
+            .create_structured_output_with_messages_raw_validated(msgs(), &schema, None, &validate)
+            .await
+            .expect("validated delegation");
+        assert_eq!(value, json!({"marker": "validated"}));
+        assert_eq!(t.metrics().total_calls, 1);
+        assert_eq!(t.metrics().allowed, 1);
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/llm/tests/openai_structured_output.rs
+++ b/crates/llm/tests/openai_structured_output.rs
@@ -13,9 +13,32 @@
     reason = "integration test code — panics are acceptable"
 )]
 
-use cognee_llm::{Llm, LlmError, OpenAIAdapter};
+use cognee_llm::{Llm, LlmError, LlmExt, OpenAIAdapter};
 use httpmock::prelude::*;
 use serde_json::json;
+
+/// A structured-output target with two required fields. `type` is the field the
+/// live regression (real OpenAI, gpt-4o-mini) intermittently omitted under tool
+/// calling, aborting cognify with `missing field \`type\``.
+#[derive(Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+struct Node {
+    name: String,
+    r#type: String,
+}
+
+/// Body of an OpenAI tool-call response whose `arguments` is `payload`
+/// (already a JSON string). Helper to keep the mock bodies readable.
+fn tool_call_response(payload_json: &str) -> String {
+    let escaped = serde_json::to_string(payload_json).expect("string escapes");
+    format!(
+        r#"{{"id":"x","object":"chat.completion","created":1,"model":"m",
+            "choices":[{{"index":0,"message":{{"role":"assistant","tool_calls":[
+                {{"id":"c1","type":"function","function":{{
+                    "name":"extract_structured_data","arguments":{escaped}
+                }}}}
+            ]}},"finish_reason":"tool_calls"}}]}}"#
+    )
+}
 
 #[tokio::test]
 async fn malformed_tool_call_arguments_surface_deserialization_error() {
@@ -100,4 +123,94 @@ async fn empty_tool_call_arguments_fall_through_to_json_mode() {
         .expect("should fall through to JSON mode and parse content");
 
     assert_eq!(value, json!({"foo":"bar"}));
+}
+
+#[tokio::test]
+async fn typed_validation_failure_retries_with_corrective_and_succeeds() {
+    // Regression: under tool calling (no strict schema) the model can return
+    // well-formed JSON that omits a required field. The first response omits
+    // `type`; deserializing into `Node` fails with `missing field \`type\``.
+    // The adapter must re-ask with a corrective instruction and succeed on the
+    // second, complete response — instead of aborting the pipeline.
+    let server = MockServer::start_async().await;
+
+    // Attempt 1: no corrective marker in the body yet → incomplete payload.
+    let incomplete = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_excludes("failed validation");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(tool_call_response(r#"{"name":"Alice"}"#));
+        })
+        .await;
+
+    // Attempt 2: the corrective instruction (carrying the validation error) is
+    // now present in the request body → complete payload.
+    let complete = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes("failed validation");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(tool_call_response(r#"{"name":"Alice","type":"Person"}"#));
+        })
+        .await;
+
+    let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(3);
+
+    let node: Node = adapter
+        .create_structured_output("some input", "extract a node", None)
+        .await
+        .expect("second (complete) response must satisfy the validator");
+
+    assert_eq!(node.name, "Alice");
+    assert_eq!(node.r#type, "Person");
+    // Exactly one retry fired: one incomplete hit, one corrective hit.
+    incomplete.assert_calls_async(1).await;
+    complete.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn typed_validation_failure_exhausts_retries_and_surfaces_error() {
+    // Every attempt returns well-formed JSON that still omits the required
+    // `type` field. After exhausting `structured_output_retries`, the adapter
+    // must surface a `DeserializationError` naming the missing field rather
+    // than silently returning an invalid object.
+    let server = MockServer::start_async().await;
+    let m = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(tool_call_response(r#"{"name":"Alice"}"#));
+        })
+        .await;
+
+    let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(3);
+
+    let err = adapter
+        .create_structured_output::<Node>("some input", "extract a node", None)
+        .await
+        .expect_err("all responses omit a required field → must fail");
+
+    match err {
+        LlmError::DeserializationError(msg) => {
+            assert!(
+                msg.contains("missing field `type`"),
+                "error should name the missing required field, got: {msg}"
+            );
+        }
+        other => panic!("expected DeserializationError, got: {other:?}"),
+    }
+    // All three attempts were made (no early success).
+    m.assert_calls_async(3).await;
 }

--- a/crates/llm/tests/openai_structured_output.rs
+++ b/crates/llm/tests/openai_structured_output.rs
@@ -1,12 +1,15 @@
 //! Structured-output behaviour tests for the OpenAI adapter using `httpmock`
 //! (no real API calls). Cover the tool-calling retry/fallback semantics:
 //!
-//! - #2: a non-empty but invalid tool-call `arguments` payload surfaces a clear
-//!   `DeserializationError` (rather than being silently swallowed) once retries
-//!   are exhausted.
-//! - #7 / #4: a tool call with missing/empty `arguments` does not crash the
-//!   response parse; the adapter retries and then falls through to the JSON-mode
-//!   path, which succeeds.
+//! - #6: an empty tool-call `arguments` string no longer shadows JSON echoed in
+//!   `message.content` — the tool path uses the content on the first attempt.
+//! - #4: a non-JSON tool-call response does not hard-error; the adapter falls
+//!   through to the legacy function-calling / JSON-mode requests, which can
+//!   still succeed (or surface the fallback's own error when all modes fail).
+//! - #8: the JSON-mode fallback retries a non-empty-but-invalid payload instead
+//!   of giving up after a single attempt.
+//! - typed validation-retry: a well-formed response omitting a required field is
+//!   re-asked with a corrective instruction and eventually surfaces an error.
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,
@@ -41,7 +44,13 @@ fn tool_call_response(payload_json: &str) -> String {
 }
 
 #[tokio::test]
-async fn malformed_tool_call_arguments_surface_deserialization_error() {
+async fn all_modes_failing_surfaces_the_fallback_error() {
+    // #4: a non-JSON tool-call response must NOT hard-error out of the tool loop.
+    // The adapter falls through to legacy function-calling and then JSON mode.
+    // Here every mode fails: the tool call has invalid `arguments`, the message
+    // also carries invalid non-blank `content`, and there is no `function_call`.
+    // The surfaced error therefore comes from the JSON-mode fallback (carrying
+    // its `content`), proving control fell through past tool calling.
     let server = MockServer::start_async().await;
     let _m = server
         .mock_async(|when, then| {
@@ -51,7 +60,9 @@ async fn malformed_tool_call_arguments_surface_deserialization_error() {
                 .body(
                     r#"{
                         "id":"x","object":"chat.completion","created":1,"model":"m",
-                        "choices":[{"index":0,"message":{"role":"assistant","tool_calls":[
+                        "choices":[{"index":0,"message":{"role":"assistant",
+                            "content":"definitely not json",
+                            "tool_calls":[
                             {"id":"c1","type":"function","function":{
                                 "name":"extract_structured_data",
                                 "arguments":"{ this is not valid json"
@@ -71,27 +82,92 @@ async fn malformed_tool_call_arguments_surface_deserialization_error() {
     let err = adapter
         .create_structured_output_raw("input text", "system prompt", &schema, None)
         .await
-        .expect_err("malformed non-empty arguments must surface an error");
+        .expect_err("all modes fail → must surface an error");
 
     match err {
         LlmError::DeserializationError(msg) => {
             assert!(
-                msg.contains("this is not valid json"),
-                "error should carry the raw payload, got: {msg}"
+                msg.contains("definitely not json"),
+                "fell through to JSON mode; error should carry its content, got: {msg}"
             );
         }
-        other => panic!("expected DeserializationError, got: {other:?}"),
+        other => panic!("expected DeserializationError from JSON-mode fallback, got: {other:?}"),
     }
 }
 
 #[tokio::test]
-async fn empty_tool_call_arguments_fall_through_to_json_mode() {
-    // The tool call carries no usable `arguments` (missing), but the same message
-    // also echoes valid JSON in `content`. The tool-calling path finds only an
-    // empty argument string (retries, does not crash on the missing field — #7),
-    // then falls through to the JSON-mode path which parses `content`.
+async fn malformed_tool_call_falls_through_to_json_mode_and_succeeds() {
+    // #4: the tool call returns invalid `arguments` (and no content), so tool
+    // calling and legacy function-calling both fail. The JSON-mode request
+    // (`response_format: json_object`) then returns a valid object → success.
     let server = MockServer::start_async().await;
-    let _m = server
+    // Tool-calling + legacy requests: no `json_object` response_format.
+    let non_json_mode = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_excludes("json_object");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "id":"x","object":"chat.completion","created":1,"model":"m",
+                        "choices":[{"index":0,"message":{"role":"assistant","tool_calls":[
+                            {"id":"c1","type":"function","function":{
+                                "name":"extract_structured_data",
+                                "arguments":"{ not valid json"
+                            }}
+                        ]},"finish_reason":"tool_calls"}]
+                    }"#,
+                );
+        })
+        .await;
+    // JSON-mode request: carries `response_format: {type: json_object}`.
+    let json_mode = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes("json_object");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "id":"x","object":"chat.completion","created":1,"model":"m",
+                        "choices":[{"index":0,"message":{"role":"assistant",
+                            "content":"{\"foo\":\"bar\"}"
+                        },"finish_reason":"stop"}]
+                    }"#,
+                );
+        })
+        .await;
+
+    let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(2);
+
+    let schema = json!({"type":"object","properties":{"foo":{"type":"string"}}});
+    let value = adapter
+        .create_structured_output_raw("input text", "system prompt", &schema, None)
+        .await
+        .expect("must fall through tool/legacy to JSON mode and parse content");
+
+    assert_eq!(value, json!({"foo":"bar"}));
+    assert!(
+        non_json_mode.calls_async().await >= 1,
+        "tool/legacy attempted"
+    );
+    json_mode.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn empty_tool_call_arguments_use_content_on_tool_path() {
+    // #6: the tool call carries an empty `arguments` string, but the same message
+    // echoes valid JSON in `content`. The empty `arguments` must be treated as
+    // absent so the content fallback engages *within the tool path* — resolved on
+    // the first request, without falling through to the JSON-mode fallback.
+    let server = MockServer::start_async().await;
+    let m = server
         .mock_async(|when, then| {
             when.method(POST).path("/chat/completions");
             then.status(200)
@@ -103,7 +179,7 @@ async fn empty_tool_call_arguments_fall_through_to_json_mode() {
                             "role":"assistant",
                             "content":"{\"foo\":\"bar\"}",
                             "tool_calls":[{"id":"c1","type":"function","function":{
-                                "name":"extract_structured_data"
+                                "name":"extract_structured_data","arguments":"   "
                             }}]
                         },"finish_reason":"tool_calls"}]
                     }"#,
@@ -114,15 +190,98 @@ async fn empty_tool_call_arguments_fall_through_to_json_mode() {
     let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
         .unwrap()
         .with_network_retries(0)
-        .with_structured_output_retries(1);
+        .with_structured_output_retries(3);
 
     let schema = json!({"type":"object","properties":{"foo":{"type":"string"}}});
     let value = adapter
         .create_structured_output_raw("input text", "system prompt", &schema, None)
         .await
-        .expect("should fall through to JSON mode and parse content");
+        .expect("empty arguments must not shadow content");
 
     assert_eq!(value, json!({"foo":"bar"}));
+    // Exactly one request: content used on the tool path, no retry/fallthrough.
+    m.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn json_mode_retries_nonblank_invalid_then_succeeds() {
+    // #8: force the flow into JSON mode (tool/legacy produce no usable object),
+    // where the first JSON-mode response is non-empty but invalid JSON. The
+    // narrowed `is_blank`-only retry condition would give up after one attempt;
+    // the fix retries with the corrective instruction and succeeds.
+    let server = MockServer::start_async().await;
+    // Tool + legacy: blank tool arguments, no content → fall through.
+    let _non_json = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_excludes("json_object");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "id":"x","object":"chat.completion","created":1,"model":"m",
+                        "choices":[{"index":0,"message":{"role":"assistant","tool_calls":[
+                            {"id":"c1","type":"function","function":{
+                                "name":"extract_structured_data","arguments":""
+                            }}
+                        ]},"finish_reason":"tool_calls"}]
+                    }"#,
+                );
+        })
+        .await;
+    // JSON mode, first attempt (no corrective marker yet): non-blank invalid.
+    let json_bad = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes("json_object")
+                .body_excludes("Return ONLY one valid JSON object");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "id":"x","object":"chat.completion","created":1,"model":"m",
+                        "choices":[{"index":0,"message":{"role":"assistant",
+                            "content":"Sure! Here is the JSON: {oops"
+                        },"finish_reason":"stop"}]
+                    }"#,
+                );
+        })
+        .await;
+    // JSON mode, corrective retry: valid object.
+    let json_good = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes("Return ONLY one valid JSON object");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "id":"x","object":"chat.completion","created":1,"model":"m",
+                        "choices":[{"index":0,"message":{"role":"assistant",
+                            "content":"{\"foo\":\"bar\"}"
+                        },"finish_reason":"stop"}]
+                    }"#,
+                );
+        })
+        .await;
+
+    let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(3);
+
+    let schema = json!({"type":"object","properties":{"foo":{"type":"string"}}});
+    let value = adapter
+        .create_structured_output_raw("input text", "system prompt", &schema, None)
+        .await
+        .expect("JSON mode must retry the invalid payload and then succeed");
+
+    assert_eq!(value, json!({"foo":"bar"}));
+    json_bad.assert_calls_async(1).await;
+    json_good.assert_calls_async(1).await;
 }
 
 #[tokio::test]

--- a/crates/llm/tests/openai_structured_output.rs
+++ b/crates/llm/tests/openai_structured_output.rs
@@ -1,0 +1,103 @@
+//! Structured-output behaviour tests for the OpenAI adapter using `httpmock`
+//! (no real API calls). Cover the tool-calling retry/fallback semantics:
+//!
+//! - #2: a non-empty but invalid tool-call `arguments` payload surfaces a clear
+//!   `DeserializationError` (rather than being silently swallowed) once retries
+//!   are exhausted.
+//! - #7 / #4: a tool call with missing/empty `arguments` does not crash the
+//!   response parse; the adapter retries and then falls through to the JSON-mode
+//!   path, which succeeds.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code — panics are acceptable"
+)]
+
+use cognee_llm::{Llm, LlmError, OpenAIAdapter};
+use httpmock::prelude::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn malformed_tool_call_arguments_surface_deserialization_error() {
+    let server = MockServer::start_async().await;
+    let _m = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "id":"x","object":"chat.completion","created":1,"model":"m",
+                        "choices":[{"index":0,"message":{"role":"assistant","tool_calls":[
+                            {"id":"c1","type":"function","function":{
+                                "name":"extract_structured_data",
+                                "arguments":"{ this is not valid json"
+                            }}
+                        ]},"finish_reason":"tool_calls"}]
+                    }"#,
+                );
+        })
+        .await;
+
+    let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(2);
+
+    let schema = json!({"type":"object","properties":{"foo":{"type":"string"}}});
+    let err = adapter
+        .create_structured_output_raw("input text", "system prompt", &schema, None)
+        .await
+        .expect_err("malformed non-empty arguments must surface an error");
+
+    match err {
+        LlmError::DeserializationError(msg) => {
+            assert!(
+                msg.contains("this is not valid json"),
+                "error should carry the raw payload, got: {msg}"
+            );
+        }
+        other => panic!("expected DeserializationError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn empty_tool_call_arguments_fall_through_to_json_mode() {
+    // The tool call carries no usable `arguments` (missing), but the same message
+    // also echoes valid JSON in `content`. The tool-calling path finds only an
+    // empty argument string (retries, does not crash on the missing field — #7),
+    // then falls through to the JSON-mode path which parses `content`.
+    let server = MockServer::start_async().await;
+    let _m = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "id":"x","object":"chat.completion","created":1,"model":"m",
+                        "choices":[{"index":0,"message":{
+                            "role":"assistant",
+                            "content":"{\"foo\":\"bar\"}",
+                            "tool_calls":[{"id":"c1","type":"function","function":{
+                                "name":"extract_structured_data"
+                            }}]
+                        },"finish_reason":"tool_calls"}]
+                    }"#,
+                );
+        })
+        .await;
+
+    let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(1);
+
+    let schema = json!({"type":"object","properties":{"foo":{"type":"string"}}});
+    let value = adapter
+        .create_structured_output_raw("input text", "system prompt", &schema, None)
+        .await
+        .expect("should fall through to JSON mode and parse content");
+
+    assert_eq!(value, json!({"foo":"bar"}));
+}

--- a/crates/llm/tests/transcribe_image_live.rs
+++ b/crates/llm/tests/transcribe_image_live.rs
@@ -9,17 +9,20 @@
 //! `OPENAI_MODEL`) environment variables pointing at a vision-capable model.
 
 use cognee_llm::Llm;
-use cognee_llm::adapters::OpenAIAdapter;
+use cognee_llm::build_openai_compatible_adapter;
 
 #[tokio::test]
 #[ignore] // Requires OPENAI_TOKEN and a vision-capable model
 async fn live_transcribe_image() {
     let api_key = std::env::var("OPENAI_TOKEN").expect("OPENAI_TOKEN required for live test");
-    let base_url = std::env::var("OPENAI_URL").ok();
+    let base_url = std::env::var("OPENAI_URL").unwrap_or_default();
     let model = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-4o-mini".to_string());
 
-    let adapter = OpenAIAdapter::new(model, api_key, base_url)
-        .expect("Failed to create OpenAIAdapter for live vision test");
+    // Route through the production factory (provider from env, default `openai`)
+    // so litellm-style model prefixes are stripped exactly as in a real run.
+    let provider = std::env::var("LLM_PROVIDER").unwrap_or_else(|_| "openai".to_string());
+    let adapter = build_openai_compatible_adapter(&provider, &model, &api_key, &base_url, 3)
+        .expect("Failed to create adapter for live vision test");
 
     // Minimal valid 1x1 red PNG
     let png_bytes: &[u8] = include_bytes!("fixtures/red_pixel.png");

--- a/crates/search/tests/temporal_retriever_integration.rs
+++ b/crates/search/tests/temporal_retriever_integration.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use cognee_embedding::mock::MockEmbeddingEngine;
 use cognee_graph::{GraphDBTrait, GraphDBTraitExt, LadybugAdapter};
-use cognee_llm::{Llm, OpenAIAdapter};
+use cognee_llm::{Llm, build_openai_compatible_adapter};
 use cognee_search::{
     SearchParams, SessionContext, TemporalRetriever,
     retrievers::SearchRetriever,
@@ -46,9 +46,13 @@ fn build_test_llm() -> Option<Arc<dyn Llm>> {
         .ok()
         .or_else(|| std::env::var("LLM_MODEL").ok())
         .unwrap_or_else(|| "gpt-4o-mini".to_string());
+    // Route through the production factory (provider from env, default `openai`)
+    // so litellm-style prefixes like `baseten/openai/gpt-oss-120b` are stripped
+    // exactly as in a real run — building the adapter directly would 404.
+    let provider = std::env::var("LLM_PROVIDER").unwrap_or_else(|_| "openai".to_string());
     Some(Arc::new(
-        OpenAIAdapter::new(model, token, Some(url))
-            .expect("OpenAIAdapter::new should succeed with valid args"),
+        build_openai_compatible_adapter(&provider, &model, &token, &url, 3)
+            .expect("build_openai_compatible_adapter should succeed with valid args"),
     ))
 }
 

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -164,8 +164,18 @@ pub fn create_openai_adapter_from_env() -> Arc<OpenAIAdapter> {
     let base_url = require_env("OPENAI_URL");
     let api_token = require_env("OPENAI_TOKEN");
     let model = llm_model_from_env();
+    // Route through the production factory so litellm-style provider prefixes
+    // (`openai/`, `baseten/`, …) are stripped exactly as in a real run — e.g.
+    // `baseten/openai/gpt-oss-120b` → `openai/gpt-oss-120b`. Building the adapter
+    // directly would send the prefixed slug verbatim and 404.
+    //
+    // NOTE: the default provider here is `openai`, which strips a leading
+    // `openai/` segment. A custom endpoint whose *real* model slug legitimately
+    // begins with `openai/` (org "openai") must therefore set `LLM_PROVIDER=custom`
+    // (or `openai_compatible`) so the slug is passed through verbatim.
+    let provider = std::env::var("LLM_PROVIDER").unwrap_or_else(|_| "openai".to_string());
     Arc::new(
-        OpenAIAdapter::new(model, api_token, Some(base_url))
+        cognee_llm::build_openai_compatible_adapter(&provider, &model, &api_token, &base_url, 3)
             .unwrap_or_else(|e| panic!("❌ Failed to create OpenAI adapter: {e}")),
     )
 }


### PR DESCRIPTION
Makes cognee-rs's OpenAI-compatible adapter behave like Python cognee's litellm/instructor path, so cognee works against custom OpenAI-compatible endpoints (e.g. **Baseten**) whose model slug legitimately begins with `openai/`.

## Changes
- **`factory.rs`** — strip exactly one leading litellm-style provider prefix (`baseten/`, `openai/`, `ollama/`, `mistral/`, `gemini/`) instead of the adapter unconditionally stripping `openai/`; `warn!` on provider/prefix mismatch. `baseten/openai/gpt-oss-120b` → `openai/gpt-oss-120b`; `openai/gpt-4o-mini` → `gpt-4o-mini`.
- **`adapters/openai.rs`** — structured output via OpenAI **tool calling** (`tools` + forced `tool_choice`) instead of strict `response_format: json_schema`. (Strict json_schema drives server-side grammar-constrained decoding, which returns HTTP 501 on some backends incl. Baseten gpt-oss-120b.) Bounded retry with a corrective instruction on malformed/empty responses; tolerate missing tool-call `arguments`/`function`.
- Route the direct-construction integration tests + `test-utils` through `build_openai_compatible_adapter` so prefixed models are stripped like production.

## Review findings addressed
#2 (dead-code error branch), #3 (over-broad prefix strip → mismatch warning), #4 (retry-on-empty), #5 (tests bypassing the factory), #7 (missing arguments/function), #8 (identical retry request). **#1** (required-field guarantee): a strict/all-required schema reproduces the 501, so it is intentionally not used; required-field parity is approximated by the retry-with-corrective-instruction loop, and typed-validation retry against `T` is a documented follow-up.

## Verification
- `cargo build`/`clippy` clean; `cargo test -p cognee-llm` 79 lib + new `openai_structured_output.rs` (2) green.
- Mock-cassette bench replays `success:true`.
- Live Baseten smoke (gpt-oss-120b): tool-calling path succeeds end-to-end, **zero HTTP 501/404** (dense-chunk truncation is a separate `max_tokens`/`LLM_ARGS` plumbing gap, not this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)