### PR TITLE
chore: re-record 50-small perf cassette + ignore .env*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ Thumbs.db
 Desktop.ini
 
 # Environment variables
-.env
+.env*
 
 # Telemetry runtime artifacts (anonymous instance ID files)
 .anon_id

--- a/scripts/perf/fixtures/cassette.json
+++ b/scripts/perf/fixtures/cassette.json
@@ -7,38 +7,26 @@
       "user_input_preview": "Title: Adopting a Cat\n\nWe adopted our cat Luna from a local shelter in 2020. She was shy at first and hid under the couc",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "Luna was adopted from a local shelter in 2020.",
-            "relationship_name": "adopted_from",
-            "source_node_id": "Luna",
-            "target_node_id": "local_shelter"
-          },
-          {
-            "description": "Luna has a distinctive orange patch on her left ear.",
-            "relationship_name": "has_feature",
-            "source_node_id": "Luna",
-            "target_node_id": "orange_patch"
-          }
-        ],
         "nodes": [
           {
-            "description": "Luna is a cat who was adopted from a local shelter.",
             "id": "Luna",
             "name": "Luna",
+            "description": "A cat adopted from a local shelter.",
             "type": "ANIMAL"
           },
           {
-            "description": "A local shelter where pets are available for adoption.",
-            "id": "local_shelter",
-            "name": "local shelter",
-            "type": "ORGANIZATION"
-          },
+            "id": "2020",
+            "name": "2020",
+            "description": "The year when Luna was adopted.",
+            "type": "DATE"
+          }
+        ],
+        "edges": [
           {
-            "description": "An orange patch on Luna's left ear.",
-            "id": "orange_patch",
-            "name": "orange patch",
-            "type": "FEATURE"
+            "source_node_id": "Luna",
+            "target_node_id": "2020",
+            "relationship_name": "adopted_in",
+            "description": "Luna was adopted in 2020."
           }
         ]
       }
@@ -48,38 +36,50 @@
       "user_input_preview": "Title: Baking Bread During Lockdown\n\nLike many people, I started baking sourdough bread during the 2020 lockdown. My fir",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The starter named Clint Yeastwood was used for baking sourdough bread.",
-            "relationship_name": "used_for",
-            "source_node_id": "Clint Yeastwood",
-            "target_node_id": "sourdough_bread"
-          },
-          {
-            "description": "The baking of sourdough bread occurred during the 2020 lockdown.",
-            "relationship_name": "occurred_during",
-            "source_node_id": "sourdough_bread",
-            "target_node_id": "lockdown_2020"
-          }
-        ],
         "nodes": [
           {
-            "description": "Clint Yeastwood is the name of a sourdough starter used for baking bread.",
-            "id": "Clint Yeastwood",
+            "id": "Baking_Bread_During_Lockdown",
+            "name": "Baking Bread During Lockdown",
+            "description": "A personal account of baking sourdough bread during the 2020 lockdown.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "Clint_Yeastwood",
             "name": "Clint Yeastwood",
+            "description": "The name given to the sourdough starter used for baking.",
             "type": "CONCEPT"
           },
           {
-            "description": "Sourdough bread is a type of bread made using a fermented dough starter.",
-            "id": "sourdough_bread",
-            "name": "Sourdough Bread",
+            "id": "sourdough",
+            "name": "sourdough",
+            "description": "A type of bread made using a fermented dough starter.",
             "type": "CONCEPT"
           },
           {
-            "description": "Lockdown refers to the period during which people were restricted to their homes due to the COVID-19 pandemic.",
             "id": "lockdown_2020",
-            "name": "2020 Lockdown",
-            "type": "CONCEPT"
+            "name": "lockdown 2020",
+            "description": "The period during which many people were confined to their homes due to the COVID-19 pandemic.",
+            "type": "DATE"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Baking_Bread_During_Lockdown",
+            "target_node_id": "sourdough",
+            "relationship_name": "involves",
+            "description": "Baking Bread During Lockdown involves making sourdough."
+          },
+          {
+            "source_node_id": "Clint_Yeastwood",
+            "target_node_id": "sourdough",
+            "relationship_name": "is_a",
+            "description": "Clint Yeastwood is a sourdough starter."
+          },
+          {
+            "source_node_id": "lockdown_2020",
+            "target_node_id": "Baking_Bread_During_Lockdown",
+            "relationship_name": "inspired",
+            "description": "The lockdown in 2020 inspired the activity of Baking Bread During Lockdown."
           }
         ]
       }
@@ -89,8 +89,8 @@
       "user_input_preview": "Title: Refactoring Legacy Code\n\nI spent three months refactoring a 10,000-line PHP file that had been accumulating featu",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the process of refactoring legacy code, specifically a large PHP file, over a three-month period. It highlights the importance of characterization tests and the methodical extraction of classes to improve code maintainability.",
-        "summary": "This chunk details a three-month effort to refactor a 10,000-line PHP file, emphasizing the use of characterization tests and gradual class extraction to enhance code safety and organization."
+        "description": "This chunk discusses the process of refactoring legacy code, specifically a large PHP file. It details the steps taken, including writing characterization tests and extracting classes, leading to a more manageable code structure.",
+        "summary": "The chunk describes a three-month effort to refactor a 10,000-line PHP file, focusing on testing and restructuring the code."
       }
     },
     "0cbc28d3b75c2b8d84e57a170520f7dd469a2ad9d75564a4b4bca93ddbf25305": {
@@ -98,8 +98,8 @@
       "user_input_preview": "Title: Setting Up a Home Network\n\nWhen I set up a mesh Wi-Fi network in my apartment, I learned more about networking th",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the process of setting up a home network, specifically a mesh Wi-Fi network, and the lessons learned during the setup. It highlights the configuration of VLANs for device separation, the implementation of Pi-hole for ad blocking, and the physical installation of Ethernet cables.",
-        "summary": "This chunk is about setting up a home network with a focus on mesh Wi-Fi, VLANs, and Pi-hole. The author shares personal experiences and technical details from the setup process."
+        "description": "This chunk discusses the experience of setting up a home network, focusing on the technical aspects and personal insights gained during the process.",
+        "summary": "The author shares their experience of setting up a mesh Wi-Fi network, highlighting the technical configurations and the benefits of their setup."
       }
     },
     "10ee273f5337fd43ae23fe7ab272253dbb4ee584d38b6d81f24c1e397bdd6502": {
@@ -107,98 +107,110 @@
       "user_input_preview": "Title: Planting a Garden\n\nIn spring 2021, I started a small vegetable garden on my balcony. I planted tomatoes, basil, a",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The vegetable garden was started in spring 2021 on the balcony.",
-            "relationship_name": "started_on",
-            "source_node_id": "vegetable_garden",
-            "target_node_id": "spring_2021"
-          },
-          {
-            "description": "Tomatoes were planted in the vegetable garden.",
-            "relationship_name": "planted",
-            "source_node_id": "vegetable_garden",
-            "target_node_id": "tomatoes"
-          },
-          {
-            "description": "Basil was planted in the vegetable garden.",
-            "relationship_name": "planted",
-            "source_node_id": "vegetable_garden",
-            "target_node_id": "basil"
-          },
-          {
-            "description": "Peppers were planted in the vegetable garden.",
-            "relationship_name": "planted",
-            "source_node_id": "vegetable_garden",
-            "target_node_id": "peppers"
-          },
-          {
-            "description": "The tomatoes thrived in the vegetable garden.",
-            "relationship_name": "thrived_in",
-            "source_node_id": "tomatoes",
-            "target_node_id": "vegetable_garden"
-          },
-          {
-            "description": "The peppers struggled with insufficient sunlight in the vegetable garden.",
-            "relationship_name": "struggled_in",
-            "source_node_id": "peppers",
-            "target_node_id": "vegetable_garden"
-          },
-          {
-            "description": "Basil was harvested every week to make pesto from the vegetable garden by August.",
-            "relationship_name": "harvested_for",
-            "source_node_id": "basil",
-            "target_node_id": "pesto"
-          },
-          {
-            "description": "The garden became a meditative morning ritual.",
-            "relationship_name": "became",
-            "source_node_id": "vegetable_garden",
-            "target_node_id": "meditative_morning_ritual"
-          }
-        ],
         "nodes": [
           {
-            "description": "A garden where vegetables are grown, started on a balcony in spring 2021.",
-            "id": "vegetable_garden",
-            "name": "Vegetable Garden",
+            "id": "Planting_a_Garden",
+            "name": "Planting a Garden",
+            "description": "A personal account of starting a vegetable garden on a balcony in spring 2021.",
             "type": "CONCEPT"
           },
           {
-            "description": "A type of plant that produces fruit, grown in the vegetable garden.",
-            "id": "tomatoes",
-            "name": "Tomatoes",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A type of herb used in cooking, grown in the vegetable garden.",
-            "id": "basil",
-            "name": "Basil",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A type of vegetable that struggled to grow due to insufficient sunlight in the vegetable garden.",
-            "id": "peppers",
-            "name": "Peppers",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A type of sauce made from basil, harvested from the vegetable garden.",
-            "id": "pesto",
-            "name": "Pesto",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "The season in which the vegetable garden was started, in the year 2021.",
             "id": "spring_2021",
             "name": "Spring 2021",
-            "type": "DATE"
+            "description": "The season when the vegetable garden was started.",
+            "type": "Date"
           },
           {
-            "description": "A morning practice that became a ritual due to the vegetable garden.",
-            "id": "meditative_morning_ritual",
-            "name": "Meditative Morning Ritual",
+            "id": "vegetable_garden",
+            "name": "Vegetable Garden",
+            "description": "A small garden planted on a balcony that includes tomatoes, basil, and peppers.",
             "type": "CONCEPT"
+          },
+          {
+            "id": "tomatoes",
+            "name": "Tomatoes",
+            "description": "A type of vegetable that thrived in the garden.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "basil",
+            "name": "Basil",
+            "description": "An herb that was harvested enough to make pesto every week.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "peppers",
+            "name": "Peppers",
+            "description": "A type of vegetable that struggled with insufficient sunlight in the garden.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "pesto",
+            "name": "Pesto",
+            "description": "A sauce made from basil that was prepared weekly from the garden's harvest.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "balcony",
+            "name": "Balcony",
+            "description": "The location where the vegetable garden was planted.",
+            "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "spring_2021",
+            "target_node_id": "vegetable_garden",
+            "relationship_name": "started_in",
+            "description": "The vegetable garden was started in spring 2021."
+          },
+          {
+            "source_node_id": "vegetable_garden",
+            "target_node_id": "tomatoes",
+            "relationship_name": "includes",
+            "description": "The vegetable garden includes tomatoes."
+          },
+          {
+            "source_node_id": "vegetable_garden",
+            "target_node_id": "basil",
+            "relationship_name": "includes",
+            "description": "The vegetable garden includes basil."
+          },
+          {
+            "source_node_id": "vegetable_garden",
+            "target_node_id": "peppers",
+            "relationship_name": "includes",
+            "description": "The vegetable garden includes peppers."
+          },
+          {
+            "source_node_id": "vegetable_garden",
+            "target_node_id": "balcony",
+            "relationship_name": "located_on",
+            "description": "The vegetable garden is located on the balcony."
+          },
+          {
+            "source_node_id": "basil",
+            "target_node_id": "pesto",
+            "relationship_name": "used_for",
+            "description": "Basil from the garden is used to make pesto."
+          },
+          {
+            "source_node_id": "peppers",
+            "target_node_id": "vegetable_garden",
+            "relationship_name": "struggled_in",
+            "description": "Peppers struggled in the vegetable garden due to insufficient sunlight."
+          },
+          {
+            "source_node_id": "vegetable_garden",
+            "target_node_id": "basil",
+            "relationship_name": "harvested",
+            "description": "Basil was harvested from the vegetable garden every week."
+          },
+          {
+            "source_node_id": "vegetable_garden",
+            "target_node_id": "Planting_a_Garden",
+            "relationship_name": "described_in",
+            "description": "The vegetable garden is described in the concept 'Planting a Garden'."
           }
         ]
       }
@@ -208,8 +220,8 @@
       "user_input_preview": "Title: Teaching Someone to Code\n\nI taught my younger cousin the basics of Python over a summer. We started with variable",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the experience of teaching coding, specifically Python, to a younger cousin, highlighting the progression from basic concepts to creating a game. It reflects on the joy of seeing the cousin's success and notes her current pursuit of computer science studies.",
-        "summary": "The chunk describes a mentorship experience in teaching Python to a younger cousin, culminating in her studying computer science at university."
+        "description": "This chunk is about teaching coding, specifically Python, to a younger cousin and the experience of mentorship.",
+        "summary": "The chunk discusses teaching Python to a younger cousin and the joy of mentorship."
       }
     },
     "1280ea71f5fb2c3fcc03b3b75a8fc0e78cb92a1ebfcff8937e823d89f66e89b7": {
@@ -217,74 +229,86 @@
       "user_input_preview": "Title: Setting Up My First Server\n\nI set up my first Linux server in 2011 — a Debian box running Apache and MySQL. I spe",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The Linux server is a Debian box running Apache and MySQL.",
-            "relationship_name": "runs_software",
-            "source_node_id": "Linux_server",
-            "target_node_id": "Debian"
-          },
-          {
-            "description": "The Linux server is a Debian box running Apache and MySQL.",
-            "relationship_name": "runs_software",
-            "source_node_id": "Linux_server",
-            "target_node_id": "Apache"
-          },
-          {
-            "description": "The Linux server is a Debian box running Apache and MySQL.",
-            "relationship_name": "runs_software",
-            "source_node_id": "Linux_server",
-            "target_node_id": "MySQL"
-          },
-          {
-            "description": "The Linux server was set up in 2011.",
-            "relationship_name": "set_up_in",
-            "source_node_id": "Linux_server",
-            "target_node_id": "2011"
-          },
-          {
-            "description": "The Linux server was hacked within a week due to default port 22 configuration.",
-            "relationship_name": "hacked_due_to",
-            "source_node_id": "Linux_server",
-            "target_node_id": "default_port_22_configuration"
-          }
-        ],
         "nodes": [
           {
-            "description": "A Linux server set up in 2011, running Debian, Apache, and MySQL.",
-            "id": "Linux_server",
-            "name": "Linux Server",
+            "id": "Linux",
+            "name": "Linux",
+            "description": "An open-source operating system kernel that is widely used in servers and other systems.",
             "type": "CONCEPT"
           },
           {
-            "description": "A Debian operating system used for the Linux server.",
             "id": "Debian",
             "name": "Debian",
+            "description": "A popular Linux distribution known for its stability and extensive package management.",
             "type": "CONCEPT"
           },
           {
-            "description": "Apache is a web server software used on the Linux server.",
             "id": "Apache",
             "name": "Apache",
+            "description": "An open-source web server software that is widely used to serve web content.",
             "type": "CONCEPT"
           },
           {
-            "description": "MySQL is a database management system used on the Linux server.",
             "id": "MySQL",
             "name": "MySQL",
+            "description": "An open-source relational database management system used for storing and retrieving data.",
             "type": "CONCEPT"
           },
           {
-            "description": "The year 2011 when the Linux server was set up.",
-            "id": "2011",
-            "name": "2011",
-            "type": "DATE"
+            "id": "iptables",
+            "name": "iptables",
+            "description": "A user-space utility program that allows a system administrator to configure the IP packet filter rules of the Linux kernel.",
+            "type": "CONCEPT"
           },
           {
-            "description": "The default configuration of port 22 which led to the server being hacked.",
-            "id": "default_port_22_configuration",
-            "name": "Default Port 22 Configuration",
+            "id": "SSH",
+            "name": "SSH",
+            "description": "A protocol for secure remote login and other secure network services over an insecure network.",
             "type": "CONCEPT"
+          },
+          {
+            "id": "server",
+            "name": "server",
+            "description": "A computer or system that provides data, resources, or services to other computers, known as clients.",
+            "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Linux",
+            "target_node_id": "Debian",
+            "relationship_name": "is_a_distribution_of",
+            "description": "Debian is a distribution of Linux."
+          },
+          {
+            "source_node_id": "server",
+            "target_node_id": "Apache",
+            "relationship_name": "runs_software",
+            "description": "The server runs Apache web server software."
+          },
+          {
+            "source_node_id": "server",
+            "target_node_id": "MySQL",
+            "relationship_name": "runs_software",
+            "description": "The server runs MySQL database management system."
+          },
+          {
+            "source_node_id": "server",
+            "target_node_id": "iptables",
+            "relationship_name": "uses_utility",
+            "description": "The server uses iptables for configuring IP packet filter rules."
+          },
+          {
+            "source_node_id": "server",
+            "target_node_id": "SSH",
+            "relationship_name": "uses_protocol",
+            "description": "The server uses SSH protocol for secure remote login."
+          },
+          {
+            "source_node_id": "server",
+            "target_node_id": "Linux",
+            "relationship_name": "is_a_type_of",
+            "description": "The server is a type of Linux server."
           }
         ]
       }
@@ -294,26 +318,50 @@
       "user_input_preview": "Title: Volunteering at a Food Bank\n\nI volunteered at a local food bank every Saturday for six months in 2019. We sorted ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The local food bank is where the volunteering took place.",
-            "relationship_name": "volunteered_at",
-            "source_node_id": "Volunteer",
-            "target_node_id": "Local Food Bank"
-          }
-        ],
         "nodes": [
           {
-            "description": "An individual who offers their time to help others without payment.",
-            "id": "Volunteer",
-            "name": "Volunteer",
-            "type": "PERSON"
+            "id": "local_food_bank",
+            "name": "local food bank",
+            "description": "A community organization where food donations are sorted and packed for families in need.",
+            "type": "ORGANIZATION"
           },
           {
-            "description": "A community organization that provides food assistance to those in need.",
-            "id": "Local Food Bank",
-            "name": "Local Food Bank",
-            "type": "ORGANIZATION"
+            "id": "volunteering",
+            "name": "volunteering",
+            "description": "The act of offering services for free to help others or a community.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "supply_chain_management",
+            "name": "supply chain management",
+            "description": "The management of the flow of goods and services, including all processes that transform raw materials into final products.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "2019",
+            "name": "2019",
+            "description": "The year in which the volunteering took place.",
+            "type": "DATE"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "local_food_bank",
+            "target_node_id": "volunteering",
+            "relationship_name": "involves",
+            "description": "Volunteering involves working at a local food bank."
+          },
+          {
+            "source_node_id": "local_food_bank",
+            "target_node_id": "supply_chain_management",
+            "relationship_name": "teaches",
+            "description": "Working at a local food bank teaches about supply chain management."
+          },
+          {
+            "source_node_id": "volunteering",
+            "target_node_id": "2019",
+            "relationship_name": "occurred_in",
+            "description": "Volunteering occurred in 2019."
           }
         ]
       }
@@ -323,98 +371,98 @@
       "user_input_preview": "Title: Stargazing in the Countryside\n\nOn a camping trip far from city lights, I saw the Milky Way clearly for the first ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The Milky Way is a galaxy that was clearly visible during the stargazing experience.",
-            "relationship_name": "is_visible_in",
-            "source_node_id": "Milky Way",
-            "target_node_id": "Stargazing"
-          },
-          {
-            "description": "Orion is a constellation that was pointed out during the stargazing experience.",
-            "relationship_name": "is_a_constellation",
-            "source_node_id": "Orion",
-            "target_node_id": "Stargazing"
-          },
-          {
-            "description": "Cassiopeia is a constellation that was pointed out during the stargazing experience.",
-            "relationship_name": "is_a_constellation",
-            "source_node_id": "Cassiopeia",
-            "target_node_id": "Stargazing"
-          },
-          {
-            "description": "The Big Dipper is a constellation that was pointed out during the stargazing experience.",
-            "relationship_name": "is_a_constellation",
-            "source_node_id": "Big Dipper",
-            "target_node_id": "Stargazing"
-          },
-          {
-            "description": "Satellites were observed crossing the sky during the stargazing experience.",
-            "relationship_name": "were_observed_in",
-            "source_node_id": "Satellites",
-            "target_node_id": "Stargazing"
-          },
-          {
-            "description": "Shooting stars were seen during the stargazing experience.",
-            "relationship_name": "were_seen_in",
-            "source_node_id": "Shooting Stars",
-            "target_node_id": "Stargazing"
-          }
-        ],
         "nodes": [
           {
-            "description": "The Milky Way is a galaxy that contains billions of stars and is visible from Earth.",
-            "id": "Milky Way",
-            "name": "Milky Way",
+            "id": "Stargazing_in_the_Countryside",
+            "name": "Stargazing in the Countryside",
+            "description": "A camping trip focused on observing celestial phenomena.",
             "type": "CONCEPT"
           },
           {
-            "description": "Orion is a prominent constellation located on the celestial equator and visible throughout the world.",
+            "id": "Milky_Way",
+            "name": "Milky Way",
+            "description": "A barred spiral galaxy containing our solar system, visible in the night sky.",
+            "type": "CONCEPT"
+          },
+          {
             "id": "Orion",
             "name": "Orion",
+            "description": "A prominent constellation located on the celestial equator, named after a hunter in Greek mythology.",
             "type": "CONCEPT"
           },
           {
-            "description": "Cassiopeia is a constellation in the northern sky, easily recognizable by its W shape.",
             "id": "Cassiopeia",
             "name": "Cassiopeia",
+            "description": "A constellation in the northern sky, easily recognizable by its W shape, named after a queen in Greek mythology.",
             "type": "CONCEPT"
           },
           {
-            "description": "The Big Dipper is an asterism consisting of seven bright stars in the constellation Ursa Major.",
-            "id": "Big Dipper",
+            "id": "Big_Dipper",
             "name": "Big Dipper",
+            "description": "An asterism consisting of seven bright stars in the constellation Ursa Major, often used for navigation.",
             "type": "CONCEPT"
           },
           {
-            "description": "Satellites are human-made objects placed in orbit around Earth for various purposes.",
             "id": "Satellites",
             "name": "Satellites",
+            "description": "Artificial objects placed in orbit around celestial bodies, visible from Earth.",
             "type": "CONCEPT"
           },
           {
-            "description": "Shooting stars are the visible paths of meteoroids as they enter the Earth's atmosphere and burn up.",
-            "id": "Shooting Stars",
+            "id": "Shooting_Stars",
             "name": "Shooting Stars",
+            "description": "Common name for meteors, which are visible as bright streaks of light in the sky when meteoroids enter the Earth's atmosphere.",
             "type": "CONCEPT"
           },
           {
-            "description": "Stargazing is the activity of observing the stars and celestial bodies in the night sky.",
-            "id": "Stargazing",
-            "name": "Stargazing",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "Camping is an outdoor activity involving overnight stays away from home in a shelter, such as a tent.",
             "id": "Camping",
             "name": "Camping",
+            "description": "An outdoor activity involving staying in temporary accommodations, often in nature.",
             "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Stargazing_in_the_Countryside",
+            "target_node_id": "Camping",
+            "relationship_name": "involves",
+            "description": "Stargazing in the Countryside involves Camping."
           },
           {
-            "description": "Astronomy is the scientific study of celestial bodies, space, and the universe as a whole.",
-            "id": "Astronomy",
-            "name": "Astronomy",
-            "type": "CONCEPT"
+            "source_node_id": "Stargazing_in_the_Countryside",
+            "target_node_id": "Milky_Way",
+            "relationship_name": "features",
+            "description": "Stargazing in the Countryside features the Milky Way."
+          },
+          {
+            "source_node_id": "Stargazing_in_the_Countryside",
+            "target_node_id": "Orion",
+            "relationship_name": "includes",
+            "description": "Stargazing in the Countryside includes the constellation Orion."
+          },
+          {
+            "source_node_id": "Stargazing_in_the_Countryside",
+            "target_node_id": "Cassiopeia",
+            "relationship_name": "includes",
+            "description": "Stargazing in the Countryside includes the constellation Cassiopeia."
+          },
+          {
+            "source_node_id": "Stargazing_in_the_Countryside",
+            "target_node_id": "Big_Dipper",
+            "relationship_name": "includes",
+            "description": "Stargazing in the Countryside includes the constellation Big Dipper."
+          },
+          {
+            "source_node_id": "Stargazing_in_the_Countryside",
+            "target_node_id": "Satellites",
+            "relationship_name": "observes",
+            "description": "Stargazing in the Countryside observes Satellites."
+          },
+          {
+            "source_node_id": "Stargazing_in_the_Countryside",
+            "target_node_id": "Shooting_Stars",
+            "relationship_name": "observes",
+            "description": "Stargazing in the Countryside observes Shooting Stars."
           }
         ]
       }
@@ -424,50 +472,62 @@
       "user_input_preview": "Title: The Neighborhood Bookstore\n\nThere was a tiny bookstore on my street run by an elderly couple. They knew every boo",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The tiny bookstore was run by an elderly couple.",
-            "relationship_name": "run_by",
-            "source_node_id": "tiny_bookstore",
-            "target_node_id": "elderly_couple"
-          },
-          {
-            "description": "The tiny bookstore was located in the neighborhood.",
-            "relationship_name": "located_in",
-            "source_node_id": "tiny_bookstore",
-            "target_node_id": "neighborhood"
-          },
-          {
-            "description": "The neighborhood felt the loss when the tiny bookstore closed.",
-            "relationship_name": "felt_loss",
-            "source_node_id": "neighborhood",
-            "target_node_id": "tiny_bookstore"
-          }
-        ],
         "nodes": [
           {
-            "description": "A small bookstore that was run by an elderly couple and closed in 2019.",
             "id": "tiny_bookstore",
             "name": "tiny bookstore",
-            "type": "CONCEPT"
+            "description": "A small bookstore run by an elderly couple, known for their extensive knowledge of books.",
+            "type": "ORGANIZATION"
           },
           {
-            "description": "An elderly couple who ran the tiny bookstore.",
             "id": "elderly_couple",
             "name": "elderly couple",
+            "description": "The couple who ran the tiny bookstore and had a deep knowledge of the books they sold.",
             "type": "PERSON"
           },
           {
-            "description": "A community area where the tiny bookstore was located.",
             "id": "neighborhood",
             "name": "neighborhood",
+            "description": "The community surrounding the tiny bookstore that felt the loss when it closed.",
             "type": "CONCEPT"
           },
           {
-            "description": "A group of people living in the same area, connected by shared interests and experiences.",
-            "id": "community",
-            "name": "community",
-            "type": "CONCEPT"
+            "id": "2019",
+            "name": "2019",
+            "description": "The year when the tiny bookstore closed after the elderly couple retired.",
+            "type": "DATE"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "tiny_bookstore",
+            "target_node_id": "elderly_couple",
+            "relationship_name": "run_by",
+            "description": "The tiny bookstore is run by the elderly couple."
+          },
+          {
+            "source_node_id": "tiny_bookstore",
+            "target_node_id": "neighborhood",
+            "relationship_name": "located_in",
+            "description": "The tiny bookstore is located in the neighborhood."
+          },
+          {
+            "source_node_id": "elderly_couple",
+            "target_node_id": "2019",
+            "relationship_name": "retired_in",
+            "description": "The elderly couple retired in 2019."
+          },
+          {
+            "source_node_id": "tiny_bookstore",
+            "target_node_id": "2019",
+            "relationship_name": "closed_in",
+            "description": "The tiny bookstore closed in 2019."
+          },
+          {
+            "source_node_id": "neighborhood",
+            "target_node_id": "tiny_bookstore",
+            "relationship_name": "felt_loss_when",
+            "description": "The neighborhood felt the loss when the tiny bookstore closed."
           }
         ]
       }
@@ -477,8 +537,8 @@
       "user_input_preview": "Title: A Conversation with a Stranger\n\nOn a delayed train from Prague to Vienna, I sat next to a retired physicist who t",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses a conversation with a retired physicist on a train journey from Prague to Vienna, focusing on his work in particle physics and the concept of quantum tunneling. The conversation led to a personal reflection on time and randomness.",
-        "summary": "The content describes a train conversation with a retired physicist about particle accelerators and quantum tunneling, which prompted a reevaluation of the author's views on time and randomness."
+        "description": "This chunk is about: \n- Topics: travel, physics, trains \n- People: retired physicist",
+        "summary": "The chunk describes a conversation with a retired physicist on a train from Prague to Vienna, focusing on his work in particle accelerators and the concept of quantum tunneling."
       }
     },
     "1c7cd226b1fb9c88d3beb53f44c9460cb1b47d36a4d9920a5606fcb5dc2cc6f7": {
@@ -486,8 +546,8 @@
       "user_input_preview": "Title: A Power Outage During a Demo\n\nDuring a client demo in 2018, the office power went out just as I was showing the n",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "In 2018, during a client demo, the office experienced a power outage while showcasing a new dashboard. The presenter quickly switched to a phone's hotspot and continued the demo on a laptop battery, impressing the client. The outage was later attributed to a construction crew cutting a cable outside the building.",
-        "summary": "In 2018, a power outage occurred during a client demo, but the presenter successfully continued using a phone's hotspot, impressing the client."
+        "description": "This chunk discusses an incident during a client demo where a power outage occurred, leading to a quick recovery using a phone's hotspot. It highlights the client's positive reaction and mentions the cause of the outage.",
+        "summary": "A power outage during a client demo in 2018 was quickly managed by switching to a phone's hotspot, impressing the client."
       }
     },
     "1ddea159cda9052fa130e385c410d1d6dc94da60ee69d95b3e89b00f30ac9ef0": {
@@ -495,8 +555,8 @@
       "user_input_preview": "Title: Learning Git the Hard Way\n\nI learned git by accidentally deleting a week's worth of work with git reset --hard in",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The content discusses a personal experience of learning Git after a significant mistake in 2013. The author emphasizes the importance of understanding Git's reflog and mentions teaching Git workshops to junior developers.",
-        "summary": "The author learned Git the hard way in 2013 after losing work due to a command error. They now teach Git workshops and highlight the importance of understanding the reflog."
+        "description": "This chunk is about: \n- Topics: git, version control, learning \n- Roles: junior developers",
+        "summary": "The author learned git through a challenging experience in 2013 and now teaches git workshops."
       }
     },
     "1f295e24576cf2edd547258a710a471b3074caf871b0e22b9c80919e02eb3a62": {
@@ -504,32 +564,62 @@
       "user_input_preview": "Title: First Flight Experience\n\nMy first time on an airplane was a flight from Belgrade to London when I was sixteen. I ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The flight from Belgrade to London was the first flight experience for the person.",
-            "relationship_name": "experienced",
-            "source_node_id": "first_flight_experience",
-            "target_node_id": "flight_from_belgrade_to_london"
-          }
-        ],
         "nodes": [
           {
-            "description": "The first flight experience of the person, which involved flying from Belgrade to London.",
+            "id": "Belgrade",
+            "name": "Belgrade",
+            "description": "Capital city of Serbia.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "London",
+            "name": "London",
+            "description": "Capital city of the United Kingdom.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "airplane_flight",
+            "name": "airplane flight",
+            "description": "Experience of traveling by airplane.",
+            "type": "CONCEPT"
+          },
+          {
             "id": "first_flight_experience",
-            "name": "First Flight Experience",
+            "name": "first flight experience",
+            "description": "The initial experience of flying on an airplane.",
             "type": "CONCEPT"
           },
           {
-            "description": "A flight that took place from Belgrade to London, marking the person's first time on an airplane.",
-            "id": "flight_from_belgrade_to_london",
-            "name": "Flight from Belgrade to London",
-            "type": "CONCEPT"
+            "id": "sixteen_years_old",
+            "name": "sixteen years old",
+            "description": "Age of the individual during the first flight experience.",
+            "type": "DATE"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "first_flight_experience",
+            "target_node_id": "Belgrade",
+            "relationship_name": "departed_from",
+            "description": "The first flight experience departed from Belgrade."
           },
           {
-            "description": "The person who experienced their first flight at the age of sixteen.",
-            "id": "person",
-            "name": "Person",
-            "type": "PERSON"
+            "source_node_id": "first_flight_experience",
+            "target_node_id": "London",
+            "relationship_name": "arrived_at",
+            "description": "The first flight experience arrived at London."
+          },
+          {
+            "source_node_id": "first_flight_experience",
+            "target_node_id": "sixteen_years_old",
+            "relationship_name": "occurred_at_age",
+            "description": "The first flight experience occurred when the individual was sixteen years old."
+          },
+          {
+            "source_node_id": "first_flight_experience",
+            "target_node_id": "airplane_flight",
+            "relationship_name": "is_a_type_of",
+            "description": "The first flight experience is a type of airplane flight."
           }
         ]
       }
@@ -539,86 +629,74 @@
       "user_input_preview": "Title: Building a Treehouse\n\nMy father and I built a treehouse in the oak tree in our backyard when I was ten. We spent ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The treehouse was built by the father and the child in the oak tree in the backyard.",
-            "relationship_name": "built",
-            "source_node_id": "father",
-            "target_node_id": "treehouse"
-          },
-          {
-            "description": "The treehouse is located in the oak tree in the backyard.",
-            "relationship_name": "located_in",
-            "source_node_id": "treehouse",
-            "target_node_id": "oak_tree"
-          },
-          {
-            "description": "The treehouse had a rope ladder and a small window facing west.",
-            "relationship_name": "has_feature",
-            "source_node_id": "treehouse",
-            "target_node_id": "rope_ladder"
-          },
-          {
-            "description": "The treehouse had a rope ladder and a small window facing west.",
-            "relationship_name": "has_feature",
-            "source_node_id": "treehouse",
-            "target_node_id": "small_window"
-          },
-          {
-            "description": "The child used the treehouse as a reading nook every summer until moving.",
-            "relationship_name": "used_as",
-            "source_node_id": "treehouse",
-            "target_node_id": "reading_nook"
-          }
-        ],
         "nodes": [
           {
-            "description": "The father is a parent who participated in building the treehouse.",
             "id": "father",
-            "name": "Father",
-            "type": "PERSON"
+            "name": "father",
+            "type": "PERSON",
+            "description": "The father of the narrator who built a treehouse."
           },
           {
-            "description": "The treehouse is a structure built in an oak tree for recreational use.",
             "id": "treehouse",
-            "name": "Treehouse",
-            "type": "CONCEPT"
+            "name": "treehouse",
+            "type": "CONCEPT",
+            "description": "A structure built in a tree, specifically an oak tree in the backyard."
           },
           {
-            "description": "The oak tree is a type of tree where the treehouse was built.",
             "id": "oak_tree",
-            "name": "Oak Tree",
-            "type": "CONCEPT"
+            "name": "oak tree",
+            "type": "CONCEPT",
+            "description": "The type of tree in which the treehouse was built."
           },
           {
-            "description": "The rope ladder is a feature of the treehouse.",
-            "id": "rope_ladder",
-            "name": "Rope Ladder",
-            "type": "CONCEPT"
+            "id": "backyard",
+            "name": "backyard",
+            "type": "CONCEPT",
+            "description": "The location where the treehouse was built."
           },
           {
-            "description": "The small window is a feature of the treehouse that faces west.",
-            "id": "small_window",
-            "name": "Small Window",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "The reading nook is a purpose for which the treehouse was used.",
             "id": "reading_nook",
-            "name": "Reading Nook",
-            "type": "CONCEPT"
+            "name": "reading nook",
+            "type": "CONCEPT",
+            "description": "The purpose of the treehouse for the narrator during summers."
           },
           {
-            "description": "Childhood refers to the period of life when the treehouse was built and used.",
             "id": "childhood",
-            "name": "Childhood",
-            "type": "CONCEPT"
+            "name": "childhood",
+            "type": "CONCEPT",
+            "description": "The period in which the treehouse was built and used."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "father",
+            "target_node_id": "treehouse",
+            "relationship_name": "built",
+            "description": "The father built the treehouse."
           },
           {
-            "description": "DIY refers to the activity of building the treehouse by oneself.",
-            "id": "DIY",
-            "name": "DIY",
-            "type": "CONCEPT"
+            "source_node_id": "treehouse",
+            "target_node_id": "oak_tree",
+            "relationship_name": "located_in",
+            "description": "The treehouse is located in the oak tree."
+          },
+          {
+            "source_node_id": "treehouse",
+            "target_node_id": "backyard",
+            "relationship_name": "located_in",
+            "description": "The treehouse is located in the backyard."
+          },
+          {
+            "source_node_id": "treehouse",
+            "target_node_id": "reading_nook",
+            "relationship_name": "used_as",
+            "description": "The treehouse was used as a reading nook."
+          },
+          {
+            "source_node_id": "treehouse",
+            "target_node_id": "childhood",
+            "relationship_name": "part_of",
+            "description": "The treehouse is part of the narrator's childhood."
           }
         ]
       }
@@ -628,8 +706,8 @@
       "user_input_preview": "Title: First Day at University\n\nI remember my first day at the University of Belgrade. The campus was bustling with new ",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk describes the author's first day at the University of Belgrade, highlighting their feelings of excitement and nervousness as they began their Computer Science program. An inspiring lecture by a professor is also mentioned.",
-        "summary": "The author recalls their first day at the University of Belgrade, where they enrolled in the Computer Science program and attended an inspiring lecture by a professor."
+        "description": "The chunk discusses the author's first day at the University of Belgrade, focusing on their feelings of excitement and nervousness, enrollment in the Computer Science program, and an inspiring lecture by a professor.",
+        "summary": "The author reflects on their first day at the University of Belgrade, where they enrolled in the Computer Science program and attended an inspiring lecture."
       }
     },
     "3488d16e6acc1b4124945f7132f2f3969b074bbbc3bab7a95fad2405a51d83c1": {
@@ -637,8 +715,8 @@
       "user_input_preview": "Title: Visiting a Museum in Florence\n\nSeeing Michelangelo's David at the Galleria dell'Accademia in Florence was overwhe",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "This chunk discusses a visit to the Galleria dell'Accademia in Florence where the author experienced Michelangelo's David. The author describes the overwhelming scale and detail of the sculpture, particularly focusing on its hands, and notes the crowded atmosphere of the museum.",
-        "summary": "The author describes an overwhelming experience viewing Michelangelo's David at the Galleria dell'Accademia in Florence, emphasizing the sculpture's scale and detail."
+        "description": "This chunk discusses a visit to the Galleria dell'Accademia in Florence to see Michelangelo's David. The experience is described as overwhelming due to the scale and detail of the sculpture, particularly focusing on the hands. The author notes the crowded museum but emphasizes a moment of personal reflection amidst the chaos.",
+        "summary": "The chunk describes a visit to see Michelangelo's David in Florence, highlighting the overwhelming experience and detail of the sculpture."
       }
     },
     "3513954a50bc2591afce322236ffe558372109824bc325d3d66ef14d19048629": {
@@ -646,56 +724,56 @@
       "user_input_preview": "Title: The Importance of Backups\n\nI learned the importance of backups when my laptop's hard drive failed in 2016, taking",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The importance of backups was learned after the laptop's hard drive failure in 2016.",
-            "relationship_name": "learned_importance_of",
-            "source_node_id": "2016",
-            "target_node_id": "backups"
-          },
-          {
-            "description": "Automated backups were set up to an external drive and cloud storage after the hard drive failure.",
-            "relationship_name": "set_up",
-            "source_node_id": "automated_backups",
-            "target_node_id": "external_drive"
-          },
-          {
-            "description": "Automated backups were set up to an external drive and cloud storage after the hard drive failure.",
-            "relationship_name": "set_up",
-            "source_node_id": "automated_backups",
-            "target_node_id": "cloud_storage"
-          }
-        ],
         "nodes": [
           {
-            "description": "The year when the laptop's hard drive failed, leading to a significant lesson about backups.",
+            "id": "Backups",
+            "name": "Backups",
+            "description": "Backups are copies of data stored separately to prevent data loss.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "Data Loss",
+            "name": "Data Loss",
+            "description": "Data loss refers to the loss of data due to various reasons, including hardware failure.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "Hard Drive Failure",
+            "name": "Hard Drive Failure",
+            "description": "Hard drive failure is a malfunction of a hard drive that results in data loss.",
+            "type": "CONCEPT"
+          },
+          {
             "id": "2016",
             "name": "2016",
+            "description": "The year when the laptop's hard drive failed, resulting in data loss.",
             "type": "DATE"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Backups",
+            "target_node_id": "Data Loss",
+            "relationship_name": "prevents",
+            "description": "Backups prevent data loss by providing copies of data stored separately."
           },
           {
-            "description": "A method of storing data to prevent loss, highlighted as crucial after a hard drive failure.",
-            "id": "backups",
-            "name": "backups",
-            "type": "CONCEPT"
+            "source_node_id": "Hard Drive Failure",
+            "target_node_id": "Data Loss",
+            "relationship_name": "causes",
+            "description": "Hard drive failure causes data loss when data is not backed up."
           },
           {
-            "description": "A storage device used for keeping copies of data, mentioned as part of the backup solution.",
-            "id": "external_drive",
-            "name": "external drive",
-            "type": "CONCEPT"
+            "source_node_id": "2016",
+            "target_node_id": "Hard Drive Failure",
+            "relationship_name": "occurred_in",
+            "description": "The hard drive failure occurred in 2016."
           },
           {
-            "description": "A storage solution that allows data to be saved online, mentioned as part of the backup solution.",
-            "id": "cloud_storage",
-            "name": "cloud storage",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A process established to regularly save data automatically, implemented after experiencing data loss.",
-            "id": "automated_backups",
-            "name": "automated backups",
-            "type": "CONCEPT"
+            "source_node_id": "Backups",
+            "target_node_id": "2016",
+            "relationship_name": "established_after",
+            "description": "Backups were established after the hard drive failure in 2016."
           }
         ]
       }
@@ -705,68 +783,50 @@
       "user_input_preview": "Title: First Time Using Docker\n\nThe first time I used Docker in 2015, it felt like magic. I went from 'it works on my ma",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The Dockerfile for the Python app solved months of deployment headaches.",
-            "relationship_name": "solved",
-            "source_node_id": "Dockerfile",
-            "target_node_id": "deployment_headaches"
-          },
-          {
-            "description": "The author became the Docker evangelist on the team for the next year.",
-            "relationship_name": "became",
-            "source_node_id": "author",
-            "target_node_id": "Docker_evangelist"
-          }
-        ],
         "nodes": [
           {
-            "description": "Docker is a platform for developing, shipping, and running applications in containers.",
             "id": "Docker",
             "name": "Docker",
+            "description": "Docker is a platform for developing, shipping, and running applications in containers.",
             "type": "CONCEPT"
           },
           {
-            "description": "A Dockerfile is a text document that contains all the commands to assemble an image.",
-            "id": "Dockerfile",
-            "name": "Dockerfile",
+            "id": "Python_app",
+            "name": "Python app",
+            "description": "A software application developed using the Python programming language.",
             "type": "CONCEPT"
           },
           {
-            "description": "Deployment headaches refer to the challenges and issues faced during the deployment of applications.",
-            "id": "deployment_headaches",
-            "name": "deployment headaches",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "The author refers to the person recounting their experience with Docker.",
-            "id": "author",
-            "name": "author",
-            "type": "PERSON"
-          },
-          {
-            "description": "A Docker evangelist is someone who promotes the use of Docker within their organization or community.",
-            "id": "Docker_evangelist",
-            "name": "Docker evangelist",
-            "type": "PERSON"
-          },
-          {
-            "description": "Containers are a standard unit of software that package up code and all its dependencies so the application runs quickly and reliably from one computing environment to another.",
-            "id": "containers",
-            "name": "containers",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "DevOps is a set of practices that combines software development (Dev) and IT operations (Ops).",
             "id": "DevOps",
             "name": "DevOps",
+            "description": "DevOps is a set of practices that combines software development and IT operations.",
             "type": "CONCEPT"
           },
           {
-            "description": "Python is a high-level programming language that is widely used for web development, data analysis, artificial intelligence, and more.",
-            "id": "Python",
-            "name": "Python",
-            "type": "CONCEPT"
+            "id": "Person",
+            "name": "Docker evangelist",
+            "description": "A person who promotes the use of Docker within a team or organization.",
+            "type": "PERSON"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Docker",
+            "target_node_id": "Python_app",
+            "relationship_name": "used_in",
+            "description": "Docker is used to create reproducible environments for the Python app."
+          },
+          {
+            "source_node_id": "Person",
+            "target_node_id": "Docker",
+            "relationship_name": "promotes",
+            "description": "The Docker evangelist promotes the use of Docker."
+          },
+          {
+            "source_node_id": "DevOps",
+            "target_node_id": "Docker",
+            "relationship_name": "related_to",
+            "description": "Docker is related to DevOps practices."
           }
         ]
       }
@@ -776,38 +836,38 @@
       "user_input_preview": "Title: Learning to Cook Pasta\n\nAn Italian roommate in college taught me that you must salt the pasta water generously — ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The Italian roommate taught the author how to cook pasta.",
-            "relationship_name": "taught",
-            "source_node_id": "Italian_roommate",
-            "target_node_id": "Cooking_rules"
-          },
-          {
-            "description": "The author learned cooking rules from the Italian roommate in college.",
-            "relationship_name": "learned_from",
-            "source_node_id": "Author",
-            "target_node_id": "Italian_roommate"
-          }
-        ],
         "nodes": [
           {
-            "description": "A person who taught cooking rules to the author.",
             "id": "Italian_roommate",
             "name": "Italian roommate",
+            "description": "A person who taught cooking techniques related to pasta.",
             "type": "PERSON"
           },
           {
-            "description": "The author who learned cooking rules.",
-            "id": "Author",
-            "name": "Author",
-            "type": "PERSON"
-          },
-          {
-            "description": "Simple rules for cooking pasta, including salting water and saving pasta water.",
-            "id": "Cooking_rules",
-            "name": "Cooking rules",
+            "id": "pasta",
+            "name": "Pasta",
+            "description": "A type of food made from wheat and water, commonly used in Italian cuisine.",
             "type": "CONCEPT"
+          },
+          {
+            "id": "college",
+            "name": "College",
+            "description": "An educational institution where students learn, often away from home.",
+            "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Italian_roommate",
+            "target_node_id": "pasta",
+            "relationship_name": "taught",
+            "description": "The Italian roommate taught cooking techniques related to pasta."
+          },
+          {
+            "source_node_id": "pasta",
+            "target_node_id": "college",
+            "relationship_name": "related_to",
+            "description": "Pasta is a common food associated with college cooking."
           }
         ]
       }
@@ -817,44 +877,62 @@
       "user_input_preview": "Title: Running My First Marathon\n\nI ran my first marathon in 2016 in Vienna. Training took five months with a gradual bu",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The marathon took place in Vienna.",
-            "relationship_name": "took_place_in",
-            "source_node_id": "marathon",
-            "target_node_id": "Vienna"
-          },
-          {
-            "description": "The marathon is a running event.",
-            "relationship_name": "is_a",
-            "source_node_id": "marathon",
-            "target_node_id": "running"
-          }
-        ],
         "nodes": [
           {
-            "description": "A long-distance running race with an official distance of 42.195 kilometers.",
-            "id": "marathon",
-            "name": "Marathon",
-            "type": "CONCEPT"
+            "id": "Running_My_First_Marathon",
+            "name": "Running My First Marathon",
+            "type": "CONCEPT",
+            "description": "A personal account of running a first marathon."
           },
           {
-            "description": "A city in Austria known for its cultural and historical significance.",
             "id": "Vienna",
             "name": "Vienna",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "The capital city of Austria where the marathon took place."
           },
           {
-            "description": "The activity of running, often for exercise or competition.",
-            "id": "running",
-            "name": "Running",
-            "type": "CONCEPT"
+            "id": "Marathon",
+            "name": "Marathon",
+            "type": "CONCEPT",
+            "description": "A long-distance running race with an official distance of 42.195 kilometers."
           },
           {
-            "description": "The year when the first marathon was run by the author.",
             "id": "2016",
             "name": "2016",
-            "type": "DATE"
+            "type": "DATE",
+            "description": "The year when the marathon was run."
+          },
+          {
+            "id": "4_hours_12_minutes",
+            "name": "4 hours 12 minutes",
+            "type": "DURATION",
+            "description": "The time taken to complete the marathon."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Running_My_First_Marathon",
+            "target_node_id": "Vienna",
+            "relationship_name": "took_place_in",
+            "description": "Running My First Marathon took place in Vienna."
+          },
+          {
+            "source_node_id": "Running_My_First_Marathon",
+            "target_node_id": "Marathon",
+            "relationship_name": "is_a",
+            "description": "Running My First Marathon is a type of Marathon."
+          },
+          {
+            "source_node_id": "Running_My_First_Marathon",
+            "target_node_id": "2016",
+            "relationship_name": "took_place_in_year",
+            "description": "Running My First Marathon took place in the year 2016."
+          },
+          {
+            "source_node_id": "Running_My_First_Marathon",
+            "target_node_id": "4_hours_12_minutes",
+            "relationship_name": "duration",
+            "description": "The duration of Running My First Marathon was 4 hours 12 minutes."
           }
         ]
       }
@@ -864,8 +942,8 @@
       "user_input_preview": "Title: Discovering Podcasts\n\nI discovered podcasts during my daily commute in 2016. The first one I binged was a technol",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the author's experience with podcasts, highlighting their discovery during a commute in 2016 and the impact it had on their daily routine. The author now dedicates significant time to listening to podcasts as a means of learning.",
-        "summary": "The author discovered podcasts in 2016 during their commute, starting with a technology history series. They now listen to about ten hours of podcasts each week, turning their commute into a valuable learning experience."
+        "description": "This chunk is about: \n- Topics: podcasts, technology history, learning\n- Events: daily commute in 2016",
+        "summary": "The author discovered podcasts during their daily commute in 2016, which transformed their commute into a learning opportunity."
       }
     },
     "4a813f9e4a2c4cf619b0d269e18753429d5d2f37e20ad266941c23eb2aa236c6": {
@@ -873,92 +951,74 @@
       "user_input_preview": "Title: Migrating a Monolith to Microservices\n\nOur team spent eight months in 2020 migrating a monolithic Python applicat",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The team migrated a monolithic Python application to microservices using the strangler fig pattern.",
-            "relationship_name": "migrated",
-            "source_node_id": "Team",
-            "target_node_id": "Monolithic Python Application"
-          },
-          {
-            "description": "The team used the strangler fig pattern to gradually route traffic to new services during the migration.",
-            "relationship_name": "used",
-            "source_node_id": "Team",
-            "target_node_id": "Strangler Fig Pattern"
-          },
-          {
-            "description": "The hardest part of the migration was splitting the shared database.",
-            "relationship_name": "faced_challenge",
-            "source_node_id": "Team",
-            "target_node_id": "Shared Database"
-          },
-          {
-            "description": "Latency improved by 40% after migrating to microservices.",
-            "relationship_name": "resulted_in",
-            "source_node_id": "Migration",
-            "target_node_id": "Latency Improvement"
-          },
-          {
-            "description": "Operational complexity tripled as a result of the migration to microservices.",
-            "relationship_name": "resulted_in",
-            "source_node_id": "Migration",
-            "target_node_id": "Operational Complexity"
-          }
-        ],
         "nodes": [
           {
-            "description": "A group of individuals working together on a project.",
-            "id": "Team",
-            "name": "Team",
-            "type": "PERSON"
-          },
-          {
-            "description": "A software application that was originally built as a single unit.",
-            "id": "Monolithic Python Application",
+            "id": "Monolithic_Python_Application",
             "name": "Monolithic Python Application",
+            "description": "A single, unified software application written in Python that was migrated to microservices.",
             "type": "CONCEPT"
           },
           {
-            "description": "A design pattern used to gradually replace a monolithic application with microservices.",
-            "id": "Strangler Fig Pattern",
-            "name": "Strangler Fig Pattern",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A database that is shared among multiple services or components.",
-            "id": "Shared Database",
-            "name": "Shared Database",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "The reduction in time taken to process requests after the migration.",
-            "id": "Latency Improvement",
-            "name": "Latency Improvement",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "The increase in complexity of operations after the migration to microservices.",
-            "id": "Operational Complexity",
-            "name": "Operational Complexity",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "The process of transitioning from a monolithic architecture to a microservices architecture.",
-            "id": "Migration",
-            "name": "Migration",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A software architectural style that structures an application as a collection of loosely coupled services.",
             "id": "Microservices",
             "name": "Microservices",
+            "description": "An architectural style that structures an application as a collection of loosely coupled services.",
             "type": "CONCEPT"
           },
           {
-            "description": "The overall structure and design of a software system.",
-            "id": "Architecture",
-            "name": "Architecture",
+            "id": "Strangler_Fig_Pattern",
+            "name": "Strangler Fig Pattern",
+            "description": "A pattern used to gradually migrate from a monolithic application to microservices by routing traffic to new services.",
             "type": "CONCEPT"
+          },
+          {
+            "id": "Database",
+            "name": "Database",
+            "description": "A structured set of data held in a computer, which was shared in the monolithic application and needed to be split during migration.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "2020",
+            "name": "2020",
+            "description": "The year during which the migration of the monolithic Python application to microservices took place.",
+            "type": "DATE"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Monolithic_Python_Application",
+            "target_node_id": "Microservices",
+            "relationship_name": "migrated_to",
+            "description": "The Monolithic Python Application was migrated to Microservices."
+          },
+          {
+            "source_node_id": "Monolithic_Python_Application",
+            "target_node_id": "Strangler_Fig_Pattern",
+            "relationship_name": "used_pattern",
+            "description": "The Monolithic Python Application used the Strangler Fig Pattern for migration."
+          },
+          {
+            "source_node_id": "Monolithic_Python_Application",
+            "target_node_id": "Database",
+            "relationship_name": "shared_database",
+            "description": "The Monolithic Python Application shared a Database that was split during migration."
+          },
+          {
+            "source_node_id": "2020",
+            "target_node_id": "Monolithic_Python_Application",
+            "relationship_name": "migrated_in",
+            "description": "The Monolithic Python Application was migrated in 2020."
+          },
+          {
+            "source_node_id": "Microservices",
+            "target_node_id": "Database",
+            "relationship_name": "increased_complexity",
+            "description": "The migration to Microservices increased operational complexity related to the Database."
+          },
+          {
+            "source_node_id": "Microservices",
+            "target_node_id": "Latency",
+            "relationship_name": "improved_latency",
+            "description": "The migration to Microservices improved latency by 40%."
           }
         ]
       }
@@ -968,32 +1028,38 @@
       "user_input_preview": "Title: A Sunrise Over the Mountains\n\nI woke up at 4 AM to hike to a summit in the Dolomites to watch the sunrise. The tr",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The sunrise occurs over the Dolomites, illuminating the rock faces with orange and pink hues.",
-            "relationship_name": "occurs_over",
-            "source_node_id": "sunrise",
-            "target_node_id": "Dolomites"
-          }
-        ],
         "nodes": [
           {
-            "description": "The Dolomites are a mountain range located in northeastern Italy, known for their stunning landscapes and hiking trails.",
             "id": "Dolomites",
             "name": "Dolomites",
+            "description": "A mountain range located in northeastern Italy, known for its stunning landscapes and hiking trails.",
             "type": "CONCEPT"
           },
           {
-            "description": "The sunrise is the moment when the sun appears above the horizon, often associated with beautiful colors in the sky.",
             "id": "sunrise",
             "name": "sunrise",
+            "description": "The time in the morning when the sun appears above the horizon, often associated with beautiful colors in the sky.",
             "type": "CONCEPT"
           },
           {
-            "description": "Hiking is an outdoor activity that involves walking in natural environments, often on trails or paths.",
             "id": "hiking",
             "name": "hiking",
+            "description": "An outdoor activity involving walking in natural environments, often on trails or paths.",
             "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Dolomites",
+            "target_node_id": "sunrise",
+            "relationship_name": "witnessed",
+            "description": "The Dolomites provided a location to witness the sunrise."
+          },
+          {
+            "source_node_id": "Dolomites",
+            "target_node_id": "hiking",
+            "relationship_name": "associated_with",
+            "description": "Hiking is an activity associated with the Dolomites."
           }
         ]
       }
@@ -1003,50 +1069,74 @@
       "user_input_preview": "Title: Learning to Ride a Bicycle\n\nMy grandfather taught me to ride a bicycle in the park near our house when I was six ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "My grandfather taught me to ride a bicycle.",
-            "relationship_name": "taught",
-            "source_node_id": "Grandfather",
-            "target_node_id": "Bicycle"
-          },
-          {
-            "description": "The park is located near our house.",
-            "relationship_name": "located_near",
-            "source_node_id": "Park",
-            "target_node_id": "House"
-          },
-          {
-            "description": "The park is where I learned to ride a bicycle.",
-            "relationship_name": "learned_in",
-            "source_node_id": "Bicycle",
-            "target_node_id": "Park"
-          }
-        ],
         "nodes": [
           {
-            "description": "A person who taught the narrator to ride a bicycle.",
             "id": "Grandfather",
             "name": "Grandfather",
-            "type": "PERSON"
+            "type": "PERSON",
+            "description": "The narrator's grandfather who taught them to ride a bicycle."
           },
           {
-            "description": "A two-wheeled vehicle that is powered by pedaling.",
             "id": "Bicycle",
             "name": "Bicycle",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A two-wheeled vehicle that the narrator learned to ride."
           },
           {
-            "description": "A public area with grass and trees, where the narrator learned to ride a bicycle.",
             "id": "Park",
             "name": "Park",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "The location where the narrator learned to ride a bicycle."
           },
           {
-            "description": "A physical structure where the narrator lives.",
-            "id": "House",
-            "name": "House",
-            "type": "CONCEPT"
+            "id": "Childhood",
+            "name": "Childhood",
+            "type": "CONCEPT",
+            "description": "The period of life when the narrator learned to ride a bicycle."
+          },
+          {
+            "id": "Family",
+            "name": "Family",
+            "type": "CONCEPT",
+            "description": "The narrator's family context in which the learning took place."
+          },
+          {
+            "id": "Joy",
+            "name": "Joy",
+            "type": "CONCEPT",
+            "description": "The feeling experienced by the narrator when they successfully rode the bicycle."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Grandfather",
+            "target_node_id": "Bicycle",
+            "relationship_name": "taught",
+            "description": "Grandfather taught the narrator to ride a bicycle."
+          },
+          {
+            "source_node_id": "Grandfather",
+            "target_node_id": "Park",
+            "relationship_name": "taught_in",
+            "description": "Grandfather taught the narrator to ride a bicycle in the park."
+          },
+          {
+            "source_node_id": "Bicycle",
+            "target_node_id": "Joy",
+            "relationship_name": "caused",
+            "description": "Riding the bicycle caused the narrator to feel joy."
+          },
+          {
+            "source_node_id": "Childhood",
+            "target_node_id": "Bicycle",
+            "relationship_name": "involved",
+            "description": "Learning to ride a bicycle was part of the narrator's childhood."
+          },
+          {
+            "source_node_id": "Family",
+            "target_node_id": "Grandfather",
+            "relationship_name": "related_to",
+            "description": "The narrator's grandfather is part of their family."
           }
         ]
       }
@@ -1056,8 +1146,8 @@
       "user_input_preview": "Title: The Neighborhood Bookstore\n\nThere was a tiny bookstore on my street run by an elderly couple. They knew every boo",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses a small neighborhood bookstore run by an elderly couple who had a deep knowledge of their inventory. The store closed in 2019 upon their retirement, leading to a sense of loss in the community.",
-        "summary": "The chunk describes a beloved neighborhood bookstore run by an elderly couple, which closed in 2019 after their retirement, leaving the community feeling a significant loss."
+        "description": "This chunk is about a neighborhood bookstore run by an elderly couple, their knowledge of books, and the impact of their retirement on the community.",
+        "summary": "The chunk discusses a neighborhood bookstore run by an elderly couple, their expertise in recommending books, and the community's reaction to their retirement in 2019."
       }
     },
     "4e6e122804a4c589b33c8f06dd6910d4861050817a9e6cda7885edb8b2512db8": {
@@ -1065,8 +1155,8 @@
       "user_input_preview": "Title: Learning to Cook Pasta\n\nAn Italian roommate in college taught me that you must salt the pasta water generously — ",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses essential tips for cooking pasta, emphasizing the importance of salting the water, not breaking spaghetti, and saving pasta water for sauce. These lessons were taught by an Italian roommate during college and significantly improved the author's cooking skills.",
-        "summary": "The chunk provides key tips for cooking pasta learned from an Italian roommate in college, highlighting the importance of salting water, not breaking spaghetti, and saving pasta water."
+        "description": "This chunk discusses essential cooking tips for pasta learned from an Italian roommate in college, emphasizing the importance of salting pasta water, not breaking spaghetti, and saving pasta water for sauce.",
+        "summary": "The chunk highlights key pasta cooking tips learned from a college roommate, focusing on salting water, not breaking spaghetti, and saving pasta water."
       }
     },
     "4ef25a5d622566c03c32c0dcdaf70457cf23ad32204bbd6e359fe3cdf2ac7741": {
@@ -1074,8 +1164,8 @@
       "user_input_preview": "Title: The Blackout of 2003\n\nDuring the Northeast blackout of August 2003, the power went out for nearly two days. Neigh",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The Northeast blackout of August 2003 caused a power outage lasting nearly two days, leading to a sense of community as neighbors gathered, shared food, and sang songs by candlelight.",
-        "summary": "The 2003 blackout resulted in a two-day power outage that fostered community bonding among neighbors in an isolating city."
+        "description": "This chunk discusses the Northeast blackout of August 2003 and its impact on community interactions.",
+        "summary": "The chunk describes the Northeast blackout of 2003 and how it fostered a sense of community among neighbors."
       }
     },
     "508c0c856bb82ffc578ef43c449210ed6207722113370e2d0a3b2c018e7d1ddb": {
@@ -1083,92 +1173,80 @@
       "user_input_preview": "Title: Winning a Hackathon\n\nOur team won a 48-hour hackathon in 2017 by building a real-time translator for sign languag",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The team won the hackathon by building a real-time translator for sign language using computer vision.",
-            "relationship_name": "won",
-            "source_node_id": "team",
-            "target_node_id": "hackathon"
-          },
-          {
-            "description": "The real-time translator for sign language was built using computer vision.",
-            "relationship_name": "built_using",
-            "source_node_id": "real_time_translator",
-            "target_node_id": "computer_vision"
-          },
-          {
-            "description": "The real-time translator for sign language was fine-tuned on ASL datasets.",
-            "relationship_name": "fine_tuned_on",
-            "source_node_id": "real_time_translator",
-            "target_node_id": "asl_datasets"
-          },
-          {
-            "description": "The judges were impressed by the demo of the real-time translator for sign language.",
-            "relationship_name": "impressed_by",
-            "source_node_id": "judges",
-            "target_node_id": "real_time_translator"
-          },
-          {
-            "description": "The demo of the real-time translator for sign language translated basic signs with 85% accuracy.",
-            "relationship_name": "translated_with_accuracy",
-            "source_node_id": "demo",
-            "target_node_id": "accuracy"
-          }
-        ],
         "nodes": [
           {
-            "description": "A group of individuals who collaborated to win a hackathon.",
-            "id": "team",
-            "name": "team",
-            "type": "GROUP"
+            "id": "hackathon_2017",
+            "name": "Hackathon 2017",
+            "type": "EVENT",
+            "description": "A 48-hour hackathon where a team built a real-time translator for sign language."
           },
           {
-            "description": "An event where participants compete to create a project within a limited time.",
-            "id": "hackathon",
-            "name": "hackathon",
-            "type": "EVENT"
-          },
-          {
-            "description": "A system designed to translate sign language in real-time using technology.",
             "id": "real_time_translator",
-            "name": "real-time translator for sign language",
-            "type": "CONCEPT"
+            "name": "Real-Time Translator for Sign Language",
+            "type": "CONCEPT",
+            "description": "A project developed during the hackathon that translates sign language using computer vision."
           },
           {
-            "description": "A field of study that enables computers to interpret and understand visual information from the world.",
-            "id": "computer_vision",
-            "name": "computer vision",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A type of machine learning model that is trained on labeled data to perform specific tasks.",
             "id": "cnn_model",
-            "name": "CNN model",
-            "type": "CONCEPT"
+            "name": "Pre-Trained CNN Model",
+            "type": "CONCEPT",
+            "description": "A convolutional neural network model used and fine-tuned for translating sign language."
           },
           {
-            "description": "Datasets containing examples of American Sign Language used for training models.",
             "id": "asl_datasets",
-            "name": "ASL datasets",
-            "type": "DATASET"
+            "name": "ASL Datasets",
+            "type": "CONCEPT",
+            "description": "Datasets used to fine-tune the CNN model for American Sign Language."
           },
           {
-            "description": "Individuals who evaluate and judge the projects presented in the hackathon.",
             "id": "judges",
-            "name": "judges",
-            "type": "GROUP"
+            "name": "Judges",
+            "type": "PERSON",
+            "description": "Individuals who evaluated the hackathon projects."
           },
           {
-            "description": "A demonstration of the real-time translator for sign language.",
-            "id": "demo",
-            "name": "demo",
-            "type": "CONCEPT"
+            "id": "team",
+            "name": "Winning Team",
+            "type": "GROUP",
+            "description": "The team that won the hackathon."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "hackathon_2017",
+            "target_node_id": "real_time_translator",
+            "relationship_name": "featured_project",
+            "description": "The Hackathon 2017 featured the Real-Time Translator for Sign Language as a project."
           },
           {
-            "description": "A measure of how accurately the demo translated basic signs.",
-            "id": "accuracy",
-            "name": "85% accuracy",
-            "type": "CONCEPT"
+            "source_node_id": "real_time_translator",
+            "target_node_id": "cnn_model",
+            "relationship_name": "utilized",
+            "description": "The Real-Time Translator for Sign Language utilized a Pre-Trained CNN Model."
+          },
+          {
+            "source_node_id": "cnn_model",
+            "target_node_id": "asl_datasets",
+            "relationship_name": "fine_tuned_on",
+            "description": "The Pre-Trained CNN Model was fine-tuned on ASL Datasets."
+          },
+          {
+            "source_node_id": "real_time_translator",
+            "target_node_id": "judges",
+            "relationship_name": "impressed",
+            "description": "The judges were impressed by the Real-Time Translator for Sign Language demo."
+          },
+          {
+            "source_node_id": "team",
+            "target_node_id": "hackathon_2017",
+            "relationship_name": "won",
+            "description": "The Winning Team won the Hackathon 2017."
+          },
+          {
+            "source_node_id": "team",
+            "target_node_id": "judges",
+            "relationship_name": "evaluated_by",
+            "description": "The Winning Team was evaluated by the judges."
           }
         ]
       }
@@ -1178,8 +1256,8 @@
       "user_input_preview": "Title: The Solar Eclipse of 1999\n\nOn August 11, 1999, a total solar eclipse was visible from parts of Europe. I watched ",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the total solar eclipse that occurred on August 11, 1999, and the personal experience of watching it. The event is noted for its impact on the observer, highlighting the silence of birds and the darkness during the day.",
-        "summary": "This chunk describes the total solar eclipse of August 11, 1999, and a personal experience of witnessing it. The event was significant due to its dramatic effects on the environment."
+        "description": "This chunk is about: \n- Events: solar eclipse, 1999 \n- Topics: astronomy",
+        "summary": "The chunk describes the total solar eclipse of 1999, which was visible from parts of Europe and left a lasting impression on the observer."
       }
     },
     "53634df0ceb67576005fbde94f1780db2902f60e4e4238d9d51f529e42a29471": {
@@ -1187,62 +1265,74 @@
       "user_input_preview": "Title: First Job Interview\n\nMy first real job interview was at a small software consultancy in 2010. I was so nervous th",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The small software consultancy offered the job to the person after the interview.",
-            "relationship_name": "offered_job",
-            "source_node_id": "small_software_consultancy",
-            "target_node_id": "person"
-          },
-          {
-            "description": "The person had their first job interview at the small software consultancy in 2010.",
-            "relationship_name": "had_interview_at",
-            "source_node_id": "person",
-            "target_node_id": "small_software_consultancy"
-          },
-          {
-            "description": "The person explained merge sort during the job interview at the small software consultancy.",
-            "relationship_name": "explained_algorithm",
-            "source_node_id": "person",
-            "target_node_id": "merge_sort"
-          },
-          {
-            "description": "The person forgot their portfolio at home before the job interview at the small software consultancy.",
-            "relationship_name": "forgot_item",
-            "source_node_id": "person",
-            "target_node_id": "portfolio"
-          }
-        ],
         "nodes": [
           {
-            "description": "A person who had their first job interview.",
-            "id": "person",
-            "name": "Person",
-            "type": "PERSON"
+            "id": "first_job_interview",
+            "name": "First Job Interview",
+            "type": "CONCEPT",
+            "description": "The first real job interview experience of the narrator."
           },
           {
-            "description": "A small software consultancy where the person had their first job interview.",
-            "id": "small_software_consultancy",
-            "name": "Small Software Consultancy",
-            "type": "ORGANIZATION"
+            "id": "software_consultancy",
+            "name": "small software consultancy",
+            "type": "ORGANIZATION",
+            "description": "A small software consultancy where the narrator had their first job interview."
           },
           {
-            "description": "A sorting algorithm that the person managed to explain during the interview.",
+            "id": "sorting_algorithm",
+            "name": "sorting algorithm",
+            "type": "CONCEPT",
+            "description": "A type of algorithm that organizes data in a specified order."
+          },
+          {
+            "id": "quicksort",
+            "name": "quicksort",
+            "type": "CONCEPT",
+            "description": "A sorting algorithm that was not recalled by the narrator during the interview."
+          },
+          {
             "id": "merge_sort",
-            "name": "Merge Sort",
-            "type": "CONCEPT"
+            "name": "merge sort",
+            "type": "CONCEPT",
+            "description": "A sorting algorithm that the narrator managed to explain clearly during the interview."
           },
           {
-            "description": "A portfolio that the person forgot at home before the interview.",
-            "id": "portfolio",
-            "name": "Portfolio",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "The year when the person had their first job interview.",
             "id": "2010",
             "name": "2010",
-            "type": "DATE"
+            "type": "DATE",
+            "description": "The year when the narrator had their first job interview."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "first_job_interview",
+            "target_node_id": "software_consultancy",
+            "relationship_name": "took_place_at",
+            "description": "The first job interview took place at a small software consultancy."
+          },
+          {
+            "source_node_id": "first_job_interview",
+            "target_node_id": "sorting_algorithm",
+            "relationship_name": "involved",
+            "description": "The first job interview involved a sorting algorithm."
+          },
+          {
+            "source_node_id": "first_job_interview",
+            "target_node_id": "2010",
+            "relationship_name": "occurred_in",
+            "description": "The first job interview occurred in 2010."
+          },
+          {
+            "source_node_id": "first_job_interview",
+            "target_node_id": "quicksort",
+            "relationship_name": "mentioned",
+            "description": "The sorting algorithm quicksort was mentioned but not recalled by the narrator."
+          },
+          {
+            "source_node_id": "first_job_interview",
+            "target_node_id": "merge_sort",
+            "relationship_name": "explained",
+            "description": "The narrator explained the sorting algorithm merge sort clearly during the interview."
           }
         ]
       }
@@ -1252,8 +1342,8 @@
       "user_input_preview": "Title: A Sunrise Over the Mountains\n\nI woke up at 4 AM to hike to a summit in the Dolomites to watch the sunrise. The tr",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "This chunk describes a personal experience of hiking in the Dolomites to watch the sunrise. The author details the early morning hike, the conditions of the trail, and the beauty of the sunrise over the mountain peaks.",
-        "summary": "The chunk recounts a 4 AM hike to a summit in the Dolomites to witness a stunning sunrise, highlighting the dark and cold trail and the vibrant colors of the rock faces."
+        "description": "This chunk describes a personal experience of hiking in the Dolomites to watch the sunrise. It captures the early morning setting, the beauty of the sunrise, and the solitude of the experience.",
+        "summary": "The chunk recounts a hike in the Dolomites to witness a sunrise, highlighting the beauty of the moment and the solitude of the experience."
       }
     },
     "597b5e3f9d9d0da4a7ffc2aabfb48db7c2ee774d6ca34305722e62e4a370ea97": {
@@ -1261,8 +1351,8 @@
       "user_input_preview": "Title: Planting a Garden\n\nIn spring 2021, I started a small vegetable garden on my balcony. I planted tomatoes, basil, a",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "In spring 2021, a small vegetable garden was started on a balcony, featuring tomatoes, basil, and peppers. By August, enough basil was harvested weekly to make pesto, while tomatoes thrived and peppers struggled due to insufficient sunlight, turning the gardening experience into a meditative morning ritual.",
-        "summary": "The chunk describes the experience of starting a vegetable garden on a balcony in spring 2021, highlighting the success of tomatoes and basil, and the challenges faced by peppers."
+        "description": "This chunk discusses the experience of starting and maintaining a vegetable garden on a balcony, including the types of plants grown and the outcomes of the gardening efforts.",
+        "summary": "The chunk describes the process of planting a vegetable garden on a balcony, focusing on the plants grown and the personal impact of gardening."
       }
     },
     "5a136d39f9b9ee836ae5ed400eb1b07402fc10ed68b60940b556d03b6beaa272": {
@@ -1270,8 +1360,8 @@
       "user_input_preview": "Title: Learning a New Language\n\nI started learning Japanese in 2019 using a combination of apps and textbooks. Hiragana ",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "This chunk discusses the process of learning Japanese, including the methods used and personal experiences related to language acquisition and travel.",
-        "summary": "The content describes the author's journey of learning Japanese, starting in 2019, and highlights the challenges and achievements encountered along the way."
+        "description": "This chunk discusses the author's experience learning Japanese, including the methods used, the challenges faced, and a memorable moment in Tokyo.",
+        "summary": "The author began learning Japanese in 2019 and reflects on their progress and experiences."
       }
     },
     "5ad736934381f61cdec23804e560323bcfeacd337d5176fab3a755969ae62652": {
@@ -1279,8 +1369,8 @@
       "user_input_preview": "Title: First Job Interview\n\nMy first real job interview was at a small software consultancy in 2010. I was so nervous th",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses a personal experience regarding a job interview at a software consultancy in 2010, highlighting the nervousness of forgetting a portfolio and the performance during a technical question.",
-        "summary": "The content recounts a first job interview experience at a software consultancy in 2010, where the author forgot their portfolio but successfully explained merge sort during a technical question."
+        "description": "This chunk discusses a personal experience related to a job interview.",
+        "summary": "The author describes their first job interview at a software consultancy in 2010."
       }
     },
     "5b18f22d9268ef2b6bf2d2ceae602339154848aa16a45a4c8f988eb35607f58d": {
@@ -1288,86 +1378,38 @@
       "user_input_preview": "Title: Hiking in the Alps\n\nIn the summer of 2015, I hiked the Tour du Mont Blanc with two friends. The 170-kilometer tra",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The Tour du Mont Blanc is a hiking trail located in the Alps.",
-            "relationship_name": "located_in",
-            "source_node_id": "Tour du Mont Blanc",
-            "target_node_id": "Alps"
-          },
-          {
-            "description": "The hiking trail Tour du Mont Blanc spans 170 kilometers.",
-            "relationship_name": "has_length",
-            "source_node_id": "Tour du Mont Blanc",
-            "target_node_id": "170 kilometers"
-          },
-          {
-            "description": "The hiking trail Tour du Mont Blanc passes through France, Italy, and Switzerland.",
-            "relationship_name": "passes_through",
-            "source_node_id": "Tour du Mont Blanc",
-            "target_node_id": "France"
-          },
-          {
-            "description": "The hiking trail Tour du Mont Blanc passes through France, Italy, and Switzerland.",
-            "relationship_name": "passes_through",
-            "source_node_id": "Tour du Mont Blanc",
-            "target_node_id": "Italy"
-          },
-          {
-            "description": "The hiking trail Tour du Mont Blanc passes through France, Italy, and Switzerland.",
-            "relationship_name": "passes_through",
-            "source_node_id": "Tour du Mont Blanc",
-            "target_node_id": "Switzerland"
-          },
-          {
-            "description": "The hike on the Tour du Mont Blanc took eleven days.",
-            "relationship_name": "took_duration",
-            "source_node_id": "Tour du Mont Blanc",
-            "target_node_id": "11 days"
-          }
-        ],
         "nodes": [
           {
-            "description": "The Tour du Mont Blanc is a famous hiking trail in the Alps, known for its scenic views.",
             "id": "Tour du Mont Blanc",
             "name": "Tour du Mont Blanc",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A 170-kilometer hiking trail that takes hikers through France, Italy, and Switzerland."
           },
           {
-            "description": "The Alps is a major mountain range in Europe, known for its stunning landscapes and outdoor activities.",
             "id": "Alps",
             "name": "Alps",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A major mountain range in Europe."
           },
           {
-            "description": "France is a country in Western Europe, known for its rich history and culture.",
-            "id": "France",
-            "name": "France",
-            "type": "CONCEPT"
+            "id": "Person",
+            "name": "Hiker",
+            "type": "PERSON",
+            "description": "An individual who engages in hiking."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Hiker",
+            "target_node_id": "Tour du Mont Blanc",
+            "relationship_name": "hiked",
+            "description": "The hiker hiked the Tour du Mont Blanc."
           },
           {
-            "description": "Italy is a country in Southern Europe, famous for its art, history, and cuisine.",
-            "id": "Italy",
-            "name": "Italy",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "Switzerland is a landlocked country in Central Europe, known for its mountains and neutrality.",
-            "id": "Switzerland",
-            "name": "Switzerland",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "170 kilometers is the length of the Tour du Mont Blanc hiking trail.",
-            "id": "170 kilometers",
-            "name": "170 kilometers",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "11 days is the duration it took to hike the Tour du Mont Blanc.",
-            "id": "11 days",
-            "name": "11 days",
-            "type": "CONCEPT"
+            "source_node_id": "Tour du Mont Blanc",
+            "target_node_id": "Alps",
+            "relationship_name": "located_in",
+            "description": "The Tour du Mont Blanc is located in the Alps."
           }
         ]
       }
@@ -1377,32 +1419,50 @@
       "user_input_preview": "Title: A Power Outage During a Demo\n\nDuring a client demo in 2018, the office power went out just as I was showing the n",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The client was impressed by the quick recovery during the demo.",
-            "relationship_name": "impressed_by",
-            "source_node_id": "client",
-            "target_node_id": "demo"
-          }
-        ],
         "nodes": [
           {
-            "description": "A demonstration of a product or service to a client.",
-            "id": "demo",
-            "name": "demo",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A person or organization that receives a service or product.",
             "id": "client",
             "name": "client",
-            "type": "CONCEPT"
+            "type": "PERSON",
+            "description": "A person or group receiving a demonstration."
           },
           {
-            "description": "An interruption of electrical power supply.",
             "id": "power_outage",
             "name": "power outage",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "An event where the electrical power supply is interrupted."
+          },
+          {
+            "id": "demo",
+            "name": "demo",
+            "type": "CONCEPT",
+            "description": "A demonstration of a product or service."
+          },
+          {
+            "id": "construction_crew",
+            "name": "construction crew",
+            "type": "ORGANIZATION",
+            "description": "A group responsible for construction work."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "demo",
+            "target_node_id": "client",
+            "relationship_name": "demonstrated_to",
+            "description": "The demo was presented to the client."
+          },
+          {
+            "source_node_id": "power_outage",
+            "target_node_id": "demo",
+            "relationship_name": "occurred_during",
+            "description": "The power outage occurred during the demo."
+          },
+          {
+            "source_node_id": "construction_crew",
+            "target_node_id": "power_outage",
+            "relationship_name": "caused",
+            "description": "The construction crew caused the power outage by cutting a cable."
           }
         ]
       }
@@ -1412,56 +1472,74 @@
       "user_input_preview": "Title: Teaching Someone to Code\n\nI taught my younger cousin the basics of Python over a summer. We started with variable",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The younger cousin is taught the basics of Python by the mentor.",
-            "relationship_name": "taught",
-            "source_node_id": "Mentor",
-            "target_node_id": "Younger Cousin"
-          },
-          {
-            "description": "The younger cousin is studying computer science at university.",
-            "relationship_name": "studies_at",
-            "source_node_id": "Younger Cousin",
-            "target_node_id": "University"
-          },
-          {
-            "description": "The mentor has a passion for programming, which was rekindled by teaching the younger cousin.",
-            "relationship_name": "has_passion_for",
-            "source_node_id": "Mentor",
-            "target_node_id": "Programming"
-          }
-        ],
         "nodes": [
           {
-            "description": "The mentor taught programming basics to their younger cousin and has a passion for programming.",
-            "id": "Mentor",
-            "name": "Mentor",
-            "type": "PERSON"
+            "id": "younger_cousin",
+            "name": "younger cousin",
+            "type": "PERSON",
+            "description": "A younger cousin who learned the basics of Python."
           },
           {
-            "description": "The younger cousin learned Python and is now pursuing computer science at university.",
-            "id": "Younger Cousin",
-            "name": "Younger Cousin",
-            "type": "PERSON"
-          },
-          {
-            "description": "Python is a programming language that was taught to the younger cousin.",
-            "id": "Python",
+            "id": "python",
             "name": "Python",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A programming language used to teach coding."
           },
           {
-            "description": "Programming is the field that the mentor is passionate about.",
-            "id": "Programming",
-            "name": "Programming",
-            "type": "CONCEPT"
+            "id": "text_adventure_game",
+            "name": "text adventure game",
+            "type": "CONCEPT",
+            "description": "A simple game built using Python."
           },
           {
-            "description": "University is where the younger cousin is studying computer science.",
-            "id": "University",
-            "name": "University",
-            "type": "CONCEPT"
+            "id": "programming",
+            "name": "programming",
+            "type": "CONCEPT",
+            "description": "The act of writing code to create software."
+          },
+          {
+            "id": "computer_science",
+            "name": "computer science",
+            "type": "CONCEPT",
+            "description": "A field of study that involves the study of computers and programming."
+          },
+          {
+            "id": "university",
+            "name": "university",
+            "type": "ORGANIZATION",
+            "description": "An institution where the younger cousin is studying computer science."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "younger_cousin",
+            "target_node_id": "python",
+            "relationship_name": "learned",
+            "description": "The younger cousin learned the basics of Python."
+          },
+          {
+            "source_node_id": "younger_cousin",
+            "target_node_id": "text_adventure_game",
+            "relationship_name": "built",
+            "description": "The younger cousin built a simple text adventure game using Python."
+          },
+          {
+            "source_node_id": "younger_cousin",
+            "target_node_id": "computer_science",
+            "relationship_name": "studying",
+            "description": "The younger cousin is studying computer science in university."
+          },
+          {
+            "source_node_id": "python",
+            "target_node_id": "programming",
+            "relationship_name": "related_to",
+            "description": "Python is related to programming."
+          },
+          {
+            "source_node_id": "younger_cousin",
+            "target_node_id": "university",
+            "relationship_name": "attends",
+            "description": "The younger cousin attends university."
           }
         ]
       }
@@ -1471,8 +1549,8 @@
       "user_input_preview": "Title: Building a Treehouse\n\nMy father and I built a treehouse in the oak tree in our backyard when I was ten. We spent ",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk describes the experience of building a treehouse with a father during childhood, highlighting the activities involved and the personal significance of the treehouse as a reading nook.",
-        "summary": "The content recounts the author's experience of building a treehouse with their father at the age of ten, which served as a cherished reading nook during summers."
+        "description": "This chunk is about a personal experience of building a treehouse with a father, focusing on childhood memories and DIY projects.",
+        "summary": "The chunk recounts a childhood experience of building a treehouse with a father."
       }
     },
     "607a599d316bd16cacb81932043135b8553257e7c2ae058e418af43f1e40d75f": {
@@ -1480,44 +1558,62 @@
       "user_input_preview": "Title: Understanding Recursion\n\nThe moment recursion clicked for me was during a lecture on the Tower of Hanoi. The prof",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The concept of recursion is illustrated through the Tower of Hanoi problem.",
-            "relationship_name": "illustrates",
-            "source_node_id": "recursion",
-            "target_node_id": "Tower of Hanoi"
-          },
-          {
-            "description": "The author implemented a recursive maze solver after understanding recursion.",
-            "relationship_name": "implemented",
-            "source_node_id": "author",
-            "target_node_id": "recursive maze solver"
-          }
-        ],
         "nodes": [
           {
-            "description": "Recursion is a concept in computer science where a function calls itself to solve a problem.",
             "id": "recursion",
             "name": "recursion",
+            "description": "A concept in computer science where a function calls itself to solve a problem.",
             "type": "CONCEPT"
           },
           {
-            "description": "The Tower of Hanoi is a mathematical puzzle that demonstrates the principles of recursion.",
-            "id": "Tower of Hanoi",
+            "id": "Tower_of_Hanoi",
             "name": "Tower of Hanoi",
+            "description": "A classic problem in recursion that illustrates the concept of solving a problem by breaking it down into smaller instances of the same problem.",
             "type": "CONCEPT"
           },
           {
-            "description": "The author is a learner who experienced a breakthrough in understanding recursion.",
-            "id": "author",
-            "name": "author",
-            "type": "PERSON"
-          },
-          {
-            "description": "A recursive maze solver is a program that uses recursion to find a path through a maze.",
-            "id": "recursive maze solver",
+            "id": "maze_solver",
             "name": "recursive maze solver",
+            "description": "A program that uses recursion to find a solution to a maze.",
             "type": "CONCEPT"
+          },
+          {
+            "id": "computer_science",
+            "name": "computer science",
+            "description": "The study of computers and computational systems, including concepts like recursion.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "learning",
+            "name": "learning",
+            "description": "The process of acquiring knowledge or skills through experience, study, or teaching.",
+            "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Tower_of_Hanoi",
+            "target_node_id": "recursion",
+            "relationship_name": "illustrates",
+            "description": "The Tower of Hanoi illustrates the concept of recursion by showing how the solution involves solving the same problem on a smaller scale."
+          },
+          {
+            "source_node_id": "recursive maze solver",
+            "target_node_id": "recursion",
+            "relationship_name": "uses",
+            "description": "The recursive maze solver uses recursion to find a solution to a maze."
+          },
+          {
+            "source_node_id": "computer_science",
+            "target_node_id": "recursion",
+            "relationship_name": "includes",
+            "description": "Computer science includes the concept of recursion as a fundamental topic."
+          },
+          {
+            "source_node_id": "learning",
+            "target_node_id": "recursion",
+            "relationship_name": "involves",
+            "description": "Learning involves understanding concepts like recursion in computer science."
           }
         ]
       }
@@ -1527,8 +1623,8 @@
       "user_input_preview": "Title: Power of a Mentor\n\nMy first real mentor was a senior engineer named David who took the time to review my code lin",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "This chunk discusses the importance of mentorship in career development, particularly in engineering. It highlights the mentoring style of a senior engineer named David, who focused on guiding rather than simply providing answers.",
-        "summary": "The chunk emphasizes the value of mentorship in engineering, showcasing how David, a senior engineer, guided the author through questioning rather than direct answers."
+        "description": "This chunk discusses the importance of mentorship in personal and professional development, highlighting the author's experience with a mentor named David, who encouraged critical thinking rather than simply providing solutions.",
+        "summary": "The chunk emphasizes the value of mentorship, illustrated through the author's experience with David, a senior engineer who fostered independent problem-solving."
       }
     },
     "63d5ccc4315d5ca0e435c1c5ba5bf51f6b31ee27df1d29ccf580777244cd5d6e": {
@@ -1536,26 +1632,20 @@
       "user_input_preview": "Title: Power of a Mentor\n\nMy first real mentor was a senior engineer named David who took the time to review my code lin",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "David is a mentor to the author, providing guidance and support in their engineering career.",
-            "relationship_name": "is_mentor_of",
-            "source_node_id": "David",
-            "target_node_id": "author"
-          }
-        ],
         "nodes": [
           {
-            "description": "David is a senior engineer who provided mentorship to the author by reviewing code and encouraging independent thinking.",
             "id": "David",
             "name": "David",
+            "description": "A senior engineer who served as a mentor.",
             "type": "PERSON"
-          },
+          }
+        ],
+        "edges": [
           {
-            "description": "The author is a person who received mentorship from David in their engineering career.",
-            "id": "author",
-            "name": "author",
-            "type": "PERSON"
+            "source_node_id": "David",
+            "target_node_id": "mentorship",
+            "relationship_name": "mentored",
+            "description": "David mentored by reviewing code and asking questions."
           }
         ]
       }
@@ -1565,8 +1655,8 @@
       "user_input_preview": "Title: A Thunderstorm at the Beach\n\nWe were at the beach when a sudden thunderstorm rolled in from the sea. The sky turn",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk describes a sudden thunderstorm that occurred at the beach, highlighting the dramatic changes in weather and the experience of seeking shelter in a car while observing the storm.",
-        "summary": "A sudden thunderstorm hit the beach, causing dark skies and strong winds, prompting a quick retreat to the car where the storm was both terrifying and beautiful."
+        "description": "This chunk describes an experience at the beach during a thunderstorm, detailing the sudden change in weather and the emotional response to the storm.",
+        "summary": "The chunk narrates a thunderstorm experience at the beach, highlighting the dramatic weather changes and the feelings evoked."
       }
     },
     "677cb6f7a54ea9a5c2e6d181d583ee413402dd1e98c733a723daa46a50ea02e6": {
@@ -1574,44 +1664,50 @@
       "user_input_preview": "Title: Discovering Podcasts\n\nI discovered podcasts during my daily commute in 2016. The first one I binged was a technol",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The technology history series covers the invention of the transistor.",
-            "relationship_name": "covers",
-            "source_node_id": "technology_history_series",
-            "target_node_id": "transistor"
-          },
-          {
-            "description": "Listening to podcasts transformed the commute into a learning opportunity.",
-            "relationship_name": "transformed",
-            "source_node_id": "podcasts",
-            "target_node_id": "commute"
-          }
-        ],
         "nodes": [
           {
-            "description": "Podcasts are digital audio files available for streaming or download, often focusing on various topics.",
-            "id": "podcasts",
+            "id": "Podcasts",
             "name": "Podcasts",
+            "description": "Digital audio files available for streaming or download, often in series format.",
             "type": "CONCEPT"
           },
           {
-            "description": "The technology history series is a podcast that discusses the history of technology, including significant inventions.",
-            "id": "technology_history_series",
-            "name": "Technology History Series",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "The transistor is a semiconductor device used to amplify or switch electronic signals and electrical power.",
-            "id": "transistor",
-            "name": "Transistor",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "Commute refers to the travel between one's home and place of work or study, often involving significant time spent in transit.",
-            "id": "commute",
+            "id": "Commute",
             "name": "Commute",
+            "description": "The act of traveling to and from work or school, often involving traffic.",
             "type": "CONCEPT"
+          },
+          {
+            "id": "Technology History Series",
+            "name": "Technology History Series",
+            "description": "A podcast series that covers the history of technology, including significant inventions like the transistor.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "Transistor",
+            "name": "Transistor",
+            "description": "An electronic component that can amplify or switch electronic signals, crucial in modern electronics.",
+            "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Podcasts",
+            "target_node_id": "Commute",
+            "relationship_name": "transforms",
+            "description": "Podcasts transformed the commute from wasted time into a learning opportunity."
+          },
+          {
+            "source_node_id": "Technology History Series",
+            "target_node_id": "Transistor",
+            "relationship_name": "covers",
+            "description": "The Technology History Series covers the invention of the transistor."
+          },
+          {
+            "source_node_id": "Podcasts",
+            "target_node_id": "Technology History Series",
+            "relationship_name": "includes",
+            "description": "Podcasts include the Technology History Series as one of the shows."
           }
         ]
       }
@@ -1621,8 +1717,8 @@
       "user_input_preview": "Title: Debugging a Production Outage\n\nIn 2019, our production database went down at 3 AM due to a misconfigured connecti",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "In 2019, a production database outage occurred at 3 AM due to a misconfigured connection pool. The issue was traced through logs for four hours, revealing that a recent deployment had reduced the maximum connections from 100 to 10, which was fixed with a one-line configuration change.",
-        "summary": "The chunk discusses a production database outage in 2019 caused by a misconfigured connection pool, which was resolved after a four-hour investigation."
+        "description": "This chunk discusses a production outage in 2019 caused by a misconfigured connection pool in a database. It details the process of debugging the issue, which involved tracing logs for four hours before identifying that a recent deployment had reduced the maximum connections from 100 to 10. The resolution required a simple one-line configuration change, although the investigation was challenging.",
+        "summary": "The chunk describes a 2019 production database outage due to a misconfigured connection pool, detailing the debugging process and the eventual fix."
       }
     },
     "6ce321e138b816b55bbef3e857198979bf7a568c3f922714066e773b3294108c": {
@@ -1630,8 +1726,8 @@
       "user_input_preview": "Title: First Programming Language\n\nI wrote my first program in BASIC on a Commodore 64 when I was twelve. It was a simpl",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the author's experience of writing their first program in BASIC on a Commodore 64, which was a number guessing game. This experience ignited their passion for programming.",
-        "summary": "The author wrote their first program in BASIC on a Commodore 64 at age twelve, which sparked a lifelong passion for programming."
+        "description": "This chunk discusses the author's experience with their first programming language and computer.",
+        "summary": "The author reflects on writing their first program in BASIC on a Commodore 64, which ignited their passion for programming."
       }
     },
     "7036a0460ae87899318a9ba1eef412438511c1f4923df8a19e052bd896129397": {
@@ -1639,26 +1735,62 @@
       "user_input_preview": "Title: A Flat Tire on a Road Trip\n\nHalfway through a road trip to the coast, we got a flat tire on a deserted stretch of",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The road trip involved car trouble due to a flat tire.",
-            "relationship_name": "involved",
-            "source_node_id": "road_trip",
-            "target_node_id": "car_trouble"
-          }
-        ],
         "nodes": [
           {
-            "description": "A journey taken by car, typically for leisure or vacation purposes.",
             "id": "road_trip",
-            "name": "road trip",
-            "type": "CONCEPT"
+            "name": "Road Trip",
+            "type": "CONCEPT",
+            "description": "A journey taken by car, often for leisure."
           },
           {
-            "description": "An issue with a vehicle that affects its operation, in this case, a flat tire.",
             "id": "car_trouble",
-            "name": "car trouble",
-            "type": "CONCEPT"
+            "name": "Car Trouble",
+            "type": "CONCEPT",
+            "description": "Issues or problems that occur with a vehicle."
+          },
+          {
+            "id": "flat_tire",
+            "name": "Flat Tire",
+            "type": "CONCEPT",
+            "description": "A tire that has lost air pressure, making it unusable."
+          },
+          {
+            "id": "truck_driver",
+            "name": "Truck Driver",
+            "type": "PERSON",
+            "description": "A person who drives a truck, often for commercial purposes."
+          },
+          {
+            "id": "beach",
+            "name": "Beach",
+            "type": "CONCEPT",
+            "description": "A landform along the shoreline of an ocean, sea, lake, or river."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "road_trip",
+            "target_node_id": "car_trouble",
+            "relationship_name": "involves",
+            "description": "A road trip can involve car trouble."
+          },
+          {
+            "source_node_id": "car_trouble",
+            "target_node_id": "flat_tire",
+            "relationship_name": "includes",
+            "description": "Car trouble includes having a flat tire."
+          },
+          {
+            "source_node_id": "flat_tire",
+            "target_node_id": "truck_driver",
+            "relationship_name": "assisted_by",
+            "description": "The truck driver assisted with the flat tire."
+          },
+          {
+            "source_node_id": "flat_tire",
+            "target_node_id": "beach",
+            "relationship_name": "delayed_arrival_at",
+            "description": "The flat tire caused a delay in arriving at the beach."
           }
         ]
       }
@@ -1668,38 +1800,38 @@
       "user_input_preview": "Title: The Solar Eclipse of 1999\n\nOn August 11, 1999, a total solar eclipse was visible from parts of Europe. I watched ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The solar eclipse occurred on August 11, 1999.",
-            "relationship_name": "occurred_on",
-            "source_node_id": "solar_eclipse",
-            "target_node_id": "1999"
-          },
-          {
-            "description": "The solar eclipse is a phenomenon studied in astronomy.",
-            "relationship_name": "related_to",
-            "source_node_id": "solar_eclipse",
-            "target_node_id": "astronomy"
-          }
-        ],
         "nodes": [
           {
-            "description": "A total solar eclipse that was visible from parts of Europe on August 11, 1999.",
-            "id": "solar_eclipse",
-            "name": "Solar Eclipse",
-            "type": "CONCEPT"
+            "id": "solar_eclipse_1999",
+            "name": "Solar Eclipse of 1999",
+            "type": "CONCEPT",
+            "description": "A total solar eclipse that occurred on August 11, 1999, visible from parts of Europe."
           },
           {
-            "description": "The year when the solar eclipse occurred.",
             "id": "1999",
             "name": "1999",
-            "type": "DATE"
+            "type": "DATE",
+            "description": "The year when the solar eclipse occurred."
           },
           {
-            "description": "The scientific study of celestial bodies and phenomena.",
             "id": "astronomy",
             "name": "Astronomy",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "The scientific study of celestial bodies, space, and the universe as a whole."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "solar_eclipse_1999",
+            "target_node_id": "1999",
+            "relationship_name": "occurred_in",
+            "description": "The Solar Eclipse of 1999 occurred in the year 1999."
+          },
+          {
+            "source_node_id": "solar_eclipse_1999",
+            "target_node_id": "astronomy",
+            "relationship_name": "related_to",
+            "description": "The Solar Eclipse of 1999 is related to the field of astronomy."
           }
         ]
       }
@@ -1709,8 +1841,8 @@
       "user_input_preview": "Title: Adopting a Cat\n\nWe adopted our cat Luna from a local shelter in 2020. She was shy at first and hid under the couc",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "This chunk discusses the adoption of a cat named Luna from a local shelter in 2020. It describes her initial shyness, her eventual acclimatization to her new home, and a distinctive feature of her appearance.",
-        "summary": "The content details the adoption of a cat named Luna in 2020, highlighting her initial shyness and her later affectionate behavior."
+        "description": "The chunk discusses the adoption of a cat named Luna, her initial shyness, and her current behavior.",
+        "summary": "The content details the experience of adopting a cat named Luna from a shelter in 2020."
       }
     },
     "7520f9b4f5564a7fec9c8345552d24a19423d8a3695a8cfb2cb125acaa580527": {
@@ -1718,68 +1850,38 @@
       "user_input_preview": "Title: Moving to a New City\n\nWhen I moved to Berlin in 2018, I knew nobody in the city. The first month was lonely — I s",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The person moved to Berlin in 2018.",
-            "relationship_name": "moved_to",
-            "source_node_id": "Person",
-            "target_node_id": "Berlin"
-          },
-          {
-            "description": "The person explored neighborhoods in Berlin.",
-            "relationship_name": "explored",
-            "source_node_id": "Person",
-            "target_node_id": "Berlin"
-          },
-          {
-            "description": "The person found a co-working space in Berlin.",
-            "relationship_name": "found",
-            "source_node_id": "Person",
-            "target_node_id": "Co-working Space"
-          },
-          {
-            "description": "The person met people who became close friends in the co-working space.",
-            "relationship_name": "met",
-            "source_node_id": "Person",
-            "target_node_id": "Friends"
-          },
-          {
-            "description": "The Kreuzberg district felt like home to the person within six months of moving to Berlin.",
-            "relationship_name": "felt_like_home",
-            "source_node_id": "Person",
-            "target_node_id": "Kreuzberg"
-          }
-        ],
         "nodes": [
           {
-            "description": "A city in Germany known for its culture and history.",
             "id": "Berlin",
             "name": "Berlin",
+            "description": "A city in Germany where the author relocated in 2018.",
             "type": "CITY"
           },
           {
-            "description": "A district in Berlin known for its vibrant culture and community.",
             "id": "Kreuzberg",
             "name": "Kreuzberg",
+            "description": "A district in Berlin that the author felt like home within six months.",
             "type": "DISTRICT"
           },
           {
-            "description": "A person who relocated to Berlin.",
-            "id": "Person",
-            "name": "Person",
-            "type": "PERSON"
+            "id": "2018",
+            "name": "2018",
+            "description": "The year the author moved to Berlin.",
+            "type": "DATE"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Berlin",
+            "target_node_id": "Kreuzberg",
+            "relationship_name": "contains",
+            "description": "Berlin contains the Kreuzberg district."
           },
           {
-            "description": "A space where individuals work independently or collaboratively, often in a shared environment.",
-            "id": "Co-working Space",
-            "name": "Co-working Space",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "Individuals who share a close bond with the person.",
-            "id": "Friends",
-            "name": "Friends",
-            "type": "PERSON"
+            "source_node_id": "Berlin",
+            "target_node_id": "2018",
+            "relationship_name": "relocated_in",
+            "description": "The author relocated to Berlin in 2018."
           }
         ]
       }
@@ -1789,8 +1891,8 @@
       "user_input_preview": "Title: Watching the World Cup Final\n\nThe 2014 World Cup final between Germany and Argentina was one of the most tense ma",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the 2014 World Cup final match between Germany and Argentina, highlighting the atmosphere during the game and the moment when Götze scored.",
-        "summary": "The chunk describes the intense experience of watching the 2014 World Cup final between Germany and Argentina, focusing on the moment Götze scored in extra time."
+        "description": "This chunk discusses the 2014 World Cup final match between Germany and Argentina, highlighting the atmosphere during the game and a specific moment when Götze scored.",
+        "summary": "The chunk describes the tense atmosphere during the 2014 World Cup final between Germany and Argentina, focusing on the moment Götze scored."
       }
     },
     "79bca1fc3d87642ec44c16b7ff8d62ab31746334539fd4d295ce0a64dcd64845": {
@@ -1798,38 +1900,80 @@
       "user_input_preview": "Title: Reading Lord of the Rings\n\nI read the entire Lord of the Rings trilogy in one week during summer break when I was",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The chapter 'The Bridge of Khazad-dûm' from 'Lord of the Rings' gave the reader chills.",
-            "relationship_name": "contains_chapter",
-            "source_node_id": "Lord of the Rings",
-            "target_node_id": "The Bridge of Khazad-dûm"
-          },
-          {
-            "description": "The ending of 'Lord of the Rings' at the Grey Havens made the reader cry.",
-            "relationship_name": "has_impact_on",
-            "source_node_id": "Lord of the Rings",
-            "target_node_id": "Grey Havens"
-          }
-        ],
         "nodes": [
           {
-            "description": "'Lord of the Rings' is a high-fantasy novel written by J.R.R. Tolkien, consisting of three volumes.",
+            "id": "J.R.R. Tolkien",
+            "name": "J.R.R. Tolkien",
+            "type": "PERSON",
+            "description": "J.R.R. Tolkien is the author of the Lord of the Rings trilogy."
+          },
+          {
             "id": "Lord of the Rings",
             "name": "Lord of the Rings",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "The Lord of the Rings is a high-fantasy novel written by J.R.R. Tolkien."
           },
           {
-            "description": "'The Bridge of Khazad-dûm' is a chapter in 'Lord of the Rings' that is notable for its emotional impact.",
+            "id": "Middle-earth",
+            "name": "Middle-earth",
+            "type": "CONCEPT",
+            "description": "Middle-earth is the fictional setting for the Lord of the Rings."
+          },
+          {
             "id": "The Bridge of Khazad-dûm",
             "name": "The Bridge of Khazad-dûm",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "The Bridge of Khazad-dûm is a chapter in the Lord of the Rings that evokes strong emotions."
           },
           {
-            "description": "The Grey Havens is a significant location in 'Lord of the Rings' associated with the ending of the story.",
-            "id": "Grey Havens",
-            "name": "Grey Havens",
-            "type": "CONCEPT"
+            "id": "The Grey Havens",
+            "name": "The Grey Havens",
+            "type": "CONCEPT",
+            "description": "The Grey Havens is the ending chapter of the Lord of the Rings that made the reader cry."
+          },
+          {
+            "id": "summer break",
+            "name": "summer break",
+            "type": "DATE",
+            "description": "The time period during which the reading took place."
+          },
+          {
+            "id": "14",
+            "name": "14",
+            "type": "DATE",
+            "description": "The age of the reader when they read the Lord of the Rings."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "J.R.R. Tolkien",
+            "target_node_id": "Lord of the Rings",
+            "relationship_name": "wrote",
+            "description": "J.R.R. Tolkien wrote the Lord of the Rings."
+          },
+          {
+            "source_node_id": "Lord of the Rings",
+            "target_node_id": "Middle-earth",
+            "relationship_name": "set_in",
+            "description": "The Lord of the Rings is set in Middle-earth."
+          },
+          {
+            "source_node_id": "Lord of the Rings",
+            "target_node_id": "The Bridge of Khazad-dûm",
+            "relationship_name": "contains_chapter",
+            "description": "The Lord of the Rings contains the chapter 'The Bridge of Khazad-dûm'."
+          },
+          {
+            "source_node_id": "Lord of the Rings",
+            "target_node_id": "The Grey Havens",
+            "relationship_name": "contains_chapter",
+            "description": "The Lord of the Rings contains the chapter 'The Grey Havens'."
+          },
+          {
+            "source_node_id": "summer break",
+            "target_node_id": "14",
+            "relationship_name": "during",
+            "description": "The reading of the Lord of the Rings took place during summer break when the reader was 14."
           }
         ]
       }
@@ -1839,44 +1983,26 @@
       "user_input_preview": "Title: Attending a Live Concert\n\nThe first live concert I attended was Radiohead at a festival in 2006. The band opened ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "Radiohead performed at a festival in 2006.",
-            "relationship_name": "performed_at",
-            "source_node_id": "Radiohead",
-            "target_node_id": "2006"
-          },
-          {
-            "description": "The crowd sang along to Karma Police during the concert by Radiohead.",
-            "relationship_name": "sang_along_to",
-            "source_node_id": "crowd",
-            "target_node_id": "Karma Police"
-          }
-        ],
         "nodes": [
           {
-            "description": "Radiohead is a British rock band formed in 1985, known for their experimental approach to music.",
             "id": "Radiohead",
             "name": "Radiohead",
-            "type": "BAND"
+            "description": "An English rock band formed in 1985.",
+            "type": "ORGANIZATION"
           },
           {
-            "description": "Karma Police is a song by Radiohead from their album OK Computer, released in 1997.",
-            "id": "Karma Police",
-            "name": "Karma Police",
-            "type": "SONG"
-          },
-          {
-            "description": "The year 2006 is noted for various events, including the live concert attended by the narrator.",
             "id": "2006",
             "name": "2006",
+            "description": "The year when the concert took place.",
             "type": "DATE"
-          },
+          }
+        ],
+        "edges": [
           {
-            "description": "The crowd refers to the audience present at the concert, participating in the live performance.",
-            "id": "crowd",
-            "name": "crowd",
-            "type": "GROUP"
+            "source_node_id": "Radiohead",
+            "target_node_id": "2006",
+            "relationship_name": "performed_in",
+            "description": "Radiohead performed at a festival in 2006."
           }
         ]
       }
@@ -1886,8 +2012,8 @@
       "user_input_preview": "Title: Coffee Culture Discovery\n\nI discovered specialty coffee when a friend took me to a third-wave coffee shop in 2017",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the author's journey into specialty coffee, starting in 2017 when they visited a third-wave coffee shop. They learned about coffee processing methods and experienced tasting unique flavors in coffee for the first time.",
-        "summary": "The author discovered specialty coffee in 2017 at a third-wave coffee shop, where they learned about coffee processing and tasted blueberries in coffee for the first time."
+        "description": "This chunk discusses the discovery of specialty coffee, highlighting the experience at a third-wave coffee shop and the introduction to different coffee processing methods.",
+        "summary": "The author discovered specialty coffee in 2017 at a third-wave coffee shop, which sparked their enthusiasm for coffee."
       }
     },
     "7d07054d19fea273fb5908a486c028deb505e0d387c9e18a06e2c5a809b26c59": {
@@ -1895,8 +2021,8 @@
       "user_input_preview": "Title: First Flight Experience\n\nMy first time on an airplane was a flight from Belgrade to London when I was sixteen. I ",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk describes a personal experience of flying for the first time on a flight from Belgrade to London at the age of sixteen. The author enjoyed the view from the window seat and felt a mix of excitement and nervousness during takeoff, ultimately finding the flight serene.",
-        "summary": "The author recounts their first airplane flight from Belgrade to London at sixteen, highlighting the excitement of the window seat and the serene views during the journey."
+        "description": "This chunk is about: \n- Topics: flying, travel, first experience\n\nFacts:\n- At the age of sixteen, I took my first flight from Belgrade to London. \n- During the flight, I had a window seat and enjoyed watching the clouds from above.",
+        "summary": "The chunk describes a person's first flight experience from Belgrade to London at the age of sixteen, highlighting the emotions and views during the journey."
       }
     },
     "805012acd819997f9c74a9bac11349e172158e282e44046d65d84ba496025be0": {
@@ -1904,56 +2030,86 @@
       "user_input_preview": "Title: A Conversation with a Stranger\n\nOn a delayed train from Prague to Vienna, I sat next to a retired physicist who t",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The retired physicist explained quantum tunneling using a coffee cup metaphor during a conversation with the narrator.",
-            "relationship_name": "explained",
-            "source_node_id": "retired_physicist",
-            "target_node_id": "quantum_tunneling"
-          },
-          {
-            "description": "The narrator had a three-hour conversation with the retired physicist on a delayed train from Prague to Vienna.",
-            "relationship_name": "had_conversation_with",
-            "source_node_id": "narrator",
-            "target_node_id": "retired_physicist"
-          },
-          {
-            "description": "The retired physicist worked on particle accelerators in the 1980s.",
-            "relationship_name": "worked_on",
-            "source_node_id": "retired_physicist",
-            "target_node_id": "particle_accelerators"
-          }
-        ],
         "nodes": [
           {
-            "description": "The narrator is a person who sat next to a retired physicist on a train and had a significant conversation about physics.",
-            "id": "narrator",
-            "name": "Narrator",
-            "type": "PERSON"
-          },
-          {
-            "description": "The retired physicist is a person who worked on particle accelerators in the 1980s and explained quantum tunneling.",
-            "id": "retired_physicist",
+            "id": "Retired Physicist",
             "name": "Retired Physicist",
-            "type": "PERSON"
+            "type": "PERSON",
+            "description": "A retired physicist who worked on particle accelerators in the 1980s."
           },
           {
-            "description": "Quantum tunneling is a concept in physics that describes the phenomenon where particles pass through a barrier that they classically shouldn't be able to cross.",
-            "id": "quantum_tunneling",
-            "name": "Quantum Tunneling",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "Particle accelerators are devices that use electromagnetic fields to propel charged particles to high speeds and contain them in well-defined beams.",
-            "id": "particle_accelerators",
+            "id": "Particle Accelerators",
             "name": "Particle Accelerators",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "Devices used to accelerate charged particles to high speeds."
           },
           {
-            "description": "The train journey from Prague to Vienna is a travel route that the narrator took while conversing with the retired physicist.",
-            "id": "train_prague_to_vienna",
+            "id": "Quantum Tunneling",
+            "name": "Quantum Tunneling",
+            "type": "CONCEPT",
+            "description": "A quantum phenomenon where particles pass through a barrier that they classically shouldn't be able to."
+          },
+          {
+            "id": "Coffee Cup Metaphor",
+            "name": "Coffee Cup Metaphor",
+            "type": "CONCEPT",
+            "description": "A metaphor used to explain quantum tunneling."
+          },
+          {
+            "id": "Train from Prague to Vienna",
             "name": "Train from Prague to Vienna",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A train route connecting Prague and Vienna."
+          },
+          {
+            "id": "1980s",
+            "name": "1980s",
+            "type": "DATE",
+            "description": "The decade during which the physicist worked on particle accelerators."
+          },
+          {
+            "id": "Time and Randomness",
+            "name": "Time and Randomness",
+            "type": "CONCEPT",
+            "description": "Concepts that were reconsidered during the conversation."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Retired Physicist",
+            "target_node_id": "Particle Accelerators",
+            "relationship_name": "worked_on",
+            "description": "Retired Physicist worked on Particle Accelerators in the 1980s."
+          },
+          {
+            "source_node_id": "Retired Physicist",
+            "target_node_id": "Quantum Tunneling",
+            "relationship_name": "explained",
+            "description": "Retired Physicist explained Quantum Tunneling using a Coffee Cup Metaphor."
+          },
+          {
+            "source_node_id": "Coffee Cup Metaphor",
+            "target_node_id": "Quantum Tunneling",
+            "relationship_name": "illustrates",
+            "description": "Coffee Cup Metaphor illustrates Quantum Tunneling."
+          },
+          {
+            "source_node_id": "Train from Prague to Vienna",
+            "target_node_id": "Retired Physicist",
+            "relationship_name": "sat_next_to",
+            "description": "The narrator sat next to Retired Physicist on the Train from Prague to Vienna."
+          },
+          {
+            "source_node_id": "Retired Physicist",
+            "target_node_id": "Time and Randomness",
+            "relationship_name": "influenced",
+            "description": "Retired Physicist influenced the narrator's thoughts on Time and Randomness."
+          },
+          {
+            "source_node_id": "1980s",
+            "target_node_id": "Particle Accelerators",
+            "relationship_name": "time_period",
+            "description": "1980s is the time period when Particle Accelerators were worked on by Retired Physicist."
           }
         ]
       }
@@ -1963,8 +2119,8 @@
       "user_input_preview": "Title: Learning to Swim\n\nI learned to swim at the municipal pool when I was eight. The instructor, Mrs. Petrovic, was pa",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the author's experience learning to swim at a municipal pool during childhood. The instructor, Mrs. Petrovic, played a significant role in teaching the author by emphasizing floating techniques and helping them overcome their fear of the deep end.",
-        "summary": "The author learned to swim at eight years old with instructor Mrs. Petrovic at a municipal pool, overcoming a fear of the deep end."
+        "description": "This chunk is about: \n- People: Mrs. Petrovic \n- Topics: swimming, childhood",
+        "summary": "The chunk describes a personal experience of learning to swim at a municipal pool, highlighting the instructor's approach and the author's initial fear of the deep end."
       }
     },
     "85bb1fc4cdf4bbcc6e5f5bd1698e983f533f618bb1927e4a87e6b18e79824e3c": {
@@ -1972,8 +2128,8 @@
       "user_input_preview": "Title: The Importance of Backups\n\nI learned the importance of backups when my laptop's hard drive failed in 2016, taking",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the significance of backups in preventing data loss, illustrated by a personal experience of losing six months of projects due to a hard drive failure in 2016. It emphasizes the necessity of having multiple backups, both on external drives and in cloud storage.",
-        "summary": "The content highlights the critical nature of backups to avoid data loss, based on a personal experience of losing important projects due to a hard drive failure."
+        "description": "This chunk discusses the significance of data backups, particularly following a personal experience of data loss due to a hard drive failure.",
+        "summary": "The chunk emphasizes the critical need for backups to prevent data loss."
       }
     },
     "8d19df0b0cfed9fbf02624617c9df6553d9c5717499e227a6e418c8d8c0f03fa": {
@@ -1981,56 +2137,50 @@
       "user_input_preview": "Title: Visiting a Museum in Florence\n\nSeeing Michelangelo's David at the Galleria dell'Accademia in Florence was overwhe",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "Michelangelo's David is located at Galleria dell'Accademia in Florence.",
-            "relationship_name": "located_in",
-            "source_node_id": "Michelangelo's David",
-            "target_node_id": "Galleria dell'Accademia"
-          },
-          {
-            "description": "Galleria dell'Accademia is located in Florence.",
-            "relationship_name": "located_in",
-            "source_node_id": "Galleria dell'Accademia",
-            "target_node_id": "Florence"
-          }
-        ],
         "nodes": [
           {
-            "description": "Michelangelo's David is a renowned sculpture created by Michelangelo.",
-            "id": "Michelangelo's David",
-            "name": "Michelangelo's David",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "Galleria dell'Accademia is a museum in Florence known for housing Michelangelo's David.",
-            "id": "Galleria dell'Accademia",
-            "name": "Galleria dell'Accademia",
-            "type": "ORGANIZATION"
-          },
-          {
-            "description": "Florence is a city in Italy known for its art and history.",
-            "id": "Florence",
-            "name": "Florence",
-            "type": "LOCATION"
-          },
-          {
-            "description": "Michelangelo was an Italian sculptor, painter, and architect of the High Renaissance.",
             "id": "Michelangelo",
             "name": "Michelangelo",
+            "description": "Michelangelo is a renowned artist known for his sculptures, paintings, and architectural works.",
             "type": "PERSON"
           },
           {
-            "description": "Art refers to the diverse range of human activities that involve the creation of visual, auditory, or performance artifacts.",
-            "id": "art",
-            "name": "art",
+            "id": "David",
+            "name": "David",
+            "description": "David is a famous sculpture created by Michelangelo, representing a biblical figure.",
             "type": "CONCEPT"
           },
           {
-            "description": "Travel refers to the movement of people between distant geographical locations.",
-            "id": "travel",
-            "name": "travel",
+            "id": "Galleria dell'Accademia",
+            "name": "Galleria dell'Accademia",
+            "description": "Galleria dell'Accademia is a museum in Florence that houses Michelangelo's David among other artworks.",
+            "type": "ORGANIZATION"
+          },
+          {
+            "id": "Florence",
+            "name": "Florence",
+            "description": "Florence is a city in Italy known for its rich history, art, and architecture.",
             "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "David",
+            "target_node_id": "Michelangelo",
+            "relationship_name": "created_by",
+            "description": "David is a sculpture created by Michelangelo."
+          },
+          {
+            "source_node_id": "David",
+            "target_node_id": "Galleria dell'Accademia",
+            "relationship_name": "located_in",
+            "description": "David is located in the Galleria dell'Accademia in Florence."
+          },
+          {
+            "source_node_id": "Galleria dell'Accademia",
+            "target_node_id": "Florence",
+            "relationship_name": "located_in",
+            "description": "Galleria dell'Accademia is located in Florence."
           }
         ]
       }
@@ -2040,56 +2190,62 @@
       "user_input_preview": "Title: A Broken Deployment Pipeline\n\nOur CI/CD pipeline broke silently for two weeks in 2021 — tests were passing but no",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The CI/CD pipeline is associated with GitHub Actions.",
-            "relationship_name": "uses",
-            "source_node_id": "CI/CD",
-            "target_node_id": "GitHub Actions"
-          },
-          {
-            "description": "The CI/CD pipeline includes testing as a component.",
-            "relationship_name": "includes",
-            "source_node_id": "CI/CD",
-            "target_node_id": "testing"
-          },
-          {
-            "description": "The broken PR was merged to the main branch of the CI/CD pipeline.",
-            "relationship_name": "merged_to",
-            "source_node_id": "broken PR",
-            "target_node_id": "main"
-          }
-        ],
         "nodes": [
           {
-            "description": "CI/CD is a software development practice that enables frequent code changes and automated testing.",
             "id": "CI/CD",
             "name": "CI/CD",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A set of practices and tools for automating the processes of software development and deployment."
           },
           {
-            "description": "GitHub Actions is a CI/CD tool that automates workflows for software development.",
             "id": "GitHub Actions",
             "name": "GitHub Actions",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A CI/CD feature that allows automation of workflows directly in GitHub."
           },
           {
-            "description": "Testing is the process of evaluating software to ensure it meets requirements and functions correctly.",
             "id": "testing",
             "name": "testing",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "The process of evaluating a system or its components to determine whether they satisfy specified requirements."
           },
           {
-            "description": "A broken PR is a pull request that contains errors or issues that prevent it from being successfully merged.",
-            "id": "broken PR",
-            "name": "broken PR",
-            "type": "CONCEPT"
+            "id": "Broken PR",
+            "name": "Broken PR",
+            "type": "CONCEPT",
+            "description": "A pull request that introduces errors or issues into the codebase."
           },
           {
-            "description": "Main is the primary branch in a version control system where the stable code resides.",
-            "id": "main",
-            "name": "main",
-            "type": "CONCEPT"
+            "id": "canary test",
+            "name": "canary test",
+            "type": "CONCEPT",
+            "description": "A test that is intentionally designed to fail to verify that the testing suite is executed."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "CI/CD",
+            "target_node_id": "GitHub Actions",
+            "relationship_name": "uses",
+            "description": "CI/CD utilizes GitHub Actions for automating workflows."
+          },
+          {
+            "source_node_id": "GitHub Actions",
+            "target_node_id": "testing",
+            "relationship_name": "supports",
+            "description": "GitHub Actions supports testing as part of the CI/CD process."
+          },
+          {
+            "source_node_id": "Broken PR",
+            "target_node_id": "CI/CD",
+            "relationship_name": "impacts",
+            "description": "A broken PR negatively impacts the CI/CD pipeline."
+          },
+          {
+            "source_node_id": "canary test",
+            "target_node_id": "CI/CD",
+            "relationship_name": "enhances",
+            "description": "The canary test enhances the CI/CD pipeline by ensuring tests are executed."
           }
         ]
       }
@@ -2099,38 +2255,38 @@
       "user_input_preview": "Title: Learning a New Language\n\nI started learning Japanese in 2019 using a combination of apps and textbooks. Hiragana ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The person started learning Japanese in 2019 using apps and textbooks.",
-            "relationship_name": "started_learning",
-            "source_node_id": "Person",
-            "target_node_id": "Japanese"
-          },
-          {
-            "description": "The person visited Tokyo and ordered food in Japanese for the first time.",
-            "relationship_name": "visited",
-            "source_node_id": "Person",
-            "target_node_id": "Tokyo"
-          }
-        ],
         "nodes": [
           {
-            "description": "A language spoken primarily in Japan, known for its three writing systems: hiragana, katakana, and kanji.",
             "id": "Japanese",
             "name": "Japanese",
-            "type": "LANGUAGE"
+            "description": "A language spoken primarily in Japan.",
+            "type": "CONCEPT"
           },
           {
-            "description": "A city in Japan, known for its modern architecture, shopping, and cultural landmarks.",
             "id": "Tokyo",
             "name": "Tokyo",
-            "type": "CITY"
+            "description": "The capital city of Japan.",
+            "type": "CONCEPT"
           },
           {
-            "description": "An individual who is learning a new language.",
-            "id": "Person",
-            "name": "Person",
-            "type": "PERSON"
+            "id": "language_learning",
+            "name": "Language Learning",
+            "description": "The process of acquiring the ability to communicate in a new language.",
+            "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "language_learning",
+            "target_node_id": "Japanese",
+            "relationship_name": "involves",
+            "description": "Language learning involves studying Japanese."
+          },
+          {
+            "source_node_id": "Tokyo",
+            "target_node_id": "Japanese",
+            "relationship_name": "spoken_in",
+            "description": "Japanese is spoken in Tokyo."
           }
         ]
       }
@@ -2140,8 +2296,8 @@
       "user_input_preview": "Title: Attending a Live Concert\n\nThe first live concert I attended was Radiohead at a festival in 2006. The band opened ",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the author's experience attending a live concert by Radiohead in 2006, highlighting the band's performance and the emotional impact of the event.",
-        "summary": "The author attended a Radiohead concert in 2006, where the band opened with 'There There' and the crowd sang along to 'Karma Police.' They still have the wristband from the concert."
+        "description": "This chunk is about: \n- People: Radiohead \n- Topics: music, concerts",
+        "summary": "The author recalls attending their first live concert featuring Radiohead in 2006, highlighting the memorable experience of the crowd singing along."
       }
     },
     "931e2ca00e4bc636ca7eeeb860cea6b86a78605516ca793d5034a6f6677df123": {
@@ -2149,68 +2305,74 @@
       "user_input_preview": "Title: Refactoring Legacy Code\n\nI spent three months refactoring a 10,000-line PHP file that had been accumulating featu",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The process of refactoring involves improving legacy code.",
-            "relationship_name": "involves",
-            "source_node_id": "refactoring",
-            "target_node_id": "legacy_code"
-          },
-          {
-            "description": "Refactoring was done on a PHP file.",
-            "relationship_name": "refactored",
-            "source_node_id": "refactoring",
-            "target_node_id": "PHP_file"
-          },
-          {
-            "description": "Characterization tests were written to ensure existing behavior during refactoring.",
-            "relationship_name": "used",
-            "source_node_id": "characterization_tests",
-            "target_node_id": "refactoring"
-          },
-          {
-            "description": "The refactoring process resulted in the code being organized into well-named files.",
-            "relationship_name": "resulted_in",
-            "source_node_id": "refactoring",
-            "target_node_id": "well_named_files"
-          }
-        ],
         "nodes": [
           {
-            "description": "Refactoring is the process of restructuring existing computer code without changing its external behavior.",
-            "id": "refactoring",
-            "name": "Refactoring",
-            "type": "CONCEPT"
+            "id": "Refactoring_Legacy_Code",
+            "name": "Refactoring Legacy Code",
+            "type": "CONCEPT",
+            "description": "The process of improving the structure of existing code without changing its external behavior."
           },
           {
-            "description": "Legacy code refers to outdated code that is still in use, often difficult to maintain or modify.",
-            "id": "legacy_code",
-            "name": "Legacy Code",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "PHP is a popular general-purpose scripting language that is especially suited to web development.",
             "id": "PHP",
             "name": "PHP",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A popular general-purpose scripting language that is especially suited to web development."
           },
           {
-            "description": "Characterization tests are tests that capture the current behavior of a system to ensure that future changes do not alter that behavior.",
-            "id": "characterization_tests",
+            "id": "Characterization_Tests",
             "name": "Characterization Tests",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "Tests that capture the existing behavior of a system to ensure that refactoring does not change its functionality."
           },
           {
-            "description": "Well-named files refer to files that are organized and named in a way that clearly indicates their purpose and functionality.",
-            "id": "well_named_files",
-            "name": "Well-Named Files",
-            "type": "CONCEPT"
+            "id": "Legacy_Code",
+            "name": "Legacy Code",
+            "type": "CONCEPT",
+            "description": "Code that is inherited from an older version of a system, often difficult to maintain."
           },
           {
-            "description": "A PHP file is a file that contains PHP code, which can be executed on a server to generate dynamic web content.",
-            "id": "PHP_file",
-            "name": "PHP File",
-            "type": "CONCEPT"
+            "id": "Test_Suite",
+            "name": "Test Suite",
+            "type": "CONCEPT",
+            "description": "A collection of tests that are run to validate the behavior of code."
+          },
+          {
+            "id": "Team",
+            "name": "Team",
+            "type": "PERSON",
+            "description": "The group of individuals involved in the refactoring process."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Refactoring_Legacy_Code",
+            "target_node_id": "Legacy_Code",
+            "relationship_name": "involves",
+            "description": "Refactoring Legacy Code involves improving the structure of Legacy Code."
+          },
+          {
+            "source_node_id": "Refactoring_Legacy_Code",
+            "target_node_id": "Characterization_Tests",
+            "relationship_name": "utilizes",
+            "description": "Refactoring Legacy Code utilizes Characterization Tests to lock down existing behavior."
+          },
+          {
+            "source_node_id": "Refactoring_Legacy_Code",
+            "target_node_id": "PHP",
+            "relationship_name": "implemented_in",
+            "description": "Refactoring Legacy Code was performed on a PHP file."
+          },
+          {
+            "source_node_id": "Refactoring_Legacy_Code",
+            "target_node_id": "Test_Suite",
+            "relationship_name": "uses",
+            "description": "Refactoring Legacy Code uses a Test Suite to validate changes after each modification."
+          },
+          {
+            "source_node_id": "Team",
+            "target_node_id": "Refactoring_Legacy_Code",
+            "relationship_name": "participated_in",
+            "description": "The Team participated in the process of Refactoring Legacy Code."
           }
         ]
       }
@@ -2220,8 +2382,8 @@
       "user_input_preview": "Title: A Broken Deployment Pipeline\n\nOur CI/CD pipeline broke silently for two weeks in 2021 — tests were passing but no",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses a broken CI/CD pipeline due to a misconfigured GitHub Actions workflow in 2021, which went unnoticed for two weeks. It highlights the importance of testing and mentions the addition of a canary test to ensure proper execution of the test suite.",
-        "summary": "The CI/CD pipeline was broken for two weeks in 2021 due to a misconfigured GitHub Actions workflow, leading to the merging of a broken PR. A canary test was later added to ensure the test suite executes properly."
+        "description": "This chunk discusses a broken CI/CD pipeline due to a misconfiguration in GitHub Actions, which resulted in tests passing without actually running. It highlights the discovery of the issue after a broken PR was merged and the subsequent addition of a canary test to ensure proper execution of the test suite.",
+        "summary": "The chunk describes a CI/CD pipeline issue caused by a misconfigured GitHub Actions workflow, leading to undetected test failures. A canary test was later added to prevent similar issues."
       }
     },
     "9aad9ad2fc976a17875be157a0438e974718adde951c2d19d64ed77ef34e73c7": {
@@ -2229,62 +2391,56 @@
       "user_input_preview": "Title: Learning to Play Chess\n\nMy uncle taught me chess when I was seven. He never let me win, which frustrated me at fi",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The uncle taught the person chess.",
-            "relationship_name": "taught",
-            "source_node_id": "uncle",
-            "target_node_id": "Person"
-          },
-          {
-            "description": "The person joined the school chess club.",
-            "relationship_name": "joined",
-            "source_node_id": "Person",
-            "target_node_id": "school_chess_club"
-          },
-          {
-            "description": "The person placed third in a regional tournament.",
-            "relationship_name": "placed_in",
-            "source_node_id": "Person",
-            "target_node_id": "regional_tournament"
-          },
-          {
-            "description": "The person plays chess online most evenings.",
-            "relationship_name": "plays",
-            "source_node_id": "Person",
-            "target_node_id": "online_chess"
-          }
-        ],
         "nodes": [
           {
-            "description": "The person who learned chess from their uncle.",
-            "id": "Person",
-            "name": "Person",
-            "type": "PERSON"
-          },
-          {
-            "description": "The uncle who taught chess.",
             "id": "uncle",
             "name": "Uncle",
-            "type": "PERSON"
+            "type": "PERSON",
+            "description": "The narrator's uncle who taught them chess."
           },
           {
-            "description": "A club at school for students interested in chess.",
+            "id": "chess",
+            "name": "Chess",
+            "type": "CONCEPT",
+            "description": "A strategic board game played between two players."
+          },
+          {
             "id": "school_chess_club",
             "name": "School Chess Club",
-            "type": "ORGANIZATION"
+            "type": "ORGANIZATION",
+            "description": "A club at the narrator's school where students play chess."
           },
           {
-            "description": "A tournament where the person placed third.",
             "id": "regional_tournament",
             "name": "Regional Tournament",
-            "type": "EVENT"
+            "type": "EVENT",
+            "description": "A chess tournament in which the narrator placed third."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "uncle",
+            "target_node_id": "chess",
+            "relationship_name": "taught",
+            "description": "Uncle taught the narrator chess."
           },
           {
-            "description": "A platform where the person plays chess online.",
-            "id": "online_chess",
-            "name": "Online Chess",
-            "type": "CONCEPT"
+            "source_node_id": "narrator",
+            "target_node_id": "school_chess_club",
+            "relationship_name": "joined",
+            "description": "The narrator joined the school chess club."
+          },
+          {
+            "source_node_id": "narrator",
+            "target_node_id": "regional_tournament",
+            "relationship_name": "placed_in",
+            "description": "The narrator placed third in a regional tournament."
+          },
+          {
+            "source_node_id": "narrator",
+            "target_node_id": "chess",
+            "relationship_name": "plays",
+            "description": "The narrator plays chess online most evenings."
           }
         ]
       }
@@ -2294,44 +2450,62 @@
       "user_input_preview": "Title: First Open Source Contribution\n\nMy first open source contribution was a bug fix to a Python logging library in 20",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The bug fix was a contribution to the Python logging library.",
-            "relationship_name": "contributed_to",
-            "source_node_id": "My first open source contribution",
-            "target_node_id": "Python logging library"
-          },
-          {
-            "description": "The contribution was made in the context of open source software.",
-            "relationship_name": "related_to",
-            "source_node_id": "My first open source contribution",
-            "target_node_id": "open source"
-          }
-        ],
         "nodes": [
           {
-            "description": "A personal account of an individual's first contribution to open source software.",
-            "id": "My first open source contribution",
-            "name": "My first open source contribution",
-            "type": "CONCEPT"
+            "id": "Open_Source_Contribution",
+            "name": "First Open Source Contribution",
+            "type": "CONCEPT",
+            "description": "The first open source contribution made by the author, involving a bug fix."
           },
           {
-            "description": "A programming language known for its readability and versatility, used in the contribution.",
-            "id": "Python",
-            "name": "Python",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A library in Python used for logging messages, which was the target of the bug fix.",
-            "id": "Python logging library",
+            "id": "Python_Logging_Library",
             "name": "Python logging library",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A library in Python used for logging, which had a bug fixed by the author."
           },
           {
-            "description": "A software development model that encourages collaboration and sharing of code.",
-            "id": "open source",
-            "name": "open source",
-            "type": "CONCEPT"
+            "id": "Race_Condition",
+            "name": "Race Condition",
+            "type": "CONCEPT",
+            "description": "A bug related to concurrent processes that caused issues in the logging library."
+          },
+          {
+            "id": "Changelog",
+            "name": "Changelog",
+            "type": "CONCEPT",
+            "description": "A record of changes made to the project, where the author's name appeared after the contribution."
+          },
+          {
+            "id": "2014",
+            "name": "2014",
+            "type": "DATE",
+            "description": "The year when the first open source contribution was made."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "First_Open_Source_Contribution",
+            "target_node_id": "Python_Logging_Library",
+            "relationship_name": "involves",
+            "description": "First Open Source Contribution involves a bug fix to the Python logging library."
+          },
+          {
+            "source_node_id": "Python_Logging_Library",
+            "target_node_id": "Race_Condition",
+            "relationship_name": "has_issue",
+            "description": "Python logging library has an issue related to a race condition."
+          },
+          {
+            "source_node_id": "First_Open_Source_Contribution",
+            "target_node_id": "Changelog",
+            "relationship_name": "resulted_in",
+            "description": "First Open Source Contribution resulted in the author's name appearing in the changelog."
+          },
+          {
+            "source_node_id": "First_Open_Source_Contribution",
+            "target_node_id": "2014",
+            "relationship_name": "occurred_in",
+            "description": "First Open Source Contribution occurred in 2014."
           }
         ]
       }
@@ -2341,68 +2515,44 @@
       "user_input_preview": "Title: Coffee Culture Discovery\n\nI discovered specialty coffee when a friend took me to a third-wave coffee shop in 2017",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The third-wave coffee shop introduced specialty coffee to the coffee enthusiast.",
-            "relationship_name": "introduced_to",
-            "source_node_id": "third_wave_coffee_shop",
-            "target_node_id": "specialty_coffee"
-          },
-          {
-            "description": "The barista explained the difference between washed and natural processing to the coffee enthusiast.",
-            "relationship_name": "explained",
-            "source_node_id": "barista",
-            "target_node_id": "washed_processing"
-          },
-          {
-            "description": "The barista explained the difference between washed and natural processing to the coffee enthusiast.",
-            "relationship_name": "explained",
-            "source_node_id": "barista",
-            "target_node_id": "natural_processing"
-          },
-          {
-            "description": "The coffee enthusiast tasted blueberries in coffee for the first time with Ethiopian Yirgacheffe.",
-            "relationship_name": "tasted",
-            "source_node_id": "coffee_enthusiast",
-            "target_node_id": "Ethiopian_Yirgacheffe"
-          }
-        ],
         "nodes": [
           {
-            "description": "A coffee shop that is part of the third wave of coffee movement, focusing on high-quality coffee and artisanal preparation.",
-            "id": "third_wave_coffee_shop",
-            "name": "Third-Wave Coffee Shop",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A type of coffee that emphasizes quality and unique flavors, often sourced from specific regions and prepared with care.",
             "id": "specialty_coffee",
-            "name": "Specialty Coffee",
+            "name": "specialty coffee",
+            "description": "A high-quality coffee that is often sourced from specific regions and processed with care.",
             "type": "CONCEPT"
           },
           {
-            "description": "A method of processing coffee beans that involves washing them to remove the mucilage before drying.",
-            "id": "washed_processing",
-            "name": "Washed Processing",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A method of processing coffee beans where the fruit is dried on the bean, allowing for a different flavor profile.",
-            "id": "natural_processing",
-            "name": "Natural Processing",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A person who has a strong interest in coffee and its various forms and preparations.",
-            "id": "coffee_enthusiast",
-            "name": "Coffee Enthusiast",
-            "type": "PERSON"
-          },
-          {
-            "description": "A coffee variety known for its bright acidity and fruity flavors, often associated with the Yirgacheffe region in Ethiopia.",
             "id": "Ethiopian_Yirgacheffe",
             "name": "Ethiopian Yirgacheffe",
+            "description": "A type of coffee known for its fruity and floral flavors, often associated with blueberry notes.",
             "type": "CONCEPT"
+          },
+          {
+            "id": "coffee",
+            "name": "coffee",
+            "description": "A brewed beverage made from roasted coffee beans, enjoyed worldwide.",
+            "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "specialty_coffee",
+            "target_node_id": "coffee",
+            "relationship_name": "is_a_type_of",
+            "description": "Specialty coffee is a type of coffee."
+          },
+          {
+            "source_node_id": "Ethiopian_Yirgacheffe",
+            "target_node_id": "coffee",
+            "relationship_name": "is_a_type_of",
+            "description": "Ethiopian Yirgacheffe is a type of coffee."
+          },
+          {
+            "source_node_id": "Ethiopian_Yirgacheffe",
+            "target_node_id": "specialty_coffee",
+            "relationship_name": "is_a_type_of",
+            "description": "Ethiopian Yirgacheffe is a type of specialty coffee."
           }
         ]
       }
@@ -2412,62 +2562,50 @@
       "user_input_preview": "Title: Snow Day in School\n\nThe heaviest snowfall I remember was in January 1998 when school was canceled for three days.",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The heaviest snowfall occurred in January 1998.",
-            "relationship_name": "occurred_in",
-            "source_node_id": "heaviest_snowfall",
-            "target_node_id": "January_1998"
-          },
-          {
-            "description": "School was canceled for three days due to the heaviest snowfall.",
-            "relationship_name": "canceled_due_to",
-            "source_node_id": "school",
-            "target_node_id": "heaviest_snowfall"
-          },
-          {
-            "description": "An enormous snow fort was built in the park during the heavy snowfall.",
-            "relationship_name": "built_in",
-            "source_node_id": "snow_fort",
-            "target_node_id": "heaviest_snowfall"
-          },
-          {
-            "description": "The snow fort survived until February before it collapsed.",
-            "relationship_name": "survived_until",
-            "source_node_id": "snow_fort",
-            "target_node_id": "February"
-          }
-        ],
         "nodes": [
           {
-            "description": "The heaviest snowfall remembered by the narrator, occurring in January 1998.",
-            "id": "heaviest_snowfall",
-            "name": "Heaviest Snowfall",
+            "id": "Snow_Day_in_School",
+            "name": "Snow Day in School",
+            "description": "A narrative about a significant snowfall event and its impact on school and childhood activities.",
             "type": "CONCEPT"
           },
           {
-            "description": "The month and year when the heaviest snowfall occurred.",
             "id": "January_1998",
             "name": "January 1998",
+            "description": "The month and year when the heaviest snowfall occurred, leading to school cancellations.",
             "type": "DATE"
           },
           {
-            "description": "The educational institution that was closed for three days due to heavy snowfall.",
-            "id": "school",
-            "name": "School",
-            "type": "ORGANIZATION"
-          },
-          {
-            "description": "An enormous structure made of snow built by the narrator and others in the park.",
             "id": "snow_fort",
-            "name": "Snow Fort",
+            "name": "snow fort",
+            "description": "An enormous snow fort built in the park during the snowfall, featuring tunnels and a watchtower.",
             "type": "CONCEPT"
           },
           {
-            "description": "The month when the snow fort collapsed after surviving the heavy snowfall.",
             "id": "February",
             "name": "February",
+            "description": "The month when the snow fort collapsed after surviving for a period.",
             "type": "DATE"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "January_1998",
+            "target_node_id": "Snow_Day_in_School",
+            "relationship_name": "describes",
+            "description": "January 1998 describes the time when the heaviest snowfall occurred, leading to school cancellations."
+          },
+          {
+            "source_node_id": "snow_fort",
+            "target_node_id": "Snow_Day_in_School",
+            "relationship_name": "is_built_during",
+            "description": "The snow fort is built during the snowfall event described in Snow Day in School."
+          },
+          {
+            "source_node_id": "snow_fort",
+            "target_node_id": "February",
+            "relationship_name": "collapses_in",
+            "description": "The snow fort collapses in February after surviving for a period."
           }
         ]
       }
@@ -2477,74 +2615,50 @@
       "user_input_preview": "Title: Learning Git the Hard Way\n\nI learned git by accidentally deleting a week's worth of work with git reset --hard in",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The author learned git after accidentally deleting work with git reset --hard.",
-            "relationship_name": "learned",
-            "source_node_id": "author",
-            "target_node_id": "git"
-          },
-          {
-            "description": "The author teaches git workshops to junior developers.",
-            "relationship_name": "teaches",
-            "source_node_id": "author",
-            "target_node_id": "junior_developers"
-          },
-          {
-            "description": "The author read the Pro Git book cover to cover after a painful lesson.",
-            "relationship_name": "read",
-            "source_node_id": "author",
-            "target_node_id": "Pro_Git_book"
-          },
-          {
-            "description": "Understanding the reflog saved the author multiple times after learning git.",
-            "relationship_name": "saved",
-            "source_node_id": "reflog",
-            "target_node_id": "author"
-          }
-        ],
         "nodes": [
           {
-            "description": "The author learned git through a painful experience and now teaches it.",
-            "id": "author",
-            "name": "author",
-            "type": "PERSON"
-          },
-          {
-            "description": "Git is a version control system used for tracking changes in source code.",
-            "id": "git",
+            "id": "Git",
             "name": "git",
+            "description": "A version control system used for tracking changes in source code during software development.",
             "type": "CONCEPT"
           },
           {
-            "description": "The Pro Git book is a comprehensive guide to using git.",
-            "id": "Pro_Git_book",
-            "name": "Pro Git book",
+            "id": "Pro Git",
+            "name": "Pro Git",
+            "description": "A book that provides comprehensive information about using git.",
             "type": "CONCEPT"
           },
           {
-            "description": "Junior developers are individuals who are new to the field and are learning skills.",
+            "id": "2013",
+            "name": "2013",
+            "description": "The year when the author learned git by accidentally deleting work.",
+            "type": "DATE"
+          },
+          {
             "id": "junior_developers",
             "name": "junior developers",
+            "description": "Developers who are relatively new to the field and often require guidance and training.",
             "type": "PERSON"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Git",
+            "target_node_id": "Pro Git",
+            "relationship_name": "describes",
+            "description": "The Pro Git book provides comprehensive information about git."
           },
           {
-            "description": "The reflog is a mechanism in git that records updates to the tip of branches.",
-            "id": "reflog",
-            "name": "reflog",
-            "type": "CONCEPT"
+            "source_node_id": "2013",
+            "target_node_id": "Git",
+            "relationship_name": "learned_in",
+            "description": "The author learned git in 2013 after accidentally deleting work."
           },
           {
-            "description": "Version control is a system that records changes to files over time.",
-            "id": "version_control",
-            "name": "version control",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "Learning is the process of acquiring knowledge or skills through experience or education.",
-            "id": "learning",
-            "name": "learning",
-            "type": "CONCEPT"
+            "source_node_id": "Git",
+            "target_node_id": "junior_developers",
+            "relationship_name": "teaches_to",
+            "description": "The author teaches git workshops to junior developers."
           }
         ]
       }
@@ -2554,8 +2668,8 @@
       "user_input_preview": "Title: First Open Source Contribution\n\nMy first open source contribution was a bug fix to a Python logging library in 20",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses an individual's first experience with open source contributions, specifically a bug fix made to a Python logging library in 2014. The contribution involved addressing a race condition in the file rotation handler, which resulted in log files being truncated. The pull request underwent three rounds of review before it was successfully merged, leading to personal satisfaction upon seeing the contributor's name in the changelog.",
-        "summary": "The chunk details a person's first open source contribution, a bug fix to a Python logging library in 2014, which involved a race condition issue. The contributor experienced satisfaction after their pull request was merged following three rounds of review."
+        "description": "This chunk discusses an individual's experience with their first open source contribution, specifically a bug fix for a Python logging library in 2014.",
+        "summary": "The individual made their first open source contribution by fixing a bug in a Python logging library in 2014."
       }
     },
     "a7560325f582204029acf4fff7179a297cb480898d6a6fe31947791241189e30": {
@@ -2563,62 +2677,74 @@
       "user_input_preview": "Title: Setting Up a Home Network\n\nWhen I set up a mesh Wi-Fi network in my apartment, I learned more about networking th",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The person configured VLANs to separate IoT devices from work machines in the home network setup.",
-            "relationship_name": "configured",
-            "source_node_id": "Person",
-            "target_node_id": "VLANs"
-          },
-          {
-            "description": "The person set up Pi-hole for DNS-level ad blocking in the home network setup.",
-            "relationship_name": "set_up",
-            "source_node_id": "Person",
-            "target_node_id": "Pi-hole"
-          },
-          {
-            "description": "The person ran Ethernet through the walls as part of the home network setup.",
-            "relationship_name": "ran",
-            "source_node_id": "Person",
-            "target_node_id": "Ethernet"
-          },
-          {
-            "description": "The person set up a mesh Wi-Fi network in their apartment.",
-            "relationship_name": "set_up",
-            "source_node_id": "Person",
-            "target_node_id": "mesh_Wi-Fi_network"
-          }
-        ],
         "nodes": [
           {
-            "description": "A person who set up a home network and learned about networking in the process.",
-            "id": "Person",
-            "name": "Person",
-            "type": "PERSON"
-          },
-          {
-            "description": "A technology used to separate different types of network traffic, such as IoT devices and work machines.",
-            "id": "VLANs",
-            "name": "VLANs",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A network-wide ad blocker that operates at the DNS level.",
-            "id": "Pi-hole",
-            "name": "Pi-hole",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A type of wired network connection that transmits data through cables.",
-            "id": "Ethernet",
-            "name": "Ethernet",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A type of wireless network that uses multiple access points to provide coverage over a large area.",
-            "id": "mesh_Wi-Fi_network",
+            "id": "mesh_wifi_network",
             "name": "mesh Wi-Fi network",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A type of network setup that uses multiple devices to provide Wi-Fi coverage throughout an area."
+          },
+          {
+            "id": "vlan_configuration",
+            "name": "VLANs",
+            "type": "CONCEPT",
+            "description": "Virtual Local Area Networks used to segment network traffic."
+          },
+          {
+            "id": "pi-hole",
+            "name": "Pi-hole",
+            "type": "CONCEPT",
+            "description": "A network-wide ad blocker that operates at the DNS level."
+          },
+          {
+            "id": "ethernet_cabling",
+            "name": "Ethernet",
+            "type": "CONCEPT",
+            "description": "A system for connecting devices in a local area network using cables."
+          },
+          {
+            "id": "partner",
+            "name": "partner",
+            "type": "PERSON",
+            "description": "The individual who provided feedback on the network setup."
+          },
+          {
+            "id": "home_network",
+            "name": "home network",
+            "type": "CONCEPT",
+            "description": "A network setup within a residential environment."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "mesh_wifi_network",
+            "target_node_id": "home_network",
+            "relationship_name": "is_a_part_of",
+            "description": "The mesh Wi-Fi network is a component of the home network."
+          },
+          {
+            "source_node_id": "vlan_configuration",
+            "target_node_id": "home_network",
+            "relationship_name": "configured_in",
+            "description": "VLANs are configured in the home network to separate IoT devices from work machines."
+          },
+          {
+            "source_node_id": "pi-hole",
+            "target_node_id": "home_network",
+            "relationship_name": "implemented_in",
+            "description": "Pi-hole is implemented in the home network for DNS-level ad blocking."
+          },
+          {
+            "source_node_id": "ethernet_cabling",
+            "target_node_id": "home_network",
+            "relationship_name": "used_in",
+            "description": "Ethernet is used in the home network to connect devices."
+          },
+          {
+            "source_node_id": "partner",
+            "target_node_id": "home_network",
+            "relationship_name": "provides_feedback_on",
+            "description": "The partner provides feedback on the home network setup."
           }
         ]
       }
@@ -2628,8 +2754,8 @@
       "user_input_preview": "Title: Migrating a Monolith to Microservices\n\nOur team spent eight months in 2020 migrating a monolithic Python applicat",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the process of migrating a monolithic Python application to microservices, highlighting the challenges and outcomes of the migration effort.",
-        "summary": "The team migrated a monolithic Python application to microservices over eight months in 2020, improving latency by 40% but increasing operational complexity."
+        "description": "This chunk discusses the migration of a monolithic application to microservices using the strangler fig pattern, focusing on the challenges and outcomes of the process.",
+        "summary": "The team migrated a monolithic Python application to microservices over eight months in 2020, facing challenges with database splitting but achieving improved latency."
       }
     },
     "a9522091351c31a28ea90fa0bc553ec5a7b52b160cea85a4214fe8a996ea6794": {
@@ -2637,8 +2763,8 @@
       "user_input_preview": "Title: First Time Using Docker\n\nThe first time I used Docker in 2015, it felt like magic. I went from 'it works on my ma",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "This chunk discusses the author's initial experience with Docker, highlighting its impact on software deployment and the author's role in promoting its use within their team.",
-        "summary": "The author first used Docker in 2015, transforming deployment processes and becoming a team advocate for the technology."
+        "description": "This chunk discusses the author's first experience with Docker in 2015, highlighting its impact on creating reproducible environments and simplifying deployment for a Python app.",
+        "summary": "The author describes their initial experience with Docker in 2015, emphasizing its transformative effect on deployment processes."
       }
     },
     "aadb3f9cf1afaeb4d862102f5cedf893b619c1eab45aca81a9f40e95ae065c66": {
@@ -2646,8 +2772,8 @@
       "user_input_preview": "Title: Reading Lord of the Rings\n\nI read the entire Lord of the Rings trilogy in one week during summer break when I was",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses a personal experience of reading the Lord of the Rings trilogy by J.R.R. Tolkien during summer break at the age of fourteen. It highlights the emotional impact of specific chapters, particularly 'The Bridge of Khazad-dûm' and the ending at the Grey Havens.",
-        "summary": "The chunk details a personal account of reading the Lord of the Rings trilogy in one week at age fourteen, emphasizing its emotional impact."
+        "description": "This chunk discusses a personal reading experience with the Lord of the Rings trilogy by J.R.R. Tolkien.",
+        "summary": "The author reflects on reading the Lord of the Rings trilogy during summer break at age fourteen."
       }
     },
     "ac8898f811aef73b906f41f5873f1f336d6534b5f28de712103d65e34732ab5f": {
@@ -2655,8 +2781,8 @@
       "user_input_preview": "Title: Childhood Pet Dog\n\nOur family dog Rex was a German Shepherd who lived with us for thirteen years. He waited at th",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses a childhood pet dog named Rex, a German Shepherd who lived for thirteen years and had memorable experiences with the family, including waiting at the door for the owner and chasing a deer.",
-        "summary": "The content reflects on the author's childhood pet dog, Rex, a German Shepherd who had a significant impact on the family during his thirteen years of life."
+        "description": "This chunk discusses a childhood pet dog named Rex, a German Shepherd, who was a significant part of the author's family life for thirteen years. It highlights Rex's loyalty, a memorable adventure chasing a deer, and the emotional impact of his passing.",
+        "summary": "The chunk reflects on the author's experiences with their childhood dog, Rex, a German Shepherd, and the lasting memories associated with him."
       }
     },
     "b59e24e510fd5b55d43bbae1b2edab9e8bd6f1fc9c3b783d309b159931474b34": {
@@ -2664,8 +2790,8 @@
       "user_input_preview": "Title: Stargazing in the Countryside\n\nOn a camping trip far from city lights, I saw the Milky Way clearly for the first ",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk describes a camping trip where the author experienced stargazing in the countryside, highlighting the visibility of the Milky Way and various constellations. The author and a friend observed satellites and shooting stars during their night out.",
-        "summary": "The chunk recounts a memorable camping trip focused on stargazing, where the author saw the Milky Way and identified constellations with a friend."
+        "description": "This chunk is about a camping trip where the author experienced stargazing, observing constellations, and witnessing shooting stars.",
+        "summary": "The author describes a camping trip where they enjoyed stargazing and identified constellations."
       }
     },
     "bbe45600a6ebe7fdfb91eebbcd7fdf76ca86ff902a59155354c6e0d19144ec00": {
@@ -2673,8 +2799,8 @@
       "user_input_preview": "Title: Moving to a New City\n\nWhen I moved to Berlin in 2018, I knew nobody in the city. The first month was lonely — I s",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the experience of relocating to Berlin in 2018, the initial loneliness, and the eventual connection with friends through a co-working space in the Kreuzberg district.",
-        "summary": "The content describes a person's move to Berlin in 2018, highlighting feelings of loneliness and the eventual establishment of friendships in the Kreuzberg district."
+        "description": "This chunk discusses the experience of relocating to Berlin, focusing on the initial loneliness, exploration of neighborhoods, finding a co-working space, and forming friendships in the Kreuzberg district.",
+        "summary": "The narrative describes moving to Berlin in 2018, the initial loneliness, and the eventual connection with friends in Kreuzberg."
       }
     },
     "bce698fef681f68f230ea37d2dd3a57bccc47116d618df9204a0f8aa746c464c": {
@@ -2682,8 +2808,8 @@
       "user_input_preview": "Title: Baking Bread During Lockdown\n\nLike many people, I started baking sourdough bread during the 2020 lockdown. My fir",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the experience of baking sourdough bread during the 2020 lockdown, including the process of creating a starter and improving the bread quality over time. The starter was humorously named 'Clint Yeastwood'.",
-        "summary": "The content describes the journey of baking sourdough bread during the 2020 lockdown, highlighting the development of a starter and the improvement of bread quality."
+        "description": "This chunk is about: \n- Topics: baking, sourdough, lockdown, 2020\n- Projects: sourdough starter, bread making",
+        "summary": "The content discusses the experience of baking sourdough bread during the 2020 lockdown."
       }
     },
     "bdfdd49bf5bed90f02da2c3e4e75bd3ce6a458885e7f93888d0838248dafbbce": {
@@ -2691,32 +2817,38 @@
       "user_input_preview": "Title: A Thunderstorm at the Beach\n\nWe were at the beach when a sudden thunderstorm rolled in from the sea. The sky turn",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The thunderstorm occurred at the beach.",
-            "relationship_name": "occurred_at",
-            "source_node_id": "Thunderstorm",
-            "target_node_id": "Beach"
-          }
-        ],
         "nodes": [
           {
-            "description": "A thunderstorm is a weather phenomenon characterized by the presence of lightning and thunder, often accompanied by heavy rain and strong winds.",
-            "id": "Thunderstorm",
-            "name": "Thunderstorm",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A beach is a landform along the shoreline of an ocean, sea, lake, or river, characterized by loose particles such as sand, gravel, or cobblestones.",
             "id": "Beach",
             "name": "Beach",
+            "description": "A sandy shore by a body of water, where the events took place.",
             "type": "CONCEPT"
           },
           {
-            "description": "Weather refers to the state of the atmosphere at a specific place and time, including factors such as temperature, humidity, precipitation, and wind.",
+            "id": "Thunderstorm",
+            "name": "Thunderstorm",
+            "description": "A sudden storm characterized by thunder, lightning, and heavy rain.",
+            "type": "CONCEPT"
+          },
+          {
             "id": "Weather",
             "name": "Weather",
+            "description": "The atmospheric conditions at a given time, including phenomena like storms.",
             "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Beach",
+            "target_node_id": "Thunderstorm",
+            "relationship_name": "experiences",
+            "description": "The Beach experienced a Thunderstorm."
+          },
+          {
+            "source_node_id": "Thunderstorm",
+            "target_node_id": "Weather",
+            "relationship_name": "is_a_type_of",
+            "description": "The Thunderstorm is a type of Weather."
           }
         ]
       }
@@ -2726,8 +2858,8 @@
       "user_input_preview": "Title: Running My First Marathon\n\nI ran my first marathon in 2016 in Vienna. Training took five months with a gradual bu",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the author's experience running their first marathon, including the training process, challenges faced during the race, and the final completion time.",
-        "summary": "The author completed their first marathon in Vienna in 2016, finishing in 4 hours and 12 minutes after five months of training."
+        "description": "This chunk is about: - Events: marathon - Places: Vienna - Topics: running",
+        "summary": "The text describes the author's experience running their first marathon in Vienna."
       }
     },
     "c41b4441f97ce2496cfe97d8bfb9de5aa7f7f952c85e0c15638969d344ad04b1": {
@@ -2735,44 +2867,62 @@
       "user_input_preview": "Title: Watching the World Cup Final\n\nThe 2014 World Cup final between Germany and Argentina was one of the most tense ma",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The 2014 World Cup final was a football match between Germany and Argentina.",
-            "relationship_name": "featured_teams",
-            "source_node_id": "2014_World_Cup_Final",
-            "target_node_id": "Germany"
-          },
-          {
-            "description": "The 2014 World Cup final was a football match between Germany and Argentina.",
-            "relationship_name": "featured_teams",
-            "source_node_id": "2014_World_Cup_Final",
-            "target_node_id": "Argentina"
-          }
-        ],
         "nodes": [
           {
-            "description": "The 2014 World Cup final was a football match held in 2014, featuring Germany and Argentina.",
-            "id": "2014_World_Cup_Final",
-            "name": "2014 World Cup Final",
-            "type": "CONCEPT"
+            "id": "World_Cup",
+            "name": "World Cup",
+            "type": "CONCEPT",
+            "description": "An international football competition held every four years."
           },
           {
-            "description": "Germany is a national football team that competed in the 2014 World Cup final.",
             "id": "Germany",
             "name": "Germany",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A country in Central Europe."
           },
           {
-            "description": "Argentina is a national football team that competed in the 2014 World Cup final.",
             "id": "Argentina",
             "name": "Argentina",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A country in South America."
           },
           {
-            "description": "Football is a team sport played between two teams of eleven players with a spherical ball.",
-            "id": "football",
-            "name": "Football",
-            "type": "CONCEPT"
+            "id": "Mario_Götze",
+            "name": "Mario Götze",
+            "type": "PERSON",
+            "description": "A German football player known for scoring the winning goal in the 2014 World Cup final."
+          },
+          {
+            "id": "2014",
+            "name": "2014",
+            "type": "DATE",
+            "description": "The year the World Cup final took place."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "2014",
+            "target_node_id": "World_Cup",
+            "relationship_name": "took_place_in",
+            "description": "The 2014 World Cup took place in the year 2014."
+          },
+          {
+            "source_node_id": "Germany",
+            "target_node_id": "Argentina",
+            "relationship_name": "competed_against",
+            "description": "Germany competed against Argentina in the 2014 World Cup final."
+          },
+          {
+            "source_node_id": "Mario_Götze",
+            "target_node_id": "Germany",
+            "relationship_name": "played_for",
+            "description": "Mario Götze played for Germany in the 2014 World Cup final."
+          },
+          {
+            "source_node_id": "Mario_Götze",
+            "target_node_id": "World_Cup",
+            "relationship_name": "scored_in",
+            "description": "Mario Götze scored in the 2014 World Cup final."
           }
         ]
       }
@@ -2782,74 +2932,38 @@
       "user_input_preview": "Title: Childhood Pet Dog\n\nOur family dog Rex was a German Shepherd who lived with us for thirteen years. He waited at th",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "Rex was a German Shepherd who lived with the family for thirteen years.",
-            "relationship_name": "was",
-            "source_node_id": "Rex",
-            "target_node_id": "German Shepherd"
-          },
-          {
-            "description": "Rex was the family dog.",
-            "relationship_name": "was",
-            "source_node_id": "Rex",
-            "target_node_id": "family dog"
-          },
-          {
-            "description": "Rex waited at the door every day when the owner came home from school.",
-            "relationship_name": "waited_for",
-            "source_node_id": "Rex",
-            "target_node_id": "owner"
-          },
-          {
-            "description": "Rex chased a deer through the woods and came back covered in mud.",
-            "relationship_name": "chased",
-            "source_node_id": "Rex",
-            "target_node_id": "deer"
-          },
-          {
-            "description": "Rex passed away, leaving the house feeling empty for months.",
-            "relationship_name": "passed_away",
-            "source_node_id": "Rex",
-            "target_node_id": "house"
-          }
-        ],
         "nodes": [
           {
-            "description": "Rex was a German Shepherd and the family dog, known for his loyalty and playful nature.",
             "id": "Rex",
             "name": "Rex",
-            "type": "PERSON"
+            "type": "ANIMAL",
+            "description": "Rex was a German Shepherd who lived with the family for thirteen years."
           },
           {
-            "description": "A German Shepherd is a breed of dog known for its intelligence and versatility.",
             "id": "German Shepherd",
             "name": "German Shepherd",
-            "type": "CONCEPT"
+            "type": "BREED",
+            "description": "A breed of dog that Rex belonged to."
           },
           {
-            "description": "The family dog is a pet that is part of the family, providing companionship and loyalty.",
-            "id": "family dog",
-            "name": "family dog",
-            "type": "CONCEPT"
+            "id": "Childhood",
+            "name": "Childhood",
+            "type": "CONCEPT",
+            "description": "The period of life when the narrator had Rex as a pet."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Rex",
+            "target_node_id": "German Shepherd",
+            "relationship_name": "is_a",
+            "description": "Rex is a German Shepherd."
           },
           {
-            "description": "The owner is the person who had Rex as a pet and experienced his companionship.",
-            "id": "owner",
-            "name": "owner",
-            "type": "PERSON"
-          },
-          {
-            "description": "The house is the place where Rex lived and where the family felt emptiness after his passing.",
-            "id": "house",
-            "name": "house",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A deer is a wild animal that Rex chased through the woods.",
-            "id": "deer",
-            "name": "deer",
-            "type": "CONCEPT"
+            "source_node_id": "Rex",
+            "target_node_id": "Childhood",
+            "relationship_name": "associated_with",
+            "description": "Rex is associated with the narrator's childhood."
           }
         ]
       }
@@ -2859,8 +2973,8 @@
       "user_input_preview": "Title: Learning to Ride a Bicycle\n\nMy grandfather taught me to ride a bicycle in the park near our house when I was six ",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses a personal experience of learning to ride a bicycle, highlighting the role of the grandfather in this childhood memory.",
-        "summary": "The content recounts a childhood memory of learning to ride a bicycle with the help of a grandfather, emphasizing the joy of achieving balance despite a minor crash."
+        "description": "This chunk is about: \n- People: grandfather \n- Topics: childhood, family",
+        "summary": "The narrative describes a personal experience of learning to ride a bicycle with the help of a grandfather."
       }
     },
     "dc27207bf90b3438ac48f8817806dbefa83ba5bf54cf94ff74354285ab2233bf": {
@@ -2868,56 +2982,56 @@
       "user_input_preview": "Title: Learning to Swim\n\nI learned to swim at the municipal pool when I was eight. The instructor, Mrs. Petrovic, was pa",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "Mrs. Petrovic taught swimming to the narrator.",
-            "relationship_name": "taught",
-            "source_node_id": "Mrs. Petrovic",
-            "target_node_id": "Swimming"
-          },
-          {
-            "description": "The narrator learned to swim at the municipal pool.",
-            "relationship_name": "learned_at",
-            "source_node_id": "Narrator",
-            "target_node_id": "Municipal Pool"
-          },
-          {
-            "description": "The narrator experienced childhood swimming lessons.",
-            "relationship_name": "related_to",
-            "source_node_id": "Narrator",
-            "target_node_id": "Childhood"
-          }
-        ],
         "nodes": [
           {
-            "description": "The narrator is the person recounting their experience of learning to swim.",
-            "id": "Narrator",
-            "name": "Narrator",
-            "type": "PERSON"
+            "id": "municipal_pool",
+            "name": "municipal pool",
+            "description": "A public swimming facility where swimming lessons were conducted.",
+            "type": "CONCEPT"
           },
           {
-            "description": "Mrs. Petrovic was the swimming instructor who taught the narrator.",
-            "id": "Mrs. Petrovic",
+            "id": "mrs_petrovic",
             "name": "Mrs. Petrovic",
+            "description": "The instructor who taught swimming lessons.",
             "type": "PERSON"
           },
           {
-            "description": "The municipal pool is where the narrator learned to swim.",
-            "id": "Municipal Pool",
-            "name": "Municipal Pool",
-            "type": "LOCATION"
-          },
-          {
-            "description": "Swimming is the activity that the narrator learned at the municipal pool.",
-            "id": "Swimming",
-            "name": "Swimming",
+            "id": "swimming",
+            "name": "swimming",
+            "description": "The activity of moving through water by using the limbs.",
             "type": "CONCEPT"
           },
           {
-            "description": "Childhood refers to the period of the narrator's early life when they learned to swim.",
-            "id": "Childhood",
-            "name": "Childhood",
+            "id": "childhood",
+            "name": "childhood",
+            "description": "The period of life when the individual was eight years old and learned to swim.",
             "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "municipal_pool",
+            "target_node_id": "mrs_petrovic",
+            "relationship_name": "taught_at",
+            "description": "Mrs. Petrovic taught swimming lessons at the municipal pool."
+          },
+          {
+            "source_node_id": "childhood",
+            "target_node_id": "swimming",
+            "relationship_name": "involves",
+            "description": "Childhood involves learning to swim."
+          },
+          {
+            "source_node_id": "mrs_petrovic",
+            "target_node_id": "swimming",
+            "relationship_name": "teaches",
+            "description": "Mrs. Petrovic teaches swimming."
+          },
+          {
+            "source_node_id": "childhood",
+            "target_node_id": "municipal_pool",
+            "relationship_name": "includes",
+            "description": "Childhood includes experiences at the municipal pool."
           }
         ]
       }
@@ -2927,8 +3041,8 @@
       "user_input_preview": "Title: Understanding Recursion\n\nThe moment recursion clicked for me was during a lecture on the Tower of Hanoi. The prof",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "This chunk discusses the concept of recursion, particularly through the example of the Tower of Hanoi. The author shares a personal experience of understanding recursion during a lecture and successfully implementing it in a maze solver.",
-        "summary": "The chunk highlights the author's realization of recursion through the Tower of Hanoi example, leading to a successful implementation of a recursive maze solver."
+        "description": "The chunk discusses the author's experience with understanding recursion through a lecture on the Tower of Hanoi, leading to practical implementations like a recursive maze solver. It highlights the moment when an abstract concept became intuitive for the author.",
+        "summary": "The author describes a pivotal moment in understanding recursion during a lecture on the Tower of Hanoi, which inspired them to implement a recursive maze solver."
       }
     },
     "ddaaf6a9bdbfd32fba445509b18c4f32f24fce57829cda75c34e84ba89ba5ae8": {
@@ -2936,8 +3050,8 @@
       "user_input_preview": "Title: A Rainy Day in Kyoto\n\nIt rained the entire day I visited Kyoto's bamboo grove. Most tourists left, but I stayed a",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "This chunk describes a personal experience visiting Kyoto's bamboo grove on a rainy day, highlighting the beauty and tranquility of the scene despite the weather. It reflects on how bad weather can enhance memorable experiences during travel.",
-        "summary": "The content recounts a visit to Kyoto's bamboo grove on a rainy day, emphasizing the serene atmosphere and vivid colors created by the rain."
+        "description": "This chunk is about a visit to a bamboo grove in Kyoto, Japan, during rainy weather, highlighting the beauty of the scene and the experience of solitude.",
+        "summary": "The chunk describes a rainy day visit to the bamboo grove in Kyoto, emphasizing the vividness of the scenery and the unique experience it provided."
       }
     },
     "ddd58705f3c35d0783cb63663f236865634d42723ada6b1ec9680e13794898df": {
@@ -2945,8 +3059,8 @@
       "user_input_preview": "Title: Snow Day in School\n\nThe heaviest snowfall I remember was in January 1998 when school was canceled for three days.",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "This chunk discusses a memorable snow day during childhood in January 1998, when school was canceled for three days due to heavy snowfall. It describes the construction of a large snow fort in the park, which included tunnels and a watchtower, and mentions the fort's eventual collapse in February.",
-        "summary": "The chunk recounts a snow day in January 1998 when school was canceled for three days, leading to the construction of a large snow fort that lasted until February."
+        "description": "This chunk is about:  \n- Events: snow day, snowfall in January 1998  \n- Topics: childhood, winter, snow",
+        "summary": "The chunk describes a memorable snow day in January 1998 when school was canceled for three days, leading to the construction of a snow fort."
       }
     },
     "ddf67fde42a98ab82658972b7d52e49b9e90a71441345b75c38f2788097ffc85": {
@@ -2954,62 +3068,62 @@
       "user_input_preview": "Title: Cooking Grandmother's Stew\n\nMy grandmother's beef stew recipe has been in the family for three generations. The s",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The beef stew recipe has been in the family for three generations.",
-            "relationship_name": "has_been_in",
-            "source_node_id": "beef_stew_recipe",
-            "target_node_id": "family"
-          },
-          {
-            "description": "The secret ingredient of the beef stew recipe is red wine vinegar.",
-            "relationship_name": "contains_ingredient",
-            "source_node_id": "beef_stew_recipe",
-            "target_node_id": "red_wine_vinegar"
-          },
-          {
-            "description": "The beef stew recipe is cooked in a cast-iron pot.",
-            "relationship_name": "cooked_in",
-            "source_node_id": "beef_stew_recipe",
-            "target_node_id": "cast_iron_pot"
-          },
-          {
-            "description": "The beef stew recipe is cooked over low heat for at least four hours.",
-            "relationship_name": "cooked_over",
-            "source_node_id": "beef_stew_recipe",
-            "target_node_id": "low_heat"
-          }
-        ],
         "nodes": [
           {
-            "description": "A recipe for beef stew that has been passed down through generations.",
-            "id": "beef_stew_recipe",
-            "name": "Beef Stew Recipe",
+            "id": "Grandmother's Beef Stew Recipe",
+            "name": "Grandmother's Beef Stew Recipe",
+            "description": "A family recipe for beef stew that has been passed down for three generations.",
             "type": "CONCEPT"
           },
           {
-            "description": "A type of vinegar made from red wine, used as a secret ingredient in the stew.",
-            "id": "red_wine_vinegar",
+            "id": "Red Wine Vinegar",
             "name": "Red Wine Vinegar",
+            "description": "A secret ingredient added to the stew at the very end of cooking.",
             "type": "CONCEPT"
           },
           {
-            "description": "A heavy cooking pot made of cast iron, used for cooking the stew.",
-            "id": "cast_iron_pot",
-            "name": "Cast Iron Pot",
+            "id": "Cast-Iron Pot",
+            "name": "Cast-Iron Pot",
+            "description": "A type of pot used to cook the stew over low heat.",
             "type": "CONCEPT"
           },
           {
-            "description": "The family that has passed down the beef stew recipe for generations.",
-            "id": "family",
-            "name": "Family",
+            "id": "Four Hours",
+            "name": "Four Hours",
+            "description": "The minimum cooking time for the stew over low heat.",
             "type": "CONCEPT"
           },
           {
-            "description": "A method of cooking that involves low temperatures for extended periods.",
-            "id": "low_heat",
-            "name": "Low Heat",
+            "id": "Winter",
+            "name": "Winter",
+            "description": "The season when the stew recipe is typically used.",
             "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Grandmother's Beef Stew Recipe",
+            "target_node_id": "Red Wine Vinegar",
+            "relationship_name": "contains",
+            "description": "Grandmother's Beef Stew Recipe contains Red Wine Vinegar as a secret ingredient."
+          },
+          {
+            "source_node_id": "Grandmother's Beef Stew Recipe",
+            "target_node_id": "Cast-Iron Pot",
+            "relationship_name": "cooked_in",
+            "description": "Grandmother's Beef Stew Recipe is cooked in a Cast-Iron Pot."
+          },
+          {
+            "source_node_id": "Grandmother's Beef Stew Recipe",
+            "target_node_id": "Four Hours",
+            "relationship_name": "requires_cooking_time",
+            "description": "Grandmother's Beef Stew Recipe requires a cooking time of Four Hours."
+          },
+          {
+            "source_node_id": "Grandmother's Beef Stew Recipe",
+            "target_node_id": "Winter",
+            "relationship_name": "cooked_in_season",
+            "description": "Grandmother's Beef Stew Recipe is typically cooked in Winter."
           }
         ]
       }
@@ -3019,8 +3133,8 @@
       "user_input_preview": "Title: Cooking Grandmother's Stew\n\nMy grandmother's beef stew recipe has been in the family for three generations. The s",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses a family recipe for beef stew that has been passed down through three generations. The recipe includes a secret ingredient of red wine vinegar and specifies cooking in a cast-iron pot for at least four hours.",
-        "summary": "This chunk details a three-generation family recipe for beef stew, highlighting the use of red wine vinegar and cooking methods."
+        "description": "This chunk is about a family recipe for beef stew, specifically focusing on the cooking method and a secret ingredient.",
+        "summary": "The chunk discusses a grandmother's beef stew recipe that has been passed down through three generations."
       }
     },
     "e504a210bdc7b46485fd8b3fdbb9a0e8229bf3981b6cf6606babca0fa81ffd4d": {
@@ -3028,8 +3142,8 @@
       "user_input_preview": "Title: Hiking in the Alps\n\nIn the summer of 2015, I hiked the Tour du Mont Blanc with two friends. The 170-kilometer tra",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The content describes a hiking experience on the Tour du Mont Blanc in the Alps during the summer of 2015. The hike covered 170 kilometers through France, Italy, and Switzerland over eleven days, featuring stunning views and camping along the trail.",
-        "summary": "The chunk recounts a hiking trip on the Tour du Mont Blanc in the Alps in 2015, covering 170 kilometers over eleven days with breathtaking views."
+        "description": "This chunk is about hiking in the Alps, specifically the Tour du Mont Blanc, which involves a multi-country trek.",
+        "summary": "The chunk details a hiking experience on the Tour du Mont Blanc in the Alps."
       }
     },
     "e5b7e824ae72368b7e9afcd349bcf7ddd3b4aa309d5ddb9d19069770a5ef3a9e": {
@@ -3037,8 +3151,8 @@
       "user_input_preview": "Title: Winning a Hackathon\n\nOur team won a 48-hour hackathon in 2017 by building a real-time translator for sign languag",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "In 2017, a team won a hackathon by developing a real-time translator for sign language using computer vision and a pre-trained CNN model. The judges were impressed with the demo that achieved 85% accuracy in translating basic signs, and the prize was divided among the four team members.",
-        "summary": "A team won a 2017 hackathon by creating a real-time sign language translator with computer vision, achieving 85% accuracy in their demo."
+        "description": "The chunk discusses a hackathon win in 2017 where a team developed a sign language translator using computer vision and machine learning techniques.",
+        "summary": "The team won a hackathon in 2017 by creating a real-time sign language translator."
       }
     },
     "e6c8069e7632f9c20abcff0828101b3b0dc040366d693ac72fcfcb06a34dbbe9": {
@@ -3046,26 +3160,26 @@
       "user_input_preview": "Title: First Day at University\n\nI remember my first day at the University of Belgrade. The campus was bustling with new ",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The University of Belgrade offers the Computer Science program.",
-            "relationship_name": "offers",
-            "source_node_id": "University of Belgrade",
-            "target_node_id": "Computer Science"
-          }
-        ],
         "nodes": [
           {
-            "description": "The University of Belgrade is a prominent educational institution located in Serbia.",
             "id": "University of Belgrade",
             "name": "University of Belgrade",
-            "type": "ORGANIZATION"
+            "type": "ORGANIZATION",
+            "description": "A university located in Belgrade, Serbia."
           },
           {
-            "description": "The Computer Science program is an academic course of study focusing on computing and technology.",
             "id": "Computer Science",
             "name": "Computer Science",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "An academic program focused on the study of computers and computational systems."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "University of Belgrade",
+            "target_node_id": "Computer Science",
+            "relationship_name": "offers",
+            "description": "University of Belgrade offers the Computer Science program."
           }
         ]
       }
@@ -3075,50 +3189,44 @@
       "user_input_preview": "Title: First Programming Language\n\nI wrote my first program in BASIC on a Commodore 64 when I was twelve. It was a simpl",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "BASIC is the programming language used on the Commodore 64.",
-            "relationship_name": "used_on",
-            "source_node_id": "BASIC",
-            "target_node_id": "Commodore 64"
-          },
-          {
-            "description": "The author wrote their first program in BASIC.",
-            "relationship_name": "wrote_first_program_in",
-            "source_node_id": "Author",
-            "target_node_id": "BASIC"
-          },
-          {
-            "description": "The author's first program was a number guessing game.",
-            "relationship_name": "was_a",
-            "source_node_id": "Number Guessing Game",
-            "target_node_id": "Author"
-          }
-        ],
         "nodes": [
           {
-            "description": "BASIC is a high-level programming language known for its simplicity and ease of use.",
             "id": "BASIC",
             "name": "BASIC",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "A programming language used for teaching programming concepts."
           },
           {
-            "description": "The Commodore 64 is an 8-bit home computer introduced in 1982, known for its versatility and large library of software.",
             "id": "Commodore 64",
             "name": "Commodore 64",
-            "type": "CONCEPT"
+            "type": "CONCEPT",
+            "description": "An 8-bit home computer introduced in 1982."
           },
           {
-            "description": "The author is a person who wrote their first program at the age of twelve.",
-            "id": "Author",
-            "name": "Author",
-            "type": "PERSON"
+            "id": "programming",
+            "name": "programming",
+            "type": "CONCEPT",
+            "description": "The process of designing and building executable computer software."
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "BASIC",
+            "target_node_id": "programming",
+            "relationship_name": "used_in",
+            "description": "BASIC is a programming language used in programming."
           },
           {
-            "description": "The number guessing game is a simple program that prompts the user to guess a number and provides feedback on their guesses.",
-            "id": "Number Guessing Game",
-            "name": "Number Guessing Game",
-            "type": "CONCEPT"
+            "source_node_id": "Commodore 64",
+            "target_node_id": "BASIC",
+            "relationship_name": "supported",
+            "description": "The Commodore 64 supported the BASIC programming language."
+          },
+          {
+            "source_node_id": "programming",
+            "target_node_id": "BASIC",
+            "relationship_name": "sparked_interest_in",
+            "description": "The experience of programming in BASIC sparked a lifelong passion for programming."
           }
         ]
       }
@@ -3128,8 +3236,8 @@
       "user_input_preview": "Title: Volunteering at a Food Bank\n\nI volunteered at a local food bank every Saturday for six months in 2019. We sorted ",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the experience of volunteering at a food bank, focusing on the activities involved and the lessons learned about supply chain management.",
-        "summary": "The content describes a six-month volunteering experience at a food bank in 2019, highlighting the sorting of donations and the impact of gratitude from recipients."
+        "description": "This chunk discusses the experience of volunteering at a food bank, focusing on the activities involved and the personal impact of the experience.",
+        "summary": "The text describes a six-month volunteering experience at a food bank in 2019, highlighting the activities performed and the lessons learned."
       }
     },
     "f43f9f5b5f5ebff50c184ebdee85cff6290a120abd3319dd063286851c9b703f": {
@@ -3137,62 +3245,62 @@
       "user_input_preview": "Title: Debugging a Production Outage\n\nIn 2019, our production database went down at 3 AM due to a misconfigured connecti",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The production database experienced an outage due to a misconfigured connection pool.",
-            "relationship_name": "experienced_outage",
-            "source_node_id": "production_database",
-            "target_node_id": "production_outage"
-          },
-          {
-            "description": "The issue was traced through logs during the debugging process.",
-            "relationship_name": "involved_in",
-            "source_node_id": "debugging",
-            "target_node_id": "production_outage"
-          },
-          {
-            "description": "The max connections for the production database were changed from 100 to 10 in a recent deployment.",
-            "relationship_name": "changed_in",
-            "source_node_id": "recent_deployment",
-            "target_node_id": "production_database"
-          },
-          {
-            "description": "The fix for the production database outage was a one-line config change.",
-            "relationship_name": "resolved_by",
-            "source_node_id": "production_outage",
-            "target_node_id": "config_change"
-          }
-        ],
         "nodes": [
           {
-            "description": "A database that is used in a production environment.",
-            "id": "production_database",
+            "id": "Production Database",
             "name": "Production Database",
+            "description": "A database used in production environments.",
             "type": "CONCEPT"
           },
           {
-            "description": "An event where the production database was unavailable due to a configuration issue.",
-            "id": "production_outage",
-            "name": "Production Outage",
+            "id": "2019-01-01",
+            "name": "2019",
+            "description": "The year when the production database outage occurred.",
+            "type": "DATE"
+          },
+          {
+            "id": "Misconfigured Connection Pool",
+            "name": "Misconfigured Connection Pool",
+            "description": "An incorrect configuration of the connection pool that caused the database outage.",
             "type": "CONCEPT"
           },
           {
-            "description": "The process of identifying and resolving issues in software or systems.",
-            "id": "debugging",
-            "name": "Debugging",
+            "id": "Deployment",
+            "name": "Deployment",
+            "description": "The process of releasing new code or configuration to the production environment.",
             "type": "CONCEPT"
           },
           {
-            "description": "A deployment that recently altered the configuration of the production database.",
-            "id": "recent_deployment",
-            "name": "Recent Deployment",
-            "type": "CONCEPT"
-          },
-          {
-            "description": "A configuration change made to resolve the production database outage.",
-            "id": "config_change",
+            "id": "Config Change",
             "name": "Config Change",
+            "description": "A modification made to the configuration settings of the production database.",
             "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Production Database",
+            "target_node_id": "Misconfigured Connection Pool",
+            "relationship_name": "caused",
+            "description": "The misconfigured connection pool caused the production database outage."
+          },
+          {
+            "source_node_id": "2019-01-01",
+            "target_node_id": "Production Database",
+            "relationship_name": "experienced_outage_in",
+            "description": "The production database experienced an outage in 2019."
+          },
+          {
+            "source_node_id": "Deployment",
+            "target_node_id": "Misconfigured Connection Pool",
+            "relationship_name": "resulted_in",
+            "description": "The recent deployment resulted in the misconfigured connection pool."
+          },
+          {
+            "source_node_id": "Misconfigured Connection Pool",
+            "target_node_id": "Config Change",
+            "relationship_name": "fixed_by",
+            "description": "The misconfigured connection pool was fixed by a one-line config change."
           }
         ]
       }
@@ -3202,8 +3310,8 @@
       "user_input_preview": "Title: Learning to Play Chess\n\nMy uncle taught me chess when I was seven. He never let me win, which frustrated me at fi",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The content discusses the author's experience learning chess from their uncle, joining a school chess club, and participating in a regional tournament. It highlights the author's ongoing enjoyment of playing chess online as a way to relax.",
-        "summary": "The author learned chess from their uncle at age seven, joined a school chess club, and placed third in a regional tournament. They continue to play online regularly for relaxation."
+        "description": "This chunk is about: - People: uncle - Topics: chess, childhood - Events: regional tournament",
+        "summary": "The chunk discusses a personal experience of learning chess from an uncle during childhood, joining a school chess club, and participating in a regional tournament."
       }
     },
     "f6b519ba987da0c86e2b8aad92016ff328dc1dc6ca9c4fc06667a29a24959a7a": {
@@ -3211,38 +3319,26 @@
       "user_input_preview": "Title: The Blackout of 2003\n\nDuring the Northeast blackout of August 2003, the power went out for nearly two days. Neigh",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The 2003 blackout caused a power outage in the Northeast for nearly two days.",
-            "relationship_name": "caused",
-            "source_node_id": "2003_blackout",
-            "target_node_id": "Northeast_power_outage"
-          },
-          {
-            "description": "The community gathered during the 2003 blackout to share food and sing songs.",
-            "relationship_name": "involved",
-            "source_node_id": "community",
-            "target_node_id": "2003_blackout"
-          }
-        ],
         "nodes": [
           {
-            "description": "The 2003 blackout refers to a significant power outage that occurred in August 2003 affecting the Northeast region.",
-            "id": "2003_blackout",
-            "name": "2003 Blackout",
-            "type": "EVENT"
+            "id": "Northeast_blackout_2003",
+            "name": "Northeast blackout of August 2003",
+            "type": "EVENT",
+            "description": "A significant power outage that affected the Northeast region of the United States for nearly two days."
           },
           {
-            "description": "The community refers to the group of neighbors who came together during the blackout.",
             "id": "community",
-            "name": "Community",
-            "type": "CONCEPT"
-          },
+            "name": "community",
+            "type": "CONCEPT",
+            "description": "A group of people living in the same place or having a particular characteristic in common."
+          }
+        ],
+        "edges": [
           {
-            "description": "The Northeast power outage refers to the widespread loss of electrical power in the Northeast region during the blackout.",
-            "id": "Northeast_power_outage",
-            "name": "Northeast Power Outage",
-            "type": "EVENT"
+            "source_node_id": "Northeast_blackout_2003",
+            "target_node_id": "community",
+            "relationship_name": "created",
+            "description": "The Northeast blackout of August 2003 created a rare moment of community among neighbors."
           }
         ]
       }
@@ -3252,8 +3348,8 @@
       "user_input_preview": "Title: A Flat Tire on a Road Trip\n\nHalfway through a road trip to the coast, we got a flat tire on a deserted stretch of",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk describes an experience during a road trip where the travelers encountered a flat tire. They had no prior experience changing a tire but managed to do so with the help of a truck driver who corrected their mistake with the jack. Ultimately, they reached their destination two hours later than planned.",
-        "summary": "The chunk narrates a road trip incident involving a flat tire and the assistance of a truck driver. The travelers learned to change the tire using the car manual and arrived at the beach two hours late."
+        "description": "This chunk is about a road trip that encountered car trouble due to a flat tire.",
+        "summary": "The story describes a road trip interrupted by a flat tire, where the travelers learned to change it with the help of a truck driver."
       }
     },
     "fa344dc34188869948486d2836dfd1c5d4b3b7bca21156035b75d388fc9e599c": {
@@ -3261,8 +3357,8 @@
       "user_input_preview": "Title: Setting Up My First Server\n\nI set up my first Linux server in 2011 — a Debian box running Apache and MySQL. I spe",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "The chunk discusses the author's experience of setting up their first Linux server in 2011, detailing the configuration process and the subsequent hacking incident due to a security oversight.",
-        "summary": "The author set up their first Linux server in 2011, configuring it with Apache and MySQL. The server was hacked within a week due to leaving port 22 on the default configuration."
+        "description": "This chunk discusses the author's experience setting up their first Linux server, specifically a Debian box running Apache and MySQL. It highlights the configuration of iptables rules and SSH keys, the excitement of making a website accessible online, and the subsequent hacking incident due to a security oversight.",
+        "summary": "The author set up their first Linux server in 2011, which was a Debian box running Apache and MySQL."
       }
     },
     "fcbbb8b07f6a9923aa93654be41435dbde5e38af68ba3b3ca4e5485b9850f13b": {
@@ -3270,38 +3366,38 @@
       "user_input_preview": "Title: A Rainy Day in Kyoto\n\nIt rained the entire day I visited Kyoto's bamboo grove. Most tourists left, but I stayed a",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "edges": [
-          {
-            "description": "The bamboo grove is located in Kyoto, Japan.",
-            "relationship_name": "located_in",
-            "source_node_id": "bamboo_grove",
-            "target_node_id": "Kyoto"
-          },
-          {
-            "description": "Kyoto is a city in Japan.",
-            "relationship_name": "is_a",
-            "source_node_id": "Kyoto",
-            "target_node_id": "Japan"
-          }
-        ],
         "nodes": [
           {
-            "description": "A city known for its classical Buddhist temples, as well as gardens, imperial palaces, Shinto shrines, and traditional wooden houses.",
             "id": "Kyoto",
             "name": "Kyoto",
-            "type": "CITY"
+            "description": "A city in Japan known for its historical sites and natural beauty.",
+            "type": "CONCEPT"
           },
           {
-            "description": "A type of plant characterized by its tall, slender stems and often found in groves.",
-            "id": "bamboo_grove",
-            "name": "bamboo grove",
-            "type": "NATURAL_FEATURE"
-          },
-          {
-            "description": "A country in East Asia, known for its rich culture and history.",
             "id": "Japan",
             "name": "Japan",
-            "type": "COUNTRY"
+            "description": "An island country in East Asia located in the Pacific Ocean.",
+            "type": "CONCEPT"
+          },
+          {
+            "id": "bamboo_grove",
+            "name": "bamboo grove",
+            "description": "A natural area filled with bamboo plants, often visited for its beauty and tranquility.",
+            "type": "CONCEPT"
+          }
+        ],
+        "edges": [
+          {
+            "source_node_id": "Kyoto",
+            "target_node_id": "Japan",
+            "relationship_name": "located_in",
+            "description": "Kyoto is a city located in Japan."
+          },
+          {
+            "source_node_id": "bamboo_grove",
+            "target_node_id": "Kyoto",
+            "relationship_name": "located_in",
+            "description": "The bamboo grove is located in Kyoto."
           }
         ]
       }


### PR DESCRIPTION
Re-records `scripts/perf/fixtures/cassette.json` against gpt-4o-mini via the fixed tool-calling adapter (record-mode validation-retry now works). **Same 100 input-hash keys** as before -> drop-in for the offline mock benchmark. Also widens `.gitignore` `.env`->`.env*` so local secret files aren't committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)