### PR TITLE
docs: correct language-binding count to four (Java)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The convenient `Cognee` class — `new(settings)` → `warm()` → `remember()` 
 `recall()` (or the lower-level `add()` / `cognify()` / `search()`) — is exposed
 by the bindings, not the raw Rust crate. `warm()` resolves `owner_id` and builds +
 caches the component graph once, giving you the wiring-free experience the
-pure-Rust path lacks. All three bindings share the same SDK-tier implementation
+pure-Rust path lacks. All four bindings share the same SDK-tier implementation
 via `crates/bindings-common/`, so their surfaces line up 1:1.
 
 | Binding | Install | README | Primary API |
@@ -202,6 +202,7 @@ via `crates/bindings-common/`, so their surfaces line up 1:1.
 | **JavaScript/TypeScript** (Neon) | `npm install @cognee/cognee-ts` ([npm](https://www.npmjs.com/package/@cognee/cognee-ts)) | [ts/README.md](ts/README.md) | `import { Cognee } from '@cognee/cognee-ts'` |
 | **Python** (PyO3) | build from source (`maturin develop`) — not yet on PyPI | [python/README.md](python/README.md) | `from cognee_py import Cognee` |
 | **C API** (FFI) | build from source — see README | [capi/README.md](capi/README.md) | `#include "cognee_sdk.h"` + `cg_sdk_*` |
+| **Java** (JNI) | build from source — see README | [java/README.md](java/README.md) | `import ai.cognee.Cognee;` |
 
 
 ### Objectives


### PR DESCRIPTION
README said 'three bindings'; the Java (JNI) binding from PR #82 makes it four. This updates the Language Bindings prose count and adds the missing Java table row. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)