### PR TITLE
chore(java): bump central-publishing-maven-plugin to 0.11.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -209,7 +209,10 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.7.0</version>
+            <!-- 0.11.0: 0.7.0's DeploymentApiResponse model rejects the Central
+                 Portal's newer `warnings` field (UnrecognizedPropertyException),
+                 failing the build after a successful upload. -->
+            <version>0.11.0</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
Fixes the cosmetic publish-job failure: `central-publishing-maven-plugin:0.7.0` crashes parsing the Central Portal status response (unrecognized `warnings` field) *after* a successful upload. 0.11.0 handles it.

Validated locally with `mvn -P release validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)