### PR TITLE
docs(java): Maven Central install (version-agnostic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ via `crates/bindings-common/`, so their surfaces line up 1:1.
 | **JavaScript/TypeScript** (Neon) | `npm install @cognee/cognee-ts` ([npm](https://www.npmjs.com/package/@cognee/cognee-ts)) | [ts/README.md](ts/README.md) | `import { Cognee } from '@cognee/cognee-ts'` |
 | **Python** (PyO3) | build from source (`maturin develop`) — not yet on PyPI | [python/README.md](python/README.md) | `from cognee_py import Cognee` |
 | **C API** (FFI) | build from source — see README | [capi/README.md](capi/README.md) | `#include "cognee_sdk.h"` + `cg_sdk_*` |
-| **Java** (JNI) | build from source (cdylib + `mvn -f java/pom.xml install`) — see README; not yet on Maven Central | [java/README.md](java/README.md) | `import ai.cognee.Cognee;` |
+| **Java** (JNI) | `io.github.topoteretes:cognee` ([Maven Central](https://central.sonatype.com/artifact/io.github.topoteretes/cognee)) | [java/README.md](java/README.md) | `import ai.cognee.Cognee;` |
 
 
 ### Objectives

--- a/java/README.md
+++ b/java/README.md
@@ -15,51 +15,39 @@ control.
 ## Requirements
 
 - JDK 17+ (the artifact is compiled for release 17).
-- Maven 3.8+.
-- A **Rust toolchain** to build the native library. Maven does **not** compile
-  the cdylib (the pom has no Cargo step); the native library comes either from a
-  published classifier jar (once on Maven Central) or from a locally built cdylib
-  you point the loader at via `COGNEE_JAVA_LIB_PATH` (see "Development builds").
+- Maven or Gradle.
+- No Rust toolchain needed to *use* the library — the native code ships prebuilt
+  in the per-platform classifier jars. A Rust toolchain is only needed to build
+  from source (see "Development builds").
 
-## Install / build
+## Install
 
-Not yet on Maven Central, so a local setup needs **two** pieces — the Java jar
-*and* the native library:
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.topoteretes/cognee?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.topoteretes/cognee)
 
-1. **Build the native cdylib** and export its path (details in "Development
-   builds" below):
+Available on [Maven Central](https://central.sonatype.com/artifact/io.github.topoteretes/cognee).
+Just add the dependency — the matching per-platform native library is pulled in
+automatically and loaded at runtime, so there is nothing else to build or
+configure. Use the **latest version shown on the badge above**.
 
-   ```bash
-   cargo build --manifest-path java/cognee-java-jni/Cargo.toml
-   export COGNEE_JAVA_LIB_PATH="$(pwd)/java/cognee-java-jni/target/debug/libcognee_java.so"
-   ```
+**Maven:**
 
-2. **Install the Java jar** into your local Maven repository (this packages the
-   Java classes only — not the native library):
+```xml
+<dependency>
+  <groupId>io.github.topoteretes</groupId>
+  <artifactId>cognee</artifactId>
+  <version>LATEST</version> <!-- replace with the version shown on the badge above -->
+</dependency>
+```
 
-   ```bash
-   mvn -f java/pom.xml install
-   ```
+**Gradle:**
 
-3. **Depend on it:**
+```kotlin
+implementation("io.github.topoteretes:cognee:LATEST") // use the version from the badge
+```
 
-   ```xml
-   <dependency>
-     <groupId>io.github.topoteretes</groupId>
-     <artifactId>cognee</artifactId>
-     <version>0.1.3</version>
-   </dependency>
-   ```
-
-   At runtime the loader still needs the native library: either
-   `COGNEE_JAVA_LIB_PATH` points at your locally built cdylib, or a classifier
-   jar is on the classpath (see below).
-
-Once published, the native library ships as a per-platform *classifier* jar
-(`io.github.topoteretes:cognee:<version>:<classifier>`, e.g. `linux-x86_64`,
-`linux-aarch_64`, `osx-aarch_64`, `windows-x86_64`); `NativeLibLoader` extracts
-and loads the one matching the host at runtime, so no `COGNEE_JAVA_LIB_PATH` is
-needed.
+At runtime, `NativeLibLoader` extracts and loads the classifier native library
+matching your OS/architecture — one of `linux-x86_64`, `linux-aarch_64`,
+`osx-aarch_64`, `windows-x86_64` — so no `COGNEE_JAVA_LIB_PATH` is needed.
 
 ### Development builds (locally built native library)
 


### PR DESCRIPTION
`io.github.topoteretes:cognee` is live on Maven Central. Docs updated to the real coordinates with a Maven Central badge as the source of truth (no pinned version, so docs don't need bumping each release). Native lib ships via classifier jars — consumers no longer build from source or set `COGNEE_JAVA_LIB_PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)