### PR TITLE
fix(cognify): seed the mock graph with `edges`, not the ignored `relationships`

### DIFF
--- a/crates/cognify/tests/integration_text_summary_payload.rs
+++ b/crates/cognify/tests/integration_text_summary_payload.rs
@@ -43,7 +43,7 @@ async fn text_summary_payload_contains_text_field() {
     // 2. Summarization response (consumed by the summarize-text stage)
     let mock_llm = MockLlm::new(vec![
         // Response 1: graph extraction -> empty graph
-        json!({"nodes": [], "relationships": []}).to_string(),
+        json!({"nodes": [], "edges": []}).to_string(),
         // Response 2: summarization -> deterministic summary
         json!({
             "summary": EXPECTED_SUMMARY,


### PR DESCRIPTION
## Summary

`integration_text_summary_payload` fails on `main` today: the cognify pipeline aborts at the graph-extraction task with `missing field \`edges\`.

#83 made `KnowledgeGraph.nodes`/`edges` required (dropping `serde(default)`) so a nodes-only payload drives a corrective retry instead of silently yielding a 0-edge graph, and it fixed `MockLlm`'s canned fallback to use the real field name. This test, however, seeds its **own** response via `MockLlm::new(..)` and still used `relationships` — a name the derive has always ignored. Once `edges` became required, that payload stops deserializing.

Seeding `edges` matches the model and `MockLlm`'s canned fallback. Semantics are unchanged: the test still asserts an empty graph, and the summarization assertions are untouched.

## Evidence

Main's own CI (`Test (stable)` on `35c738b`):

```
Summary [458.162s] 2403 tests run: 2401 passed, 2 failed, 4 skipped
TRY 1 FAIL  cognee-cognify::integration_text_summary_payload text_summary_payload_contains_text_field
TRY 2 FAIL  cognee-cognify::integration_text_summary_payload text_summary_payload_contains_text_field
  cognify pipeline should succeed with mock backends:
    Execute("task 2 failed after 1 attempt(s): LLM error: Deserialization error: \
             Failed to deserialize structured output: missing field \`edges\`")
```

Follow-up to #83.

> Note: main's `Test (stable)` also shows a second, unrelated failure (`cognee-search::temporal_retriever_multiple_events`) which this PR does not touch.