### PR TITLE
fix(cognify): require node descriptions in prompt so non-strict LLMs don't fail (#66)

### DIFF
--- a/.github/workflows/record-cassettes.yml
+++ b/.github/workflows/record-cassettes.yml
@@ -26,9 +26,13 @@ env:
   CCACHE_COMPILERCHECK: content
   # Record mode: wrap the real adapter and write/merge each cassette on drop.
   COGNEE_RECORD_LLM: "1"
-  OPENAI_URL: https://api.openai.com/v1
-  OPENAI_TOKEN: ${{ secrets.OPENAI_KEY }}
-  OPENAI_MODEL: gpt-4o-mini
+  # Integration cassettes are baselined on Baseten's gpt-oss-120b — a non-strict
+  # tool-caller — so replay exercises the same fallback path real edge/self-host
+  # users hit (see issue #66). Requires a BASETEN_KEY repo/org secret; the only
+  # other LLM secret is OPENAI_KEY, which cannot reach this endpoint.
+  OPENAI_URL: https://inference.baseten.co/v1
+  OPENAI_TOKEN: ${{ secrets.BASETEN_KEY }}
+  OPENAI_MODEL: baseten/openai/gpt-oss-120b
 
 jobs:
   record:
@@ -94,8 +98,19 @@ jobs:
       # so tests in the same file merge into one cassette without racing the
       # final atomic write. The deterministic embedding engine is chosen in-code
       # (no MOCK_EMBEDDING env needed), so embeddings match replay exactly.
+      # Delete first so each recording is clean: RecordingLlm merges into an
+      # existing file, which would keep now-orphaned entries after a prompt/schema
+      # change (mirrors record-perf-cassette.yml). The refreshed files are what
+      # gets committed below. Delete only the cassettes this step regenerates (NOT
+      # a `*.json` wildcard) so a cassette owned by a test not listed here isn't
+      # wiped without being re-recorded — keep this list in sync with the --test
+      # targets below.
       - name: Record cognify cassettes
         run: |
+          cd crates/cognify/tests/fixtures/cassettes
+          rm -f fact_extraction.json summarization.json triplet_vector_cleanup.json \
+                delete_preview_accuracy.json shared_entity_graph_delete.json lifecycle_loop.json
+          cd - >/dev/null
           cargo test -p cognee-cognify \
             --test integration_fact_extraction \
             --test integration_summarization \
@@ -106,16 +121,20 @@ jobs:
             -- --test-threads=1
 
       - name: Record search cassettes
-        run: cargo test -p cognee-search --test last_accessed_update -- --test-threads=1
+        run: |
+          rm -f crates/search/tests/fixtures/cassettes/last_accessed_update.json
+          cargo test -p cognee-search --test last_accessed_update -- --test-threads=1
 
       - name: Record delete cassettes
-        run: cargo test -p cognee-delete --test hard_mode_orphan_sweep -- --test-threads=1
+        run: |
+          rm -f crates/delete/tests/fixtures/cassettes/hard_mode_orphan_sweep.json
+          cargo test -p cognee-delete --test hard_mode_orphan_sweep -- --test-threads=1
 
       - name: Commit refreshed cassettes
         # Pass the user-controlled ref through an env var, never interpolated
         # directly into the shell — `${{ … }}` is substituted as raw text before
         # bash parses it, so a crafted ref would be a script-injection sink on a
-        # runner holding contents:write + OPENAI_KEY.
+        # runner holding contents:write + BASETEN_KEY.
         env:
           REF: ${{ github.event.inputs.ref }}
         run: |

--- a/crates/cognify/src/fact_extraction/extractor.rs
+++ b/crates/cognify/src/fact_extraction/extractor.rs
@@ -15,9 +15,15 @@ use crate::error::CognifyError;
 
 /// Default system prompt for knowledge graph extraction.
 ///
-/// Vendored byte-for-byte from Python's
-/// `cognee/infrastructure/llm/prompts/generate_graph_prompt.txt` (kept in sync via
-/// the prompt-parity drift guard in the inline `#[cfg(test)]` block below).
+/// Vendored from Python's
+/// `cognee/infrastructure/llm/prompts/generate_graph_prompt.txt`, with one
+/// intentional Rust-only addition: the "Node Descriptions" instruction (see the
+/// drift guard in the inline `#[cfg(test)]` block below). Python advertises
+/// `Node.description` as required only via the injected schema in instructor's
+/// JSON mode, which is absent in tool/function/`json_schema` modes and on
+/// providers that reject `json_schema` (e.g. Groq) — so a non-strict model omits
+/// the field and hard-fails cognify (issue #66). Reinforcing it in the prompt
+/// text closes that gap. Any future re-sync from Python MUST preserve this line.
 const DEFAULT_GRAPH_PROMPT: &str = include_str!("prompts/generate_graph_prompt.txt");
 
 /// Appended to the system prompt when extracting a group of chunks in one call.
@@ -590,8 +596,11 @@ mod tests {
     #[test]
     fn graph_prompt_matches_vendored_txt() {
         // Drift guard: const must equal the vendored .txt byte-for-byte.
-        // Manual re-sync: cp /tmp/cognee-python/cognee/infrastructure/llm/prompts/generate_graph_prompt.txt \
-        //   crates/cognify/src/fact_extraction/prompts/generate_graph_prompt.txt
+        // Re-sync from Python, then RE-APPLY the Rust-only "Node Descriptions"
+        // addition (issue #66) — do not blindly overwrite:
+        //   cp /tmp/cognee-python/cognee/infrastructure/llm/prompts/generate_graph_prompt.txt \
+        //     crates/cognify/src/fact_extraction/prompts/generate_graph_prompt.txt
+        //   # then restore the "Node Descriptions" block under "# 1. Labeling Nodes"
         let vendored = include_str!("prompts/generate_graph_prompt.txt");
         assert_eq!(
             DEFAULT_GRAPH_PROMPT, vendored,
@@ -601,6 +610,13 @@ mod tests {
         assert!(
             vendored.contains("Every edge should include a description"),
             "edge-description paragraph missing — not the Python prompt"
+        );
+        // Rust-only addition (issue #66): non-strict LLMs (e.g. Groq) omit node
+        // `description` unless the prompt demands it. Guard against a re-sync
+        // from Python silently dropping this line.
+        assert!(
+            vendored.contains(r#"Every node MUST include a "description" field"#),
+            "Node-description instruction missing — issue #66 fix regressed"
         );
         assert!(
             vendored.contains(r#"label it as **"Person"**"#),

--- a/crates/cognify/src/fact_extraction/prompts/generate_graph_prompt.txt
+++ b/crates/cognify/src/fact_extraction/prompts/generate_graph_prompt.txt
@@ -18,6 +18,9 @@ The aim is to achieve simplicity and clarity in the knowledge graph.
   - Node IDs should be names or human-readable identifiers found in the text.
 **Node Names**: Every node MUST include a "name" field.
   - Use the most complete human-readable name for the entity (e.g., "Albert Einstein", "Python").
+**Node Descriptions**: Every node MUST include a "description" field.
+  - Provide a brief 1-2 sentence description of the entity, grounded in the source text.
+  - Do not add outside knowledge. If the text says little about the entity, keep it short.
 # 2. Handling Numerical Data and Dates
   - For example, when you identify an entity representing a date, make sure it has type **"Date"**.
   - Extract the date in the format "YYYY-MM-DD"

--- a/crates/cognify/tests/e2e_delete_preview_accuracy.rs
+++ b/crates/cognify/tests/e2e_delete_preview_accuracy.rs
@@ -133,7 +133,7 @@ async fn test_delete_preview_counts_match_execution() {
     {
         Ok(r) => r,
         Err(e) => {
-            test_utils::fail_loudly_on_replay_miss("cognify", &e);
+            test_utils::fail_loudly_in_cassette_mode("cognify", &e);
             eprintln!("Cognify failed (LLM may be unavailable): {e}");
             return;
         }

--- a/crates/cognify/tests/e2e_lifecycle_loop.rs
+++ b/crates/cognify/tests/e2e_lifecycle_loop.rs
@@ -190,7 +190,7 @@ async fn test_readd_and_recognify_after_delete() {
     {
         Ok(r) => r,
         Err(e) => {
-            test_utils::fail_loudly_on_replay_miss("first cognify", &e);
+            test_utils::fail_loudly_in_cassette_mode("first cognify", &e);
             eprintln!("Skipping test: first cognify failed: {e}");
             return;
         }

--- a/crates/cognify/tests/e2e_shared_entity_graph_delete.rs
+++ b/crates/cognify/tests/e2e_shared_entity_graph_delete.rs
@@ -158,7 +158,7 @@ async fn test_shared_entity_graph_delete() {
     {
         Ok(r) => r,
         Err(e) => {
-            test_utils::fail_loudly_on_replay_miss("cognify ds_ai", &e);
+            test_utils::fail_loudly_in_cassette_mode("cognify ds_ai", &e);
             eprintln!("Skipping: cognify ds_ai failed: {e}");
             return;
         }
@@ -188,7 +188,7 @@ async fn test_shared_entity_graph_delete() {
     {
         Ok(r) => r,
         Err(e) => {
-            test_utils::fail_loudly_on_replay_miss("cognify ds_ml", &e);
+            test_utils::fail_loudly_in_cassette_mode("cognify ds_ml", &e);
             eprintln!("Skipping: cognify ds_ml failed: {e}");
             return;
         }

--- a/crates/cognify/tests/e2e_triplet_vector_cleanup.rs
+++ b/crates/cognify/tests/e2e_triplet_vector_cleanup.rs
@@ -149,7 +149,7 @@ async fn test_triplet_vector_cleanup_after_data_delete() {
     {
         Ok(r) => r,
         Err(e) => {
-            test_utils::fail_loudly_on_replay_miss("cognify ds_ai", &e);
+            test_utils::fail_loudly_in_cassette_mode("cognify ds_ai", &e);
             eprintln!("Skipping: cognify ds_ai failed: {e}");
             return;
         }
@@ -179,7 +179,7 @@ async fn test_triplet_vector_cleanup_after_data_delete() {
     {
         Ok(r) => r,
         Err(e) => {
-            test_utils::fail_loudly_on_replay_miss("cognify ds_quantum", &e);
+            test_utils::fail_loudly_in_cassette_mode("cognify ds_quantum", &e);
             eprintln!("Skipping: cognify ds_quantum failed: {e}");
             return;
         }

--- a/crates/cognify/tests/fixtures/cassettes/delete_preview_accuracy.json
+++ b/crates/cognify/tests/fixtures/cassettes/delete_preview_accuracy.json
@@ -1,343 +1,473 @@
 {
   "version": 1,
-  "model": "gpt-4o-mini",
+  "model": "openai/gpt-oss-120b",
   "entries": {
-    "1a8145b910238c183a191e2967475fb26f43ad2be9252fa9d1df419a7ca953f2": {
+    "6c54fe76005337a3f3494e3f4a7967b78159ea788692deb38ff8b96eb1cac970": {
       "method": "structured_output",
       "user_input_preview": "\nAlice Johnson is a software engineer at TechCorp, a technology company based in San Francisco, California. \nShe has bee",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "Alice Johnson",
-            "name": "Alice Johnson",
-            "type": "PERSON",
-            "description": "Alice Johnson is a software engineer specializing in machine learning and artificial intelligence."
-          },
-          {
-            "id": "TechCorp",
-            "name": "TechCorp",
-            "type": "ORGANIZATION",
-            "description": "TechCorp is a technology company based in San Francisco, California."
-          },
-          {
-            "id": "Bob Smith",
-            "name": "Bob Smith",
-            "type": "PERSON",
-            "description": "Bob Smith is the CEO of TechCorp and founded the company in 2010."
-          },
-          {
-            "id": "San Francisco",
-            "name": "San Francisco",
-            "type": "LOCATION",
-            "description": "San Francisco is a city in California where TechCorp is based."
-          },
-          {
-            "id": "Seattle",
-            "name": "Seattle",
-            "type": "LOCATION",
-            "description": "Seattle is a city in Washington where the AI Conference took place."
-          },
-          {
-            "id": "Emma Chen",
-            "name": "Dr. Emma Chen",
-            "type": "PERSON",
-            "description": "Dr. Emma Chen is a collaborator of Alice Johnson from Stanford University."
-          },
-          {
-            "id": "DataSystems Inc.",
-            "name": "DataSystems Inc.",
-            "type": "ORGANIZATION",
-            "description": "DataSystems Inc. is a major player in the technology sector that partnered with TechCorp."
-          },
-          {
-            "id": "Stanford University",
-            "name": "Stanford University",
-            "type": "ORGANIZATION",
-            "description": "Stanford University is where Dr. Emma Chen is affiliated."
-          },
-          {
-            "id": "New York City",
-            "name": "New York City",
-            "type": "LOCATION",
-            "description": "New York City is one of the locations where TechCorp has satellite offices."
-          },
-          {
-            "id": "Austin",
-            "name": "Austin",
-            "type": "LOCATION",
-            "description": "Austin is another location where TechCorp has satellite offices."
-          },
-          {
-            "id": "California",
-            "name": "California",
-            "type": "LOCATION",
-            "description": "California is the state where San Francisco is located."
-          },
-          {
-            "id": "2010",
-            "name": "2010",
-            "type": "DATE",
-            "description": "2010 is the year TechCorp was founded."
-          },
-          {
-            "id": "AI Conference",
-            "name": "AI Conference",
-            "type": "EVENT",
-            "description": "The AI Conference is an event where Alice presented her project."
-          },
-          {
-            "id": "natural language processing",
-            "name": "natural language processing",
-            "type": "CONCEPT",
-            "description": "Natural language processing is a field of study that Alice worked on improving."
-          },
-          {
-            "id": "cloud infrastructure platform",
-            "name": "cloud infrastructure platform",
-            "type": "CONCEPT",
-            "description": "The cloud infrastructure platform is what TechCorp aims to integrate with DataSystems' capabilities."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "Alice Johnson",
-            "target_node_id": "TechCorp",
             "relationship_name": "works_at",
-            "description": "Alice Johnson works at TechCorp as a software engineer."
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "TechCorp"
           },
           {
+            "relationship_name": "specializes_in",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "Machine learning"
+          },
+          {
+            "relationship_name": "specializes_in",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "Artificial intelligence"
+          },
+          {
+            "relationship_name": "ceo_of",
             "source_node_id": "Bob Smith",
-            "target_node_id": "TechCorp",
+            "target_node_id": "TechCorp"
+          },
+          {
             "relationship_name": "founded",
-            "description": "Bob Smith founded TechCorp in 2010."
+            "source_node_id": "Bob Smith",
+            "target_node_id": "TechCorp"
           },
           {
+            "relationship_name": "headquartered_in",
             "source_node_id": "TechCorp",
-            "target_node_id": "San Francisco",
-            "relationship_name": "located_in",
-            "description": "TechCorp is located in San Francisco, California."
+            "target_node_id": "San Francisco"
           },
           {
+            "relationship_name": "has_satellite_office",
             "source_node_id": "TechCorp",
-            "target_node_id": "New York City",
-            "relationship_name": "has_office_in",
-            "description": "TechCorp has a satellite office in New York City."
+            "target_node_id": "New York City"
           },
           {
+            "relationship_name": "has_satellite_office",
             "source_node_id": "TechCorp",
-            "target_node_id": "Austin",
-            "relationship_name": "has_office_in",
-            "description": "TechCorp has a satellite office in Austin, Texas."
+            "target_node_id": "Austin, Texas"
           },
           {
-            "source_node_id": "Alice Johnson",
-            "target_node_id": "AI Conference",
             "relationship_name": "presented_at",
-            "description": "Alice Johnson presented her latest project at the AI Conference in Seattle."
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "AI Conference"
           },
           {
-            "source_node_id": "Alice Johnson",
-            "target_node_id": "natural language processing",
-            "relationship_name": "worked_on",
-            "description": "Alice Johnson worked on improving natural language processing models."
+            "relationship_name": "located_in",
+            "source_node_id": "AI Conference",
+            "target_node_id": "Seattle, Washington"
           },
           {
-            "source_node_id": "Alice Johnson",
-            "target_node_id": "Emma Chen",
             "relationship_name": "collaborated_with",
-            "description": "Alice Johnson collaborated with Dr. Emma Chen on her research."
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "Dr. Emma Chen"
           },
           {
+            "relationship_name": "affiliated_with",
+            "source_node_id": "Dr. Emma Chen",
+            "target_node_id": "Stanford University"
+          },
+          {
+            "relationship_name": "partnership_with",
             "source_node_id": "TechCorp",
-            "target_node_id": "DataSystems Inc.",
-            "relationship_name": "partnered_with",
-            "description": "TechCorp partnered with DataSystems Inc. to integrate AI capabilities."
+            "target_node_id": "DataSystems Inc."
+          },
+          {
+            "relationship_name": "worked_on",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "Natural language processing models"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Alice Johnson is a software engineer at TechCorp, specializing in machine learning and artificial intelligence.",
+            "id": "Alice Johnson",
+            "name": "Alice Johnson",
+            "type": "PERSON"
+          },
+          {
+            "description": "Bob Smith is the CEO of TechCorp and founded the company in 2010.",
+            "id": "Bob Smith",
+            "name": "Bob Smith",
+            "type": "PERSON"
+          },
+          {
+            "description": "TechCorp is a technology company based in San Francisco, California, with headquarters in the city's financial district and satellite offices in New York City and Austin, Texas.",
+            "id": "TechCorp",
+            "name": "TechCorp",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "San Francisco is a city in California where TechCorp's headquarters are located.",
+            "id": "San Francisco",
+            "name": "San Francisco",
+            "type": "LOCATION"
+          },
+          {
+            "description": "California is the state where San Francisco is located.",
+            "id": "California",
+            "name": "California",
+            "type": "LOCATION"
+          },
+          {
+            "description": "New York City is a city where TechCorp has a satellite office.",
+            "id": "New York City",
+            "name": "New York City",
+            "type": "LOCATION"
+          },
+          {
+            "description": "Austin, Texas is a city where TechCorp has a satellite office.",
+            "id": "Austin, Texas",
+            "name": "Austin, Texas",
+            "type": "LOCATION"
+          },
+          {
+            "description": "The AI Conference in Seattle, Washington where Alice presented her latest project.",
+            "id": "AI Conference",
+            "name": "AI Conference",
+            "type": "EVENT"
+          },
+          {
+            "description": "Seattle, Washington is the location of the AI Conference.",
+            "id": "Seattle, Washington",
+            "name": "Seattle, Washington",
+            "type": "LOCATION"
+          },
+          {
+            "description": "Dr. Emma Chen from Stanford University collaborated with Alice on research.",
+            "id": "Dr. Emma Chen",
+            "name": "Dr. Emma Chen",
+            "type": "PERSON"
+          },
+          {
+            "description": "Stanford University is the institution affiliated with Dr. Emma Chen.",
+            "id": "Stanford University",
+            "name": "Stanford University",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "DataSystems Inc. is a technology company partnering with TechCorp to integrate AI capabilities with its cloud infrastructure platform.",
+            "id": "DataSystems Inc.",
+            "name": "DataSystems Inc.",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Machine learning is a field in which Alice specializes.",
+            "id": "Machine learning",
+            "name": "Machine learning",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Artificial intelligence is a field in which Alice specializes.",
+            "id": "Artificial intelligence",
+            "name": "Artificial intelligence",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Natural language processing models are the focus of Alice's recent work.",
+            "id": "Natural language processing models",
+            "name": "Natural language processing models",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The year TechCorp was founded by Bob Smith.",
+            "id": "2010",
+            "name": "2010",
+            "type": "DATE"
           }
         ]
       }
     },
-    "5c397c186b938f4ab7cf6316ffec697dda85a8e7480a61ca5fb9e04083668b81": {
+    "d23a3095ca95b38f1b7585a3541ade12e37596c366a3f8303a7deac8d50fea10": {
       "method": "structured_output",
       "user_input_preview": "\nDr. Maria Rodriguez leads the Quantum Computing Laboratory at MIT, where she has been conducting groundbreaking \nresear",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "Maria Rodriguez",
-            "name": "Dr. Maria Rodriguez",
-            "type": "PERSON",
-            "description": "Dr. Maria Rodriguez leads the Quantum Computing Laboratory at MIT and conducts research on quantum error correction."
-          },
-          {
-            "id": "MIT",
-            "name": "Massachusetts Institute of Technology",
-            "type": "ORGANIZATION",
-            "description": "MIT is where Dr. Maria Rodriguez leads the Quantum Computing Laboratory."
-          },
-          {
-            "id": "Quantum Computing Laboratory",
-            "name": "Quantum Computing Laboratory",
-            "type": "ORGANIZATION",
-            "description": "The laboratory led by Dr. Maria Rodriguez, focusing on quantum error correction."
-          },
-          {
-            "id": "James Lee",
-            "name": "Dr. James Lee",
-            "type": "PERSON",
-            "description": "Dr. James Lee is a researcher from South Korea in Dr. Maria Rodriguez's team."
-          },
-          {
-            "id": "Fatima Abbas",
-            "name": "Dr. Fatima Abbas",
-            "type": "PERSON",
-            "description": "Dr. Fatima Abbas is a researcher from Egypt in Dr. Maria Rodriguez's team."
-          },
-          {
-            "id": "National Science Foundation",
-            "name": "National Science Foundation",
-            "type": "ORGANIZATION",
-            "description": "The NSF funded the Quantum Computing Laboratory with a $10 million grant."
-          },
-          {
-            "id": "QuantumTech Industries",
-            "name": "QuantumTech Industries",
-            "type": "ORGANIZATION",
-            "description": "A Canadian company specializing in quantum hardware that manufactured quantum computers for the laboratory."
-          },
-          {
-            "id": "Chen Wei",
-            "name": "Professor Chen Wei",
-            "type": "PERSON",
-            "description": "Professor Chen Wei co-authored a paper with Dr. Maria Rodriguez in Nature Physics."
-          },
-          {
-            "id": "Tsinghua University",
-            "name": "Tsinghua University",
-            "type": "ORGANIZATION",
-            "description": "The university in Beijing where Professor Chen Wei is affiliated."
-          },
-          {
-            "id": "Nature Physics",
-            "name": "Nature Physics",
-            "type": "CONCEPT",
-            "description": "A scientific journal where Dr. Maria Rodriguez published her research paper."
-          },
-          {
-            "id": "Cambridge University",
-            "name": "Cambridge University",
-            "type": "ORGANIZATION",
-            "description": "An institution in the UK collaborating with the MIT laboratory."
-          },
-          {
-            "id": "Max Planck Institute",
-            "name": "Max Planck Institute",
-            "type": "ORGANIZATION",
-            "description": "An institution in Germany collaborating with the MIT laboratory."
-          },
-          {
-            "id": "RIKEN",
-            "name": "RIKEN",
-            "type": "ORGANIZATION",
-            "description": "An institution in Japan collaborating with the MIT laboratory."
-          },
-          {
-            "id": "2020-01-01",
-            "name": "2020",
-            "type": "DATE",
-            "description": "The year when the National Science Foundation awarded the grant."
-          },
-          {
-            "id": "2018-01-01",
-            "name": "2018",
-            "type": "DATE",
-            "description": "The year when Dr. Maria Rodriguez began conducting research on quantum error correction."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "Maria Rodriguez",
-            "target_node_id": "Quantum Computing Laboratory",
             "relationship_name": "leads",
-            "description": "Dr. Maria Rodriguez leads the Quantum Computing Laboratory at MIT."
+            "source_node_id": "Maria Rodriguez",
+            "target_node_id": "Quantum Computing Laboratory at MIT"
           },
           {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "MIT",
             "relationship_name": "located_in",
-            "description": "The Quantum Computing Laboratory is located at MIT."
+            "source_node_id": "Quantum Computing Laboratory at MIT",
+            "target_node_id": "MIT"
           },
           {
+            "relationship_name": "conducts_research_on",
             "source_node_id": "Maria Rodriguez",
-            "target_node_id": "James Lee",
-            "relationship_name": "works_with",
-            "description": "Dr. Maria Rodriguez works with Dr. James Lee in her research team."
+            "target_node_id": "Quantum error correction"
           },
           {
+            "relationship_name": "research_started_in",
             "source_node_id": "Maria Rodriguez",
-            "target_node_id": "Fatima Abbas",
-            "relationship_name": "works_with",
-            "description": "Dr. Maria Rodriguez works with Dr. Fatima Abbas in her research team."
+            "target_node_id": "2018"
           },
           {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "National Science Foundation",
+            "relationship_name": "team_member",
+            "source_node_id": "Maria Rodriguez",
+            "target_node_id": "James Lee"
+          },
+          {
+            "relationship_name": "team_member",
+            "source_node_id": "Maria Rodriguez",
+            "target_node_id": "Fatima Abbas"
+          },
+          {
+            "relationship_name": "from_country",
+            "source_node_id": "James Lee",
+            "target_node_id": "South Korea"
+          },
+          {
+            "relationship_name": "from_country",
+            "source_node_id": "Fatima Abbas",
+            "target_node_id": "Egypt"
+          },
+          {
             "relationship_name": "funded_by",
-            "description": "The Quantum Computing Laboratory is funded by a $10 million grant from the National Science Foundation."
+            "source_node_id": "NSF Grant 2020",
+            "target_node_id": "National Science Foundation"
           },
           {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "QuantumTech Industries",
-            "relationship_name": "uses_equipment_from",
-            "description": "The Quantum Computing Laboratory uses quantum computers manufactured by QuantumTech Industries."
-          },
-          {
-            "source_node_id": "Maria Rodriguez",
-            "target_node_id": "Chen Wei",
-            "relationship_name": "co_authored_with",
-            "description": "Dr. Maria Rodriguez co-authored a paper with Professor Chen Wei."
-          },
-          {
-            "source_node_id": "Chen Wei",
-            "target_node_id": "Tsinghua University",
-            "relationship_name": "affiliated_with",
-            "description": "Professor Chen Wei is affiliated with Tsinghua University."
-          },
-          {
-            "source_node_id": "Maria Rodriguez",
-            "target_node_id": "Nature Physics",
-            "relationship_name": "published_in",
-            "description": "Dr. Maria Rodriguez published a paper in Nature Physics."
-          },
-          {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "Cambridge University",
-            "relationship_name": "collaborates_with",
-            "description": "The Quantum Computing Laboratory collaborates with Cambridge University."
-          },
-          {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "Max Planck Institute",
-            "relationship_name": "collaborates_with",
-            "description": "The Quantum Computing Laboratory collaborates with the Max Planck Institute."
-          },
-          {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "RIKEN",
-            "relationship_name": "collaborates_with",
-            "description": "The Quantum Computing Laboratory collaborates with RIKEN."
-          },
-          {
-            "source_node_id": "National Science Foundation",
-            "target_node_id": "2020",
             "relationship_name": "awarded_in",
-            "description": "The National Science Foundation awarded the grant in 2020."
+            "source_node_id": "NSF Grant 2020",
+            "target_node_id": "2020"
           },
           {
+            "relationship_name": "manufactures",
+            "source_node_id": "QuantumTech Industries",
+            "target_node_id": "Quantum computers"
+          },
+          {
+            "relationship_name": "acquired_from",
+            "source_node_id": "Quantum Computing Laboratory at MIT",
+            "target_node_id": "QuantumTech Industries"
+          },
+          {
+            "relationship_name": "published_in",
             "source_node_id": "Maria Rodriguez",
-            "target_node_id": "2018",
-            "relationship_name": "started_research_in",
-            "description": "Dr. Maria Rodriguez started her research on quantum error correction in 2018."
+            "target_node_id": "Nature Physics"
+          },
+          {
+            "relationship_name": "co_authored_by",
+            "source_node_id": "Maria Rodriguez",
+            "target_node_id": "Chen Wei"
+          },
+          {
+            "relationship_name": "affiliated_with",
+            "source_node_id": "Chen Wei",
+            "target_node_id": "Tsinghua University"
+          },
+          {
+            "relationship_name": "located_in",
+            "source_node_id": "Tsinghua University",
+            "target_node_id": "Beijing"
+          },
+          {
+            "relationship_name": "collaborates_with",
+            "source_node_id": "Quantum Computing Laboratory at MIT",
+            "target_node_id": "Cambridge University"
+          },
+          {
+            "relationship_name": "collaborates_with",
+            "source_node_id": "Quantum Computing Laboratory at MIT",
+            "target_node_id": "Max Planck Institute"
+          },
+          {
+            "relationship_name": "collaborates_with",
+            "source_node_id": "Quantum Computing Laboratory at MIT",
+            "target_node_id": "RIKEN"
+          },
+          {
+            "relationship_name": "located_in",
+            "source_node_id": "Cambridge University",
+            "target_node_id": "United Kingdom"
+          },
+          {
+            "relationship_name": "located_in",
+            "source_node_id": "Max Planck Institute",
+            "target_node_id": "Germany"
+          },
+          {
+            "relationship_name": "located_in",
+            "source_node_id": "RIKEN",
+            "target_node_id": "Japan"
+          },
+          {
+            "relationship_name": "demonstrates_approach_to",
+            "source_node_id": "Maria Rodriguez",
+            "target_node_id": "Quantum decoherence"
+          },
+          {
+            "relationship_name": "improves",
+            "source_node_id": "Quantum decoherence",
+            "target_node_id": "Reliability of quantum computers"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Dr. Maria Rodriguez leads the Quantum Computing Laboratory at MIT and conducts research on quantum error correction since 2018.",
+            "id": "Maria Rodriguez",
+            "name": "Dr. Maria Rodriguez",
+            "type": "PERSON"
+          },
+          {
+            "description": "Quantum Computing Laboratory at MIT focuses on quantum computing research.",
+            "id": "Quantum Computing Laboratory at MIT",
+            "name": "Quantum Computing Laboratory",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Massachusetts Institute of Technology, the university where the laboratory is located.",
+            "id": "MIT",
+            "name": "MIT",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Research area dealing with correcting errors in quantum computers.",
+            "id": "Quantum error correction",
+            "name": "Quantum error correction",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Year when Dr. Rodriguez began her quantum error correction research.",
+            "id": "2018",
+            "name": "2018",
+            "type": "DATE"
+          },
+          {
+            "description": "Dr. James Lee is a researcher on the team, originating from South Korea.",
+            "id": "James Lee",
+            "name": "Dr. James Lee",
+            "type": "PERSON"
+          },
+          {
+            "description": "Country in East Asia, the origin of Dr. James Lee.",
+            "id": "South Korea",
+            "name": "South Korea",
+            "type": "COUNTRY"
+          },
+          {
+            "description": "Dr. Fatima Abbas is a researcher on the team, originating from Egypt.",
+            "id": "Fatima Abbas",
+            "name": "Dr. Fatima Abbas",
+            "type": "PERSON"
+          },
+          {
+            "description": "Country in North Africa, the origin of Dr. Fatima Abbas.",
+            "id": "Egypt",
+            "name": "Egypt",
+            "type": "COUNTRY"
+          },
+          {
+            "description": "$10 million grant awarded by the National Science Foundation in 2020.",
+            "id": "NSF Grant 2020",
+            "name": "NSF Grant 2020",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "U.S. agency that provided the $10 million grant.",
+            "id": "National Science Foundation",
+            "name": "National Science Foundation",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Year the NSF grant was awarded.",
+            "id": "2020",
+            "name": "2020",
+            "type": "DATE"
+          },
+          {
+            "description": "Canadian company that manufactures state-of-the-art quantum computers.",
+            "id": "QuantumTech Industries",
+            "name": "QuantumTech Industries",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Country where QuantumTech Industries is based.",
+            "id": "Canada",
+            "name": "Canada",
+            "type": "COUNTRY"
+          },
+          {
+            "description": "State-of-the-art quantum computers acquired by the laboratory.",
+            "id": "Quantum computers",
+            "name": "Quantum computers",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Scientific journal where Dr. Rodriguez's paper was published.",
+            "id": "Nature Physics",
+            "name": "Nature Physics",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Professor Chen Wei co-authored the paper and is affiliated with Tsinghua University.",
+            "id": "Chen Wei",
+            "name": "Professor Chen Wei",
+            "type": "PERSON"
+          },
+          {
+            "description": "University in Beijing, China, affiliated with Professor Chen Wei.",
+            "id": "Tsinghua University",
+            "name": "Tsinghua University",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Capital city of China, location of Tsinghua University.",
+            "id": "Beijing",
+            "name": "Beijing",
+            "type": "CITY"
+          },
+          {
+            "description": "University in the United Kingdom collaborating with the MIT laboratory.",
+            "id": "Cambridge University",
+            "name": "Cambridge University",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Country of the United Kingdom.",
+            "id": "United Kingdom",
+            "name": "United Kingdom",
+            "type": "COUNTRY"
+          },
+          {
+            "description": "German research institute collaborating with the MIT laboratory.",
+            "id": "Max Planck Institute",
+            "name": "Max Planck Institute",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Country of Germany.",
+            "id": "Germany",
+            "name": "Germany",
+            "type": "COUNTRY"
+          },
+          {
+            "description": "Japanese research institute collaborating with the MIT laboratory.",
+            "id": "RIKEN",
+            "name": "RIKEN",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Country of Japan.",
+            "id": "Japan",
+            "name": "Japan",
+            "type": "COUNTRY"
+          },
+          {
+            "description": "Phenomenon of loss of quantum coherence that the research aims to reduce.",
+            "id": "Quantum decoherence",
+            "name": "Quantum decoherence",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Improved reliability of quantum computers as a result of reduced decoherence.",
+            "id": "Reliability of quantum computers",
+            "name": "Reliability of quantum computers",
+            "type": "CONCEPT"
           }
         ]
       }

--- a/crates/cognify/tests/fixtures/cassettes/fact_extraction.json
+++ b/crates/cognify/tests/fixtures/cassettes/fact_extraction.json
@@ -1,289 +1,184 @@
 {
   "version": 1,
-  "model": "gpt-4o-mini",
+  "model": "openai/gpt-oss-120b",
   "entries": {
-    "1a8145b910238c183a191e2967475fb26f43ad2be9252fa9d1df419a7ca953f2": {
+    "6c54fe76005337a3f3494e3f4a7967b78159ea788692deb38ff8b96eb1cac970": {
       "method": "structured_output",
       "user_input_preview": "\nAlice Johnson is a software engineer at TechCorp, a technology company based in San Francisco, California. \nShe has bee",
       "schema_name": "KnowledgeGraph",
       "response": {
+        "edges": [
+          {
+            "relationship_name": "works_at",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "TechCorp"
+          },
+          {
+            "relationship_name": "specializes_in",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "machine learning"
+          },
+          {
+            "relationship_name": "specializes_in",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "artificial intelligence"
+          },
+          {
+            "relationship_name": "founded",
+            "source_node_id": "Bob Smith",
+            "target_node_id": "TechCorp"
+          },
+          {
+            "relationship_name": "holds_position",
+            "source_node_id": "Bob Smith",
+            "target_node_id": "TechCorp"
+          },
+          {
+            "relationship_name": "based_in",
+            "source_node_id": "TechCorp",
+            "target_node_id": "San Francisco"
+          },
+          {
+            "relationship_name": "headquarters_in",
+            "source_node_id": "TechCorp",
+            "target_node_id": "San Francisco"
+          },
+          {
+            "relationship_name": "has_satellite_office",
+            "source_node_id": "TechCorp",
+            "target_node_id": "New York City"
+          },
+          {
+            "relationship_name": "has_satellite_office",
+            "source_node_id": "TechCorp",
+            "target_node_id": "Austin, Texas"
+          },
+          {
+            "relationship_name": "presented_at",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "AI Conference"
+          },
+          {
+            "relationship_name": "located_in",
+            "source_node_id": "AI Conference",
+            "target_node_id": "Seattle, Washington"
+          },
+          {
+            "relationship_name": "collaborated_with",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "Dr. Emma Chen"
+          },
+          {
+            "relationship_name": "affiliated_with",
+            "source_node_id": "Dr. Emma Chen",
+            "target_node_id": "Stanford University"
+          },
+          {
+            "relationship_name": "partnership_with",
+            "source_node_id": "TechCorp",
+            "target_node_id": "DataSystems Inc."
+          },
+          {
+            "relationship_name": "founded_in_year",
+            "source_node_id": "TechCorp",
+            "target_node_id": "2010"
+          },
+          {
+            "relationship_name": "presented_project_on",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "natural language processing models"
+          }
+        ],
         "nodes": [
           {
+            "description": "Alice Johnson is a software engineer at TechCorp, specializing in machine learning and artificial intelligence.",
             "id": "Alice Johnson",
             "name": "Alice Johnson",
-            "type": "PERSON",
-            "description": "Alice Johnson is a software engineer specializing in machine learning and artificial intelligence."
+            "type": "PERSON"
           },
           {
-            "id": "TechCorp",
-            "name": "TechCorp",
-            "type": "ORGANIZATION",
-            "description": "TechCorp is a technology company based in San Francisco, California."
-          },
-          {
+            "description": "Bob Smith is the CEO of TechCorp and founded the company in 2010.",
             "id": "Bob Smith",
             "name": "Bob Smith",
-            "type": "PERSON",
-            "description": "Bob Smith is the CEO of TechCorp and founded the company in 2010."
+            "type": "PERSON"
           },
           {
-            "id": "San Francisco",
-            "name": "San Francisco",
-            "type": "LOCATION",
-            "description": "San Francisco is a city in California, where TechCorp is headquartered."
+            "description": "TechCorp is a technology company based in San Francisco, California, with headquarters in the financial district and satellite offices in New York City and Austin.",
+            "id": "TechCorp",
+            "name": "TechCorp",
+            "type": "ORGANIZATION"
           },
           {
-            "id": "Seattle",
-            "name": "Seattle",
-            "type": "LOCATION",
-            "description": "Seattle is a city in Washington, where the AI Conference took place."
-          },
-          {
-            "id": "Stanford University",
-            "name": "Stanford University",
-            "type": "ORGANIZATION",
-            "description": "Stanford University is an educational institution where Dr. Emma Chen works."
-          },
-          {
-            "id": "Dr. Emma Chen",
-            "name": "Dr. Emma Chen",
-            "type": "PERSON",
-            "description": "Dr. Emma Chen is a collaborator of Alice Johnson on natural language processing research."
-          },
-          {
+            "description": "DataSystems Inc. is a major player in the technology sector that partnered with TechCorp.",
             "id": "DataSystems Inc.",
             "name": "DataSystems Inc.",
-            "type": "ORGANIZATION",
-            "description": "DataSystems Inc. is a major player in the technology sector that partnered with TechCorp."
+            "type": "ORGANIZATION"
           },
           {
+            "description": "San Francisco, California, is the city where TechCorp is based and its headquarters are located.",
+            "id": "San Francisco",
+            "name": "San Francisco",
+            "type": "LOCATION"
+          },
+          {
+            "description": "New York City is a location of a TechCorp satellite office.",
             "id": "New York City",
             "name": "New York City",
-            "type": "LOCATION",
-            "description": "New York City is one of the locations where TechCorp has satellite offices."
+            "type": "LOCATION"
           },
           {
-            "id": "Austin",
-            "name": "Austin",
-            "type": "LOCATION",
-            "description": "Austin is another location where TechCorp has satellite offices."
+            "description": "Austin, Texas is a location of a TechCorp satellite office.",
+            "id": "Austin, Texas",
+            "name": "Austin, Texas",
+            "type": "LOCATION"
           },
           {
+            "description": "Seattle, Washington is where the AI Conference took place.",
+            "id": "Seattle, Washington",
+            "name": "Seattle, Washington",
+            "type": "LOCATION"
+          },
+          {
+            "description": "The AI Conference is an event where Alice Johnson presented her project in Seattle.",
             "id": "AI Conference",
             "name": "AI Conference",
-            "type": "EVENT",
-            "description": "The AI Conference is an event where Alice presented her project on natural language processing."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Alice Johnson",
-            "target_node_id": "TechCorp",
-            "relationship_name": "works_at",
-            "description": "Alice Johnson works at TechCorp as a software engineer."
+            "type": "EVENT"
           },
           {
-            "source_node_id": "TechCorp",
-            "target_node_id": "Bob Smith",
-            "relationship_name": "founded_by",
-            "description": "TechCorp was founded by Bob Smith in 2010."
+            "description": "Dr. Emma Chen from Stanford University collaborated with Alice Johnson on research.",
+            "id": "Dr. Emma Chen",
+            "name": "Dr. Emma Chen",
+            "type": "PERSON"
           },
           {
-            "source_node_id": "TechCorp",
-            "target_node_id": "San Francisco",
-            "relationship_name": "located_in",
-            "description": "TechCorp is located in San Francisco, California."
+            "description": "Stanford University is the institution affiliated with Dr. Emma Chen.",
+            "id": "Stanford University",
+            "name": "Stanford University",
+            "type": "ORGANIZATION"
           },
           {
-            "source_node_id": "TechCorp",
-            "target_node_id": "New York City",
-            "relationship_name": "has_office_in",
-            "description": "TechCorp has a satellite office in New York City."
+            "description": "Machine learning is a field in which Alice Johnson specializes.",
+            "id": "machine learning",
+            "name": "machine learning",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "TechCorp",
-            "target_node_id": "Austin",
-            "relationship_name": "has_office_in",
-            "description": "TechCorp has a satellite office in Austin, Texas."
+            "description": "Artificial intelligence is a field in which Alice Johnson specializes.",
+            "id": "artificial intelligence",
+            "name": "artificial intelligence",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "Alice Johnson",
-            "target_node_id": "AI Conference",
-            "relationship_name": "presented_at",
-            "description": "Alice Johnson presented her latest project at the AI Conference in Seattle."
+            "description": "Natural language processing models are the focus of Alice Johnson's recent project.",
+            "id": "natural language processing models",
+            "name": "natural language processing models",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "Alice Johnson",
-            "target_node_id": "Dr. Emma Chen",
-            "relationship_name": "collaborated_with",
-            "description": "Alice Johnson collaborated with Dr. Emma Chen on natural language processing research."
-          },
-          {
-            "source_node_id": "TechCorp",
-            "target_node_id": "DataSystems Inc.",
-            "relationship_name": "partnered_with",
-            "description": "TechCorp partnered with DataSystems Inc. to integrate AI capabilities with cloud infrastructure."
-          }
-        ]
-      }
-    },
-    "5c397c186b938f4ab7cf6316ffec697dda85a8e7480a61ca5fb9e04083668b81": {
-      "method": "structured_output",
-      "user_input_preview": "\nDr. Maria Rodriguez leads the Quantum Computing Laboratory at MIT, where she has been conducting groundbreaking \nresear",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Maria Rodriguez",
-            "name": "Dr. Maria Rodriguez",
-            "type": "PERSON",
-            "description": "Dr. Maria Rodriguez leads the Quantum Computing Laboratory at MIT and conducts research on quantum error correction."
-          },
-          {
-            "id": "MIT",
-            "name": "Massachusetts Institute of Technology",
-            "type": "ORGANIZATION",
-            "description": "MIT is where Dr. Maria Rodriguez leads the Quantum Computing Laboratory."
-          },
-          {
-            "id": "Quantum Computing Laboratory",
-            "name": "Quantum Computing Laboratory",
-            "type": "ORGANIZATION",
-            "description": "The laboratory led by Dr. Maria Rodriguez at MIT, focusing on quantum error correction."
-          },
-          {
-            "id": "James Lee",
-            "name": "Dr. James Lee",
-            "type": "PERSON",
-            "description": "Dr. James Lee is a researcher from South Korea who is part of Dr. Maria Rodriguez's team."
-          },
-          {
-            "id": "Fatima Abbas",
-            "name": "Dr. Fatima Abbas",
-            "type": "PERSON",
-            "description": "Dr. Fatima Abbas is a researcher from Egypt who is part of Dr. Maria Rodriguez's team."
-          },
-          {
-            "id": "National Science Foundation",
-            "name": "National Science Foundation",
-            "type": "ORGANIZATION",
-            "description": "The NSF funded the Quantum Computing Laboratory with a $10 million grant."
-          },
-          {
-            "id": "QuantumTech Industries",
-            "name": "QuantumTech Industries",
-            "type": "ORGANIZATION",
-            "description": "A Canadian company specializing in quantum hardware that manufactures quantum computers."
-          },
-          {
-            "id": "Chen Wei",
-            "name": "Professor Chen Wei",
-            "type": "PERSON",
-            "description": "Professor Chen Wei from Tsinghua University co-authored a paper with Dr. Maria Rodriguez."
-          },
-          {
-            "id": "Tsinghua University",
-            "name": "Tsinghua University",
-            "type": "ORGANIZATION",
-            "description": "A university in Beijing where Professor Chen Wei is affiliated."
-          },
-          {
-            "id": "Nature Physics",
-            "name": "Nature Physics",
-            "type": "CONCEPT",
-            "description": "A scientific journal where Dr. Maria Rodriguez published her research paper."
-          },
-          {
-            "id": "Cambridge University",
-            "name": "Cambridge University",
-            "type": "ORGANIZATION",
-            "description": "A university in the UK that collaborates with the MIT Quantum Computing Laboratory."
-          },
-          {
-            "id": "Max Planck Institute",
-            "name": "Max Planck Institute",
-            "type": "ORGANIZATION",
-            "description": "An institute in Germany that collaborates with the MIT Quantum Computing Laboratory."
-          },
-          {
-            "id": "RIKEN",
-            "name": "RIKEN",
-            "type": "ORGANIZATION",
-            "description": "A research institute in Japan that collaborates with the MIT Quantum Computing Laboratory."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Maria Rodriguez",
-            "target_node_id": "Quantum Computing Laboratory",
-            "relationship_name": "leads",
-            "description": "Dr. Maria Rodriguez leads the Quantum Computing Laboratory at MIT."
-          },
-          {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "MIT",
-            "relationship_name": "located_in",
-            "description": "The Quantum Computing Laboratory is located at MIT."
-          },
-          {
-            "source_node_id": "Maria Rodriguez",
-            "target_node_id": "James Lee",
-            "relationship_name": "works_with",
-            "description": "Dr. Maria Rodriguez works with Dr. James Lee, who is part of her research team."
-          },
-          {
-            "source_node_id": "Maria Rodriguez",
-            "target_node_id": "Fatima Abbas",
-            "relationship_name": "works_with",
-            "description": "Dr. Maria Rodriguez works with Dr. Fatima Abbas, who is part of her research team."
-          },
-          {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "National Science Foundation",
-            "relationship_name": "funded_by",
-            "description": "The Quantum Computing Laboratory is funded by a $10 million grant from the National Science Foundation."
-          },
-          {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "QuantumTech Industries",
-            "relationship_name": "uses_equipment_from",
-            "description": "The Quantum Computing Laboratory uses quantum computers manufactured by QuantumTech Industries."
-          },
-          {
-            "source_node_id": "Maria Rodriguez",
-            "target_node_id": "Chen Wei",
-            "relationship_name": "co_authored_with",
-            "description": "Dr. Maria Rodriguez co-authored a paper with Professor Chen Wei."
-          },
-          {
-            "source_node_id": "Chen Wei",
-            "target_node_id": "Tsinghua University",
-            "relationship_name": "affiliated_with",
-            "description": "Professor Chen Wei is affiliated with Tsinghua University."
-          },
-          {
-            "source_node_id": "Maria Rodriguez",
-            "target_node_id": "Nature Physics",
-            "relationship_name": "published_in",
-            "description": "Dr. Maria Rodriguez published her research in Nature Physics."
-          },
-          {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "Cambridge University",
-            "relationship_name": "collaborates_with",
-            "description": "The Quantum Computing Laboratory collaborates with Cambridge University."
-          },
-          {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "Max Planck Institute",
-            "relationship_name": "collaborates_with",
-            "description": "The Quantum Computing Laboratory collaborates with the Max Planck Institute."
-          },
-          {
-            "source_node_id": "Quantum Computing Laboratory",
-            "target_node_id": "RIKEN",
-            "relationship_name": "collaborates_with",
-            "description": "The Quantum Computing Laboratory collaborates with RIKEN."
+            "description": "The year TechCorp was founded.",
+            "id": "2010",
+            "name": "2010",
+            "type": "DATE"
           }
         ]
       }
@@ -293,116 +188,458 @@
       "user_input_preview": "\nAlice Johnson is a software engineer at TechCorp, a technology company based in San Francisco, California. \nShe has bee",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "Alice_Johnson",
-            "name": "Alice Johnson",
-            "type": "PERSON",
-            "description": "A software engineer at TechCorp specializing in machine learning and artificial intelligence."
-          },
-          {
-            "id": "TechCorp",
-            "name": "TechCorp",
-            "type": "ORGANIZATION",
-            "description": "A technology company based in San Francisco, California, founded in 2010."
-          },
-          {
-            "id": "Bob_Smith",
-            "name": "Bob Smith",
-            "type": "PERSON",
-            "description": "The CEO and founder of TechCorp, who has led the company since its inception."
-          },
-          {
-            "id": "San_Francisco",
-            "name": "San Francisco",
-            "type": "LOCATION",
-            "description": "A major city in California, known for its financial district and technology companies."
-          },
-          {
-            "id": "Emma_Chen",
-            "name": "Dr. Emma Chen",
-            "type": "PERSON",
-            "description": "A researcher from Stanford University who collaborated with Alice Johnson on natural language processing."
-          },
-          {
-            "id": "DataSystems_Inc",
-            "name": "DataSystems Inc.",
-            "type": "ORGANIZATION",
-            "description": "A major player in the technology sector that partnered with TechCorp."
-          },
-          {
-            "id": "Seattle",
-            "name": "Seattle",
-            "type": "LOCATION",
-            "description": "A city in Washington where the AI Conference was held."
-          },
-          {
-            "id": "New_York_City",
-            "name": "New York City",
-            "type": "LOCATION",
-            "description": "A major city in the United States where TechCorp has a satellite office."
-          },
-          {
-            "id": "Austin",
-            "name": "Austin",
-            "type": "LOCATION",
-            "description": "A city in Texas where TechCorp has a satellite office."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "Alice_Johnson",
-            "target_node_id": "TechCorp",
             "relationship_name": "works_at",
-            "description": "Alice Johnson is a software engineer at TechCorp."
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "TechCorp"
           },
           {
-            "source_node_id": "Bob_Smith",
-            "target_node_id": "TechCorp",
+            "relationship_name": "specializes_in",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "Machine Learning"
+          },
+          {
+            "relationship_name": "specializes_in",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "Artificial Intelligence"
+          },
+          {
+            "relationship_name": "works_at",
+            "source_node_id": "Bob Smith",
+            "target_node_id": "TechCorp"
+          },
+          {
+            "relationship_name": "ceo_of",
+            "source_node_id": "Bob Smith",
+            "target_node_id": "TechCorp"
+          },
+          {
             "relationship_name": "founded",
-            "description": "Bob Smith founded TechCorp in 2010."
+            "source_node_id": "Bob Smith",
+            "target_node_id": "TechCorp"
           },
           {
-            "source_node_id": "Bob_Smith",
-            "target_node_id": "TechCorp",
-            "relationship_name": "works_as",
-            "description": "Bob Smith is the CEO of TechCorp."
-          },
-          {
+            "relationship_name": "headquartered_in",
             "source_node_id": "TechCorp",
-            "target_node_id": "San_Francisco",
-            "relationship_name": "located_in",
-            "description": "TechCorp is based in San Francisco, California."
+            "target_node_id": "San Francisco"
           },
           {
-            "source_node_id": "Alice_Johnson",
-            "target_node_id": "Emma_Chen",
-            "relationship_name": "collaborates_with",
-            "description": "Alice Johnson collaborated with Dr. Emma Chen on natural language processing research."
-          },
-          {
+            "relationship_name": "has_office_location",
             "source_node_id": "TechCorp",
-            "target_node_id": "DataSystems_Inc",
-            "relationship_name": "partnered_with",
-            "description": "TechCorp announced a partnership with DataSystems Inc."
+            "target_node_id": "New York City"
           },
           {
+            "relationship_name": "has_office_location",
             "source_node_id": "TechCorp",
-            "target_node_id": "New_York_City",
-            "relationship_name": "has_office_in",
-            "description": "TechCorp has a satellite office in New York City."
+            "target_node_id": "Austin, Texas"
           },
           {
-            "source_node_id": "TechCorp",
-            "target_node_id": "Austin",
-            "relationship_name": "has_office_in",
-            "description": "TechCorp has a satellite office in Austin, Texas."
-          },
-          {
-            "source_node_id": "Alice_Johnson",
-            "target_node_id": "Seattle",
             "relationship_name": "presented_at",
-            "description": "Alice Johnson presented her project at the AI Conference in Seattle."
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "AI Conference"
+          },
+          {
+            "relationship_name": "located_in",
+            "source_node_id": "AI Conference",
+            "target_node_id": "Seattle, Washington"
+          },
+          {
+            "relationship_name": "collaborates_with",
+            "source_node_id": "Alice Johnson",
+            "target_node_id": "Dr. Emma Chen"
+          },
+          {
+            "relationship_name": "affiliated_with",
+            "source_node_id": "Dr. Emma Chen",
+            "target_node_id": "Stanford University"
+          },
+          {
+            "relationship_name": "partnership",
+            "source_node_id": "TechCorp",
+            "target_node_id": "DataSystems Inc."
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Software engineer at TechCorp specializing in machine learning and artificial intelligence, with five years of experience.",
+            "id": "Alice Johnson",
+            "name": "Alice Johnson",
+            "type": "PERSON"
+          },
+          {
+            "description": "CEO of TechCorp who founded the company in 2010.",
+            "id": "Bob Smith",
+            "name": "Bob Smith",
+            "type": "PERSON"
+          },
+          {
+            "description": "Researcher from Stanford University who collaborated with Alice Johnson on natural language processing research.",
+            "id": "Dr. Emma Chen",
+            "name": "Dr. Emma Chen",
+            "type": "PERSON"
+          },
+          {
+            "description": "Technology company based in San Francisco, founded in 2010, with over 500 employees.",
+            "id": "TechCorp",
+            "name": "TechCorp",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Major technology company providing cloud infrastructure platforms.",
+            "id": "DataSystems Inc.",
+            "name": "DataSystems Inc.",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Academic institution where Dr. Emma Chen conducts research.",
+            "id": "Stanford University",
+            "name": "Stanford University",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Conference held in Seattle, Washington where Alice Johnson presented her AI project.",
+            "id": "AI Conference",
+            "name": "AI Conference",
+            "type": "EVENT"
+          },
+          {
+            "description": "City in California, location of TechCorp's headquarters.",
+            "id": "San Francisco",
+            "name": "San Francisco",
+            "type": "LOCATION"
+          },
+          {
+            "description": "City where TechCorp has a satellite office.",
+            "id": "New York City",
+            "name": "New York City",
+            "type": "LOCATION"
+          },
+          {
+            "description": "City in Texas where TechCorp has a satellite office.",
+            "id": "Austin, Texas",
+            "name": "Austin, Texas",
+            "type": "LOCATION"
+          },
+          {
+            "description": "City in Washington state where the AI Conference took place.",
+            "id": "Seattle, Washington",
+            "name": "Seattle, Washington",
+            "type": "LOCATION"
+          },
+          {
+            "description": "Field of study focusing on algorithms that improve automatically through experience.",
+            "id": "Machine Learning",
+            "name": "Machine Learning",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Field of study concerning the creation of intelligent machines.",
+            "id": "Artificial Intelligence",
+            "name": "Artificial Intelligence",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "d23a3095ca95b38f1b7585a3541ade12e37596c366a3f8303a7deac8d50fea10": {
+      "method": "structured_output",
+      "user_input_preview": "\nDr. Maria Rodriguez leads the Quantum Computing Laboratory at MIT, where she has been conducting groundbreaking \nresear",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "relationship_name": "leads",
+            "source_node_id": "Maria Rodriguez",
+            "target_node_id": "Quantum Computing Laboratory"
+          },
+          {
+            "relationship_name": "located_in",
+            "source_node_id": "Quantum Computing Laboratory",
+            "target_node_id": "MIT"
+          },
+          {
+            "relationship_name": "researches",
+            "source_node_id": "Maria Rodriguez",
+            "target_node_id": "Quantum Error Correction"
+          },
+          {
+            "relationship_name": "research_started_in",
+            "source_node_id": "Maria Rodriguez",
+            "target_node_id": "2018"
+          },
+          {
+            "relationship_name": "has_team_member",
+            "source_node_id": "Maria Rodriguez",
+            "target_node_id": "James Lee"
+          },
+          {
+            "relationship_name": "nationality",
+            "source_node_id": "James Lee",
+            "target_node_id": "South Korea"
+          },
+          {
+            "relationship_name": "has_team_member",
+            "source_node_id": "Maria Rodriguez",
+            "target_node_id": "Fatima Abbas"
+          },
+          {
+            "relationship_name": "nationality",
+            "source_node_id": "Fatima Abbas",
+            "target_node_id": "Egypt"
+          },
+          {
+            "relationship_name": "funded_by",
+            "source_node_id": "Quantum Computing Laboratory",
+            "target_node_id": "NSF Grant 2020"
+          },
+          {
+            "relationship_name": "awarded_by",
+            "source_node_id": "NSF Grant 2020",
+            "target_node_id": "National Science Foundation"
+          },
+          {
+            "relationship_name": "awarded_in",
+            "source_node_id": "NSF Grant 2020",
+            "target_node_id": "2020"
+          },
+          {
+            "relationship_name": "acquired",
+            "source_node_id": "Quantum Computing Laboratory",
+            "target_node_id": "Quantum Computers"
+          },
+          {
+            "relationship_name": "manufactured_by",
+            "source_node_id": "Quantum Computers",
+            "target_node_id": "QuantumTech Industries"
+          },
+          {
+            "relationship_name": "based_in",
+            "source_node_id": "QuantumTech Industries",
+            "target_node_id": "Canada"
+          },
+          {
+            "relationship_name": "published_in",
+            "source_node_id": "Maria Rodriguez",
+            "target_node_id": "Nature Physics"
+          },
+          {
+            "relationship_name": "co_authored_by",
+            "source_node_id": "Nature Physics",
+            "target_node_id": "Chen Wei"
+          },
+          {
+            "relationship_name": "affiliated_with",
+            "source_node_id": "Chen Wei",
+            "target_node_id": "Tsinghua University"
+          },
+          {
+            "relationship_name": "located_in",
+            "source_node_id": "Tsinghua University",
+            "target_node_id": "Beijing"
+          },
+          {
+            "relationship_name": "demonstrates",
+            "source_node_id": "Nature Physics",
+            "target_node_id": "Quantum Decoherence"
+          },
+          {
+            "relationship_name": "collaborates_with",
+            "source_node_id": "Quantum Computing Laboratory",
+            "target_node_id": "Cambridge University"
+          },
+          {
+            "relationship_name": "located_in",
+            "source_node_id": "Cambridge University",
+            "target_node_id": "United Kingdom"
+          },
+          {
+            "relationship_name": "collaborates_with",
+            "source_node_id": "Quantum Computing Laboratory",
+            "target_node_id": "Max Planck Institute"
+          },
+          {
+            "relationship_name": "located_in",
+            "source_node_id": "Max Planck Institute",
+            "target_node_id": "Germany"
+          },
+          {
+            "relationship_name": "collaborates_with",
+            "source_node_id": "Quantum Computing Laboratory",
+            "target_node_id": "RIKEN"
+          },
+          {
+            "relationship_name": "located_in",
+            "source_node_id": "RIKEN",
+            "target_node_id": "Japan"
+          },
+          {
+            "relationship_name": "research_area",
+            "source_node_id": "Quantum Computing Laboratory",
+            "target_node_id": "Quantum Error Correction"
+          },
+          {
+            "relationship_name": "research_area",
+            "source_node_id": "Quantum Computing Laboratory",
+            "target_node_id": "Quantum Decoherence"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Dr. Maria Rodriguez leads the Quantum Computing Laboratory at MIT and conducts research on quantum error correction since 2018.",
+            "id": "Maria Rodriguez",
+            "name": "Maria Rodriguez",
+            "type": "PERSON"
+          },
+          {
+            "description": "The Quantum Computing Laboratory at MIT conducts research on quantum error correction.",
+            "id": "Quantum Computing Laboratory",
+            "name": "Quantum Computing Laboratory",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "MIT hosts the Quantum Computing Laboratory.",
+            "id": "MIT",
+            "name": "MIT",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Dr. James Lee is a researcher in the Quantum Computing Laboratory, from South Korea.",
+            "id": "James Lee",
+            "name": "James Lee",
+            "type": "PERSON"
+          },
+          {
+            "description": "South Korea is a country.",
+            "id": "South Korea",
+            "name": "South Korea",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Dr. Fatima Abbas is a researcher in the Quantum Computing Laboratory, from Egypt.",
+            "id": "Fatima Abbas",
+            "name": "Fatima Abbas",
+            "type": "PERSON"
+          },
+          {
+            "description": "Egypt is a country.",
+            "id": "Egypt",
+            "name": "Egypt",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The National Science Foundation awarded a $10 million grant in 2020.",
+            "id": "National Science Foundation",
+            "name": "National Science Foundation",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "A $10 million grant awarded by the National Science Foundation in 2020.",
+            "id": "NSF Grant 2020",
+            "name": "$10 million grant",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "QuantumTech Industries is a Canadian company that manufactures quantum computers.",
+            "id": "QuantumTech Industries",
+            "name": "QuantumTech Industries",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Canada is a country.",
+            "id": "Canada",
+            "name": "Canada",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Nature Physics is a scientific journal.",
+            "id": "Nature Physics",
+            "name": "Nature Physics",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Professor Chen Wei from Tsinghua University co-authored a paper with Maria Rodriguez.",
+            "id": "Chen Wei",
+            "name": "Chen Wei",
+            "type": "PERSON"
+          },
+          {
+            "description": "Tsinghua University is located in Beijing.",
+            "id": "Tsinghua University",
+            "name": "Tsinghua University",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Beijing is a city in China.",
+            "id": "Beijing",
+            "name": "Beijing",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Cambridge University in the UK collaborates with MIT lab.",
+            "id": "Cambridge University",
+            "name": "Cambridge University",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "United Kingdom is a country.",
+            "id": "United Kingdom",
+            "name": "United Kingdom",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Max Planck Institute in Germany collaborates with MIT lab.",
+            "id": "Max Planck Institute",
+            "name": "Max Planck Institute",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Germany is a country.",
+            "id": "Germany",
+            "name": "Germany",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "RIKEN in Japan collaborates with MIT lab.",
+            "id": "RIKEN",
+            "name": "RIKEN",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Japan is a country.",
+            "id": "Japan",
+            "name": "Japan",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Research area focused on correcting errors in quantum computers.",
+            "id": "Quantum Error Correction",
+            "name": "Quantum Error Correction",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Phenomenon that reduces reliability of quantum computers.",
+            "id": "Quantum Decoherence",
+            "name": "Quantum Decoherence",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "State-of-the-art quantum computers manufactured by QuantumTech Industries.",
+            "id": "Quantum Computers",
+            "name": "Quantum Computers",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Year when Maria Rodriguez started research on quantum error correction.",
+            "id": "2018",
+            "name": "2018",
+            "type": "DATE"
+          },
+          {
+            "description": "Year when NSF grant was awarded.",
+            "id": "2020",
+            "name": "2020",
+            "type": "DATE"
           }
         ]
       }

--- a/crates/cognify/tests/fixtures/cassettes/lifecycle_loop.json
+++ b/crates/cognify/tests/fixtures/cassettes/lifecycle_loop.json
@@ -1,44 +1,58 @@
 {
   "version": 1,
-  "model": "gpt-4o-mini",
+  "model": "openai/gpt-oss-120b",
   "entries": {
-    "668c2315d1d16afd48ab174d47928f3baea15c04615b508e014f0e824ab29ed9": {
+    "5c9a8b3957e115c37204a493e4542f986c6ab0da06086bfbcba5bd750039b22e": {
       "method": "structured_output",
       "user_input_preview": "Alice works at TechCorp in San Francisco as a software engineer.",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "Alice",
-            "name": "Alice",
-            "type": "PERSON",
-            "description": "A software engineer working at TechCorp."
-          },
-          {
-            "id": "TechCorp",
-            "name": "TechCorp",
-            "type": "ORGANIZATION",
-            "description": "An organization where Alice works."
-          },
-          {
-            "id": "San Francisco",
-            "name": "San Francisco",
-            "type": "LOCATION",
-            "description": "The location of TechCorp."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "Alice",
-            "target_node_id": "TechCorp",
             "relationship_name": "works_at",
-            "description": "Alice works at TechCorp."
+            "source_node_id": "Alice",
+            "target_node_id": "TechCorp"
           },
           {
-            "source_node_id": "TechCorp",
-            "target_node_id": "San Francisco",
+            "relationship_name": "works_in",
+            "source_node_id": "Alice",
+            "target_node_id": "San Francisco"
+          },
+          {
+            "relationship_name": "has_profession",
+            "source_node_id": "Alice",
+            "target_node_id": "Software Engineer"
+          },
+          {
             "relationship_name": "located_in",
-            "description": "TechCorp is located in San Francisco."
+            "source_node_id": "TechCorp",
+            "target_node_id": "San Francisco"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Alice is a software engineer who works at TechCorp in San Francisco.",
+            "id": "Alice",
+            "name": "Alice",
+            "type": "PERSON"
+          },
+          {
+            "description": "TechCorp is the employer where Alice works.",
+            "id": "TechCorp",
+            "name": "TechCorp",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "San Francisco is the city where TechCorp is located and where Alice works.",
+            "id": "San Francisco",
+            "name": "San Francisco",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Software engineer is the profession of Alice.",
+            "id": "Software Engineer",
+            "name": "Software Engineer",
+            "type": "CONCEPT"
           }
         ]
       }

--- a/crates/cognify/tests/fixtures/cassettes/shared_entity_graph_delete.json
+++ b/crates/cognify/tests/fixtures/cassettes/shared_entity_graph_delete.json
@@ -1,499 +1,529 @@
 {
   "version": 1,
-  "model": "gpt-4o-mini",
+  "model": "openai/gpt-oss-120b",
   "entries": {
-    "672af090cfb794d6447257168682a5143cfe57d4912b533200c8f873041776e0": {
-      "method": "structured_output",
-      "user_input_preview": "Machine learning is a core subfield of artificial intelligence that enables computers to learn from data without being e",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Machine Learning",
-            "name": "Machine Learning",
-            "type": "CONCEPT",
-            "description": "Machine learning is a core subfield of artificial intelligence that enables computers to learn from data without being explicitly programmed."
-          },
-          {
-            "id": "Artificial Intelligence",
-            "name": "Artificial Intelligence",
-            "type": "CONCEPT",
-            "description": "Artificial intelligence is the broader field that encompasses machine learning."
-          },
-          {
-            "id": "Deep Learning",
-            "name": "Deep Learning",
-            "type": "CONCEPT",
-            "description": "Deep learning is a subfield of machine learning that uses neural networks with many layers."
-          },
-          {
-            "id": "Natural Language Processing",
-            "name": "Natural Language Processing",
-            "type": "CONCEPT",
-            "description": "Natural language processing is a field that has seen breakthroughs due to deep learning."
-          },
-          {
-            "id": "Computer Vision",
-            "name": "Computer Vision",
-            "type": "CONCEPT",
-            "description": "Computer vision is another field that has benefited from advancements in deep learning."
-          },
-          {
-            "id": "GPT-4",
-            "name": "GPT-4",
-            "type": "CONCEPT",
-            "description": "GPT-4 is a large language model developed by OpenAI."
-          },
-          {
-            "id": "OpenAI",
-            "name": "OpenAI",
-            "type": "ORGANIZATION",
-            "description": "OpenAI is the organization that developed GPT-4."
-          },
-          {
-            "id": "LLaMA",
-            "name": "LLaMA",
-            "type": "CONCEPT",
-            "description": "LLaMA is a large language model developed by Meta."
-          },
-          {
-            "id": "Meta",
-            "name": "Meta",
-            "type": "ORGANIZATION",
-            "description": "Meta is the organization that developed LLaMA."
-          },
-          {
-            "id": "Transformer Architecture",
-            "name": "Transformer Architecture",
-            "type": "CONCEPT",
-            "description": "Transformer architectures are used in large language models like GPT-4 and LLaMA."
-          },
-          {
-            "id": "Reinforcement Learning",
-            "name": "Reinforcement Learning",
-            "type": "CONCEPT",
-            "description": "Reinforcement learning is a branch of machine learning that trains agents through trial and error."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Machine Learning",
-            "target_node_id": "Artificial Intelligence",
-            "relationship_name": "is_a_subfield_of",
-            "description": "Machine Learning is a core subfield of Artificial Intelligence."
-          },
-          {
-            "source_node_id": "Deep Learning",
-            "target_node_id": "Machine Learning",
-            "relationship_name": "is_a_subfield_of",
-            "description": "Deep Learning is a subfield of Machine Learning."
-          },
-          {
-            "source_node_id": "Deep Learning",
-            "target_node_id": "Natural Language Processing",
-            "relationship_name": "drives_breakthroughs_in",
-            "description": "Deep Learning has driven breakthroughs in Natural Language Processing."
-          },
-          {
-            "source_node_id": "Deep Learning",
-            "target_node_id": "Computer Vision",
-            "relationship_name": "drives_breakthroughs_in",
-            "description": "Deep Learning has driven breakthroughs in Computer Vision."
-          },
-          {
-            "source_node_id": "GPT-4",
-            "target_node_id": "Transformer Architecture",
-            "relationship_name": "is_based_on",
-            "description": "GPT-4 is based on Transformer Architecture."
-          },
-          {
-            "source_node_id": "LLaMA",
-            "target_node_id": "Transformer Architecture",
-            "relationship_name": "is_based_on",
-            "description": "LLaMA is based on Transformer Architecture."
-          },
-          {
-            "source_node_id": "OpenAI",
-            "target_node_id": "GPT-4",
-            "relationship_name": "developed",
-            "description": "OpenAI developed GPT-4."
-          },
-          {
-            "source_node_id": "Meta",
-            "target_node_id": "LLaMA",
-            "relationship_name": "developed",
-            "description": "Meta developed LLaMA."
-          },
-          {
-            "source_node_id": "Reinforcement Learning",
-            "target_node_id": "Machine Learning",
-            "relationship_name": "is_a_branch_of",
-            "description": "Reinforcement Learning is another branch of Machine Learning."
-          }
-        ]
-      }
-    },
-    "fbff5ad35093e7c5cc5e947feb7d62db0cd9b09b1fca8b352b19f3f98cd64668": {
+    "3d8acd1ff4f2deec219dc511a868f74f13b601e916175d3fb92f09e61028166f": {
       "method": "structured_output",
       "user_input_preview": "Artificial intelligence (AI) is the intelligence of machines or software, as opposed to the intelligence of living being",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "Artificial Intelligence",
-            "name": "Artificial Intelligence",
-            "type": "CONCEPT",
-            "description": "Artificial intelligence (AI) is the intelligence of machines or software, as opposed to the intelligence of living beings, primarily of humans."
-          },
-          {
-            "id": "Computer Science",
-            "name": "Computer Science",
-            "type": "CONCEPT",
-            "description": "Computer science is a field of research that develops and studies methods and software enabling machines to perceive their environment."
-          },
-          {
-            "id": "Google Search",
-            "name": "Google Search",
-            "type": "CONCEPT",
-            "description": "Google Search is an advanced web search engine that is a high-profile application of AI."
-          },
-          {
-            "id": "YouTube",
-            "name": "YouTube",
-            "type": "ORGANIZATION",
-            "description": "YouTube is a platform that uses recommendation systems as a high-profile application of AI."
-          },
-          {
-            "id": "Amazon",
-            "name": "Amazon",
-            "type": "ORGANIZATION",
-            "description": "Amazon is a platform that uses recommendation systems as a high-profile application of AI."
-          },
-          {
-            "id": "Netflix",
-            "name": "Netflix",
-            "type": "ORGANIZATION",
-            "description": "Netflix is a platform that uses recommendation systems as a high-profile application of AI."
-          },
-          {
-            "id": "Google Assistant",
-            "name": "Google Assistant",
-            "type": "CONCEPT",
-            "description": "Google Assistant is an AI that interacts via human speech."
-          },
-          {
-            "id": "Siri",
-            "name": "Siri",
-            "type": "CONCEPT",
-            "description": "Siri is an AI that interacts via human speech."
-          },
-          {
-            "id": "Alexa",
-            "name": "Alexa",
-            "type": "CONCEPT",
-            "description": "Alexa is an AI that interacts via human speech."
-          },
-          {
-            "id": "Waymo",
-            "name": "Waymo",
-            "type": "ORGANIZATION",
-            "description": "Waymo is a company that develops autonomous vehicles as a high-profile application of AI."
-          },
-          {
-            "id": "ChatGPT",
-            "name": "ChatGPT",
-            "type": "CONCEPT",
-            "description": "ChatGPT is a generative AI tool."
-          },
-          {
-            "id": "AI Art",
-            "name": "AI Art",
-            "type": "CONCEPT",
-            "description": "AI Art is a generative AI tool."
-          },
-          {
-            "id": "Chess",
-            "name": "Chess",
-            "type": "CONCEPT",
-            "description": "Chess is a strategy game where AI demonstrates superhuman play and analysis."
-          },
-          {
-            "id": "Go",
-            "name": "Go",
-            "type": "CONCEPT",
-            "description": "Go is a strategy game where AI demonstrates superhuman play and analysis."
-          },
-          {
-            "id": "Large Language Models",
-            "name": "Large Language Models",
-            "type": "CONCEPT",
-            "description": "Large language models (LLMs) are a type of AI trained on enormous amounts of text data."
-          },
-          {
-            "id": "GPT-4",
-            "name": "GPT-4",
-            "type": "CONCEPT",
-            "description": "GPT-4 is a large language model developed by OpenAI, capable of generating coherent text and answering complex questions."
-          },
-          {
-            "id": "PaLM",
-            "name": "PaLM",
-            "type": "CONCEPT",
-            "description": "PaLM is a large language model developed by Google, demonstrating strong reasoning and multilingual capabilities."
-          },
-          {
-            "id": "LLaMA",
-            "name": "LLaMA",
-            "type": "CONCEPT",
-            "description": "LLaMA is an open-weights large language model released by Meta."
-          },
-          {
-            "id": "Claude",
-            "name": "Claude",
-            "type": "CONCEPT",
-            "description": "Claude is a large language model developed by Anthropic, emphasizing safety and helpfulness."
-          },
-          {
-            "id": "Transformer Architecture",
-            "name": "Transformer Architecture",
-            "type": "CONCEPT",
-            "description": "Transformer architectures with self-attention mechanisms are used by large language models to learn relationships between tokens in text."
-          },
-          {
-            "id": "Reinforcement Learning from Human Feedback",
-            "name": "Reinforcement Learning from Human Feedback",
-            "type": "CONCEPT",
-            "description": "Reinforcement learning from human feedback (RLHF) is used to align model behavior with human preferences."
-          },
-          {
-            "id": "Natural Language Processing",
-            "name": "Natural Language Processing",
-            "type": "CONCEPT",
-            "description": "Natural language processing is a field where AI models perform tasks like question answering and summarization."
-          },
-          {
-            "id": "Computer Vision",
-            "name": "Computer Vision",
-            "type": "CONCEPT",
-            "description": "Computer vision is a field where deep learning models achieve superhuman accuracy on image classification benchmarks."
-          },
-          {
-            "id": "Multimodal Models",
-            "name": "Multimodal Models",
-            "type": "CONCEPT",
-            "description": "Multimodal models process both text and images and are becoming increasingly powerful."
-          },
-          {
-            "id": "AI Safety and Alignment Research",
-            "name": "AI Safety and Alignment Research",
-            "type": "CONCEPT",
-            "description": "AI safety and alignment research focuses on ensuring that AI systems behave as intended."
-          },
-          {
-            "id": "Anthropic",
-            "name": "Anthropic",
-            "type": "ORGANIZATION",
-            "description": "Anthropic is an organization working on AI safety and alignment research."
-          },
-          {
-            "id": "DeepMind",
-            "name": "DeepMind",
-            "type": "ORGANIZATION",
-            "description": "DeepMind is an organization working on AI safety and alignment research."
-          },
-          {
-            "id": "OpenAI",
-            "name": "OpenAI",
-            "type": "ORGANIZATION",
-            "description": "OpenAI is an organization working on AI safety and alignment research."
-          },
-          {
-            "id": "Economic Impact of AI",
-            "name": "Economic Impact of AI",
-            "type": "CONCEPT",
-            "description": "The economic impact of AI includes job displacement and the creation of new work categories."
-          },
-          {
-            "id": "Scientific Discovery",
-            "name": "Scientific Discovery",
-            "type": "CONCEPT",
-            "description": "AI-powered tools are accelerating scientific discovery in various domains."
-          },
-          {
-            "id": "AI Regulations",
-            "name": "AI Regulations",
-            "type": "CONCEPT",
-            "description": "Policymakers are developing regulations to govern AI deployment."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Computer Science",
-            "relationship_name": "is_a_field_of",
-            "description": "Artificial Intelligence is a field of research in Computer Science."
+            "relationship_name": "intelligence_of",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Machines"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Google Search",
-            "relationship_name": "has_application",
-            "description": "Google Search is a high-profile application of Artificial Intelligence."
+            "relationship_name": "field_of_research_in",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Computer science"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "YouTube",
-            "relationship_name": "has_application",
-            "description": "YouTube uses recommendation systems as a high-profile application of Artificial Intelligence."
+            "relationship_name": "enables",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Machines"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Amazon",
-            "relationship_name": "has_application",
-            "description": "Amazon uses recommendation systems as a high-profile application of Artificial Intelligence."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Google Search"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Netflix",
-            "relationship_name": "has_application",
-            "description": "Netflix uses recommendation systems as a high-profile application of Artificial Intelligence."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "YouTube"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Google Assistant",
-            "relationship_name": "has_application",
-            "description": "Google Assistant is an AI that interacts via human speech as a high-profile application of Artificial Intelligence."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Amazon"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Siri",
-            "relationship_name": "has_application",
-            "description": "Siri is an AI that interacts via human speech as a high-profile application of Artificial Intelligence."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Netflix"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Alexa",
-            "relationship_name": "has_application",
-            "description": "Alexa is an AI that interacts via human speech as a high-profile application of Artificial Intelligence."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Google Assistant"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Waymo",
-            "relationship_name": "has_application",
-            "description": "Waymo develops autonomous vehicles as a high-profile application of Artificial Intelligence."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Siri"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "ChatGPT",
-            "relationship_name": "has_application",
-            "description": "ChatGPT is a generative AI tool as a high-profile application of Artificial Intelligence."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Alexa"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "AI Art",
-            "relationship_name": "has_application",
-            "description": "AI Art is a generative AI tool as a high-profile application of Artificial Intelligence."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Waymo"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Chess",
-            "relationship_name": "has_application",
-            "description": "Chess is a strategy game where AI demonstrates superhuman play and analysis as a high-profile application of Artificial Intelligence."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "ChatGPT"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Go",
-            "relationship_name": "has_application",
-            "description": "Go is a strategy game where AI demonstrates superhuman play and analysis as a high-profile application of Artificial Intelligence."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "AI art"
           },
           {
-            "source_node_id": "Large Language Models",
-            "target_node_id": "GPT-4",
-            "relationship_name": "is_a_type_of",
-            "description": "GPT-4 is a type of Large Language Model developed by OpenAI."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Chess"
           },
           {
-            "source_node_id": "Large Language Models",
-            "target_node_id": "PaLM",
-            "relationship_name": "is_a_type_of",
-            "description": "PaLM is a type of Large Language Model developed by Google."
+            "relationship_name": "includes_application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Go"
           },
           {
-            "source_node_id": "Large Language Models",
-            "target_node_id": "LLaMA",
-            "relationship_name": "is_a_type_of",
-            "description": "LLaMA is a type of Large Language Model released by Meta."
+            "relationship_name": "type_of",
+            "source_node_id": "Large language models",
+            "target_node_id": "Artificial intelligence"
           },
           {
-            "source_node_id": "Large Language Models",
-            "target_node_id": "Claude",
-            "relationship_name": "is_a_type_of",
-            "description": "Claude is a type of Large Language Model developed by Anthropic."
+            "relationship_name": "developed_by",
+            "source_node_id": "GPT-4",
+            "target_node_id": "OpenAI"
           },
           {
-            "source_node_id": "Large Language Models",
-            "target_node_id": "Transformer Architecture",
+            "relationship_name": "developed_by",
+            "source_node_id": "PaLM",
+            "target_node_id": "Google"
+          },
+          {
+            "relationship_name": "released_by",
+            "source_node_id": "LLaMA",
+            "target_node_id": "Meta"
+          },
+          {
+            "relationship_name": "developed_by",
+            "source_node_id": "Claude",
+            "target_node_id": "Anthropic"
+          },
+          {
+            "relationship_name": "uses_architecture",
+            "source_node_id": "Large language models",
+            "target_node_id": "Transformer architecture"
+          },
+          {
+            "relationship_name": "uses_mechanism",
+            "source_node_id": "Transformer architecture",
+            "target_node_id": "Self-attention mechanism"
+          },
+          {
+            "relationship_name": "trained_by_predicting",
+            "source_node_id": "Large language models",
+            "target_node_id": "Next token"
+          },
+          {
+            "relationship_name": "aligned_using",
+            "source_node_id": "Large language models",
+            "target_node_id": "Reinforcement learning from human feedback"
+          },
+          {
+            "relationship_name": "researches",
+            "source_node_id": "Anthropic",
+            "target_node_id": "AI safety and alignment research"
+          },
+          {
+            "relationship_name": "researches",
+            "source_node_id": "DeepMind",
+            "target_node_id": "AI safety and alignment research"
+          },
+          {
+            "relationship_name": "researches",
+            "source_node_id": "OpenAI",
+            "target_node_id": "AI safety and alignment research"
+          },
+          {
+            "relationship_name": "develops",
+            "source_node_id": "Policymakers",
+            "target_node_id": "AI regulations"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Artificial intelligence is the intelligence of machines or software, contrasted with human intelligence.",
+            "id": "Artificial intelligence",
+            "name": "Artificial intelligence",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Machines are non-living devices that can be enabled by artificial intelligence.",
+            "id": "Machines",
+            "name": "Machines",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Computer science is the academic discipline that studies artificial intelligence as a field of research.",
+            "id": "Computer science",
+            "name": "Computer science",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Google Search is an advanced web search engine powered by artificial intelligence.",
+            "id": "Google Search",
+            "name": "Google Search",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "YouTube is a video platform that uses AI recommendation systems.",
+            "id": "YouTube",
+            "name": "YouTube",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Amazon is an e‑commerce platform that uses AI recommendation systems.",
+            "id": "Amazon",
+            "name": "Amazon",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Netflix is a streaming service that uses AI recommendation systems.",
+            "id": "Netflix",
+            "name": "Netflix",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Google Assistant is a voice‑based AI assistant for human speech interaction.",
+            "id": "Google Assistant",
+            "name": "Google Assistant",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Siri is Apple’s AI voice assistant for human speech interaction.",
+            "id": "Siri",
+            "name": "Siri",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Alexa is Amazon’s AI voice assistant for human speech interaction.",
+            "id": "Alexa",
+            "name": "Alexa",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Waymo is an autonomous vehicle project that uses artificial intelligence.",
+            "id": "Waymo",
+            "name": "Waymo",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "ChatGPT is a generative AI tool based on large language models.",
+            "id": "ChatGPT",
+            "name": "ChatGPT",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "AI art refers to generative creative tools powered by artificial intelligence.",
+            "id": "AI art",
+            "name": "AI art",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Chess is a strategy game where AI systems achieve superhuman play.",
+            "id": "Chess",
+            "name": "Chess",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Go is a strategy board game where AI systems achieve superhuman play.",
+            "id": "Go",
+            "name": "Go",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Large language models are AI systems trained on massive text corpora.",
+            "id": "Large language models",
+            "name": "Large language models",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "GPT-4 is a highly capable large language model developed by OpenAI.",
+            "id": "GPT-4",
+            "name": "GPT-4",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "OpenAI is an organization that develops artificial intelligence technologies.",
+            "id": "OpenAI",
+            "name": "OpenAI",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "PaLM is a large language model developed by Google with strong reasoning abilities.",
+            "id": "PaLM",
+            "name": "PaLM",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Google is a technology company that develops artificial intelligence systems.",
+            "id": "Google",
+            "name": "Google",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "LLaMA is an open‑weights large language model released by Meta.",
+            "id": "LLaMA",
+            "name": "LLaMA",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Meta is a technology company that released the LLaMA model.",
+            "id": "Meta",
+            "name": "Meta",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Claude is a large language model developed by Anthropic emphasizing safety.",
+            "id": "Claude",
+            "name": "Claude",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Anthropic is an AI research organization focusing on safety and helpfulness.",
+            "id": "Anthropic",
+            "name": "Anthropic",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Transformer architecture is a neural network design using self‑attention mechanisms.",
+            "id": "Transformer architecture",
+            "name": "Transformer architecture",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Self‑attention mechanism allows models to weigh relationships between tokens.",
+            "id": "Self-attention mechanism",
+            "name": "Self-attention mechanism",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Next token prediction is the training objective for large language models.",
+            "id": "Next token",
+            "name": "Next token",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Reinforcement learning from human feedback aligns model behavior with human preferences.",
+            "id": "Reinforcement learning from human feedback",
+            "name": "Reinforcement learning from human feedback",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "AI safety and alignment research aims to ensure AI systems behave as intended.",
+            "id": "AI safety and alignment research",
+            "name": "AI safety and alignment research",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "DeepMind is an AI research organization working on safety and alignment.",
+            "id": "DeepMind",
+            "name": "DeepMind",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Policymakers are officials developing regulations for artificial intelligence.",
+            "id": "Policymakers",
+            "name": "Policymakers",
+            "type": "PERSON"
+          },
+          {
+            "description": "AI regulations are rules governing the deployment and use of artificial intelligence.",
+            "id": "AI regulations",
+            "name": "AI regulations",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "dfafc0a563e0544bd538ac38cf931f9623378de4a6a4a59186e159a64b17ec0b": {
+      "method": "structured_output",
+      "user_input_preview": "Machine learning is a core subfield of artificial intelligence that enables computers to learn from data without being e",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "relationship_name": "subfield_of",
+            "source_node_id": "Machine learning",
+            "target_node_id": "Artificial intelligence"
+          },
+          {
             "relationship_name": "uses",
-            "description": "Large Language Models use Transformer Architecture with self-attention mechanisms."
+            "source_node_id": "Deep learning",
+            "target_node_id": "Neural networks"
           },
           {
-            "source_node_id": "Large Language Models",
-            "target_node_id": "Reinforcement Learning from Human Feedback",
-            "relationship_name": "uses",
-            "description": "Large Language Models use Reinforcement Learning from Human Feedback to align model behavior."
+            "relationship_name": "has_driven_breakthroughs_in",
+            "source_node_id": "Deep learning",
+            "target_node_id": "Natural language processing"
           },
           {
-            "source_node_id": "Natural Language Processing",
-            "target_node_id": "Large Language Models",
-            "relationship_name": "is_supported_by",
-            "description": "Natural Language Processing is supported by Large Language Models."
+            "relationship_name": "has_driven_breakthroughs_in",
+            "source_node_id": "Deep learning",
+            "target_node_id": "Computer vision"
           },
           {
-            "source_node_id": "Computer Vision",
-            "target_node_id": "Large Language Models",
-            "relationship_name": "is_supported_by",
-            "description": "Computer Vision is supported by Large Language Models."
+            "relationship_name": "demonstrates_power_of",
+            "source_node_id": "Large language models",
+            "target_node_id": "Transformer architectures"
           },
           {
-            "source_node_id": "Multimodal Models",
-            "target_node_id": "Large Language Models",
-            "relationship_name": "is_a_type_of",
-            "description": "Multimodal Models are a type of Large Language Model."
+            "relationship_name": "trained_on",
+            "source_node_id": "Transformer architectures",
+            "target_node_id": "Massive datasets"
           },
           {
-            "source_node_id": "AI Safety and Alignment Research",
-            "target_node_id": "Anthropic",
-            "relationship_name": "is_conducted_by",
-            "description": "AI Safety and Alignment Research is conducted by Anthropic."
+            "relationship_name": "example_of",
+            "source_node_id": "GPT-4",
+            "target_node_id": "Large language models"
           },
           {
-            "source_node_id": "AI Safety and Alignment Research",
-            "target_node_id": "DeepMind",
-            "relationship_name": "is_conducted_by",
-            "description": "AI Safety and Alignment Research is conducted by DeepMind."
+            "relationship_name": "developed_by",
+            "source_node_id": "GPT-4",
+            "target_node_id": "OpenAI"
           },
           {
-            "source_node_id": "AI Safety and Alignment Research",
-            "target_node_id": "OpenAI",
-            "relationship_name": "is_conducted_by",
-            "description": "AI Safety and Alignment Research is conducted by OpenAI."
+            "relationship_name": "example_of",
+            "source_node_id": "LLaMA",
+            "target_node_id": "Large language models"
           },
           {
-            "source_node_id": "Economic Impact of AI",
-            "target_node_id": "AI Safety and Alignment Research",
-            "relationship_name": "is_related_to",
-            "description": "The Economic Impact of AI is related to AI Safety and Alignment Research."
+            "relationship_name": "developed_by",
+            "source_node_id": "LLaMA",
+            "target_node_id": "Meta"
           },
           {
-            "source_node_id": "Scientific Discovery",
-            "target_node_id": "AI",
-            "relationship_name": "is_accelerated_by",
-            "description": "Scientific Discovery is accelerated by AI."
+            "relationship_name": "branch_of",
+            "source_node_id": "Reinforcement learning",
+            "target_node_id": "Machine learning"
           },
           {
-            "source_node_id": "AI Regulations",
-            "target_node_id": "AI",
-            "relationship_name": "governs",
-            "description": "AI Regulations govern the deployment of AI."
+            "relationship_name": "trains",
+            "source_node_id": "Reinforcement learning",
+            "target_node_id": "Agents"
+          },
+          {
+            "relationship_name": "through",
+            "source_node_id": "Reinforcement learning",
+            "target_node_id": "Trial and error"
+          },
+          {
+            "relationship_name": "in",
+            "source_node_id": "Reinforcement learning",
+            "target_node_id": "Complex environments"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "A core subfield of artificial intelligence that enables computers to learn from data without being explicitly programmed.",
+            "id": "Machine learning",
+            "name": "Machine learning",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "The broader field of artificial intelligence encompassing machine learning.",
+            "id": "Artificial intelligence",
+            "name": "Artificial intelligence",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A subfield of machine learning that uses neural networks with many layers.",
+            "id": "Deep learning",
+            "name": "Deep learning",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Computational models composed of interconnected nodes organized in layers.",
+            "id": "Neural networks",
+            "name": "Neural networks",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A field of AI focused on understanding and generating human language.",
+            "id": "Natural language processing",
+            "name": "Natural language processing",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A field of AI focused on interpreting visual information from images and videos.",
+            "id": "Computer vision",
+            "name": "Computer vision",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Large language models such as GPT-4 and LLaMA that demonstrate the power of transformer architectures.",
+            "id": "Large language models",
+            "name": "Large language models",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A transformer-based model released by OpenAI, exemplifying large language models.",
+            "id": "GPT-4",
+            "name": "GPT-4",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "An organization that developed the LLaMA model.",
+            "id": "Meta",
+            "name": "Meta",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "An organization that developed GPT-4.",
+            "id": "OpenAI",
+            "name": "OpenAI",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "A transformer-based architecture used in large language models.",
+            "id": "Transformer architectures",
+            "name": "Transformer architectures",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Extremely large datasets used to train transformer architectures.",
+            "id": "Massive datasets",
+            "name": "Massive datasets",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A branch of machine learning that trains agents through trial and error in complex environments.",
+            "id": "Reinforcement learning",
+            "name": "Reinforcement learning",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Entities that act within environments and are trained by reinforcement learning.",
+            "id": "Agents",
+            "name": "Agents",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A learning method involving trial and error.",
+            "id": "Trial and error",
+            "name": "Trial and error",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Complex environments where reinforcement learning agents operate.",
+            "id": "Complex environments",
+            "name": "Complex environments",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A large language model released by Meta, exemplifying large language models.",
+            "id": "LLaMA",
+            "name": "LLaMA",
+            "type": "CONCEPT"
           }
         ]
       }

--- a/crates/cognify/tests/fixtures/cassettes/summarization.json
+++ b/crates/cognify/tests/fixtures/cassettes/summarization.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "model": "gpt-4o-mini",
+  "model": "openai/gpt-oss-120b",
   "entries": {
     "387b736045e82244049e1078a34201d94c067a03f44d957791fac5135ebe61ae": {
       "method": "structured_output",
       "user_input_preview": "\nQuantum computing represents a paradigm shift in computation. Unlike classical computers \nthat use bits, quantum comput",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "Quantum computing is a new approach to computation that utilizes qubits instead of bits, enabling faster problem-solving capabilities compared to classical computers.",
-        "summary": "Quantum computing introduces qubits that can exist in superposition, allowing for exponential speed improvements over classical computing."
+        "description": "Quantum computing uses qubits in superposition to achieve exponential speedups over classical computers that use bits, representing a paradigm shift in computation.",
+        "summary": "Quantum computers employ qubits capable of superposition, enabling exponentially faster solutions compared to classical bit-based computers."
       }
     },
     "66d8e212656178a5e475902bd6a7be383fd927b85ddd586457fce61f88796985": {
@@ -16,8 +16,8 @@
       "user_input_preview": "\nQuantum computing represents a paradigm shift in computation. Unlike classical computers \nthat use bits, quantum comput",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "Quantum computing fundamentally changes how computations are performed by utilizing qubits, which can exist in multiple states simultaneously (superposition). This unique property enables quantum computers to solve specific problems at an exponentially faster rate compared to classical computers that rely on bits.",
-        "summary": "Quantum computing introduces a new way of computation using qubits, allowing for exponentially faster problem-solving compared to classical computers."
+        "description": "Quantum computing is a new computational paradigm that uses qubits, which can exist in superposition, unlike classical bits. This capability enables quantum computers to solve certain problems exponentially faster than traditional computers.",
+        "summary": "Quantum computing uses qubits in superposition to achieve exponential speedups over classical computers for specific problems."
       }
     },
     "faa749dbc29a9858f82f2591975f3bf77552007a75523af1c64b5ab951316eb9": {
@@ -25,8 +25,8 @@
       "user_input_preview": "\nArtificial intelligence has made remarkable progress over the past decade, transforming \nindustries ranging from health",
       "schema_name": "SummarizedContent",
       "response": {
-        "description": "This chunk discusses the advancements in artificial intelligence, particularly in machine learning, natural language processing, and the ethical considerations surrounding these technologies. It highlights the role of large language models and anticipates future developments in AI integration into daily life.",
-        "summary": "The chunk covers the significant progress in artificial intelligence over the past decade, including advancements in machine learning and natural language processing, while also addressing ethical concerns and future trends."
+        "description": "Artificial intelligence has rapidly progressed over the past decade, impacting healthcare and transportation through advanced machine learning, autonomous vehicles, and natural language processing. Large language models using transformer architectures enable diverse tasks, while raising ethical issues like bias, privacy, and environmental impact, prompting researchers and policymakers to create responsible AI frameworks. Future growth will rely on edge computing, efficient architectures, and multi‑modal learning across text, images, and audio.",
+        "summary": "AI's decade‑long advances span healthcare, transportation, and language technologies, bring ethical challenges, and point toward edge‑based, multi‑modal future applications."
       }
     }
   }

--- a/crates/cognify/tests/fixtures/cassettes/triplet_vector_cleanup.json
+++ b/crates/cognify/tests/fixtures/cassettes/triplet_vector_cleanup.json
@@ -1,487 +1,457 @@
 {
   "version": 1,
-  "model": "gpt-4o-mini",
+  "model": "openai/gpt-oss-120b",
   "entries": {
-    "8457e869c57b13800bc4db253ceaee4bdc87400ee56f47922d94166b80ab057d": {
-      "method": "structured_output",
-      "user_input_preview": "Quantum computing leverages quantum mechanical phenomena like superposition and entanglement to perform computations. Qu",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Quantum_Computing",
-            "name": "Quantum Computing",
-            "type": "CONCEPT",
-            "description": "Quantum Computing leverages quantum mechanical phenomena to perform computations."
-          },
-          {
-            "id": "Quantum_Bits",
-            "name": "Quantum Bits",
-            "type": "CONCEPT",
-            "description": "Quantum Bits (qubits) can exist in multiple states simultaneously."
-          },
-          {
-            "id": "IBM",
-            "name": "IBM",
-            "type": "ORGANIZATION",
-            "description": "IBM is a company investing in quantum hardware and quantum error correction research."
-          },
-          {
-            "id": "Google",
-            "name": "Google",
-            "type": "ORGANIZATION",
-            "description": "Google is a company investing in quantum hardware and quantum error correction research."
-          },
-          {
-            "id": "Microsoft",
-            "name": "Microsoft",
-            "type": "ORGANIZATION",
-            "description": "Microsoft is a company investing in quantum hardware and quantum error correction research."
-          },
-          {
-            "id": "Superposition",
-            "name": "Superposition",
-            "type": "CONCEPT",
-            "description": "Superposition is a quantum mechanical phenomenon utilized in quantum computing."
-          },
-          {
-            "id": "Entanglement",
-            "name": "Entanglement",
-            "type": "CONCEPT",
-            "description": "Entanglement is a quantum mechanical phenomenon utilized in quantum computing."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Quantum_Computing",
-            "target_node_id": "Superposition",
-            "relationship_name": "leverages",
-            "description": "Quantum Computing leverages Superposition to perform computations."
-          },
-          {
-            "source_node_id": "Quantum_Computing",
-            "target_node_id": "Entanglement",
-            "relationship_name": "leverages",
-            "description": "Quantum Computing leverages Entanglement to perform computations."
-          },
-          {
-            "source_node_id": "Quantum_Bits",
-            "target_node_id": "Quantum_Computing",
-            "relationship_name": "enables",
-            "description": "Quantum Bits enable Quantum Computing by existing in multiple states simultaneously."
-          },
-          {
-            "source_node_id": "IBM",
-            "target_node_id": "Quantum_Computing",
-            "relationship_name": "invests_in",
-            "description": "IBM invests in Quantum Computing through quantum hardware and quantum error correction research."
-          },
-          {
-            "source_node_id": "Google",
-            "target_node_id": "Quantum_Computing",
-            "relationship_name": "invests_in",
-            "description": "Google invests in Quantum Computing through quantum hardware and quantum error correction research."
-          },
-          {
-            "source_node_id": "Microsoft",
-            "target_node_id": "Quantum_Computing",
-            "relationship_name": "invests_in",
-            "description": "Microsoft invests in Quantum Computing through quantum hardware and quantum error correction research."
-          }
-        ]
-      }
-    },
-    "fbff5ad35093e7c5cc5e947feb7d62db0cd9b09b1fca8b352b19f3f98cd64668": {
+    "3d8acd1ff4f2deec219dc511a868f74f13b601e916175d3fb92f09e61028166f": {
       "method": "structured_output",
       "user_input_preview": "Artificial intelligence (AI) is the intelligence of machines or software, as opposed to the intelligence of living being",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "Artificial Intelligence",
-            "name": "Artificial Intelligence",
-            "type": "CONCEPT",
-            "description": "Artificial intelligence (AI) is the intelligence of machines or software, as opposed to the intelligence of living beings, primarily of humans."
-          },
-          {
-            "id": "Computer Science",
-            "name": "Computer Science",
-            "type": "CONCEPT",
-            "description": "Computer science is a field of research that develops and studies methods and software for enabling machines to perceive their environment."
-          },
-          {
-            "id": "Google Search",
-            "name": "Google Search",
-            "type": "CONCEPT",
-            "description": "Google Search is an advanced web search engine that is a high-profile application of AI."
-          },
-          {
-            "id": "YouTube",
-            "name": "YouTube",
-            "type": "CONCEPT",
-            "description": "YouTube is a platform that uses recommendation systems as a high-profile application of AI."
-          },
-          {
-            "id": "Amazon",
-            "name": "Amazon",
-            "type": "CONCEPT",
-            "description": "Amazon is a platform that uses recommendation systems as a high-profile application of AI."
-          },
-          {
-            "id": "Netflix",
-            "name": "Netflix",
-            "type": "CONCEPT",
-            "description": "Netflix is a platform that uses recommendation systems as a high-profile application of AI."
-          },
-          {
-            "id": "Google Assistant",
-            "name": "Google Assistant",
-            "type": "CONCEPT",
-            "description": "Google Assistant is an AI that interacts via human speech."
-          },
-          {
-            "id": "Siri",
-            "name": "Siri",
-            "type": "CONCEPT",
-            "description": "Siri is an AI that interacts via human speech."
-          },
-          {
-            "id": "Alexa",
-            "name": "Alexa",
-            "type": "CONCEPT",
-            "description": "Alexa is an AI that interacts via human speech."
-          },
-          {
-            "id": "Waymo",
-            "name": "Waymo",
-            "type": "CONCEPT",
-            "description": "Waymo is an autonomous vehicle company that is a high-profile application of AI."
-          },
-          {
-            "id": "ChatGPT",
-            "name": "ChatGPT",
-            "type": "CONCEPT",
-            "description": "ChatGPT is a generative AI tool developed by OpenAI."
-          },
-          {
-            "id": "AI Art",
-            "name": "AI Art",
-            "type": "CONCEPT",
-            "description": "AI Art is a generative and creative tool that is a high-profile application of AI."
-          },
-          {
-            "id": "Chess",
-            "name": "Chess",
-            "type": "CONCEPT",
-            "description": "Chess is a strategy game where AI demonstrates superhuman play and analysis."
-          },
-          {
-            "id": "Go",
-            "name": "Go",
-            "type": "CONCEPT",
-            "description": "Go is a strategy game where AI demonstrates superhuman play and analysis."
-          },
-          {
-            "id": "Large Language Models",
-            "name": "Large Language Models",
-            "type": "CONCEPT",
-            "description": "Large language models (LLMs) are a type of AI trained on enormous amounts of text data."
-          },
-          {
-            "id": "GPT-4",
-            "name": "GPT-4",
-            "type": "CONCEPT",
-            "description": "GPT-4 is a capable large language model developed by OpenAI."
-          },
-          {
-            "id": "PaLM",
-            "name": "PaLM",
-            "type": "CONCEPT",
-            "description": "PaLM is a large language model developed by Google that demonstrates strong reasoning and multilingual capabilities."
-          },
-          {
-            "id": "LLaMA",
-            "name": "LLaMA",
-            "type": "CONCEPT",
-            "description": "LLaMA is an open-weights large language model released by Meta."
-          },
-          {
-            "id": "Claude",
-            "name": "Claude",
-            "type": "CONCEPT",
-            "description": "Claude is a large language model developed by Anthropic that emphasizes safety and helpfulness."
-          },
-          {
-            "id": "Transformer Architecture",
-            "name": "Transformer Architecture",
-            "type": "CONCEPT",
-            "description": "Transformer architectures with self-attention mechanisms are used by large language models to learn relationships between tokens in text."
-          },
-          {
-            "id": "Reinforcement Learning from Human Feedback",
-            "name": "Reinforcement Learning from Human Feedback",
-            "type": "CONCEPT",
-            "description": "Reinforcement learning from human feedback (RLHF) is used to align model behavior with human preferences."
-          },
-          {
-            "id": "Natural Language Processing",
-            "name": "Natural Language Processing",
-            "type": "CONCEPT",
-            "description": "Natural language processing is a field where AI models perform tasks like question answering and summarization."
-          },
-          {
-            "id": "Computer Vision",
-            "name": "Computer Vision",
-            "type": "CONCEPT",
-            "description": "Computer vision is a field where deep learning models achieve superhuman accuracy on image classification benchmarks."
-          },
-          {
-            "id": "Multimodal Models",
-            "name": "Multimodal Models",
-            "type": "CONCEPT",
-            "description": "Multimodal models process both text and images and are becoming increasingly powerful."
-          },
-          {
-            "id": "AI Safety and Alignment Research",
-            "name": "AI Safety and Alignment Research",
-            "type": "CONCEPT",
-            "description": "AI safety and alignment research focuses on ensuring that AI systems behave as intended and do not cause unintended harm."
-          },
-          {
-            "id": "Anthropic",
-            "name": "Anthropic",
-            "type": "ORGANIZATION",
-            "description": "Anthropic is an organization working on AI safety and alignment research."
-          },
-          {
-            "id": "DeepMind",
-            "name": "DeepMind",
-            "type": "ORGANIZATION",
-            "description": "DeepMind is an organization working on AI safety and alignment research."
-          },
-          {
-            "id": "OpenAI",
-            "name": "OpenAI",
-            "type": "ORGANIZATION",
-            "description": "OpenAI is an organization working on AI safety and alignment research."
-          },
-          {
-            "id": "Economic Impact of AI",
-            "name": "Economic Impact of AI",
-            "type": "CONCEPT",
-            "description": "The economic impact of AI includes job displacement and the creation of new work categories."
-          },
-          {
-            "id": "Scientific Discovery",
-            "name": "Scientific Discovery",
-            "type": "CONCEPT",
-            "description": "AI-powered tools are accelerating scientific discovery in various domains."
-          },
-          {
-            "id": "AI Regulations",
-            "name": "AI Regulations",
-            "type": "CONCEPT",
-            "description": "Policymakers are developing regulations to govern AI deployment."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Computer Science",
-            "relationship_name": "is_a_field_of",
-            "description": "Artificial Intelligence is a field of research in Computer Science."
+            "relationship_name": "field_of",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Computer science"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Google Search",
-            "relationship_name": "has_application",
-            "description": "Google Search is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Google Search"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "YouTube",
-            "relationship_name": "has_application",
-            "description": "YouTube is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "YouTube"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Amazon",
-            "relationship_name": "has_application",
-            "description": "Amazon is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Amazon"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Netflix",
-            "relationship_name": "has_application",
-            "description": "Netflix is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Netflix"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Google Assistant",
-            "relationship_name": "has_application",
-            "description": "Google Assistant is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Google Assistant"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Siri",
-            "relationship_name": "has_application",
-            "description": "Siri is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Siri"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Alexa",
-            "relationship_name": "has_application",
-            "description": "Alexa is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Alexa"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Waymo",
-            "relationship_name": "has_application",
-            "description": "Waymo is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Waymo"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "ChatGPT",
-            "relationship_name": "has_application",
-            "description": "ChatGPT is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "ChatGPT"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "AI Art",
-            "relationship_name": "has_application",
-            "description": "AI Art is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "AI art"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Chess",
-            "relationship_name": "has_application",
-            "description": "Chess is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Chess"
           },
           {
-            "source_node_id": "Artificial Intelligence",
-            "target_node_id": "Go",
-            "relationship_name": "has_application",
-            "description": "Go is a high-profile application of Artificial Intelligence."
+            "relationship_name": "application",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "Go"
           },
           {
-            "source_node_id": "Large Language Models",
-            "target_node_id": "GPT-4",
-            "relationship_name": "is_a_type_of",
-            "description": "GPT-4 is a type of Large Language Model."
+            "relationship_name": "type_of",
+            "source_node_id": "Large language models",
+            "target_node_id": "Artificial intelligence"
           },
           {
-            "source_node_id": "Large Language Models",
-            "target_node_id": "PaLM",
-            "relationship_name": "is_a_type_of",
-            "description": "PaLM is a type of Large Language Model."
-          },
-          {
-            "source_node_id": "Large Language Models",
-            "target_node_id": "LLaMA",
-            "relationship_name": "is_a_type_of",
-            "description": "LLaMA is a type of Large Language Model."
-          },
-          {
-            "source_node_id": "Large Language Models",
-            "target_node_id": "Claude",
-            "relationship_name": "is_a_type_of",
-            "description": "Claude is a type of Large Language Model."
-          },
-          {
+            "relationship_name": "developed_by",
             "source_node_id": "GPT-4",
-            "target_node_id": "Transformer Architecture",
-            "relationship_name": "uses",
-            "description": "GPT-4 uses Transformer Architecture to learn relationships between tokens in text."
+            "target_node_id": "OpenAI"
           },
           {
+            "relationship_name": "developed_by",
             "source_node_id": "PaLM",
-            "target_node_id": "Transformer Architecture",
-            "relationship_name": "uses",
-            "description": "PaLM uses Transformer Architecture to learn relationships between tokens in text."
+            "target_node_id": "Google"
           },
           {
+            "relationship_name": "released_by",
             "source_node_id": "LLaMA",
-            "target_node_id": "Transformer Architecture",
-            "relationship_name": "uses",
-            "description": "LLaMA uses Transformer Architecture to learn relationships between tokens in text."
+            "target_node_id": "Meta"
           },
           {
+            "relationship_name": "developed_by",
             "source_node_id": "Claude",
-            "target_node_id": "Transformer Architecture",
+            "target_node_id": "Anthropic"
+          },
+          {
             "relationship_name": "uses",
-            "description": "Claude uses Transformer Architecture to learn relationships between tokens in text."
+            "source_node_id": "Large language models",
+            "target_node_id": "Transformer architectures"
           },
           {
-            "source_node_id": "GPT-4",
-            "target_node_id": "Reinforcement Learning from Human Feedback",
             "relationship_name": "uses",
-            "description": "GPT-4 uses Reinforcement Learning from Human Feedback to align model behavior with human preferences."
+            "source_node_id": "Transformer architectures",
+            "target_node_id": "Self-attention mechanisms"
           },
           {
-            "source_node_id": "PaLM",
-            "target_node_id": "Reinforcement Learning from Human Feedback",
-            "relationship_name": "uses",
-            "description": "PaLM uses Reinforcement Learning from Human Feedback to align model behavior with human preferences."
+            "relationship_name": "training_method",
+            "source_node_id": "Large language models",
+            "target_node_id": "Next token prediction"
           },
           {
-            "source_node_id": "LLaMA",
-            "target_node_id": "Reinforcement Learning from Human Feedback",
-            "relationship_name": "uses",
-            "description": "LLaMA uses Reinforcement Learning from Human Feedback to align model behavior with human preferences."
+            "relationship_name": "alignment_method",
+            "source_node_id": "Large language models",
+            "target_node_id": "Reinforcement learning from human feedback"
           },
           {
-            "source_node_id": "Claude",
-            "target_node_id": "Reinforcement Learning from Human Feedback",
-            "relationship_name": "uses",
-            "description": "Claude uses Reinforcement Learning from Human Feedback to align model behavior with human preferences."
+            "relationship_name": "research_focus",
+            "source_node_id": "AI safety and alignment research",
+            "target_node_id": "AI safety"
           },
           {
-            "source_node_id": "Natural Language Processing",
-            "target_node_id": "Large Language Models",
-            "relationship_name": "utilizes",
-            "description": "Natural Language Processing utilizes Large Language Models for tasks like question answering and summarization."
-          },
-          {
-            "source_node_id": "Computer Vision",
-            "target_node_id": "Large Language Models",
-            "relationship_name": "utilizes",
-            "description": "Computer Vision utilizes Large Language Models for tasks like image classification."
-          },
-          {
-            "source_node_id": "AI Safety and Alignment Research",
-            "target_node_id": "Anthropic",
             "relationship_name": "conducted_by",
-            "description": "AI Safety and Alignment Research is conducted by Anthropic."
+            "source_node_id": "AI safety and alignment research",
+            "target_node_id": "Anthropic"
           },
           {
-            "source_node_id": "AI Safety and Alignment Research",
-            "target_node_id": "DeepMind",
             "relationship_name": "conducted_by",
-            "description": "AI Safety and Alignment Research is conducted by DeepMind."
+            "source_node_id": "AI safety and alignment research",
+            "target_node_id": "DeepMind"
           },
           {
-            "source_node_id": "AI Safety and Alignment Research",
-            "target_node_id": "OpenAI",
             "relationship_name": "conducted_by",
-            "description": "AI Safety and Alignment Research is conducted by OpenAI."
+            "source_node_id": "AI safety and alignment research",
+            "target_node_id": "OpenAI"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Intelligence of machines or software, as opposed to the intelligence of living beings, primarily of humans.",
+            "id": "Artificial intelligence",
+            "name": "Artificial intelligence",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "Economic Impact of AI",
-            "target_node_id": "AI",
-            "relationship_name": "affects",
-            "description": "The Economic Impact of AI affects various aspects of society."
+            "description": "Field of research that develops and studies methods and software enabling machines to perceive environment and act toward defined goals.",
+            "id": "Computer science",
+            "name": "Computer science",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "Scientific Discovery",
-            "target_node_id": "AI",
-            "relationship_name": "accelerated_by",
-            "description": "Scientific Discovery is accelerated by AI-powered tools."
+            "description": "Advanced web search engine.",
+            "id": "Google Search",
+            "name": "Google Search",
+            "type": "CONCEPT"
           },
           {
-            "source_node_id": "AI Regulations",
-            "target_node_id": "AI",
-            "relationship_name": "governs",
-            "description": "AI Regulations govern the deployment of AI."
+            "description": "Video-sharing platform that uses recommendation systems powered by AI.",
+            "id": "YouTube",
+            "name": "YouTube",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "E‑commerce company that uses AI recommendation systems.",
+            "id": "Amazon",
+            "name": "Amazon",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Streaming service that uses AI recommendation systems.",
+            "id": "Netflix",
+            "name": "Netflix",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Google's voice‑assistant powered by AI.",
+            "id": "Google Assistant",
+            "name": "Google Assistant",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Apple's voice‑assistant powered by AI.",
+            "id": "Siri",
+            "name": "Siri",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Amazon's voice‑assistant powered by AI.",
+            "id": "Alexa",
+            "name": "Alexa",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Company developing autonomous vehicles using AI.",
+            "id": "Waymo",
+            "name": "Waymo",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Conversational AI tool developed by OpenAI.",
+            "id": "ChatGPT",
+            "name": "ChatGPT",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "AI‑generated visual artwork tools.",
+            "id": "AI art",
+            "name": "AI art",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Strategy board game where AI has achieved superhuman play.",
+            "id": "Chess",
+            "name": "Chess",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Ancient board game where AI has achieved superhuman play.",
+            "id": "Go",
+            "name": "Go",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Class of models that process large amounts of text data to generate language output.",
+            "id": "Large language models",
+            "name": "Large language models",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "A highly capable language model developed by OpenAI.",
+            "id": "GPT-4",
+            "name": "GPT-4",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Organization that developed GPT-4 and conducts AI safety research.",
+            "id": "OpenAI",
+            "name": "OpenAI",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "A language model developed by Google demonstrating strong reasoning and multilingual abilities.",
+            "id": "PaLM",
+            "name": "PaLM",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Technology company that developed PaLM.",
+            "id": "Google",
+            "name": "Google",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Open‑weights language model released by Meta.",
+            "id": "LLaMA",
+            "name": "LLaMA",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Parent company of Meta that released LLaMA.",
+            "id": "Meta",
+            "name": "Meta",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "A language model developed by Anthropic emphasizing safety and helpfulness.",
+            "id": "Claude",
+            "name": "Claude",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Organization that developed Claude and works on AI safety research.",
+            "id": "Anthropic",
+            "name": "Anthropic",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Neural network architecture that uses self‑attention to process sequences.",
+            "id": "Transformer architectures",
+            "name": "Transformer architectures",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Mechanism within transformers that allows each token to attend to others.",
+            "id": "Self-attention mechanisms",
+            "name": "Self-attention mechanisms",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Training objective where models predict the next token in a sequence.",
+            "id": "Next token prediction",
+            "name": "Next token prediction",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Method that fine‑tunes models using human feedback to align behavior.",
+            "id": "Reinforcement learning from human feedback",
+            "name": "Reinforcement learning from human feedback",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Research area focused on ensuring AI systems behave as intended and avoid harm.",
+            "id": "AI safety and alignment research",
+            "name": "AI safety and alignment research",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Aspect of AI research concerned with preventing harmful outputs and ensuring robustness.",
+            "id": "AI safety",
+            "name": "AI safety",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "AI research organization owned by Alphabet, involved in AI safety work.",
+            "id": "DeepMind",
+            "name": "DeepMind",
+            "type": "ORGANIZATION"
+          }
+        ]
+      }
+    },
+    "4caa4117c78855222e3ffe4031b67607f64f8552f87154e29f8f26d9f234056e": {
+      "method": "structured_output",
+      "user_input_preview": "Quantum computing leverages quantum mechanical phenomena like superposition and entanglement to perform computations. Qu",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "relationship_name": "leverages",
+            "source_node_id": "Quantum computing",
+            "target_node_id": "Superposition"
+          },
+          {
+            "relationship_name": "leverages",
+            "source_node_id": "Quantum computing",
+            "target_node_id": "Entanglement"
+          },
+          {
+            "relationship_name": "enable",
+            "source_node_id": "Qubit",
+            "target_node_id": "Quantum computers"
+          },
+          {
+            "relationship_name": "invests_in",
+            "source_node_id": "IBM",
+            "target_node_id": "Quantum hardware"
+          },
+          {
+            "relationship_name": "invests_in",
+            "source_node_id": "IBM",
+            "target_node_id": "Quantum error correction"
+          },
+          {
+            "relationship_name": "invests_in",
+            "source_node_id": "Google",
+            "target_node_id": "Quantum hardware"
+          },
+          {
+            "relationship_name": "invests_in",
+            "source_node_id": "Google",
+            "target_node_id": "Quantum error correction"
+          },
+          {
+            "relationship_name": "invests_in",
+            "source_node_id": "Microsoft",
+            "target_node_id": "Quantum hardware"
+          },
+          {
+            "relationship_name": "invests_in",
+            "source_node_id": "Microsoft",
+            "target_node_id": "Quantum error correction"
+          },
+          {
+            "relationship_name": "solve_faster_than",
+            "source_node_id": "Quantum computers",
+            "target_node_id": "Classical computers"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Quantum computing leverages quantum mechanical phenomena like superposition and entanglement to perform computations.",
+            "id": "Quantum computing",
+            "name": "Quantum computing",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Quantum mechanical phenomena such as superposition and entanglement are used in quantum computing.",
+            "id": "Quantum mechanical phenomena",
+            "name": "Quantum mechanical phenomena",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Superposition is a quantum mechanical phenomenon where a system can be in multiple states simultaneously.",
+            "id": "Superposition",
+            "name": "Superposition",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Entanglement is a quantum mechanical phenomenon linking particles such that the state of one instantly influences the other.",
+            "id": "Entanglement",
+            "name": "Entanglement",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Quantum bits (qubits) can exist in multiple states simultaneously.",
+            "id": "Qubit",
+            "name": "Qubit",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Quantum computers can solve certain problems exponentially faster than classical computers.",
+            "id": "Quantum computers",
+            "name": "Quantum computers",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "IBM is a company investing heavily in quantum hardware and quantum error correction research.",
+            "id": "IBM",
+            "name": "IBM",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Google is a company investing heavily in quantum hardware and quantum error correction research.",
+            "id": "Google",
+            "name": "Google",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Microsoft is a company investing heavily in quantum hardware and quantum error correction research.",
+            "id": "Microsoft",
+            "name": "Microsoft",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Quantum hardware refers to the physical devices used to build quantum computers.",
+            "id": "Quantum hardware",
+            "name": "Quantum hardware",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Quantum error correction research aims to protect quantum information from errors.",
+            "id": "Quantum error correction",
+            "name": "Quantum error correction",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Classical computers are traditional computers that quantum computers can outperform on certain problems.",
+            "id": "Classical computers",
+            "name": "Classical computers",
+            "type": "CONCEPT"
           }
         ]
       }

--- a/crates/cognify/tests/integration_text_summary_payload.rs
+++ b/crates/cognify/tests/integration_text_summary_payload.rs
@@ -42,8 +42,11 @@ async fn text_summary_payload_contains_text_field() {
     // 1. Empty knowledge graph  (consumed by the graph-extraction stage)
     // 2. Summarization response (consumed by the summarize-text stage)
     let mock_llm = MockLlm::new(vec![
-        // Response 1: graph extraction -> empty graph
-        json!({"nodes": [], "relationships": []}).to_string(),
+        // Response 1: graph extraction -> empty graph. Field is `edges`, not the
+        // ignored `relationships`: since #83 dropped `#[serde(default)]` from
+        // `KnowledgeGraph.edges`, it is a required field and a payload missing it
+        // fails typed deserialization ("missing field `edges`").
+        json!({"nodes": [], "edges": []}).to_string(),
         // Response 2: summarization -> deterministic summary
         json!({
             "summary": EXPECTED_SUMMARY,

--- a/crates/cognify/tests/test_utils.rs
+++ b/crates/cognify/tests/test_utils.rs
@@ -7,27 +7,13 @@ use std::sync::Arc;
 // crate uses one implementation (consistent alias fallback + model default).
 // Re-exported here (with the historical `create_adapter_from_env` name) so the
 // many `test_utils::…` call sites in this crate's tests keep compiling.
+// `fail_loudly_in_cassette_mode` also lives in the shared crate (single source
+// of truth — see its docs there) and is re-exported here alongside the env helpers.
 #[allow(unused_imports)]
 pub use cognee_test_utils::{
-    create_openai_adapter_from_env as create_adapter_from_env, llm_env_available, require_env,
+    create_openai_adapter_from_env as create_adapter_from_env, fail_loudly_in_cassette_mode,
+    llm_env_available, require_env,
 };
-
-/// In cassette-replay mode (`COGNEE_TEST_REPLAY` set), a pipeline error means a
-/// cassette miss — a stale/edited prompt or schema whose input hash no longer
-/// matches a recorded entry (`ReplayLlm` returns `LlmError::InvalidResponse`).
-/// The `Err(e) => { eprintln!("Skipping…"); return }` blocks the e2e tests use
-/// to tolerate a missing real LLM would otherwise swallow that miss and pass
-/// with zero assertions. Call this in those blocks so replay misses fail loudly
-/// (re-record via the record-cassettes workflow); outside replay mode it is a
-/// no-op and the legitimate skip proceeds.
-#[allow(dead_code)]
-pub fn fail_loudly_on_replay_miss(what: &str, err: &impl std::fmt::Display) {
-    if std::env::var("COGNEE_TEST_REPLAY").is_ok_and(|v| !v.is_empty()) {
-        panic!(
-            "{what} failed in replay mode — likely a stale/missing cassette entry; re-record cassettes. Error: {err}"
-        );
-    }
-}
 
 /// Resolve the on-disk path of a named cassette under this crate's
 /// `tests/fixtures/cassettes/` directory.

--- a/crates/delete/tests/fixtures/cassettes/hard_mode_orphan_sweep.json
+++ b/crates/delete/tests/fixtures/cassettes/hard_mode_orphan_sweep.json
@@ -1,85 +1,81 @@
 {
   "version": 1,
-  "model": "gpt-4o-mini",
+  "model": "openai/gpt-oss-120b",
   "entries": {
-    "55b94768377ea536da46d1c6adf7e67fed59b39be58b6c3f663590d9206bda5e": {
-      "method": "structured_output",
-      "user_input_preview": "Bob is an engineer at TechCorp. Bob develops cloud infrastructure.",
-      "schema_name": "KnowledgeGraph",
-      "response": {
-        "nodes": [
-          {
-            "id": "Bob",
-            "name": "Bob",
-            "type": "PERSON",
-            "description": "Bob is an engineer at TechCorp."
-          },
-          {
-            "id": "TechCorp",
-            "name": "TechCorp",
-            "type": "ORGANIZATION",
-            "description": "TechCorp is the organization where Bob works."
-          },
-          {
-            "id": "cloud_infrastructure",
-            "name": "cloud infrastructure",
-            "type": "CONCEPT",
-            "description": "Cloud infrastructure is the technology that Bob develops."
-          }
-        ],
-        "edges": [
-          {
-            "source_node_id": "Bob",
-            "target_node_id": "TechCorp",
-            "relationship_name": "works_at",
-            "description": "Bob works at TechCorp."
-          },
-          {
-            "source_node_id": "Bob",
-            "target_node_id": "cloud_infrastructure",
-            "relationship_name": "develops",
-            "description": "Bob develops cloud infrastructure."
-          }
-        ]
-      }
-    },
-    "f5ce7d46da2e8a89b581d8771568546279706bbe927a5ad13999f467338303ac": {
+    "7784435908d277abbb8377ca25237097fd2686b612d13babddb261788b2ea6fe": {
       "method": "structured_output",
       "user_input_preview": "Alice is a researcher at TechCorp. Alice studies machine learning.",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
-          {
-            "id": "Alice",
-            "name": "Alice",
-            "type": "PERSON",
-            "description": "Alice is a researcher."
-          },
-          {
-            "id": "TechCorp",
-            "name": "TechCorp",
-            "type": "ORGANIZATION",
-            "description": "TechCorp is the organization where Alice works."
-          },
-          {
-            "id": "machine_learning",
-            "name": "machine learning",
-            "type": "CONCEPT",
-            "description": "Machine learning is the field of study that Alice focuses on."
-          }
-        ],
         "edges": [
           {
-            "source_node_id": "Alice",
-            "target_node_id": "TechCorp",
             "relationship_name": "works_at",
-            "description": "Alice works at TechCorp."
+            "source_node_id": "Alice",
+            "target_node_id": "TechCorp"
           },
           {
-            "source_node_id": "Alice",
-            "target_node_id": "machine_learning",
             "relationship_name": "studies",
-            "description": "Alice studies machine learning."
+            "source_node_id": "Alice",
+            "target_node_id": "machine learning"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Alice is a researcher at TechCorp.",
+            "id": "Alice",
+            "name": "Alice",
+            "type": "PERSON"
+          },
+          {
+            "description": "TechCorp is the organization where Alice works.",
+            "id": "TechCorp",
+            "name": "TechCorp",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Machine learning is the field that Alice studies.",
+            "id": "machine learning",
+            "name": "machine learning",
+            "type": "CONCEPT"
+          }
+        ]
+      }
+    },
+    "9a3b3c922e5f59448bd18c6ccd7f16636383d701d020bb925bc0f34cd62529f5": {
+      "method": "structured_output",
+      "user_input_preview": "Bob is an engineer at TechCorp. Bob develops cloud infrastructure.",
+      "schema_name": "KnowledgeGraph",
+      "response": {
+        "edges": [
+          {
+            "relationship_name": "works_at",
+            "source_node_id": "Bob",
+            "target_node_id": "TechCorp"
+          },
+          {
+            "relationship_name": "develops",
+            "source_node_id": "Bob",
+            "target_node_id": "cloud_infrastructure"
+          }
+        ],
+        "nodes": [
+          {
+            "description": "Bob is an engineer at TechCorp who develops cloud infrastructure.",
+            "id": "Bob",
+            "name": "Bob",
+            "type": "PERSON"
+          },
+          {
+            "description": "TechCorp is the company where Bob works as an engineer.",
+            "id": "TechCorp",
+            "name": "TechCorp",
+            "type": "ORGANIZATION"
+          },
+          {
+            "description": "Cloud infrastructure is the system that Bob develops.",
+            "id": "cloud_infrastructure",
+            "name": "cloud infrastructure",
+            "type": "CONCEPT"
           }
         ]
       }

--- a/crates/delete/tests/hard_mode_orphan_sweep.rs
+++ b/crates/delete/tests/hard_mode_orphan_sweep.rs
@@ -30,7 +30,7 @@ use cognee_llm::{Llm, build_openai_compatible_adapter};
 use cognee_models::DataInput;
 use cognee_ontology::NoOpOntologyResolver;
 use cognee_storage::{LocalStorage, StorageTrait};
-use cognee_test_utils::MockVectorDB;
+use cognee_test_utils::{MockVectorDB, fail_loudly_in_cassette_mode};
 use cognee_vector::VectorDB;
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -60,18 +60,6 @@ fn require_env(var_name: &str) -> String {
         return v;
     }
     panic!("Required environment variable '{var_name}' is not set")
-}
-
-/// In cassette-replay mode a pipeline error means a stale/missing cassette
-/// entry; the `Err => eprintln + return` skip blocks below would otherwise
-/// swallow it and pass with zero assertions. Call this in those blocks so a
-/// replay miss fails loudly (re-record cassettes); no-op outside replay mode.
-fn fail_loudly_on_replay_miss(what: &str, err: &impl std::fmt::Display) {
-    if std::env::var("COGNEE_TEST_REPLAY").is_ok_and(|v| !v.is_empty()) {
-        panic!(
-            "{what} failed in replay mode — likely a stale/missing cassette entry; re-record cassettes. Error: {err}"
-        );
-    }
 }
 
 /// LLM for this test: offline replay when `COGNEE_TEST_REPLAY=1` (MissPolicy::Error
@@ -252,7 +240,7 @@ async fn test_hard_mode_sweeps_orphan_entities() {
     {
         Ok(r) => r,
         Err(e) => {
-            fail_loudly_on_replay_miss("cognify", &e);
+            fail_loudly_in_cassette_mode("cognify", &e);
             eprintln!("Skipping test: cognify failed: {e}");
             return;
         }
@@ -432,7 +420,7 @@ async fn test_soft_mode_preserves_orphan_entities() {
     )
     .await
     {
-        fail_loudly_on_replay_miss("cognify (re-add)", &e);
+        fail_loudly_in_cassette_mode("cognify (re-add)", &e);
         eprintln!("Skipping test: cognify failed: {e}");
         return;
     }

--- a/crates/llm/src/mock/cassette.rs
+++ b/crates/llm/src/mock/cassette.rs
@@ -146,7 +146,7 @@ fn role_str(role: &crate::types::MessageRole) -> &'static str {
 /// version bump or a field reorder in a schema type (`KnowledgeGraph`,
 /// `SummarizedContent`, …) changes the hash and misses every recorded entry.
 /// That surfaces loudly — replay tests use `MissPolicy::Error` and the e2e
-/// skip-blocks call `fail_loudly_on_replay_miss` — so the remedy is simply to
+/// skip-blocks call `fail_loudly_in_cassette_mode` — so the remedy is simply to
 /// re-record the cassettes (see docs/build/ci-test-parallelism.md), not a
 /// silent test-coverage loss.
 fn canonicalize(value: &Value) -> String {

--- a/crates/search/tests/fixtures/cassettes/last_accessed_update.json
+++ b/crates/search/tests/fixtures/cassettes/last_accessed_update.json
@@ -1,21 +1,44 @@
 {
   "version": 1,
-  "model": "gpt-4o-mini",
+  "model": "openai/gpt-oss-120b",
   "entries": {
-    "fbc41f79369b7e05f4efbceb42baa39c2c51b38ef6d4c1ef152824eab1f510a1": {
+    "bc43a4459d234edd47aeee428a0774a83d6181bcac5643ef4c15e2cbfaa62d90": {
       "method": "structured_output",
       "user_input_preview": "Artificial intelligence enables machines to simulate human intelligence.",
       "schema_name": "KnowledgeGraph",
       "response": {
-        "nodes": [
+        "edges": [
           {
-            "id": "Artificial Intelligence",
-            "name": "Artificial Intelligence",
-            "type": "CONCEPT",
-            "description": "Artificial intelligence enables machines to simulate human intelligence."
+            "relationship_name": "enables",
+            "source_node_id": "Artificial intelligence",
+            "target_node_id": "machines"
+          },
+          {
+            "relationship_name": "simulates",
+            "source_node_id": "machines",
+            "target_node_id": "human intelligence"
           }
         ],
-        "edges": []
+        "nodes": [
+          {
+            "description": "Artificial intelligence enables machines to simulate human intelligence.",
+            "id": "Artificial intelligence",
+            "name": "Artificial intelligence",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Machines are devices that can be enabled by artificial intelligence to simulate human intelligence.",
+            "id": "machines",
+            "name": "machines",
+            "type": "CONCEPT"
+          },
+          {
+            "description": "Human intelligence is the intelligence exhibited by humans, which machines aim to simulate.",
+            "id": "human intelligence",
+            "name": "human intelligence",
+            "type": "CONCEPT"
+          }
+        ]
       }
     }
   }

--- a/crates/search/tests/last_accessed_update.rs
+++ b/crates/search/tests/last_accessed_update.rs
@@ -142,7 +142,7 @@ async fn test_search_updates_last_accessed_timestamp() {
     {
         Ok(_) => {}
         Err(e) => {
-            test_utils::fail_loudly_on_replay_miss("cognify", &e);
+            test_utils::fail_loudly_in_cassette_mode("cognify", &e);
             eprintln!("Skipping test: cognify failed: {e}");
             return;
         }

--- a/crates/search/tests/test_utils.rs
+++ b/crates/search/tests/test_utils.rs
@@ -7,23 +7,13 @@ use std::sync::Arc;
 // crate uses one implementation (consistent alias fallback + model default).
 // Re-exported here (with the historical `create_adapter_from_env` name) so the
 // many `test_utils::…` call sites in this crate's tests keep compiling.
+// `fail_loudly_in_cassette_mode` also lives in the shared crate (single source
+// of truth — see its docs there) and is re-exported here alongside the env helpers.
 #[allow(unused_imports)]
 pub use cognee_test_utils::{
-    create_openai_adapter_from_env as create_adapter_from_env, llm_env_available, require_env,
+    create_openai_adapter_from_env as create_adapter_from_env, fail_loudly_in_cassette_mode,
+    llm_env_available, require_env,
 };
-
-/// In cassette-replay mode a pipeline error means a stale/missing cassette
-/// entry; the `Err => eprintln + return` skip blocks would otherwise swallow it
-/// and pass with zero assertions. Call this in those blocks so a replay miss
-/// fails loudly (re-record cassettes); no-op outside replay mode.
-#[allow(dead_code)]
-pub fn fail_loudly_on_replay_miss(what: &str, err: &impl std::fmt::Display) {
-    if std::env::var("COGNEE_TEST_REPLAY").is_ok_and(|v| !v.is_empty()) {
-        panic!(
-            "{what} failed in replay mode — likely a stale/missing cassette entry; re-record cassettes. Error: {err}"
-        );
-    }
-}
 
 /// Resolve a named cassette under this crate's `tests/fixtures/cassettes/`.
 #[allow(dead_code)]

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -127,6 +127,35 @@ pub fn require_env(var_name: &str) -> String {
     panic!("❌ Required environment variable '{var_name}' is not set")
 }
 
+/// Fail loudly when a pipeline error occurs in either cassette mode, so the
+/// `Err(e) => { eprintln!("Skipping…"); return }` skip blocks the e2e tests use
+/// to tolerate a missing real LLM don't swallow it and pass with zero assertions.
+///
+/// - Replay mode (`COGNEE_TEST_REPLAY`): the error is a cassette miss — a
+///   stale/edited prompt or schema whose input hash no longer matches a recorded
+///   entry (`ReplayLlm` returns `LlmError::InvalidResponse`). Re-record.
+/// - Record mode (`COGNEE_RECORD_LLM`): the live LLM call failed, so the cassette
+///   would be silently left empty/partial (`RecordingLlm` only records successful
+///   calls) and pass recording but fail the next replay. Fail now instead. Note
+///   Baseten 501 "Error making prediction" is transient — just re-run.
+///
+/// Outside both modes (a legacy live run with no cassette) it is a no-op and the
+/// legitimate "no LLM configured" skip proceeds. Single source of truth: the
+/// per-crate `tests/test_utils.rs` shims re-export this so the skip-swallowing
+/// gap it closes cannot silently reopen in one copy.
+pub fn fail_loudly_in_cassette_mode(what: &str, err: &impl std::fmt::Display) {
+    if std::env::var("COGNEE_TEST_REPLAY").is_ok_and(|v| !v.is_empty()) {
+        panic!(
+            "{what} failed in replay mode — likely a stale/missing cassette entry; re-record cassettes. Error: {err}"
+        );
+    }
+    if std::env::var("COGNEE_RECORD_LLM").is_ok_and(|v| !v.is_empty()) {
+        panic!(
+            "{what} failed while recording — the cassette would be left empty/partial; fix the LLM error and re-record (Baseten 501s are transient — retry). Error: {err}"
+        );
+    }
+}
+
 /// Returns `true` when live LLM credentials are configured — `OPENAI_URL`/
 /// `OPENAI_TOKEN` or the canonical `LLM_ENDPOINT`/`LLM_API_KEY`. Integration/E2E
 /// tests call this to skip gracefully (per the repo convention) instead of


### PR DESCRIPTION
## Summary

Fixes #66 — `cognify` fails on non-strict-schema LLMs (Groq `llama-3.3-70b`, Baseten `gpt-oss-120b`) because the model omits the required `description` field on graph **nodes** during structured extraction, and the whole pipeline hard-fails.

## Root cause

The schema requires `Node.description`, but the extraction prompt (`generate_graph_prompt.txt`) only ever instructed the model about **edge** descriptions — never node descriptions. Non-strict models follow the prompt, omit node `description`, and typed deserialization fails after the corrective-retry loop is exhausted.

Python only escapes this because instructor's JSON mode injects the schema (with its `required` array) into the prompt as text — a safety net that is **absent** in tool/function/`json_schema` modes and on providers that reject `json_schema` (Groq). This Rust port faithfully mirrors Python's schema, so it inherits the same latent gap, exposed on non-strict providers.

## Fix (prompt-only, parity-preserving)

- **Add a "Node Descriptions" instruction** to the extraction prompt. Verified live against `gpt-oss-120b` (same non-strict class as the reporter's Groq model): **15/15 nodes now carry non-empty descriptions** (previously 0 → hard failure).
- **Drift-guard assertion** so a future byte-for-byte re-sync from Python can't silently drop this Rust-only line.
- **Deliberately not** relaxing the schema/deserialization: Python hard-requires `Node.description` (missing → `ValidationError` → instructor reask → raise). The adapter's existing corrective-retry loop already mirrors that, so making the field optional would *diverge* from Python, not match it.

## Test-infrastructure changes

- **Re-recorded the 8 integration cassettes against Baseten `gpt-oss-120b`** — a non-strict tool-caller — so offline replay now exercises the exact fallback path #66 users hit. `record-cassettes.yml` is pointed at `gpt-oss-120b` (⚠️ **requires a new `BASETEN_KEY` repo/org secret**; only `OPENAI_KEY` exists today).
- **Hardened `fail_loudly_in_cassette_mode`**: it now also fails loudly in **record** mode. Previously a failed live call during recording was silently skipped, producing an empty cassette that passed recording but failed the next replay (this actually happened via a transient Baseten `HTTP 501`). Consolidated into the shared `cognee-test-utils` crate (was triplicated across cognify/search/delete).
- **Clean-record safety**: the record workflow now deletes only the specific cassettes it regenerates (not a `*.json` wildcard), so a future test's cassette can't be silently wiped without being re-recorded.

## Verification

- fmt ✓, `cargo check --all-targets` ✓, clippy `-D warnings` ✓, C API checks ✓
- All **8** cassette suites pass offline replay (`COGNEE_TEST_REPLAY=1`)
- Live re-record run passed all assertions against `gpt-oss-120b`
- Record-mode loud-fail validated (forced LLM error now panics instead of writing an empty cassette)

## Follow-ups (not blocking)

- Add the `BASETEN_KEY` secret so `record-cassettes.yml` can authenticate.
- Baseten intermittently returns `HTTP 501 "Error making prediction"` (transient — succeeds on retry); the record workflow may need a manual re-run or a retry loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
