### PR TITLE
docs: correct cognee-cli install note and workspace tree root

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ root `README.md` link here rather than duplicating it.
 ## Workspace structure
 
 ```
-cognee-rust-oss/
+cognee-rs/
 ├── Cargo.toml                  # Workspace root (edition 2024, resolver 3)
 ├── crates/
 │   ├── models/                 # Core data types: Data, Dataset, DataInput, Document, DocumentChunk

--- a/docs/http-server/architecture.md
+++ b/docs/http-server/architecture.md
@@ -533,7 +533,7 @@ fn init_tracing() {
 
 - The new binary is named **`cognee-http-server`** (matches the package name; unambiguous on `$PATH`).
 - The existing `cognee-cli serve` subcommand (commit `ab18925`) handles the cloud OAuth flow. It stays as-is; this work does not modify `cognee-cli`.
-- A user who wants both installs both: `cargo install cognee-cli` and `cargo install cognee-http-server --features bin`. Distribution-wise (Docker, deb/rpm, brew) we publish them as two artifacts.
+- A user who wants both installs both: the `cognee-cli` binary (built from source — `cargo build --release -p cognee-cli`; it is not published to crates.io) and `cargo install cognee-http-server --features bin`. Distribution-wise (Docker, deb/rpm, brew) we publish them as two artifacts.
 
 ### Deployment shape
 


### PR DESCRIPTION
Two doc-only fixes found while auditing stale references in this repo.

1. **`docs/http-server/architecture.md`** — `cognee-cli` has `publish = false` in `crates/cli/Cargo.toml` and is not on crates.io, so the documented `cargo install cognee-cli` would fail. Changed to note it is built from source (`cargo build --release -p cognee-cli`).
2. **`docs/architecture.md`** — the workspace tree diagram was rooted at the local checkout dir name `cognee-rust-oss/`; corrected to the canonical repo name `cognee-rs/`.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)