### PR TITLE
fix(llm): apply llm_max_completion_tokens to recall/search (#67)

### DIFF
--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -135,6 +135,7 @@ mod tests {
                 api_key: "sk-test".to_string(),
                 endpoint: String::new(),
                 max_retries: 3,
+                max_completion_tokens: 16384,
                 llm_args: serde_json::Map::new(),
                 mock: false,
                 cassette: String::new(),

--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -135,7 +135,7 @@ mod tests {
                 api_key: "sk-test".to_string(),
                 endpoint: String::new(),
                 max_retries: 3,
-                max_completion_tokens: 16384,
+                max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
                 llm_args: serde_json::Map::new(),
                 mock: false,
                 cassette: String::new(),

--- a/crates/components/src/builtins/llm.rs
+++ b/crates/components/src/builtins/llm.rs
@@ -49,7 +49,8 @@ impl LlmFactory for OpenAiCompatibleLlmFactory {
             ctx.llm.max_retries,
         )
         .map_err(|e| ComponentError::Llm(e.to_string()))?
-        .with_extra_args(ctx.llm.llm_args.clone());
+        .with_extra_args(ctx.llm.llm_args.clone())
+        .with_default_max_tokens(Some(ctx.llm.max_completion_tokens));
         Ok(Arc::new(adapter))
     }
 

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -102,6 +102,12 @@ pub struct LlmInputs {
     pub api_key: String,
     pub endpoint: String,
     pub max_retries: u32,
+    /// Output-token cap applied to LLM calls that pass no per-call generation
+    /// options (the search/completion retrievers), lowered from
+    /// `Settings.llm_max_completion_tokens` (`setLlmMaxCompletionTokens`) so the
+    /// setter actually caps `recall`/`search`. Wired into the adapter by the
+    /// OpenAI-compatible factory via `OpenAIAdapter::with_default_max_tokens`.
+    pub max_completion_tokens: u32,
     /// Extra request parameters merged into every chat-completion request body,
     /// lowered from `LLM_ARGS` (Python `llm_config.llm_args`). Empty = no-op.
     /// Applied by the OpenAI-compatible factory via

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -404,6 +404,7 @@ mod tests {
                 api_key: "sk-test".to_string(),
                 endpoint: String::new(),
                 max_retries: 3,
+                max_completion_tokens: 16384,
                 llm_args: serde_json::Map::new(),
                 mock: false,
                 cassette: String::new(),

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -404,7 +404,7 @@ mod tests {
                 api_key: "sk-test".to_string(),
                 endpoint: String::new(),
                 max_retries: 3,
-                max_completion_tokens: 16384,
+                max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
                 llm_args: serde_json::Map::new(),
                 mock: false,
                 cassette: String::new(),

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -202,6 +202,12 @@ pub struct HttpServerConfig {
     /// Env: `LLM_MAX_RETRIES`.
     pub llm_max_retries: u32,
 
+    /// Output-token cap for the option-less completion (`recall`/`search`
+    /// answer) LLM call. Env: `LLM_MAX_COMPLETION_TOKENS`. Mirrors
+    /// `Settings.llm_max_completion_tokens` so the setter caps search on the
+    /// HTTP-server surface too (issue #67).
+    pub llm_max_completion_tokens: u32,
+
     /// Session store backend selector.
     /// Env: `COGNEE_SESSION_STORE`.
     pub session_store_backend: String,
@@ -346,6 +352,7 @@ impl Default for HttpServerConfig {
             llm_api_key: SecretString::new(String::new().into()),
             llm_endpoint: String::new(),
             llm_max_retries: 3,
+            llm_max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
             session_store_backend: "seaorm".to_string(),
             session_root_directory: default_session_root_directory(&system_root),
             notebook_runner_enabled: false,
@@ -537,6 +544,13 @@ impl HttpServerConfig {
                 .parse::<u32>()
                 .map_err(|e| ServerError::Other(anyhow::anyhow!("LLM_MAX_RETRIES: {e}")))?;
         }
+        // Honor the `LLM_MAX_TOKENS` alias too, matching the CLI/Settings path
+        // (`str_alias("LLM_MAX_COMPLETION_TOKENS", "LLM_MAX_TOKENS")`).
+        if let Some(v) = first_non_empty_env(&["LLM_MAX_COMPLETION_TOKENS", "LLM_MAX_TOKENS"]) {
+            cfg.llm_max_completion_tokens = v.parse::<u32>().map_err(|e| {
+                ServerError::Other(anyhow::anyhow!("LLM_MAX_COMPLETION_TOKENS: {e}"))
+            })?;
+        }
 
         if let Ok(v) = std::env::var("COGNEE_SESSION_STORE") {
             cfg.session_store_backend = v;
@@ -664,6 +678,10 @@ impl HttpServerConfig {
                 api_key: self.llm_api_key.expose_secret().to_string(),
                 endpoint: self.llm_endpoint.clone(),
                 max_retries: self.llm_max_retries,
+                // Env-configurable via `LLM_MAX_COMPLETION_TOKENS`, mirroring
+                // `Settings.llm_max_completion_tokens` on the CLI/SDK path so
+                // `recall`/`search` is capped consistently across surfaces.
+                max_completion_tokens: self.llm_max_completion_tokens,
                 // The HTTP server config does not yet expose an `LLM_ARGS`
                 // equivalent; default to no extra request params (a no-op).
                 // The CLI/ComponentManager path wires `LLM_ARGS` via

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -753,6 +753,7 @@ impl Settings {
                 api_key: self.llm_api_key.clone(),
                 endpoint: self.llm_endpoint.clone(),
                 max_retries: self.llm_max_retries,
+                max_completion_tokens: self.llm_max_completion_tokens,
                 llm_args: self.llm_args.clone(),
                 mock: self.llm_mock,
                 cassette: self.llm_cassette.clone(),
@@ -932,7 +933,9 @@ impl Default for Settings {
             llm_api_version: String::new(),
             llm_temperature: 0.0,
             llm_streaming: false,
-            llm_max_completion_tokens: 16384,
+            // Single-sourced with the adapter/http-server default so lowering
+            // the global completion ceiling in one place applies everywhere.
+            llm_max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
             llm_max_retries: 2,
             llm_max_parallel_requests: 20,
             llm_args: serde_json::Map::new(),

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -88,10 +88,12 @@ pub struct OpenAIAdapter {
     ///   control of `max_tokens` (including `None` = no cap), so the config
     ///   default never overrides an explicit choice.
     /// - Structured-output extraction (`structured_output_impl`) deliberately
-    ///   ignores this default: a cap there would truncate tool-call JSON
-    ///   mid-object, so it stays uncapped — matching cognify's explicit
-    ///   `max_tokens: None` stance and keeping internal structured calls (e.g.
-    ///   feedback detection) robust regardless of the configured ceiling.
+    ///   ignores this *configured* default and keeps the historical
+    ///   [`GenerationOptions::default`] cap (16384) for option-less calls: a
+    ///   lower cap there would truncate tool-call JSON mid-object, so lowering
+    ///   the completion ceiling never silently breaks internal structured calls
+    ///   (e.g. feedback detection). Callers wanting NO cap pass explicit
+    ///   `max_tokens: None` (as cognify's extraction paths do).
     ///
     /// `None` means "send no default cap". Defaults to
     /// [`Some(DEFAULT_MAX_COMPLETION_TOKENS)`](Self::DEFAULT_MAX_COMPLETION_TOKENS),
@@ -835,11 +837,13 @@ impl OpenAIAdapter {
             |parsed: &Value| -> Option<String> { validator.and_then(|v| v(parsed).err()) };
 
         // Structured extraction intentionally does NOT inherit the config
-        // `default_max_tokens` (that cap targets user-facing *answer* length via
-        // `generate`). A cap here would truncate the tool-call JSON mid-object;
-        // the cognify extraction paths already opt out with explicit
-        // `max_tokens: None`, and internal structured calls (e.g. feedback
-        // detection) must not silently break when a user lowers the answer cap.
+        // `default_max_tokens` (the global completion ceiling applied to
+        // `generate`): it keeps the historical `GenerationOptions::default()`
+        // cap (16384) for option-less calls. Applying the *configured* ceiling
+        // here risks truncating the tool-call JSON mid-object, so a user
+        // lowering the answer ceiling never silently breaks internal structured
+        // calls (e.g. feedback detection). Callers that want NO cap at all pass
+        // explicit `max_tokens: None` (as cognify's extraction paths do).
         let opts = options.unwrap_or_default();
         // Align the advertised `required` array with what instructor sends on its
         // default TOOLS path (every non-default property is required). See

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -65,6 +65,39 @@ pub struct OpenAIAdapter {
     /// would otherwise truncate a dense graph-extraction tool call mid-JSON.
     /// Empty by default (Python default `llm_args = {}`) — a no-op.
     extra_args: serde_json::Map<String, Value>,
+    /// Default output-token ceiling applied to a plain-completion
+    /// ([`generate`](Self::generate)) request when the caller passes **no**
+    /// [`GenerationOptions`] at all. Lowered from
+    /// `Settings.llm_max_completion_tokens` (`setLlmMaxCompletionTokens`) by the
+    /// component factory so config actually governs the `max_tokens` the
+    /// search/completion retrievers emit (issue #67).
+    ///
+    /// This is a *global* completion ceiling, not an answer-length knob: it
+    /// applies to every option-less `generate` call — the user-facing
+    /// `recall`/`search` answer **and** the internal machine generations that
+    /// share that path (NL→Cypher query synthesis, the feeling-lucky retriever
+    /// selector, graph-summary intermediates). That is deliberate: its primary
+    /// purpose is to stay under a provider's hard `max_tokens` limit (e.g. Groq
+    /// rejects `> 8192`), which requires *all* of those calls to respect it —
+    /// leaving any uncapped would still emit the 16384 default and 400 on such a
+    /// provider. Set it high enough to satisfy the largest internal generation.
+    ///
+    /// Scope and precedence:
+    /// - Only the *fully option-less* `generate` path is filled from this
+    ///   default. A caller that passes explicit `GenerationOptions` keeps full
+    ///   control of `max_tokens` (including `None` = no cap), so the config
+    ///   default never overrides an explicit choice.
+    /// - Structured-output extraction (`structured_output_impl`) deliberately
+    ///   ignores this default: a cap there would truncate tool-call JSON
+    ///   mid-object, so it stays uncapped — matching cognify's explicit
+    ///   `max_tokens: None` stance and keeping internal structured calls (e.g.
+    ///   feedback detection) robust regardless of the configured ceiling.
+    ///
+    /// `None` means "send no default cap". Defaults to
+    /// [`Some(DEFAULT_MAX_COMPLETION_TOKENS)`](Self::DEFAULT_MAX_COMPLETION_TOKENS),
+    /// matching the historical [`GenerationOptions::default`] cap so an adapter
+    /// built without config behaves exactly as before.
+    default_max_tokens: Option<u32>,
 }
 
 impl OpenAIAdapter {
@@ -79,6 +112,11 @@ impl OpenAIAdapter {
     pub const DEFAULT_STRUCTURED_OUTPUT_RETRIES: usize = 5;
     /// Default retry attempts for transient network/server errors.
     pub const DEFAULT_NETWORK_RETRIES: usize = 3;
+    /// Default output-token cap applied to option-less calls, mirroring the
+    /// historical [`GenerationOptions::default`] cap and Python cognee's
+    /// `llm_max_completion_tokens` default (`config.py`). Overridden per-adapter
+    /// via [`with_default_max_tokens`](Self::with_default_max_tokens).
+    pub const DEFAULT_MAX_COMPLETION_TOKENS: u32 = 16384;
 
     /// Create a new OpenAI adapter.
     ///
@@ -125,6 +163,7 @@ impl OpenAIAdapter {
             network_retries: Self::DEFAULT_NETWORK_RETRIES,
             transcription_model,
             extra_args: serde_json::Map::new(),
+            default_max_tokens: Some(Self::DEFAULT_MAX_COMPLETION_TOKENS),
         })
     }
 
@@ -139,6 +178,39 @@ impl OpenAIAdapter {
     pub fn with_extra_args(mut self, args: serde_json::Map<String, Value>) -> Self {
         self.extra_args = args;
         self
+    }
+
+    /// Set the output-token cap applied to an option-less
+    /// [`generate`](Self::generate) call, lowered from
+    /// `Settings.llm_max_completion_tokens` (`setLlmMaxCompletionTokens`). See
+    /// the [`default_max_tokens`](Self::default_max_tokens) field docs for scope
+    /// and precedence.
+    ///
+    /// A `Some(0)` is treated as "no cap" (`None`): `0` is meaningless as an
+    /// output cap and providers reject `max_tokens: 0` with HTTP 400, so a
+    /// stray `setLlmMaxCompletionTokens(0)` must not break `recall`/`search`.
+    pub fn with_default_max_tokens(mut self, value: Option<u32>) -> Self {
+        self.default_max_tokens = value.filter(|&v| v > 0);
+        self
+    }
+
+    /// Resolve caller options for the plain-completion ([`generate`](Self::generate))
+    /// path. When the caller passes no options at all, the config-derived
+    /// [`default_max_tokens`](Self::default_max_tokens) becomes the output cap
+    /// (every other field takes [`GenerationOptions::default`]); when the caller
+    /// passes explicit options they are honoured verbatim, so an explicit
+    /// `max_tokens` (including `None` = no cap) always wins over config. This
+    /// applies the configured completion ceiling to every option-less
+    /// `generate` call while leaving explicit callers (and, separately,
+    /// structured extraction) alone.
+    fn resolve_options(&self, options: Option<GenerationOptions>) -> GenerationOptions {
+        match options {
+            Some(opts) => opts,
+            None => GenerationOptions {
+                max_tokens: self.default_max_tokens,
+                ..GenerationOptions::default()
+            },
+        }
     }
 
     /// Merge [`extra_args`](Self::extra_args) into a request body, filling only
@@ -556,7 +628,7 @@ impl Llm for OpenAIAdapter {
         messages: Vec<Message>,
         options: Option<GenerationOptions>,
     ) -> LlmResult<GenerationResponse> {
-        let opts = options.unwrap_or_default();
+        let opts = self.resolve_options(options);
 
         let mut request_body = json!({
             "model": self.model,
@@ -762,6 +834,12 @@ impl OpenAIAdapter {
         let validation_error =
             |parsed: &Value| -> Option<String> { validator.and_then(|v| v(parsed).err()) };
 
+        // Structured extraction intentionally does NOT inherit the config
+        // `default_max_tokens` (that cap targets user-facing *answer* length via
+        // `generate`). A cap here would truncate the tool-call JSON mid-object;
+        // the cognify extraction paths already opt out with explicit
+        // `max_tokens: None`, and internal structured calls (e.g. feedback
+        // detection) must not silently break when a user lowers the answer cap.
         let opts = options.unwrap_or_default();
         // Align the advertised `required` array with what instructor sends on its
         // default TOOLS path (every non-default property is required). See

--- a/crates/llm/tests/openai_max_completion_tokens.rs
+++ b/crates/llm/tests/openai_max_completion_tokens.rs
@@ -1,0 +1,231 @@
+//! Regression tests for issue #67: `setLlmMaxCompletionTokens(N)` must cap the
+//! LLM request made by `recall`/`search`.
+//!
+//! The completion retrievers construct with `generation_options: None`, so the
+//! request they trigger carries *no* per-call [`GenerationOptions`]. Before the
+//! fix that option-less path hardcoded `max_tokens: 16384`
+//! (`GenerationOptions::default()`), ignoring the configured value entirely — on
+//! a provider with a lower hard ceiling (e.g. Groq's 8192) the request 400'd
+//! regardless of `setLlmMaxCompletionTokens`. The fix threads the config value
+//! into the adapter's `default_max_tokens`, applied precisely to the option-less
+//! path, while an explicit per-call `max_tokens` still wins.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code — panics are acceptable"
+)]
+
+use cognee_llm::adapters::OpenAIAdapter;
+use cognee_llm::{GenerationOptions, Llm, Message, MessageRole};
+use httpmock::prelude::*;
+
+const CHAT_RESPONSE: &str = r#"{
+    "id": "chatcmpl-test",
+    "object": "chat.completion",
+    "created": 1700000000,
+    "model": "gpt-4o-mini",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "ok"},
+            "finish_reason": "stop"
+        }
+    ]
+}"#;
+
+fn user_msg() -> Vec<Message> {
+    vec![Message {
+        role: MessageRole::User,
+        content: "hello".to_string(),
+    }]
+}
+
+/// The option-less path (what `recall`/`search` retrievers use) must send the
+/// configured `default_max_tokens`, not the hardcoded 16384. This is the global
+/// completion ceiling that lets a user stay under a provider's hard `max_tokens`
+/// limit — the case that reproduced the issue.
+#[tokio::test]
+async fn option_less_generate_uses_configured_default_max_tokens() {
+    let server = MockServer::start_async().await;
+    // Mock only matches when the body carries the configured cap; a hit proves
+    // the request used 4096, not the old hardcoded 16384.
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .json_body_includes(r#"{"max_tokens": 4096}"#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(CHAT_RESPONSE);
+        })
+        .await;
+
+    let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_default_max_tokens(Some(4096));
+
+    // `None` options == the retriever construction (`generation_options: None`).
+    adapter
+        .generate(user_msg(), None)
+        .await
+        .expect("generate succeeds against mock requiring max_tokens=4096");
+
+    mock.assert_calls_async(1).await;
+}
+
+/// An explicit per-call `max_tokens` must win over the configured default,
+/// matching Python's `{**llm_args, **kwargs}` precedence.
+#[tokio::test]
+async fn explicit_max_tokens_overrides_configured_default() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .json_body_includes(r#"{"max_tokens": 1024}"#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(CHAT_RESPONSE);
+        })
+        .await;
+
+    let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_default_max_tokens(Some(4096));
+
+    adapter
+        .generate(
+            user_msg(),
+            Some(GenerationOptions {
+                max_tokens: Some(1024),
+                ..GenerationOptions::default()
+            }),
+        )
+        .await
+        .expect("explicit max_tokens=1024 must be sent, overriding the 4096 default");
+
+    mock.assert_calls_async(1).await;
+}
+
+/// An explicit `max_tokens: None` must send *no* cap — the cognify extraction
+/// paths rely on this to avoid truncating structured JSON — even when a config
+/// default is set. Proven by asserting the request omits both token-cap keys.
+#[tokio::test]
+async fn explicit_none_max_tokens_sends_no_cap() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_excludes("max_tokens")
+                .body_excludes("max_completion_tokens");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(CHAT_RESPONSE);
+        })
+        .await;
+
+    let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_default_max_tokens(Some(4096));
+
+    adapter
+        .generate(
+            user_msg(),
+            Some(GenerationOptions {
+                max_tokens: None,
+                ..GenerationOptions::default()
+            }),
+        )
+        .await
+        .expect("explicit max_tokens=None must send no token cap");
+
+    mock.assert_calls_async(1).await;
+}
+
+/// A stray `setLlmMaxCompletionTokens(0)` must not break `recall`/`search`: a
+/// `0` default is meaningless and providers reject `max_tokens: 0`, so it is
+/// coerced to "no cap" rather than written to the wire.
+#[tokio::test]
+async fn zero_default_max_tokens_sends_no_cap() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_excludes("max_tokens")
+                .body_excludes("max_completion_tokens");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(CHAT_RESPONSE);
+        })
+        .await;
+
+    let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_default_max_tokens(Some(0));
+
+    adapter
+        .generate(user_msg(), None)
+        .await
+        .expect("a 0 default must send no cap, not max_tokens=0");
+
+    mock.assert_calls_async(1).await;
+}
+
+/// Structured-output extraction must NOT inherit the config `default_max_tokens`
+/// (that cap targets user-facing answer length via `generate`). Applying it here
+/// would truncate tool-call JSON and silently break internal structured calls
+/// like feedback detection. An option-less structured call keeps the historical
+/// default cap (16384), independent of the configured answer cap.
+#[tokio::test]
+async fn structured_output_ignores_configured_default_max_tokens() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                // Historical default, NOT the small configured answer cap (256).
+                .json_body_includes(r#"{"max_tokens": 16384}"#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(tool_call_response(r#"{"name":"Alice"}"#));
+        })
+        .await;
+
+    let adapter = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_default_max_tokens(Some(256));
+
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"],
+    });
+
+    adapter
+        .create_structured_output_with_messages_raw(user_msg(), &schema, None)
+        .await
+        .expect("structured extraction must send the 16384 default, not the 256 answer cap");
+
+    mock.assert_calls_async(1).await;
+}
+
+/// Builds the tool-call chat-completion body shape returned by an OpenAI-style
+/// structured-output response (mirrors `openai_structured_output.rs`).
+fn tool_call_response(payload_json: &str) -> String {
+    let escaped = serde_json::to_string(payload_json).expect("string escapes");
+    format!(
+        r#"{{"id":"x","object":"chat.completion","created":1,"model":"m",
+            "choices":[{{"index":0,"message":{{"role":"assistant","tool_calls":[
+                {{"id":"c1","type":"function","function":{{
+                    "name":"extract_structured_data","arguments":{escaped}
+                }}}}
+            ]}},"finish_reason":"tool_calls"}}]}}"#
+    )
+}

--- a/crates/llm/tests/openai_max_completion_tokens.rs
+++ b/crates/llm/tests/openai_max_completion_tokens.rs
@@ -190,7 +190,10 @@ async fn structured_output_ignores_configured_default_max_tokens() {
             when.method(POST)
                 .path("/chat/completions")
                 // Historical default, NOT the small configured answer cap (256).
-                .json_body_includes(r#"{"max_tokens": 16384}"#);
+                .json_body_includes(format!(
+                    r#"{{"max_tokens": {}}}"#,
+                    OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS
+                ));
             then.status(200)
                 .header("content-type", "application/json")
                 .body(tool_call_response(r#"{"name":"Alice"}"#));


### PR DESCRIPTION
## Summary

Fixes #67 — `setLlmMaxCompletionTokens(N)` had **no effect** on the LLM call made inside `recall()`/`search()`. Setting it below a provider's hard ceiling still produced a provider-side `max_tokens too high` 400 (e.g. Groq's 8192).

### Root cause (two combined defects)

1. **The setter's value was orphaned.** `set_llm_max_completion_tokens` writes `Settings.llm_max_completion_tokens`, but `LlmInputs`/`BackendBuildContext` never carried that field — only `llm_args` reached the adapter. So the setter updated a value that flowed nowhere near the request.
2. **Option-less calls hardcoded 16384.** Completion retrievers are built with `generation_options: None`; `OpenAIAdapter::generate` then did `options.unwrap_or_default()`, and `GenerationOptions::default()` hardcodes `max_tokens: Some(16384)`. Every option-less call emitted 16384 regardless of config.

**Why cognify succeeded but recall failed:** cognify's extraction paths pass explicit `GenerationOptions { max_tokens: None }` → no cap on the wire → Groq accepts it. Only the option-less retriever path inherited the 16384 default.

### Fix

- Thread `llm_max_completion_tokens` through `LlmInputs` into `OpenAIAdapter` as `default_max_tokens`, applied by `resolve_options()` in `generate()`.
- Treated as a **global completion ceiling**: it caps every option-less `generate` call — the user-facing answer *and* the internal machine generations that share that path (NL→Cypher synthesis, feeling-lucky selection, graph-summary intermediates). This is deliberate: the setting's purpose is staying under a provider's hard `max_tokens` limit, which requires all those calls to respect it (leaving any uncapped would still emit 16384 and 400 on Groq).
- **Precedence preserved:** explicit per-call `max_tokens` wins; explicit `None` still sends no cap; a stray `0` is coerced to "no cap" (providers reject `max_tokens: 0`).
- **Structured extraction ignores the configured ceiling** (`structured_output_impl` keeps `unwrap_or_default()` → the historical `16384` default): applying the lower configured cap there would truncate tool-call JSON, so lowering the ceiling never breaks internal structured calls like feedback detection. Callers wanting no cap at all pass explicit `None` (as cognify's extraction paths do).
- Wire the ceiling on the **HTTP-server surface** too (`LLM_MAX_COMPLETION_TOKENS`, with `LLM_MAX_TOKENS` alias to match the CLI/Settings path), and single-source the default via `OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS`.

### Parity note

Python's `acreate_structured_output` sends only `{**llm_args, **kwargs}` and never auto-applies `max_completion_tokens` to OpenAI calls, so Python recall works on Groq out of the box. This PR goes slightly beyond Python (per the issue's ask) to make the setter actually cap the completion request, while keeping extraction uncapped like Python/cognify.

### Tests

New `crates/llm/tests/openai_max_completion_tokens.rs` (httpmock, mirroring `openai_span_instrumentation.rs`), 5 tests:
- option-less `generate` sends the configured cap (fails before the fix)
- explicit `Some(N)` overrides the config default
- explicit `None` sends no cap
- `0` default → no cap
- structured extraction is **not** capped by the config ceiling

`cargo check --all-targets`, `cargo fmt --check`, `cargo clippy -D warnings`, and the affected lib test suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
