### PR TITLE
ci(ios): link both iOS targets instead of type-check only

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   ios-check:
-    name: iOS targets (cargo check + Swift parse)
+    name: iOS targets (cargo build + Swift typecheck)
     # macos-14 = Apple Silicon (M1).  Required for aarch64-apple-ios targets.
     runs-on: macos-14
 
@@ -50,24 +50,25 @@ jobs:
       - name: Install protoc (required by lance-encoding build script)
         run: brew install protobuf
 
-      # `cargo check` type-checks the crate for iOS without linking —
-      # avoids the 6–7 GB .a files that a full `cargo build --release` produces
-      # and keeps peak disk usage well under the runner's ~14 GB limit.
-      - name: Check — aarch64-apple-ios (device)
+      # `cargo build` (debug, CARGO_PROFILE_DEV_DEBUG=0) links both iOS targets,
+      # catching linker errors that type-checking alone misses.
+      - name: Build — aarch64-apple-ios (device)
         run: |
-          cargo check \
+          cargo build \
             --target aarch64-apple-ios \
             --manifest-path capi/cognee-capi/Cargo.toml \
             --no-default-features \
             --features sqlite,testing,mock-llm,lancedb
+          df -h /
 
-      - name: Check — aarch64-apple-ios-sim (simulator)
+      - name: Build — aarch64-apple-ios-sim (simulator)
         run: |
-          cargo check \
+          cargo build \
             --target aarch64-apple-ios-sim \
             --manifest-path capi/cognee-capi/Cargo.toml \
             --no-default-features \
             --features sqlite,testing,mock-llm,lancedb
+          df -h / && du -sh capi/target
 
       # Validate Package.swift parses correctly (does not require the xcframework
       # binary — `dump-package` only reads the manifest).

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -11,15 +11,21 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Incremental state is useless on CI (fresh checkout every run) and wastes
-  # 2–5 GB of the macOS runner's ~14 GB disk.
+  # Incremental state is useless on CI (fresh checkout every run), so it is
+  # pure disk cost.
   CARGO_INCREMENTAL: "0"
-  # Debug info inflates .a files by ~40 %; strip it on CI to reduce disk pressure.
+  # Strips debug info from cognee-capi itself. This is *not* what keeps the
+  # build small, despite the obvious reading: capi/Cargo.toml sets
+  # `debug = true` per package for the 24 first-party cognee-* crates, and a
+  # named package override beats `profile.dev.debug` (which is all this env var
+  # maps to), so every one of those still compiles with full DWARF. The size
+  # win comes from [profile.dev.package."*"] debug = 0 on the dependency
+  # closure, which is in the manifest and needs no help from here.
   CARGO_PROFILE_DEV_DEBUG: "0"
 
 jobs:
   ios-check:
-    name: iOS targets (cargo build + Swift typecheck)
+    name: iOS targets (link + Swift typecheck)
     # macos-14 = Apple Silicon (M1).  Required for aarch64-apple-ios targets.
     runs-on: macos-14
 
@@ -50,25 +56,57 @@ jobs:
       - name: Install protoc (required by lance-encoding build script)
         run: brew install protobuf
 
-      # `cargo build` (debug, CARGO_PROFILE_DEV_DEBUG=0) links both iOS targets,
-      # catching linker errors that type-checking alone misses.
-      - name: Build — aarch64-apple-ios (device)
+      # Link — not merely type-check — both iOS targets, so an unresolved or
+      # mismatched symbol anywhere in the Rust closure fails here instead of in
+      # a downstream Xcode build.
+      #
+      # `--crate-type cdylib` overrides the `["cdylib", "staticlib"]` list in
+      # capi/cognee-capi/Cargo.toml for this invocation only (the same trick
+      # build_xcframework.sh uses in the other direction, documented at
+      # capi/cognee-capi/Cargo.toml:20-25). The cdylib is the slice worth
+      # building: rustc emits a staticlib by archiving objects *without*
+      # resolving symbols, so a staticlib build runs no linker at all and would
+      # add nothing this job does not already get from `cargo check`. The
+      # shipped staticlib is built separately, in release, by
+      # capi/scripts/build_xcframework.sh.
+      #
+      # The `test -f` guard is deliberate: rustc treats an unsupported crate
+      # type as a warning, not an error, so without it a future toolchain could
+      # quietly downgrade this step to a compile-only check.
+      - name: Link — aarch64-apple-ios (device)
         run: |
-          cargo build \
+          cargo rustc --crate-type cdylib \
             --target aarch64-apple-ios \
             --manifest-path capi/cognee-capi/Cargo.toml \
             --no-default-features \
             --features sqlite,testing,mock-llm,lancedb
-          df -h /
+          test -f capi/target/aarch64-apple-ios/debug/libcognee_capi.dylib
 
-      - name: Build — aarch64-apple-ios-sim (simulator)
+      - name: Link — aarch64-apple-ios-sim (simulator)
         run: |
-          cargo build \
+          cargo rustc --crate-type cdylib \
             --target aarch64-apple-ios-sim \
             --manifest-path capi/cognee-capi/Cargo.toml \
             --no-default-features \
             --features sqlite,testing,mock-llm,lancedb
-          df -h / && du -sh capi/target
+          test -f capi/target/aarch64-apple-ios-sim/debug/libcognee_capi.dylib
+
+      # Its own step with `if: always()`, both deliberate. ENOSPC aborts the
+      # step it occurs in, so a `df` appended to a build step never runs on the
+      # one failure it exists to diagnose.
+      #
+      # `/System/Volumes/Data` is the writable volume the build lands on. `/` is
+      # the read-only system snapshot: across both builds of run 31305066951 its
+      # `Used` column sat unchanged at 9.6Gi while capi/target grew to 5.8G, so
+      # only the container-shared `Avail` there carried any signal (36Gi ->
+      # 34Gi of a 320Gi disk). Peak usage is nowhere near the runner's limit —
+      # the "full builds do not fit" premise this job was originally written
+      # against no longer holds.
+      - name: Disk usage after linking
+        if: always()
+        run: |
+          df -h /System/Volumes/Data
+          du -sh capi/target || true
 
       # Validate Package.swift parses correctly (does not require the xcframework
       # binary — `dump-package` only reads the manifest).

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -73,6 +73,15 @@ jobs:
       # The `test -f` guard is deliberate: rustc treats an unsupported crate
       # type as a warning, not an error, so without it a future toolchain could
       # quietly downgrade this step to a compile-only check.
+      # Baseline for the post-link probe below. Without a starting figure the
+      # probe can report what is left but not what this run consumed, and if
+      # the first link hits ENOSPC the only reading ever taken is the one from
+      # after the failure.
+      - name: Disk usage before linking
+        run: |
+          df -h /System/Volumes/Data || true
+          du -sh capi/target 2>/dev/null || true
+
       - name: Link — aarch64-apple-ios (device)
         run: |
           cargo rustc --crate-type cdylib \
@@ -98,14 +107,16 @@ jobs:
       # `/System/Volumes/Data` is the writable volume the build lands on. `/` is
       # the read-only system snapshot: across both builds of run 31305066951 its
       # `Used` column sat unchanged at 9.6Gi while capi/target grew to 5.8G, so
-      # only the container-shared `Avail` there carried any signal (36Gi ->
-      # 34Gi of a 320Gi disk). Peak usage is nowhere near the runner's limit —
+      # only the container-shared `Avail` there carried any signal. Note those
+      # figures were taken *between* the two builds, so they are mid-run
+      # readings rather than starting headroom — which is what the baseline
+      # step above now records. Peak usage is nowhere near the runner's limit —
       # the "full builds do not fit" premise this job was originally written
       # against no longer holds.
       - name: Disk usage after linking
         if: always()
         run: |
-          df -h /System/Volumes/Data
+          df -h /System/Volumes/Data || true
           du -sh capi/target || true
 
       # Validate Package.swift parses correctly (does not require the xcframework

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -56,23 +56,6 @@ jobs:
       - name: Install protoc (required by lance-encoding build script)
         run: brew install protobuf
 
-      # Link — not merely type-check — both iOS targets, so an unresolved or
-      # mismatched symbol anywhere in the Rust closure fails here instead of in
-      # a downstream Xcode build.
-      #
-      # `--crate-type cdylib` overrides the `["cdylib", "staticlib"]` list in
-      # capi/cognee-capi/Cargo.toml for this invocation only (the same trick
-      # build_xcframework.sh uses in the other direction, documented at
-      # capi/cognee-capi/Cargo.toml:20-25). The cdylib is the slice worth
-      # building: rustc emits a staticlib by archiving objects *without*
-      # resolving symbols, so a staticlib build runs no linker at all and would
-      # add nothing this job does not already get from `cargo check`. The
-      # shipped staticlib is built separately, in release, by
-      # capi/scripts/build_xcframework.sh.
-      #
-      # The `test -f` guard is deliberate: rustc treats an unsupported crate
-      # type as a warning, not an error, so without it a future toolchain could
-      # quietly downgrade this step to a compile-only check.
       # Baseline for the post-link probe below. Without a starting figure the
       # probe can report what is left but not what this run consumed, and if
       # the first link hits ENOSPC the only reading ever taken is the one from
@@ -82,6 +65,23 @@ jobs:
           df -h /System/Volumes/Data || true
           du -sh capi/target 2>/dev/null || true
 
+      # Link — not merely type-check — both iOS targets, so an unresolved or
+      # mismatched symbol anywhere in the Rust closure fails here instead of in
+      # a downstream Xcode build.
+      #
+      # `--crate-type cdylib` overrides the `["cdylib", "staticlib"]` list in
+      # capi/cognee-capi/Cargo.toml for this invocation only (the same trick
+      # build_xcframework.sh uses in the other direction, documented at
+      # capi/cognee-capi/Cargo.toml:20-25). The cdylib is the slice worth
+      # building: rustc emits a staticlib by archiving objects *without*
+      # resolving symbols, so a staticlib build runs no linker at all and
+      # therefore catches no unresolved-symbol errors — which is the one class
+      # of failure this step exists to surface. The shipped staticlib is built
+      # separately, in release, by capi/scripts/build_xcframework.sh.
+      #
+      # The `test -f` guard is deliberate: rustc treats an unsupported crate
+      # type as a warning, not an error, so without it a future toolchain could
+      # quietly downgrade this step to a compile-only check.
       - name: Link — aarch64-apple-ios (device)
         run: |
           cargo rustc --crate-type cdylib \
@@ -105,8 +105,8 @@ jobs:
       # one failure it exists to diagnose.
       #
       # `/System/Volumes/Data` is the writable volume the build lands on. `/` is
-      # the read-only system snapshot: across both builds of run 31305066951 its
-      # `Used` column sat unchanged at 9.6Gi while capi/target grew to 5.8G, so
+      # the read-only system snapshot: across both builds of run 33517170717 its
+      # `Used` column sat unchanged at 9.6Gi while capi/target grew to 4.0G, so
       # only the container-shared `Avail` there carried any signal. Note those
       # figures were taken *between* the two builds, so they are mid-run
       # readings rather than starting headroom — which is what the baseline

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -88,8 +88,9 @@ Runs behind the **`release` environment** (required reviewers). Order:
      releases are immutable: re-deploying an existing version fails.
 3. **GitHub Release** — created/updated with the changelog section.
 
-`ios.yml` is **not** part of the release. It is a `main`/PR check only (cargo
-check for the iOS targets + a Swift parse) and ships no artifact; the Swift
+`ios.yml` is **not** part of the release. It is a `main`/PR check only — it
+links both iOS targets with `cargo rustc --crate-type cdylib` and type-checks
+the Swift wrapper with `swiftc -typecheck` — and ships no artifact; the Swift
 package is consumed from source.
 
 Publishing crates.io *before* the tag cascade means a crates.io failure aborts

--- a/ios/README.md
+++ b/ios/README.md
@@ -97,15 +97,17 @@ Test Suite 'All tests' passed at …
 
 ## CI
 
-The `ios` workflow (`.github/workflows/ios.yml`) runs on every push and PR on a `macos-14` Apple Silicon runner. Because a full xcframework build exceeds GitHub Actions' available disk, CI uses `cargo check` rather than `cargo build`:
+The `ios` workflow (`.github/workflows/ios.yml`) runs on every push and PR on a `macos-14` Apple Silicon runner. CI **links** both iOS targets rather than only type-checking them:
 
-- `cargo check --target aarch64-apple-ios` — type-checks the Rust C API for the device target
-- `cargo check --target aarch64-apple-ios-sim` — type-checks for the simulator target
+- `cargo rustc --crate-type cdylib --target aarch64-apple-ios` — compiles *and links* the Rust C API for the device target
+- `cargo rustc --crate-type cdylib --target aarch64-apple-ios-sim` — same for the simulator target
 - `swift package dump-package` — validates `Package.swift`
 - `swiftc -typecheck` — type-checks the Swift wrapper against the real C API header via a synthesised Clang module, catching renamed `cg_sdk_*` functions, changed argument counts, and changed `CgErrorCode` values — no xcframework needed
 - `swiftc -parse` — syntax-checks the Swift test sources (`@testable import CogneeSDK` requires a built module, so only parse-checking is possible in CI)
 
-This catches Rust type errors, C API signature drift, and Swift syntax mistakes without needing the ~6.6 GB xcframework on the runner. XCTest behavioral tests run manually via `xcodebuild test` before each push.
+`cdylib` is the crate type that exercises the linker: rustc emits a staticlib by archiving objects without resolving symbols, so building one would catch nothing beyond `cargo check`. The shipped staticlib slices are a separate, release build performed by `capi/scripts/build_xcframework.sh`.
+
+This catches Rust type errors, unresolved symbols, C API signature drift, and Swift syntax mistakes without assembling the ~6.6 GB xcframework on the runner. The two debug link builds together occupy ~5.8 GB of `capi/target` against ~36 GB of free space on the runner, so disk is not the constraint it once was — an earlier revision of this job used `cargo check` on the assumption that a full build would not fit. What CI still cannot do is *run* the tests: XCTest behavioral tests are executed manually via `xcodebuild test` before each push.
 
 ## Architecture
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -107,7 +107,7 @@ The `ios` workflow (`.github/workflows/ios.yml`) runs on every push and PR on a 
 
 `cdylib` is the crate type that exercises the linker: rustc emits a staticlib by archiving objects without resolving symbols, so building one would catch nothing beyond `cargo check`. The shipped staticlib slices are a separate, release build performed by `capi/scripts/build_xcframework.sh`.
 
-This catches Rust type errors, unresolved symbols, C API signature drift, and Swift syntax mistakes without assembling the ~6.6 GB xcframework on the runner. The two debug link builds together occupy ~5.8 GB of `capi/target` against ~36 GB of free space on the runner, so disk is not the constraint it once was — an earlier revision of this job used `cargo check` on the assumption that a full build would not fit. What CI still cannot do is *run* the tests: XCTest behavioral tests are executed manually via `xcodebuild test` before each push.
+This catches Rust type errors, unresolved symbols, C API signature drift, and Swift syntax mistakes without assembling the ~6.6 GB xcframework on the runner. The two debug link builds together occupy ~4.0 GB of `capi/target` against ~34 GB of free space on the runner, so disk is not the constraint it once was — an earlier revision of this job used `cargo check` on the assumption that a full build would not fit. What CI still cannot do is *run* the tests: XCTest behavioral tests are executed manually via `xcodebuild test` before each push.
 
 ## Architecture
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -105,7 +105,7 @@ The `ios` workflow (`.github/workflows/ios.yml`) runs on every push and PR on a 
 - `swiftc -typecheck` — type-checks the Swift wrapper against the real C API header via a synthesised Clang module, catching renamed `cg_sdk_*` functions, changed argument counts, and changed `CgErrorCode` values — no xcframework needed
 - `swiftc -parse` — syntax-checks the Swift test sources (`@testable import CogneeSDK` requires a built module, so only parse-checking is possible in CI)
 
-`cdylib` is the crate type that exercises the linker: rustc emits a staticlib by archiving objects without resolving symbols, so building one would catch nothing beyond `cargo check`. The shipped staticlib slices are a separate, release build performed by `capi/scripts/build_xcframework.sh`.
+`cdylib` is the crate type that exercises the linker: rustc emits a staticlib by archiving objects without resolving symbols, so building one runs no linker at all and would therefore catch no unresolved-symbol errors. The shipped staticlib slices are a separate, release build performed by `capi/scripts/build_xcframework.sh`.
 
 This catches Rust type errors, unresolved symbols, C API signature drift, and Swift syntax mistakes without assembling the ~6.6 GB xcframework on the runner. The two debug link builds together occupy ~4.0 GB of `capi/target` against ~34 GB of free space on the runner, so disk is not the constraint it once was — an earlier revision of this job used `cargo check` on the assumption that a full build would not fit. What CI still cannot do is *run* the tests: XCTest behavioral tests are executed manually via `xcodebuild test` before each push.
 


### PR DESCRIPTION
Follow-up to #38.

`cargo check` → `cargo build` (debug, `CARGO_PROFILE_DEV_DEBUG=0`) for both iOS targets. `df -h /` and `du -sh capi/target` after each build for the disk numbers.

Pipeline assertion changes dropped — superseded by #112.