### PR TITLE
fix(http-server): accept single & repeated dataset params on GET /datasets/status

### DIFF
--- a/crates/http-server/Cargo.toml
+++ b/crates/http-server/Cargo.toml
@@ -90,6 +90,10 @@ dev-mock = ["cognee-vector/testing", "cognee-components/testing"]
 # in the closed cognee-cloud-rs workspace alongside the qdrant adapter —
 # so the version pinned below is the only hyper in the OSS dependency graph.
 axum = { version = "0.8", features = ["multipart", "ws"] }
+# `query` feature provides a serde_html_form-backed Query extractor that, unlike
+# axum's default serde_urlencoded Query, deserializes repeated/single params into
+# a Vec (used by GET /datasets/status).
+axum-extra = { version = "0.10", features = ["query"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace", "limit"] }
 hyper = { version = "1", features = ["server", "http1", "http2"] }

--- a/crates/http-server/src/dto/datasets.rs
+++ b/crates/http-server/src/dto/datasets.rs
@@ -89,8 +89,11 @@ pub struct DatasetSchemaResponseDTO {
 /// Query string for `GET /api/v1/datasets/status`.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct DatasetStatusQuery {
-    /// Repeated query param `?dataset=<uuid>&dataset=<uuid>`.
-    /// Defaults to an empty list when the parameter is absent.
+    /// Dataset ids as a single (`?dataset=<uuid>`) or repeated
+    /// (`?dataset=<uuid>&dataset=<uuid>`) query param. Deserialized via the
+    /// `axum_extra` (serde_html_form) Query extractor; the default axum Query
+    /// (serde_urlencoded) cannot decode a sequence here. Defaults to an empty
+    /// list when the parameter is absent.
     #[serde(rename = "dataset", default)]
     pub dataset: Vec<Uuid>,
 }

--- a/crates/http-server/src/routers/datasets.rs
+++ b/crates/http-server/src/routers/datasets.rs
@@ -8,10 +8,15 @@ use std::collections::HashMap;
 
 use axum::{
     Json, Router,
-    extract::{Path, Query, State},
+    extract::{Path, State},
     http::StatusCode,
     routing::{delete, get, post, put},
 };
+// serde_html_form-backed Query: deserializes single (`?dataset=a`) and repeated
+// (`?dataset=a&dataset=b`) params into `Vec<Uuid>`. axum's default Query uses
+// serde_urlencoded, which cannot deserialize a sequence and rejects the request
+// with HTTP 400 "invalid type: string …, expected a sequence".
+use axum_extra::extract::Query;
 use cognee_database::{
     DatasetConfigDb, DeleteDb, IngestDb, PipelineRunStatus as DbPipelineRunStatus,
 };

--- a/crates/http-server/tests/test_dataset_status.rs
+++ b/crates/http-server/tests/test_dataset_status.rs
@@ -1,0 +1,73 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression tests for `GET /api/v1/datasets/status`.
+//!
+//! The handler's `dataset: Vec<Uuid>` query used axum's default `Query`
+//! (serde_urlencoded), which cannot deserialize a sequence from query params and
+//! rejected every real request with HTTP 400 "invalid type: string …, expected a
+//! sequence". Switching to the `axum_extra` (serde_html_form) Query extractor
+//! makes both single and repeated `dataset` params deserialize into the Vec.
+
+mod support;
+
+use support::{body_json, build_p4_state, oneshot_get};
+
+use cognee_http_server::build_router;
+
+// A random dataset id with no pipeline run: the handler omits it from the map,
+// so the response is `{}` — but only if the query deserializes at all (the bug
+// made this a 400 before the fix).
+const DATASET_A: &str = "11111111-1111-4111-8111-111111111111";
+const DATASET_B: &str = "22222222-2222-4222-8222-222222222222";
+
+#[tokio::test]
+async fn single_dataset_param_is_accepted() {
+    let state = build_p4_state(None, None, None).await;
+    let app = build_router(state).await.expect("router");
+
+    let resp = oneshot_get(app, &format!("/api/v1/datasets/status?dataset={DATASET_A}")).await;
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "single ?dataset=<uuid> must deserialize (was 400 with serde_urlencoded)"
+    );
+    let body = body_json(resp).await;
+    assert!(body.is_object(), "expected a JSON status map, got {body}");
+    // No pipeline run for a random id -> omitted -> empty map.
+    assert_eq!(body.as_object().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn repeated_dataset_params_are_accepted() {
+    let state = build_p4_state(None, None, None).await;
+    let app = build_router(state).await.expect("router");
+
+    let resp = oneshot_get(
+        app,
+        &format!("/api/v1/datasets/status?dataset={DATASET_A}&dataset={DATASET_B}"),
+    )
+    .await;
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "repeated ?dataset=a&dataset=b must deserialize into Vec<Uuid>"
+    );
+    assert!(body_json(resp).await.is_object());
+}
+
+#[tokio::test]
+async fn absent_dataset_param_returns_empty_map() {
+    let state = build_p4_state(None, None, None).await;
+    let app = build_router(state).await.expect("router");
+
+    let resp = oneshot_get(app, "/api/v1/datasets/status").await;
+
+    assert_eq!(resp.status(), 200);
+    let body = body_json(resp).await;
+    assert_eq!(body.as_object().unwrap().len(), 0);
+}


### PR DESCRIPTION
## Problem

`GET /api/v1/datasets/status` declares its query as `dataset: Vec<Uuid>` behind axum's **default** `Query` extractor (serde_urlencoded), which cannot deserialize a sequence from query params. Every real request is rejected before the handler runs:

- `?dataset=<uuid>` (single) → **400** `Failed to deserialize query string: dataset: invalid type: string "…", expected a sequence`
- `?dataset=<a>&dataset=<b>` (repeated — the form the doc-comment advertised) → **400** (serde_urlencoded ignores repeated keys)
- param absent → `{}`

So the endpoint can never report a real status. Clients that speak the Python SDK wire contract (FastAPI coerces a scalar query param into a one-element `list[UUID]`) — e.g. status-polling test/benchmark clients — break against the Rust server.

## Fix

Switch that one handler to the [`axum_extra`](https://docs.rs/axum-extra) `Query` extractor (serde_html_form backend), which deserializes both single (`?dataset=a`) and repeated (`?dataset=a&dataset=b`) params into the `Vec<Uuid>`. Everything else is unchanged — auth, the per-dataset `read` permission check, the status-string mapping, and empty/absent handling.

## Changes
- `crates/http-server/Cargo.toml` — add `axum-extra = { version = "0.10", features = ["query"] }`
- `crates/http-server/src/routers/datasets.rs` — use `axum_extra::extract::Query` for `get_dataset_status`
- `crates/http-server/src/dto/datasets.rs` — doc-comment update
- `crates/http-server/tests/test_dataset_status.rs` — new regression tests (single / repeated / absent → 200, previously 400)

## Test
```
cargo test -p cognee-http-server --test test_dataset_status
# running 3 tests ... ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)