### PR TITLE
fix(llm): apply PR #40 review findings (Anthropic adapter)

### DIFF
--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -135,6 +135,7 @@ mod tests {
                 model: "gpt-4o-mini".to_string(),
                 api_key: "sk-test".to_string(),
                 endpoint: String::new(),
+                anthropic_base_url: None,
                 max_retries: 3,
                 max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
                 llm_args: serde_json::Map::new(),

--- a/crates/components/src/builtins/llm.rs
+++ b/crates/components/src/builtins/llm.rs
@@ -101,17 +101,24 @@ impl LlmFactory for AnthropicLlmFactory {
                 "anthropic provider requires an API key (set LLM_API_KEY)".to_string(),
             ));
         }
-        // Do NOT inherit `ctx.llm.endpoint`: it aliases OPENAI_URL (a
-        // documented-required var in this repo), so flipping LLM_PROVIDER=anthropic
-        // while OPENAI_URL is still set would POST every request to the OpenAI host
-        // with an x-api-key header (404/401 on all traffic). Python's Anthropic
-        // path passes no base_url either, so use the Anthropic default.
-        let adapter = AnthropicAdapter::new(ctx.llm.model.clone(), ctx.llm.api_key.clone(), None)
-            .map_err(|e| ComponentError::Llm(e.to_string()))?
-            .with_structured_output_retries(ctx.llm.max_retries)
-            .with_network_retries(ctx.llm.max_retries)
-            .with_max_completion_tokens(ctx.llm.max_completion_tokens)
-            .with_extra_args(ctx.llm.llm_args.clone());
+        // Use the dedicated `ctx.llm.anthropic_base_url` (env `ANTHROPIC_BASE_URL`
+        // / `ANTHROPIC_API_BASE`), NOT `ctx.llm.endpoint`: the latter aliases
+        // OPENAI_URL (a documented-required var in this repo), so flipping
+        // LLM_PROVIDER=anthropic while OPENAI_URL is still set would POST every
+        // request to the OpenAI host with an x-api-key header (404/401 on all
+        // traffic). `None` (the default) uses the public Anthropic API, matching
+        // Python; the override exists for proxy / gateway / Bedrock-compatible
+        // endpoints.
+        let adapter = AnthropicAdapter::new(
+            ctx.llm.model.clone(),
+            ctx.llm.api_key.clone(),
+            ctx.llm.anthropic_base_url.clone(),
+        )
+        .map_err(|e| ComponentError::Llm(e.to_string()))?
+        .with_structured_output_retries(ctx.llm.max_retries)
+        .with_network_retries(ctx.llm.max_retries)
+        .with_max_completion_tokens(ctx.llm.max_completion_tokens)
+        .with_extra_args(ctx.llm.llm_args.clone());
         Ok(Arc::new(adapter))
     }
 

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -101,6 +101,12 @@ pub struct LlmInputs {
     pub model: String,
     pub api_key: String,
     pub endpoint: String,
+    /// Optional Anthropic Messages API base URL override (env `ANTHROPIC_BASE_URL`,
+    /// alias `ANTHROPIC_API_BASE`). `None` uses the public Anthropic API. Kept
+    /// separate from `endpoint` on purpose: `endpoint` aliases `OPENAI_URL`, so
+    /// inheriting it would point Anthropic traffic at the OpenAI host. Only the
+    /// Anthropic factory consumes it; other providers ignore it.
+    pub anthropic_base_url: Option<String>,
     pub max_retries: u32,
     /// Output-token ceiling (Python's `llm_max_completion_tokens`), lowered from
     /// `Settings.llm_max_completion_tokens` (`setLlmMaxCompletionTokens`). Applied
@@ -121,4 +127,19 @@ pub struct LlmInputs {
     pub cassette: String,
     /// When non-empty, wraps the real adapter in a recorder (`mock-llm`).
     pub record_path: String,
+}
+
+/// Read the optional Anthropic base-URL override from the environment
+/// (`ANTHROPIC_BASE_URL`, alias `ANTHROPIC_API_BASE`). Trims surrounding
+/// whitespace and treats an empty value as unset (`None`).
+///
+/// Lives here — the env-read boundary for [`LlmInputs`] — so both the SDK
+/// `Settings` and the standalone HTTP server resolve the same knob identically
+/// when lowering their config into a [`BackendBuildContext`].
+pub fn anthropic_base_url_from_env() -> Option<String> {
+    std::env::var("ANTHROPIC_BASE_URL")
+        .or_else(|_| std::env::var("ANTHROPIC_API_BASE"))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }

--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -34,7 +34,7 @@ mod registry;
 mod traits;
 
 pub use builtins::{build_database, build_embedding_config, build_storage};
-pub use context::{BackendBuildContext, EmbeddingInputs, LlmInputs};
+pub use context::{BackendBuildContext, EmbeddingInputs, LlmInputs, anthropic_base_url_from_env};
 pub use error::ComponentError;
 pub use registry::ComponentRegistry;
 pub use traits::{EmbeddingFactory, GraphDbFactory, LlmFactory, VectorDbFactory};

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -405,6 +405,7 @@ mod tests {
                 model: "gpt-4o-mini".to_string(),
                 api_key: "sk-test".to_string(),
                 endpoint: String::new(),
+                anthropic_base_url: None,
                 max_retries: 3,
                 max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
                 llm_args: serde_json::Map::new(),

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -677,6 +677,7 @@ impl HttpServerConfig {
                 model: self.llm_model.clone(),
                 api_key: self.llm_api_key.expose_secret().to_string(),
                 endpoint: self.llm_endpoint.clone(),
+                anthropic_base_url: cognee_components::anthropic_base_url_from_env(),
                 max_retries: self.llm_max_retries,
                 // Env-configurable via `LLM_MAX_COMPLETION_TOKENS`, mirroring
                 // `Settings.llm_max_completion_tokens` on the CLI/SDK path so

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -843,6 +843,7 @@ impl Settings {
                 model: self.llm_model.clone(),
                 api_key: self.llm_api_key.clone(),
                 endpoint: self.llm_endpoint.clone(),
+                anthropic_base_url: cognee_components::anthropic_base_url_from_env(),
                 max_retries: self.llm_max_retries,
                 max_completion_tokens: self.llm_max_completion_tokens,
                 llm_args: self.llm_args.clone(),

--- a/crates/llm/src/adapters/anthropic.rs
+++ b/crates/llm/src/adapters/anthropic.rs
@@ -452,20 +452,30 @@ impl AnthropicAdapter {
                             // finished at the budget from one whose nested
                             // list/string was cut off. Re-asking with the SAME budget
                             // would truncate again at the same point, so raise it
-                            // toward the model's documented cap for the next attempt.
-                            // If we are already at that cap a larger budget is
-                            // impossible, so fail terminally rather than re-ask until
-                            // MaxRetriesExceeded.
-                            let model_cap = Self::model_max_output_tokens(&self.model);
+                            // toward the effective output budget for the next attempt.
+                            // That budget is the model cap bounded by the configured
+                            // `llm_max_completion_tokens` ceiling: `effective_max_tokens`
+                            // documents the ceiling as an upper bound on *every* path,
+                            // so the retry must not exceed it — matching the Python
+                            // reference, which caps every path at
+                            // `llm_max_completion_tokens` and never raises the budget on
+                            // truncation. If we are already at that effective cap a
+                            // larger budget is not allowed, so fail terminally rather
+                            // than re-ask until MaxRetriesExceeded (a truncation under a
+                            // binding cost ceiling is unrecoverable by design).
+                            let effective_cap = Self::model_max_output_tokens(&self.model)
+                                .min(self.max_completion_tokens)
+                                .max(1);
                             let current = body["max_tokens"].as_u64().unwrap_or(0) as u32;
-                            if current >= model_cap {
+                            if current >= effective_cap {
                                 return Err(LlmError::InvalidResponse(format!(
-                                    "Anthropic structured output was truncated at the model's \
-                                     {model_cap}-token output cap and cannot be completed within \
-                                     that budget"
+                                    "Anthropic structured output was truncated at the effective \
+                                     {effective_cap}-token output budget (the lesser of the \
+                                     llm_max_completion_tokens ceiling and the model cap) and \
+                                     cannot be completed within that budget"
                                 )));
                             }
-                            body["max_tokens"] = json!(model_cap);
+                            body["max_tokens"] = json!(effective_cap);
                             let reason = "the previous answer was cut off at max_tokens before \
                                           the object was complete";
                             last_error = LlmError::InvalidResponse(format!(

--- a/crates/llm/src/adapters/anthropic.rs
+++ b/crates/llm/src/adapters/anthropic.rs
@@ -168,10 +168,25 @@ impl AnthropicAdapter {
     /// forwarded above a model's real cap and 400 the request.
     fn model_max_output_tokens(model: &str) -> u32 {
         let m = model.to_ascii_lowercase();
-        Self::MODEL_OUTPUT_CAPS
+        match Self::MODEL_OUTPUT_CAPS
             .iter()
             .find(|(pattern, _)| m.contains(*pattern))
-            .map_or(Self::UNKNOWN_MODEL_OUTPUT_CAP, |(_, cap)| *cap)
+        {
+            Some((_, cap)) => *cap,
+            None => {
+                // An unlisted model falls back to the conservative cap, which
+                // under-budgets a model that actually supports more until
+                // MODEL_OUTPUT_CAPS is refreshed. Surface it at debug level so the
+                // under-budgeting is diagnosable rather than silent (no per-request
+                // warn spam, but visible when tracing the LLM path).
+                debug!(
+                    model,
+                    fallback_cap = Self::UNKNOWN_MODEL_OUTPUT_CAP,
+                    "Anthropic model not in MODEL_OUTPUT_CAPS; using conservative output cap",
+                );
+                Self::UNKNOWN_MODEL_OUTPUT_CAP
+            }
+        }
     }
 
     /// The `max_tokens` to send: `min(caller value, configured ceiling, model cap)`.
@@ -370,38 +385,6 @@ impl AnthropicAdapter {
         body
     }
 
-    /// Build a schema-aware validator for the type-erased raw path (which has no
-    /// Rust type to deserialize into).
-    ///
-    /// Enforces that every property named in the schema's top-level `required`
-    /// array is present and non-null, so a tool input omitting a required field
-    /// drives a corrective retry instead of being returned as `Ok`. Mirrors the
-    /// OpenAI adapter's validator; folding the two into one shared helper belongs
-    /// with the `llm::http` extraction follow-up rather than churning `openai.rs`
-    /// here.
-    fn schema_required_validator(schema: &Value) -> impl Fn(&Value) -> Result<(), String> + '_ {
-        move |value: &Value| {
-            let Some(required) = schema.get("required").and_then(Value::as_array) else {
-                return Ok(());
-            };
-            let Some(obj) = value.as_object() else {
-                return Err("expected a JSON object".to_string());
-            };
-            for field in required {
-                if let Some(name) = field.as_str() {
-                    match obj.get(name) {
-                        None => return Err(format!("missing required field `{name}`")),
-                        Some(Value::Null) => {
-                            return Err(format!("required field `{name}` is null"));
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            Ok(())
-        }
-    }
-
     /// Append a corrective instruction to the last user turn so the next attempt
     /// carries the failure reason, the way instructor reasks with the validation
     /// error (mirrors `OpenAIAdapter::append_corrective_instruction`).
@@ -480,17 +463,32 @@ impl AnthropicAdapter {
                     // Re-ask instead of returning a partial object.
                     let truncated = response.stop_reason.as_deref() == Some("max_tokens");
                     match response.tool_input(STRUCTURED_OUTPUT_TOOL) {
-                        Some(_) if truncated => {
-                            // The tool input was cut off at max_tokens: present and
-                            // JSON-parseable, but incomplete. Re-asking with the SAME
-                            // budget would truncate again at the same point, so raise
-                            // it toward the model's documented cap for the next
-                            // attempt. If we are already at that cap a larger budget
-                            // is impossible, so fail terminally rather than re-ask
-                            // until MaxRetriesExceeded.
+                        Some(input) if truncated => {
+                            // The tool input was cut off at max_tokens. Re-asking
+                            // with the SAME budget would truncate again at the same
+                            // point, so raise it toward the model's documented cap
+                            // for the next attempt — this lets a *semantically*
+                            // truncated object (required fields present but a
+                            // cut-off list/string) be completed rather than returned
+                            // half-filled.
                             let model_cap = Self::model_max_output_tokens(&self.model);
                             let current = body["max_tokens"].as_u64().unwrap_or(0) as u32;
                             if current >= model_cap {
+                                // No headroom left to raise the budget: re-asking
+                                // cannot produce a longer answer, so this is the most
+                                // complete result obtainable. A stop at max_tokens can
+                                // still coincide with a complete, schema-valid object
+                                // that finished exactly at the cap, so return it as
+                                // best-effort rather than discarding a usable answer
+                                // as a hard failure. Only fail terminally when it is
+                                // actually unusable (fails the validator).
+                                let usable = match validator {
+                                    Some(v) => v(&input).is_ok(),
+                                    None => true,
+                                };
+                                if usable {
+                                    return Ok(input);
+                                }
                                 return Err(LlmError::InvalidResponse(format!(
                                     "Anthropic structured output was truncated at the model's \
                                      {model_cap}-token output cap and cannot be completed within \
@@ -588,10 +586,10 @@ impl Llm for AnthropicAdapter {
         options: Option<GenerationOptions>,
     ) -> LlmResult<Value> {
         // The raw path has no Rust type to deserialize into, so synthesise a
-        // schema-aware validator (same as the OpenAI adapter): a tool input that
-        // omits a required field drives a corrective retry instead of returning
-        // `Ok` and aborting the caller at deserialization.
-        let validator = Self::schema_required_validator(json_schema);
+        // schema-aware validator (shared with the OpenAI adapter): a tool input
+        // that omits a required field drives a corrective retry instead of
+        // returning `Ok` and aborting the caller at deserialization.
+        let validator = crate::schema::schema_required_validator(json_schema);
         self.structured_output_impl(messages, json_schema, options, Some(&validator))
             .await
     }
@@ -642,14 +640,24 @@ impl Llm for AnthropicAdapter {
             )));
         }
         let b64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
-        let max_tokens = options.as_ref().and_then(|o| o.max_tokens).unwrap_or(300);
+        // Clamp to the model's documented output cap, like the chat path's
+        // `effective_max_tokens`. A caller supplying GenerationOptions with the
+        // default max_tokens (16384) on a model whose cap is lower (e.g. Claude
+        // 3.5 at 8192) would otherwise 400 the vision request. Floored at 1 so a
+        // zero never 400s either.
+        let max_tokens = options
+            .as_ref()
+            .and_then(|o| o.max_tokens)
+            .unwrap_or(300)
+            .min(Self::model_max_output_tokens(&self.model))
+            .max(1);
 
         // Anthropic vision uses a base64 `image` content block (not OpenAI's
         // `image_url`). Built directly, not via `base_request`, so `LLM_ARGS` do
         // not bleed into the description request (matching the OpenAI adapter).
         let request_body = json!({
             "model": self.model,
-            "max_tokens": max_tokens.max(1),
+            "max_tokens": max_tokens,
             "messages": [{
                 "role": "user",
                 "content": [

--- a/crates/llm/src/adapters/anthropic.rs
+++ b/crates/llm/src/adapters/anthropic.rs
@@ -386,32 +386,11 @@ impl AnthropicAdapter {
     }
 
     /// Append a corrective instruction to the last user turn so the next attempt
-    /// carries the failure reason, the way instructor reasks with the validation
-    /// error (mirrors `OpenAIAdapter::append_corrective_instruction`).
+    /// carries the failure reason. Thin wrapper over the shared
+    /// [`crate::schema::append_corrective_instruction`] naming the forced tool as
+    /// Anthropic addresses it (`tool_use`).
     fn append_corrective_instruction(body: &mut Value, reason: Option<&str>) {
-        let detail = match reason {
-            Some(r) => format!("Your previous response failed validation: {r}. "),
-            None => "Your previous response could not be parsed into the required structure. "
-                .to_string(),
-        };
-        let instruction = format!(
-            "{detail}Call the `{STRUCTURED_OUTPUT_TOOL}` tool again and return ONE complete \
-             object that fills in every required field, strictly matching the schema. No extra text."
-        );
-        let Some(messages) = body["messages"].as_array_mut() else {
-            return;
-        };
-        match messages.last_mut() {
-            // Extend the existing user turn in place.
-            Some(last) if last["role"] == "user" => {
-                let original = last["content"].as_str().unwrap_or("").to_string();
-                last["content"] = json!(format!("{original}\n\n{instruction}"));
-            }
-            // Last turn is assistant, or there is no turn: a bare append would be
-            // a no-op and the correction would be silently dropped, so add a new
-            // user turn carrying it.
-            _ => messages.push(json!({ "role": "user", "content": instruction })),
-        }
+        crate::schema::append_corrective_instruction(body, reason, STRUCTURED_OUTPUT_TOOL, "tool");
     }
 
     /// Shared structured-output loop with instructor-style corrective retries.
@@ -463,32 +442,23 @@ impl AnthropicAdapter {
                     // Re-ask instead of returning a partial object.
                     let truncated = response.stop_reason.as_deref() == Some("max_tokens");
                     match response.tool_input(STRUCTURED_OUTPUT_TOOL) {
-                        Some(input) if truncated => {
-                            // The tool input was cut off at max_tokens. Re-asking
-                            // with the SAME budget would truncate again at the same
-                            // point, so raise it toward the model's documented cap
-                            // for the next attempt — this lets a *semantically*
-                            // truncated object (required fields present but a
-                            // cut-off list/string) be completed rather than returned
-                            // half-filled.
+                        Some(_) if truncated => {
+                            // The tool input was cut off at max_tokens: present and
+                            // JSON-parseable, but incomplete. Match the Python
+                            // reference (instructor), which rejects a length-truncated
+                            // structured response outright — before validation —
+                            // rather than returning a partial object: a shallow
+                            // top-level check cannot tell a complete object that
+                            // finished at the budget from one whose nested
+                            // list/string was cut off. Re-asking with the SAME budget
+                            // would truncate again at the same point, so raise it
+                            // toward the model's documented cap for the next attempt.
+                            // If we are already at that cap a larger budget is
+                            // impossible, so fail terminally rather than re-ask until
+                            // MaxRetriesExceeded.
                             let model_cap = Self::model_max_output_tokens(&self.model);
                             let current = body["max_tokens"].as_u64().unwrap_or(0) as u32;
                             if current >= model_cap {
-                                // No headroom left to raise the budget: re-asking
-                                // cannot produce a longer answer, so this is the most
-                                // complete result obtainable. A stop at max_tokens can
-                                // still coincide with a complete, schema-valid object
-                                // that finished exactly at the cap, so return it as
-                                // best-effort rather than discarding a usable answer
-                                // as a hard failure. Only fail terminally when it is
-                                // actually unusable (fails the validator).
-                                let usable = match validator {
-                                    Some(v) => v(&input).is_ok(),
-                                    None => true,
-                                };
-                                if usable {
-                                    return Ok(input);
-                                }
                                 return Err(LlmError::InvalidResponse(format!(
                                     "Anthropic structured output was truncated at the model's \
                                      {model_cap}-token output cap and cannot be completed within \

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -566,39 +566,16 @@ impl OpenAIAdapter {
     }
 
     /// Append a corrective instruction so the next attempt carries the failure
-    /// reason, the way instructor reasks with the validation error. When `reason`
-    /// is `Some`, it is surfaced verbatim (e.g. a serde `missing field type`
-    /// message) so the model knows precisely which required field or structural
-    /// constraint the previous response violated.
-    ///
-    /// Extends the last user turn in place when there is one; otherwise (the last
-    /// turn is an assistant message, or there is no turn) it pushes a new user
-    /// turn carrying the instruction, so the correction is never silently
-    /// dropped. Mirrors `AnthropicAdapter::append_corrective_instruction`.
+    /// reason. Thin wrapper over the shared
+    /// [`crate::schema::append_corrective_instruction`] naming the forced tool as
+    /// OpenAI addresses it (a `function` call).
     fn append_corrective_instruction(request: &mut Value, reason: Option<&str>) {
-        let detail = match reason {
-            Some(r) => format!("Your previous response failed validation: {r}. "),
-            None => "Your previous response could not be parsed into the required structure. "
-                .to_string(),
-        };
-        let instruction = format!(
-            "{detail}Call the `extract_structured_data` function again and return ONE valid \
-             object that fills in every required field, strictly matching the schema. No extra text."
+        crate::schema::append_corrective_instruction(
+            request,
+            reason,
+            "extract_structured_data",
+            "function",
         );
-        let Some(messages) = request["messages"].as_array_mut() else {
-            return;
-        };
-        match messages.last_mut() {
-            // Extend the existing user turn in place.
-            Some(last) if last["role"] == "user" => {
-                let original = last["content"].as_str().unwrap_or("").to_string();
-                last["content"] = json!(format!("{original}\n\n{instruction}"));
-            }
-            // Last turn is assistant, or there is no turn: a bare append would be a
-            // no-op and the correction would be silently dropped, so add a new user
-            // turn carrying it.
-            _ => messages.push(json!({ "role": "user", "content": instruction })),
-        }
     }
 }
 

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -525,47 +525,6 @@ impl OpenAIAdapter {
         serde_json::to_string_pretty(&example).unwrap_or_else(|_| "{}".to_string())
     }
 
-    /// Append a corrective instruction to the last user message of `request`,
-    /// nudging the model to return a single valid object on a retry attempt.
-    /// Mirrors instructor's repair prompt on a validation/parse failure.
-    ///
-    /// When `reason` is `Some`, it is surfaced verbatim (e.g. a serde
-    /// `missing field \`type\`` message) so the model knows precisely which
-    /// required field or structural constraint the previous response violated —
-    /// this threads `T`'s typed validation into the repair prompt, matching how
-    /// instructor feeds the validation error back to the model.
-    /// Build a schema-aware validator for the type-erased raw path (which has no
-    /// Rust type to deserialize into).
-    ///
-    /// Enforces that every property named in the schema's top-level `required`
-    /// array is present and non-null. This gives the raw path the same
-    /// required-field guarantee instructor provides for a typed model, *without*
-    /// strict/grammar-constrained decoding (`response_format: json_schema`, which
-    /// 501s on Baseten): a response omitting a required field is fed back into the
-    /// existing corrective-retry loop instead of being accepted or hard-failing.
-    fn schema_required_validator(schema: &Value) -> impl Fn(&Value) -> Result<(), String> + '_ {
-        move |value: &Value| {
-            let Some(required) = schema.get("required").and_then(Value::as_array) else {
-                return Ok(());
-            };
-            let Some(obj) = value.as_object() else {
-                return Err("expected a JSON object".to_string());
-            };
-            for field in required {
-                if let Some(name) = field.as_str() {
-                    match obj.get(name) {
-                        None => return Err(format!("missing required field `{name}`")),
-                        Some(Value::Null) => {
-                            return Err(format!("required field `{name}` is null"));
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            Ok(())
-        }
-    }
-
     /// Recompute the schema's top-level `required` array to list every property
     /// whose subschema carries no literal `"default"` key — a port of
     /// instructor's `generate_openai_schema` (`instructor/processing/schema.py`),
@@ -606,22 +565,39 @@ impl OpenAIAdapter {
         schema
     }
 
+    /// Append a corrective instruction so the next attempt carries the failure
+    /// reason, the way instructor reasks with the validation error. When `reason`
+    /// is `Some`, it is surfaced verbatim (e.g. a serde `missing field type`
+    /// message) so the model knows precisely which required field or structural
+    /// constraint the previous response violated.
+    ///
+    /// Extends the last user turn in place when there is one; otherwise (the last
+    /// turn is an assistant message, or there is no turn) it pushes a new user
+    /// turn carrying the instruction, so the correction is never silently
+    /// dropped. Mirrors `AnthropicAdapter::append_corrective_instruction`.
     fn append_corrective_instruction(request: &mut Value, reason: Option<&str>) {
-        if let Some(messages) = request["messages"].as_array_mut()
-            && let Some(last_msg) = messages.last_mut()
-            && last_msg["role"] == "user"
-        {
-            let original = last_msg["content"].as_str().unwrap_or("");
-            let detail = match reason {
-                Some(r) => format!("Your previous response failed validation: {r}. "),
-                None => "Your previous response could not be parsed into the required structure. "
-                    .to_string(),
-            };
-            last_msg["content"] = json!(format!(
-                "{original}\n\n{detail}Call the `extract_structured_data` function again and \
-                 return ONE valid object that fills in every required field, strictly matching \
-                 the schema. No extra text."
-            ));
+        let detail = match reason {
+            Some(r) => format!("Your previous response failed validation: {r}. "),
+            None => "Your previous response could not be parsed into the required structure. "
+                .to_string(),
+        };
+        let instruction = format!(
+            "{detail}Call the `extract_structured_data` function again and return ONE valid \
+             object that fills in every required field, strictly matching the schema. No extra text."
+        );
+        let Some(messages) = request["messages"].as_array_mut() else {
+            return;
+        };
+        match messages.last_mut() {
+            // Extend the existing user turn in place.
+            Some(last) if last["role"] == "user" => {
+                let original = last["content"].as_str().unwrap_or("").to_string();
+                last["content"] = json!(format!("{original}\n\n{instruction}"));
+            }
+            // Last turn is assistant, or there is no turn: a bare append would be a
+            // no-op and the correction would be silently dropped, so add a new user
+            // turn carrying it.
+            _ => messages.push(json!({ "role": "user", "content": instruction })),
         }
     }
 }
@@ -700,7 +676,7 @@ impl Llm for OpenAIAdapter {
         // `summarize_one` needs the `summary` field present). Synthesise a
         // schema-aware validator so an omitted required field drives the same
         // corrective retry a typed caller gets, matching instructor.
-        let validator = Self::schema_required_validator(json_schema);
+        let validator = crate::schema::schema_required_validator(json_schema);
         self.structured_output_impl(messages, json_schema, options, Some(&validator))
             .await
     }
@@ -1739,26 +1715,6 @@ mod tests {
         classic.apply_extra_args(&mut body);
         assert_eq!(body["max_tokens"], 16384);
         assert!(body.get("max_completion_tokens").is_none());
-    }
-
-    #[test]
-    fn test_schema_required_validator_enforces_required_fields() {
-        // #3: the raw path synthesises a schema-aware validator so an omitted
-        // required field is a retryable miss (not silently accepted).
-        let schema = json!({
-            "type": "object",
-            "required": ["summary"],
-            "properties": {"summary": {"type": "string"}}
-        });
-        let validate = OpenAIAdapter::schema_required_validator(&schema);
-        assert!(validate(&json!({"summary": "hello"})).is_ok());
-        assert!(validate(&json!({"other": "x"})).is_err());
-        assert!(validate(&json!({"summary": null})).is_err());
-
-        // No `required` array → nothing to enforce.
-        let loose = json!({"type": "object"});
-        let validate = OpenAIAdapter::schema_required_validator(&loose);
-        assert!(validate(&json!({})).is_ok());
     }
 
     #[test]

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -74,7 +74,7 @@ pub use llm_trait::{Llm, LlmExt};
 pub use responses_client::{OpenAIResponsesClient, ResponsesClient, ResponsesRequest};
 pub use schema::{
     build_schema_prompt, generate_json_schema, generate_json_schema_string, graph_model_to_schema,
-    graph_model_to_schema_string,
+    graph_model_to_schema_string, schema_required_validator,
 };
 pub use transcriber::{Transcriber, TranscriptionOutput, validate_audio_format};
 pub use types::{

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -73,8 +73,9 @@ pub use factory::build_openai_compatible_adapter;
 pub use llm_trait::{Llm, LlmExt};
 pub use responses_client::{OpenAIResponsesClient, ResponsesClient, ResponsesRequest};
 pub use schema::{
-    build_schema_prompt, generate_json_schema, generate_json_schema_string, graph_model_to_schema,
-    graph_model_to_schema_string, schema_required_validator,
+    append_corrective_instruction, build_schema_prompt, generate_json_schema,
+    generate_json_schema_string, graph_model_to_schema, graph_model_to_schema_string,
+    schema_required_validator,
 };
 pub use transcriber::{Transcriber, TranscriptionOutput, validate_audio_format};
 pub use types::{

--- a/crates/llm/src/schema.rs
+++ b/crates/llm/src/schema.rs
@@ -5,7 +5,7 @@
 //! correctly structured output.
 
 use schemars::{JsonSchema, schema_for};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 /// Generate a JSON schema for a given type.
 ///
@@ -215,6 +215,53 @@ pub fn schema_required_validator(schema: &Value) -> impl Fn(&Value) -> Result<()
     }
 }
 
+/// Append a corrective instruction to a chat request's `messages` array so the
+/// next structured-output attempt carries the failure reason, the way instructor
+/// reasks with the validation error. When `reason` is `Some`, it is surfaced
+/// verbatim (e.g. a serde "missing field type" message) so the model knows
+/// precisely which required field or structural constraint the previous response
+/// violated.
+///
+/// Extends the last user turn in place when there is one; otherwise (the last
+/// turn is an assistant message, or there is no turn) it pushes a new user turn
+/// carrying the instruction, so the correction is never silently dropped.
+/// `tool_name` / `tool_kind` name the forced extractor as the provider addresses
+/// it — e.g. `"extract_structured_data"` + `"tool"` for Anthropic, or
+/// `+ "function"` for OpenAI. Shared by both adapters (previously a near-verbatim
+/// copy in each) so the corrective-retry prompt stays consistent across
+/// providers.
+pub fn append_corrective_instruction(
+    request: &mut Value,
+    reason: Option<&str>,
+    tool_name: &str,
+    tool_kind: &str,
+) {
+    let detail = match reason {
+        Some(r) => format!("Your previous response failed validation: {r}. "),
+        None => {
+            "Your previous response could not be parsed into the required structure. ".to_string()
+        }
+    };
+    let instruction = format!(
+        "{detail}Call the `{tool_name}` {tool_kind} again and return ONE complete object that \
+         fills in every required field, strictly matching the schema. No extra text."
+    );
+    let Some(messages) = request["messages"].as_array_mut() else {
+        return;
+    };
+    match messages.last_mut() {
+        // Extend the existing user turn in place.
+        Some(last) if last["role"] == "user" => {
+            let original = last["content"].as_str().unwrap_or("").to_string();
+            last["content"] = json!(format!("{original}\n\n{instruction}"));
+        }
+        // Last turn is assistant, or there is no turn: a bare append would be a
+        // no-op and the correction would be silently dropped, so add a new user
+        // turn carrying it.
+        _ => messages.push(json!({ "role": "user", "content": instruction })),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(
@@ -224,7 +271,6 @@ mod tests {
     )]
     use super::*;
     use serde::{Deserialize, Serialize};
-    use serde_json::json;
 
     #[derive(Serialize, Deserialize, JsonSchema)]
     struct TestPerson {

--- a/crates/llm/src/schema.rs
+++ b/crates/llm/src/schema.rs
@@ -181,6 +181,40 @@ IMPORTANT: Return ONLY the JSON object. No additional text before or after."#
     )
 }
 
+/// Build a schema-aware validator for the type-erased raw structured-output path
+/// (which has no Rust type to deserialize into).
+///
+/// Enforces that every property named in the schema's top-level `required` array
+/// is present and non-null, so a tool/function input omitting a required field
+/// drives a corrective retry instead of being returned as `Ok`. Deliberately
+/// shallow (top-level only), matching the non-strict tool-calling path both
+/// adapters use — it does not recurse into `$defs` or set `additionalProperties`.
+///
+/// Shared by the OpenAI and Anthropic adapters so the raw path validates
+/// identically across providers (previously a verbatim copy in each adapter).
+pub fn schema_required_validator(schema: &Value) -> impl Fn(&Value) -> Result<(), String> + '_ {
+    move |value: &Value| {
+        let Some(required) = schema.get("required").and_then(Value::as_array) else {
+            return Ok(());
+        };
+        let Some(obj) = value.as_object() else {
+            return Err("expected a JSON object".to_string());
+        };
+        for field in required {
+            if let Some(name) = field.as_str() {
+                match obj.get(name) {
+                    None => return Err(format!("missing required field `{name}`")),
+                    Some(Value::Null) => {
+                        return Err(format!("required field `{name}` is null"));
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(
@@ -190,6 +224,7 @@ mod tests {
     )]
     use super::*;
     use serde::{Deserialize, Serialize};
+    use serde_json::json;
 
     #[derive(Serialize, Deserialize, JsonSchema)]
     struct TestPerson {
@@ -246,5 +281,27 @@ mod tests {
 
         let pretty_str = graph_model_to_schema_string::<TestPerson>(true);
         assert!(pretty_str.contains('\n'));
+    }
+
+    #[test]
+    fn schema_required_validator_enforces_required_fields() {
+        // The raw structured-output path synthesises this validator so an omitted
+        // required field is a retryable miss (not silently accepted). Shared by
+        // the OpenAI and Anthropic adapters.
+        let schema = json!({
+            "type": "object",
+            "required": ["summary"],
+            "properties": {"summary": {"type": "string"}}
+        });
+        let validate = schema_required_validator(&schema);
+        assert!(validate(&json!({"summary": "hello"})).is_ok());
+        assert!(validate(&json!({"other": "x"})).is_err());
+        assert!(validate(&json!({"summary": null})).is_err());
+        assert!(validate(&json!("not an object")).is_err());
+
+        // No `required` array → nothing to enforce.
+        let loose = json!({"type": "object"});
+        let validate = schema_required_validator(&loose);
+        assert!(validate(&json!({})).is_ok());
     }
 }

--- a/crates/llm/tests/anthropic_truncation_retry.rs
+++ b/crates/llm/tests/anthropic_truncation_retry.rs
@@ -8,10 +8,13 @@
 //!
 //! When Anthropic returns `stop_reason == "max_tokens"` the tool input was cut
 //! off mid-object. Re-asking with the *same* `max_tokens` would truncate again
-//! at the same point, so the adapter must raise the budget toward the model's
-//! documented output cap on the retry. This test pins that behavior: the first
-//! request (a low configured ceiling) truncates, and the retry must arrive with
-//! `max_tokens` raised to the model cap and then succeed.
+//! at the same point, so the adapter raises the budget toward the *effective*
+//! output cap — `min(llm_max_completion_tokens ceiling, model cap)` — on the
+//! retry, and fails terminally once that effective cap is reached (the ceiling
+//! is an upper bound on every path, matching the Python reference). These tests
+//! pin both behaviors: a caller request below the effective cap gets a raised
+//! retry that succeeds, while a budget already at the effective cap fails
+//! without looping.
 
 use cognee_llm::{AnthropicAdapter, GenerationOptions, LlmExt};
 use httpmock::prelude::*;
@@ -25,11 +28,12 @@ struct Person {
 }
 
 #[tokio::test]
-async fn truncation_retry_raises_max_tokens_to_the_model_cap() {
+async fn truncation_retry_raises_max_tokens_to_the_effective_cap() {
     let server = MockServer::start_async().await;
 
-    // First attempt is sent at the configured ceiling (1000). Return a
-    // tool_use that is present and JSON-parseable but flagged truncated.
+    // First attempt is sent at the caller-requested budget (1000), which is
+    // below the effective cap so there is headroom to raise. Return a tool_use
+    // that is present and JSON-parseable but flagged truncated.
     let truncated = server
         .mock_async(|when, then| {
             when.method(POST)
@@ -54,9 +58,9 @@ async fn truncation_retry_raises_max_tokens_to_the_model_cap() {
         })
         .await;
 
-    // The retry must arrive with max_tokens raised to the model cap (64000 for
-    // Claude Sonnet 4), not the original 1000. Only then do we return a
-    // complete object.
+    // The retry must arrive with max_tokens raised to the effective cap: 64000 =
+    // min(ceiling 64000, Claude Sonnet 4 model cap 64000), not the original 1000.
+    // Only then do we return a complete object.
     let completed = server
         .mock_async(|when, then| {
             when.method(POST)
@@ -81,14 +85,17 @@ async fn truncation_retry_raises_max_tokens_to_the_model_cap() {
         })
         .await;
 
-    // Sonnet 4 caps output at 64k; a 1000-token ceiling leaves headroom to raise.
+    // Ceiling is set to the model cap (64000), and the caller requests only 1000,
+    // so the effective cap is 64000 and there is headroom above the first budget
+    // to raise into. (A ceiling *below* the model cap that binds the first budget
+    // is the terminal case — see the test below.)
     let adapter = AnthropicAdapter::new(
         "claude-sonnet-4-20250514",
         "test-key",
         Some(server.base_url()),
     )
     .expect("construct AnthropicAdapter")
-    .with_max_completion_tokens(1000)
+    .with_max_completion_tokens(64_000)
     .with_network_retries(0);
 
     let person: Person = adapter
@@ -97,6 +104,7 @@ async fn truncation_retry_raises_max_tokens_to_the_model_cap() {
             "Extract the person's name and age.",
             Some(GenerationOptions {
                 temperature: Some(0.0),
+                max_tokens: Some(1000),
                 ..Default::default()
             }),
         )
@@ -106,10 +114,73 @@ async fn truncation_retry_raises_max_tokens_to_the_model_cap() {
     assert_eq!(person.name, "Ada Lovelace");
     assert_eq!(person.age, 36);
 
-    // Both exchanges must have happened exactly once: the truncated first ask
-    // at the ceiling, then the raised retry at the model cap.
+    // Both exchanges must have happened exactly once: the truncated first ask at
+    // the caller budget, then the raised retry at the effective cap.
     truncated.assert_calls_async(1).await;
     completed.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn truncation_at_a_binding_ceiling_fails_terminally_without_raising() {
+    // When `llm_max_completion_tokens` is the binding constraint (below the model
+    // cap), the first request already goes out at the ceiling, so there is no
+    // headroom to raise: the effective cap == the budget that just truncated. The
+    // call must fail terminally rather than silently exceed the operator's cost
+    // ceiling by jumping to the model cap. Matches the Python reference, where
+    // `llm_max_completion_tokens` bounds every path and truncation is not
+    // recovered by enlarging the budget.
+    let server = MockServer::start_async().await;
+
+    // Sonnet 4's model cap is 64000, but the ceiling is 1000, so the first (and
+    // only) request goes out at 1000 and there is no room to raise.
+    let truncated = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/messages")
+                .body_includes("\"max_tokens\":1000");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "id": "msg_trunc_ceiling",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": "claude-sonnet-4-20250514",
+                        "content": [
+                            {"type": "tool_use", "name": "extract_structured_data",
+                             "input": {"name": "Ada", "age": 36}}
+                        ],
+                        "stop_reason": "max_tokens",
+                        "usage": {"input_tokens": 10, "output_tokens": 1000}
+                    }"#,
+                );
+        })
+        .await;
+
+    let adapter = AnthropicAdapter::new(
+        "claude-sonnet-4-20250514",
+        "test-key",
+        Some(server.base_url()),
+    )
+    .expect("construct AnthropicAdapter")
+    .with_max_completion_tokens(1000)
+    .with_network_retries(0);
+
+    let err = adapter
+        .create_structured_output::<Person>(
+            "Ada Lovelace was 36.",
+            "Extract the person's name and age.",
+            None,
+        )
+        .await
+        .expect_err("a truncation at the binding ceiling must fail, not raise past it");
+
+    // Exactly one exchange: it did not raise the budget past the ceiling.
+    truncated.assert_calls_async(1).await;
+    assert!(
+        err.to_string().contains("output budget"),
+        "unexpected error: {err}"
+    );
 }
 
 #[tokio::test]
@@ -167,7 +238,7 @@ async fn truncation_at_the_model_cap_fails_terminally_without_looping() {
     // Exactly one exchange: it did not re-ask at the same budget.
     truncated.assert_calls_async(1).await;
     assert!(
-        err.to_string().contains("output cap"),
+        err.to_string().contains("output budget"),
         "unexpected error: {err}"
     );
 }

--- a/crates/llm/tests/anthropic_truncation_retry.rs
+++ b/crates/llm/tests/anthropic_truncation_retry.rs
@@ -117,9 +117,12 @@ async fn truncation_at_the_model_cap_fails_terminally_without_looping() {
     let server = MockServer::start_async().await;
 
     // Claude 3.5 Sonnet caps output at 8192, which is also the default ceiling
-    // that gets sent, so there is no headroom to raise. A truncation whose object
-    // is genuinely incomplete (missing the required `age`) must fail immediately
-    // rather than re-ask at the same budget until MaxRetriesExceeded.
+    // that gets sent, so there is no headroom to raise. A max_tokens stop here
+    // must fail immediately rather than re-ask at the same budget until
+    // MaxRetriesExceeded — and, matching the Python reference (instructor rejects
+    // any length-truncated structured response before validation), it fails even
+    // though the tool input parses as a complete object: the truncation flag, not
+    // shallow validity, decides.
     let truncated = server
         .mock_async(|when, then| {
             when.method(POST)
@@ -135,7 +138,7 @@ async fn truncation_at_the_model_cap_fails_terminally_without_looping() {
                         "model": "claude-3-5-sonnet-20241022",
                         "content": [
                             {"type": "tool_use", "name": "extract_structured_data",
-                             "input": {"name": "Ada"}}
+                             "input": {"name": "Ada", "age": 36}}
                         ],
                         "stop_reason": "max_tokens",
                         "usage": {"input_tokens": 10, "output_tokens": 8192}
@@ -167,62 +170,4 @@ async fn truncation_at_the_model_cap_fails_terminally_without_looping() {
         err.to_string().contains("output cap"),
         "unexpected error: {err}"
     );
-}
-
-#[tokio::test]
-async fn truncated_but_complete_object_at_cap_is_returned_not_discarded() {
-    // Regression (review finding #1): `stop_reason == "max_tokens"` can still
-    // carry a complete, schema-valid object when generation finished exactly at
-    // the budget. When there is no headroom left to raise the budget, re-asking
-    // cannot produce a longer answer, so the usable object must be returned as
-    // best-effort rather than discarded as a hard failure.
-    let server = MockServer::start_async().await;
-
-    // Claude 3.5 Sonnet caps at 8192 == the default ceiling: no headroom. The
-    // response is flagged truncated but the object is complete and valid.
-    let at_cap = server
-        .mock_async(|when, then| {
-            when.method(POST)
-                .path("/messages")
-                .body_includes("\"max_tokens\":8192");
-            then.status(200)
-                .header("content-type", "application/json")
-                .body(
-                    r#"{
-                        "id": "msg_trunc_complete",
-                        "type": "message",
-                        "role": "assistant",
-                        "model": "claude-3-5-sonnet-20241022",
-                        "content": [
-                            {"type": "tool_use", "name": "extract_structured_data",
-                             "input": {"name": "Ada Lovelace", "age": 36}}
-                        ],
-                        "stop_reason": "max_tokens",
-                        "usage": {"input_tokens": 10, "output_tokens": 8192}
-                    }"#,
-                );
-        })
-        .await;
-
-    let adapter = AnthropicAdapter::new(
-        "claude-3-5-sonnet-20241022",
-        "test-key",
-        Some(server.base_url()),
-    )
-    .expect("construct AnthropicAdapter")
-    .with_network_retries(0);
-
-    let person: Person = adapter
-        .create_structured_output::<Person>(
-            "Ada Lovelace was 36.",
-            "Extract the person's name and age.",
-            None,
-        )
-        .await
-        .expect("a complete object at the cap must be returned, not discarded");
-
-    assert_eq!(person.name, "Ada Lovelace");
-    assert_eq!(person.age, 36);
-    // Returned on the first response: no wasteful re-ask at the same budget.
-    at_cap.assert_calls_async(1).await;
 }

--- a/crates/llm/tests/anthropic_truncation_retry.rs
+++ b/crates/llm/tests/anthropic_truncation_retry.rs
@@ -117,9 +117,9 @@ async fn truncation_at_the_model_cap_fails_terminally_without_looping() {
     let server = MockServer::start_async().await;
 
     // Claude 3.5 Sonnet caps output at 8192, which is also the default ceiling
-    // that gets sent, so there is no headroom to raise. A truncation here must
-    // fail immediately rather than re-ask at the same budget until
-    // MaxRetriesExceeded.
+    // that gets sent, so there is no headroom to raise. A truncation whose object
+    // is genuinely incomplete (missing the required `age`) must fail immediately
+    // rather than re-ask at the same budget until MaxRetriesExceeded.
     let truncated = server
         .mock_async(|when, then| {
             when.method(POST)
@@ -135,7 +135,7 @@ async fn truncation_at_the_model_cap_fails_terminally_without_looping() {
                         "model": "claude-3-5-sonnet-20241022",
                         "content": [
                             {"type": "tool_use", "name": "extract_structured_data",
-                             "input": {"name": "Ada", "age": 36}}
+                             "input": {"name": "Ada"}}
                         ],
                         "stop_reason": "max_tokens",
                         "usage": {"input_tokens": 10, "output_tokens": 8192}
@@ -167,4 +167,62 @@ async fn truncation_at_the_model_cap_fails_terminally_without_looping() {
         err.to_string().contains("output cap"),
         "unexpected error: {err}"
     );
+}
+
+#[tokio::test]
+async fn truncated_but_complete_object_at_cap_is_returned_not_discarded() {
+    // Regression (review finding #1): `stop_reason == "max_tokens"` can still
+    // carry a complete, schema-valid object when generation finished exactly at
+    // the budget. When there is no headroom left to raise the budget, re-asking
+    // cannot produce a longer answer, so the usable object must be returned as
+    // best-effort rather than discarded as a hard failure.
+    let server = MockServer::start_async().await;
+
+    // Claude 3.5 Sonnet caps at 8192 == the default ceiling: no headroom. The
+    // response is flagged truncated but the object is complete and valid.
+    let at_cap = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/messages")
+                .body_includes("\"max_tokens\":8192");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "id": "msg_trunc_complete",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": "claude-3-5-sonnet-20241022",
+                        "content": [
+                            {"type": "tool_use", "name": "extract_structured_data",
+                             "input": {"name": "Ada Lovelace", "age": 36}}
+                        ],
+                        "stop_reason": "max_tokens",
+                        "usage": {"input_tokens": 10, "output_tokens": 8192}
+                    }"#,
+                );
+        })
+        .await;
+
+    let adapter = AnthropicAdapter::new(
+        "claude-3-5-sonnet-20241022",
+        "test-key",
+        Some(server.base_url()),
+    )
+    .expect("construct AnthropicAdapter")
+    .with_network_retries(0);
+
+    let person: Person = adapter
+        .create_structured_output::<Person>(
+            "Ada Lovelace was 36.",
+            "Extract the person's name and age.",
+            None,
+        )
+        .await
+        .expect("a complete object at the cap must be returned, not discarded");
+
+    assert_eq!(person.name, "Ada Lovelace");
+    assert_eq!(person.age, 36);
+    // Returned on the first response: no wasteful re-ask at the same budget.
+    at_cap.assert_calls_async(1).await;
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,10 +76,13 @@ factory): it authenticates with `x-api-key`, hoists the system prompt into the
 top-level `system` field, and produces structured output via a forced `tool_use`.
 It requires `LLM_API_KEY`, strips an `anthropic/` model prefix, honors `LLM_ARGS`
 (merged into each request), and supports image description (vision) but not audio
-transcription. The endpoint is always `https://api.anthropic.com/v1`: unlike the
+transcription. The endpoint defaults to `https://api.anthropic.com/v1`: unlike the
 OpenAI-compatible path it deliberately ignores `LLM_ENDPOINT`/`OPENAI_URL` (which
 alias each other) so a stray `OPENAI_URL` cannot misroute Anthropic traffic —
-matching the Python SDK, which passes no base URL. Native Azure and Bedrock
+matching the Python SDK, which passes no base URL. To route Anthropic traffic
+through a proxy / gateway / Bedrock-compatible endpoint, set the dedicated
+`ANTHROPIC_BASE_URL` (alias `ANTHROPIC_API_BASE`); it overrides the default only
+on the Anthropic path and other providers ignore it. Native Azure and Bedrock
 adapters are tracked separately in issue #17.
 
 > **Ollama embeddings:** set `EMBEDDING_ENDPOINT` explicitly when using


### PR DESCRIPTION
Follow-up to PR #40 (native Anthropic Messages API adapter), applying the verified findings from a high-effort code review plus a self-review of those fixes, with Python-`cognee` parity as the tie-breaker.

## Applied
- **#1 truncation-at-cap** — match the Python reference (`instructor` rejects a length-truncated structured response before validation): hard-fail at the model cap, keep the raise-budget-and-reask path when headroom remains.
- **#4 Anthropic base-URL** — dedicated `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_BASE` knob (not the `OPENAI_URL`-aliased endpoint) for proxy/gateway/Bedrock-compatible endpoints.
- **#6 vision clamp** — clamp `transcribe_image` `max_tokens` to the model cap so default options don't 400.
- **#7 corrective instruction** — no longer silently drops corrections when the last turn is an assistant message.
- **#8 / #578 dedup** — `schema_required_validator` and `append_corrective_instruction` extracted into shared `cognee_llm::schema` helpers used by both adapters.
- **#10** — surface the `MODEL_OUTPUT_CAPS` unlisted-model fallback at debug level.

## Not applied (rationale)
- **#5 (402 terminal)** — deliberate, documented Python-parity behavior, consistent across both adapters.
- **#9 (retry-loop dedup)** — full unification deferred to the planned `llm::http` extraction (divergent semantics); #8 is the safe first step.
- **vision cost ceiling (#648)** — Python's vision path ignores the completion-tokens ceiling, so adding it would diverge from parity.
- **#2 / #3** — already resolved by the merge with `main` (#67/#97).

## Verification
`cargo fmt` · `cargo check --all-targets` · `cargo clippy --all-targets` (clean) · 104 unit + httpmock integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8NCoRngpTVyY6U5jMyJqe