### PR TITLE
fix(llm): address PR #41 review findings (Azure/reasoning follow-ups)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,9 @@ LLM_API_KEY="your_api_key"
 ################################################################################
 #LLM_MAX_TOKENS=16384
 #LLM_API_VERSION=""               # needed for Azure OpenAI
+#LLM_REASONING="auto"            # auto | always | never — override OpenAI reasoning-model (o1/o3/o4/gpt-5)
+                                 # parameter detection; use "never" for a remote gateway that serves a
+                                 # reasoning-named model but only accepts legacy max_tokens+temperature
 #LLM_TEMPERATURE=0.0
 #LLM_MAX_RETRIES=2
 #LLM_MAX_PARALLEL_REQUESTS=20
@@ -142,11 +145,15 @@ TOKENIZERS_PARALLELISM=false
 
 ########## Azure OpenAI (API key auth) ########################################
 #LLM_PROVIDER="azure"             # api-key auth + ?api-version= query on the OpenAI path
-#LLM_MODEL="gpt-4o-mini"          # deployment name (ignored by Azure; the deployment is in the URL)
+#LLM_MODEL="gpt-4o-mini"          # deployment name; Azure ignores it for ROUTING (the deployment is in the URL),
+                                  # but it still drives reasoning-model detection — for an o-series/gpt-5
+                                  # deployment set it to the underlying model (or name the deployment o3/gpt-5*),
+                                  # or force it with LLM_REASONING below.
 #LLM_ENDPOINT="https://YOUR-RESOURCE.openai.azure.com/openai/deployments/gpt-4o-mini"  # deployment URL, required
 #LLM_API_KEY="your-azure-api-key"
 #LLM_API_VERSION="2024-12-01-preview"   # required for azure
 #LLM_MAX_TOKENS=16384
+#LLM_REASONING="auto"            # auto (default) | always | never — override reasoning-parameter detection
 #EMBEDDING_MODEL="text-embedding-3-large"
 #EMBEDDING_ENDPOINT="https://YOUR-RESOURCE.openai.azure.com/openai/deployments/text-embedding-3-large"
 #EMBEDDING_API_KEY="your-azure-api-key"

--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -140,6 +140,7 @@ mod tests {
                 max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
                 llm_args: serde_json::Map::new(),
                 api_version: String::new(),
+                reasoning_override: None,
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),

--- a/crates/components/src/builtins/llm.rs
+++ b/crates/components/src/builtins/llm.rs
@@ -50,7 +50,8 @@ impl LlmFactory for OpenAiCompatibleLlmFactory {
         )
         .map_err(|e| ComponentError::Llm(e.to_string()))?
         .with_extra_args(ctx.llm.llm_args.clone())
-        .with_default_max_tokens(Some(ctx.llm.max_completion_tokens));
+        .with_default_max_tokens(Some(ctx.llm.max_completion_tokens))
+        .with_reasoning_override(ctx.llm.reasoning_override);
         Ok(Arc::new(adapter))
     }
 
@@ -175,7 +176,13 @@ impl LlmFactory for AzureLlmFactory {
         )
         .map_err(|e| ComponentError::Llm(e.to_string()))?
         .with_api_version(api_version)
-        .with_extra_args(ctx.llm.llm_args.clone());
+        .with_extra_args(ctx.llm.llm_args.clone())
+        // Honour the operator's completion ceiling on Azure too, matching the
+        // OpenAI-compatible factory: without this, option-less generate() calls
+        // (search/recall/feedback) fall back to the adapter's hardcoded 16384 and
+        // Azure deployments with a smaller output cap 400 on every such call.
+        .with_default_max_tokens(Some(ctx.llm.max_completion_tokens))
+        .with_reasoning_override(ctx.llm.reasoning_override);
         Ok(Arc::new(adapter))
     }
 

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -124,6 +124,13 @@ pub struct LlmInputs {
     /// Azure `api-version` (empty = unset). Only consumed by the azure provider,
     /// which requires it alongside a deployment `endpoint`.
     pub api_version: String,
+    /// Explicit override for OpenAI reasoning-model detection, from `LLM_REASONING`
+    /// (`auto` | `always` | `never`). `None` keeps the adapter's name/host
+    /// auto-detection; `Some(true)`/`Some(false)` force the reasoning / legacy
+    /// parameter shape. Lets an operator correct an endpoint whose reasoning
+    /// nature the model name mis-signals. Applied via
+    /// `OpenAIAdapter::with_reasoning_override`.
+    pub reasoning_override: Option<bool>,
     /// Replaces the provider adapter with a cassette replay mock.
     pub mock: bool,
     /// Cassette path for the replay mock (consumed only under `mock-llm`).
@@ -145,4 +152,39 @@ pub fn anthropic_base_url_from_env() -> Option<String> {
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
+}
+
+/// Parse the `LLM_REASONING` knob into a reasoning-detection override for
+/// [`LlmInputs::reasoning_override`]. `always`/`true`/`on`/`1` force reasoning
+/// mode on, `never`/`false`/`off`/`0` force it off, and everything else —
+/// including the default `auto`, an empty value, or an unrecognised token —
+/// leaves auto-detection in place (`None`). Case- and whitespace-insensitive.
+///
+/// Lives here — the shared config→[`LlmInputs`] boundary — so the SDK `Settings`
+/// and the standalone HTTP server resolve the knob identically.
+pub fn parse_reasoning_override(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "always" | "true" | "on" | "1" => Some(true),
+        "never" | "false" | "off" | "0" => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_reasoning_override;
+
+    #[test]
+    fn parse_reasoning_override_maps_known_tokens() {
+        for on in ["always", "true", "on", "1", "  ALWAYS  ", "True"] {
+            assert_eq!(parse_reasoning_override(on), Some(true), "{on:?}");
+        }
+        for off in ["never", "false", "off", "0", "Never"] {
+            assert_eq!(parse_reasoning_override(off), Some(false), "{off:?}");
+        }
+        // Default, empty, and unrecognised tokens fall through to auto (None).
+        for auto in ["auto", "", "   ", "maybe", "yes"] {
+            assert_eq!(parse_reasoning_override(auto), None, "{auto:?}");
+        }
+    }
 }

--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -34,7 +34,10 @@ mod registry;
 mod traits;
 
 pub use builtins::{build_database, build_embedding_config, build_storage};
-pub use context::{BackendBuildContext, EmbeddingInputs, LlmInputs, anthropic_base_url_from_env};
+pub use context::{
+    BackendBuildContext, EmbeddingInputs, LlmInputs, anthropic_base_url_from_env,
+    parse_reasoning_override,
+};
 pub use error::ComponentError;
 pub use registry::ComponentRegistry;
 pub use traits::{EmbeddingFactory, GraphDbFactory, LlmFactory, VectorDbFactory};

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -412,6 +412,7 @@ mod tests {
                 max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
                 llm_args: serde_json::Map::new(),
                 api_version: String::new(),
+                reasoning_override: None,
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -202,6 +202,10 @@ pub struct HttpServerConfig {
     /// Env: `LLM_API_VERSION`.
     pub llm_api_version: String,
 
+    /// Reasoning-model detection override: `auto` (default), `always`, `never`.
+    /// Env: `LLM_REASONING`.
+    pub llm_reasoning: String,
+
     /// LLM retry count for both structured-output and network retries.
     /// Env: `LLM_MAX_RETRIES`.
     pub llm_max_retries: u32,
@@ -356,6 +360,7 @@ impl Default for HttpServerConfig {
             llm_api_key: SecretString::new(String::new().into()),
             llm_endpoint: String::new(),
             llm_api_version: String::new(),
+            llm_reasoning: "auto".to_string(),
             llm_max_retries: 3,
             llm_max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
             session_store_backend: "seaorm".to_string(),
@@ -547,6 +552,9 @@ impl HttpServerConfig {
         if let Ok(v) = std::env::var("LLM_API_VERSION") {
             cfg.llm_api_version = v;
         }
+        if let Ok(v) = std::env::var("LLM_REASONING") {
+            cfg.llm_reasoning = v;
+        }
         if let Ok(v) = std::env::var("LLM_MAX_RETRIES") {
             cfg.llm_max_retries = v
                 .parse::<u32>()
@@ -697,6 +705,9 @@ impl HttpServerConfig {
                 // `cognee::Settings`.
                 llm_args: serde_json::Map::new(),
                 api_version: self.llm_api_version.clone(),
+                reasoning_override: cognee_components::parse_reasoning_override(
+                    &self.llm_reasoning,
+                ),
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -296,9 +296,17 @@ fn wire_responses_client(cfg: &HttpServerConfig) -> Option<Arc<dyn ResponsesClie
         provider.as_str(),
         "openai" | "" | "custom" | "openai_compatible"
     ) {
-        tracing::info!(
-            "responses client not wired for provider '{provider}' \
-             (its gateway does not serve the OpenAI /responses route)"
+        // Reaching here means the operator *explicitly* enabled the responses
+        // client (the disabled case returned above), so warn rather than info:
+        // POST /api/v1/responses will 500 ("responses client is not wired") until
+        // they either drop the flag or switch to `custom`/`openai_compatible`
+        // (which keeps Bearer auth + a custom endpoint, so an OpenAI-style
+        // gateway fronting this provider still works).
+        tracing::warn!(
+            "responses client enabled but not wired for provider '{provider}': \
+             it is not on the OpenAI /responses allowlist \
+             (openai / custom / openai_compatible). POST /api/v1/responses will be \
+             unavailable; set LLM_PROVIDER=custom if your gateway serves /responses."
         );
         return None;
     }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -133,6 +133,11 @@ pub struct Settings {
     pub llm_api_key: String,
     pub llm_endpoint: String,
     pub llm_api_version: String,
+    /// Reasoning-model detection override (`LLM_REASONING`): `auto` (default,
+    /// name/host auto-detection), `always` (force the reasoning parameter shape),
+    /// or `never` (force the legacy `max_tokens`+sampling shape). Lets an operator
+    /// correct an endpoint whose model name mis-signals its reasoning nature.
+    pub llm_reasoning: String,
     pub llm_temperature: f64,
     pub llm_streaming: bool,
     pub llm_max_completion_tokens: u32,
@@ -371,6 +376,9 @@ impl Settings {
         }
         if let Some(v) = str_var("LLM_API_VERSION") {
             self.llm_api_version = v;
+        }
+        if let Some(v) = str_var("LLM_REASONING") {
+            self.llm_reasoning = v;
         }
         if let Some(v) = str_var("LLM_TEMPERATURE")
             && let Ok(f) = v.parse::<f64>()
@@ -848,6 +856,9 @@ impl Settings {
                 max_completion_tokens: self.llm_max_completion_tokens,
                 llm_args: self.llm_args.clone(),
                 api_version: self.llm_api_version.clone(),
+                reasoning_override: cognee_components::parse_reasoning_override(
+                    &self.llm_reasoning,
+                ),
                 mock: self.llm_mock,
                 cassette: self.llm_cassette.clone(),
                 record_path: self.llm_record_path.clone(),
@@ -1074,6 +1085,7 @@ impl Default for Settings {
             llm_api_key: String::new(),
             llm_endpoint: String::new(),
             llm_api_version: String::new(),
+            llm_reasoning: "auto".to_string(),
             llm_temperature: 0.0,
             llm_streaming: false,
             // Single-sourced with the adapter/http-server default so lowering
@@ -1623,6 +1635,15 @@ impl ConfigManager {
         self.bump_version();
     }
 
+    /// Set the reasoning-detection override (`auto` | `always` | `never`); see
+    /// [`Settings::llm_reasoning`].
+    pub fn set_llm_reasoning(&self, mode: &str) {
+        let mut s = self.inner.write().expect("lock poison is unrecoverable"); // lock poison is unrecoverable
+        s.llm_reasoning = mode.to_string();
+        drop(s);
+        self.bump_version();
+    }
+
     pub fn set_llm_temperature(&self, temperature: f64) {
         let mut s = self.inner.write().expect("lock poison is unrecoverable"); // lock poison is unrecoverable
         s.llm_temperature = temperature;
@@ -1829,6 +1850,10 @@ impl ConfigManager {
             Value::String(s.llm_api_version.clone()),
         );
         m.insert(
+            "llm_reasoning".into(),
+            Value::String(s.llm_reasoning.clone()),
+        );
+        m.insert(
             "llm_temperature".into(),
             Value::Number(
                 serde_json::Number::from_f64(s.llm_temperature)
@@ -2000,6 +2025,7 @@ impl ConfigManager {
                 "llm_api_key" => s.llm_api_key = as_string(key, value)?,
                 "llm_endpoint" => s.llm_endpoint = as_string(key, value)?,
                 "llm_api_version" => s.llm_api_version = as_string(key, value)?,
+                "llm_reasoning" => s.llm_reasoning = as_string(key, value)?,
                 "llm_temperature" => s.llm_temperature = as_f64(key, value)?,
                 "llm_max_completion_tokens" => s.llm_max_completion_tokens = as_u32(key, value)?,
                 "llm_streaming" => s.llm_streaming = as_bool(key, value)?,
@@ -2101,6 +2127,7 @@ impl ConfigManager {
             "llm_endpoint" => self.set_llm_endpoint(as_string(key, &value)?.as_str()),
             // LLM tuning
             "llm_api_version" => self.set_llm_api_version(as_string(key, &value)?.as_str()),
+            "llm_reasoning" => self.set_llm_reasoning(as_string(key, &value)?.as_str()),
             "llm_temperature" => self.set_llm_temperature(as_f64(key, &value)?),
             "llm_streaming" => self.set_llm_streaming(as_bool(key, &value)?),
             "llm_max_completion_tokens" => {

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -154,8 +154,18 @@ fn is_reasoning_model_name(model: &str) -> bool {
 /// path segment immediately following a `deployments` segment. Returns `None`
 /// for any URL without that shape, so it is a no-op for standard OpenAI /
 /// OpenAI-compatible endpoints.
+///
+/// Gated on the Azure host (`*.openai.azure.com`): only Azure encodes the model
+/// in a `deployments/<name>` segment, so a non-Azure gateway whose path happens
+/// to contain a `deployments` route segment (e.g.
+/// `https://gw.example.com/deployments/o3-router/v1`) is NOT misclassified as a
+/// reasoning model.
 fn azure_deployment_name(base_url: &str) -> Option<String> {
     let url = reqwest::Url::parse(base_url).ok()?;
+    let host = url.host_str()?;
+    if !host.to_ascii_lowercase().ends_with(".openai.azure.com") {
+        return None;
+    }
     let mut segments = url.path_segments()?;
     while let Some(seg) = segments.next() {
         if seg.eq_ignore_ascii_case("deployments") {
@@ -356,20 +366,34 @@ impl OpenAIAdapter {
         if self.extra_args.is_empty() {
             return;
         }
-        // Reasoning models (`gpt-5*`/`o1*`/`o3*`/`o4*` on api.openai.com) reject
-        // `max_tokens` and require `max_completion_tokens`. The request body's
-        // output cap is written by `write_max_tokens` as `max_completion_tokens`,
-        // so a bare `max_tokens` coming from `LLM_ARGS` here would land alongside
-        // it and OpenAI rejects a request carrying *both* keys with a 400. Fold a
-        // `LLM_ARGS` `max_tokens` into `max_completion_tokens` (only filling the
-        // gap) so exactly one of the two keys is ever emitted.
+        // Reasoning models (`gpt-5*`/`o1*`/`o3*`/`o4*`, detected by name/host —
+        // NOT gated on api.openai.com, so this covers Azure o-series deployments
+        // and remote gateways too) constrain the request body two ways:
+        //   1. they require `max_completion_tokens` and reject `max_tokens`, and
+        //   2. they reject `temperature`/`top_p`/`frequency_penalty`/
+        //      `presence_penalty`.
+        // The request builder already honours both (writes `max_completion_tokens`
+        // via `write_max_tokens` and omits the sampling params for reasoning
+        // models), so an `LLM_ARGS` value must not re-introduce a rejected key
+        // here: fold a bare `max_tokens` into `max_completion_tokens`, drop the
+        // suppressed sampling params, and only fill gaps for everything else
+        // (matching Python's `{**self.llm_args, **kwargs}`).
         let reasoning = self.is_reasoning_model();
         if let Some(obj) = body.as_object_mut() {
             for (key, value) in &self.extra_args {
-                if reasoning && key == "max_tokens" {
-                    obj.entry("max_completion_tokens")
-                        .or_insert_with(|| value.clone());
-                    continue;
+                if reasoning {
+                    if key == "max_tokens" {
+                        obj.entry("max_completion_tokens")
+                            .or_insert_with(|| value.clone());
+                        continue;
+                    }
+                    if matches!(
+                        key.as_str(),
+                        "temperature" | "top_p" | "frequency_penalty" | "presence_penalty"
+                    ) {
+                        // Suppressed for reasoning models; re-adding 400s the call.
+                        continue;
+                    }
                 }
                 obj.entry(key.clone()).or_insert_with(|| value.clone());
             }
@@ -1995,6 +2019,17 @@ mod tests {
         .unwrap()
         .with_api_version("2024-12-01-preview");
         assert!(!non_reasoning.is_reasoning_model());
+
+        // The deployment fallback is gated on the Azure host: a NON-Azure gateway
+        // whose path merely contains a `deployments/<reasoning-name>` route
+        // segment must NOT be misclassified (it may only accept legacy params).
+        let non_azure_deployments_path = OpenAIAdapter::new(
+            "my-alias", // non-reasoning model name
+            "sk-test",
+            Some("https://gw.example.com/deployments/o3-router/v1".to_string()),
+        )
+        .unwrap();
+        assert!(!non_azure_deployments_path.is_reasoning_model());
     }
 
     #[test]
@@ -2141,6 +2176,54 @@ mod tests {
         classic.apply_extra_args(&mut body);
         assert_eq!(body["max_tokens"], 16384);
         assert!(body.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn test_apply_extra_args_drops_suppressed_sampling_params_for_reasoning() {
+        // Reasoning models reject temperature/top_p/frequency_penalty/
+        // presence_penalty, and the request builder omits them. An LLM_ARGS value
+        // for any of these must NOT be re-added by apply_extra_args, else the call
+        // 400s ("Unsupported value: temperature").
+        let args = json!({
+            "temperature": 0.3,
+            "top_p": 0.9,
+            "frequency_penalty": 0.1,
+            "presence_penalty": 0.2,
+            "logit_bias": {"50256": -100}
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let reasoning = OpenAIAdapter::new("gpt-5-mini", "test-key", None)
+            .unwrap()
+            .with_extra_args(args.clone());
+        let mut body = json!({"model": "gpt-5-mini"});
+        reasoning.apply_extra_args(&mut body);
+        for suppressed in [
+            "temperature",
+            "top_p",
+            "frequency_penalty",
+            "presence_penalty",
+        ] {
+            assert!(
+                body.get(suppressed).is_none(),
+                "reasoning model must not carry {suppressed}"
+            );
+        }
+        // Non-sampling extra args (e.g. logit_bias) are still applied.
+        assert_eq!(body["logit_bias"]["50256"], -100);
+
+        // A classic model keeps all of them (they are valid there).
+        let classic = OpenAIAdapter::new("gpt-4o-mini", "test-key", None)
+            .unwrap()
+            .with_extra_args(args);
+        let mut body = json!({"model": "gpt-4o-mini"});
+        classic.apply_extra_args(&mut body);
+        assert_eq!(body["temperature"], 0.3);
+        assert_eq!(body["top_p"], 0.9);
+        assert_eq!(body["frequency_penalty"], 0.1);
+        assert_eq!(body["presence_penalty"], 0.2);
     }
 
     #[test]

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -130,10 +130,42 @@ pub struct OpenAIAdapter {
 /// shape is correct. A deployment that needs the opposite can point the model at
 /// a loopback bind or use Ollama's port.
 fn compute_reasoning_model(model: &str, base_url: &str) -> bool {
+    if is_local_base_url(base_url) {
+        return false;
+    }
+    // Name-based detection on the request-body model, plus a fallback on the
+    // Azure deployment segment: Azure ignores the body model (the deployment in
+    // the URL routes the request), and the config docs tell operators the model
+    // is inert, so an o-series/gpt-5 deployment named after its model would
+    // otherwise go undetected and 400 on `max_tokens`+`temperature`.
+    is_reasoning_model_name(model)
+        || azure_deployment_name(base_url).is_some_and(|d| is_reasoning_model_name(&d))
+}
+
+/// Whether a model name belongs to an OpenAI reasoning family (`gpt-5*`, `o1*`,
+/// `o3*`, `o4*`), case-insensitively.
+fn is_reasoning_model_name(model: &str) -> bool {
     let m = model.to_lowercase();
-    let is_reasoning_name =
-        m.starts_with("gpt-5") || m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4");
-    is_reasoning_name && !is_local_base_url(base_url)
+    m.starts_with("gpt-5") || m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4")
+}
+
+/// Extract the Azure deployment name from a deployment-style base URL
+/// (`https://<resource>.openai.azure.com/openai/deployments/<deployment>`) — the
+/// path segment immediately following a `deployments` segment. Returns `None`
+/// for any URL without that shape, so it is a no-op for standard OpenAI /
+/// OpenAI-compatible endpoints.
+fn azure_deployment_name(base_url: &str) -> Option<String> {
+    let url = reqwest::Url::parse(base_url).ok()?;
+    let mut segments = url.path_segments()?;
+    while let Some(seg) = segments.next() {
+        if seg.eq_ignore_ascii_case("deployments") {
+            return segments
+                .next()
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+        }
+    }
+    None
 }
 
 /// Heuristic for a local / non-OpenAI-compatible host that does not accept the
@@ -281,6 +313,24 @@ impl OpenAIAdapter {
         self
     }
 
+    /// Override reasoning-model auto-detection (see [`compute_reasoning_model`]).
+    /// `Some(true)` forces the reasoning parameter shape (`max_completion_tokens`,
+    /// suppressed `temperature`/`top_p`/penalties), `Some(false)` forces the
+    /// legacy shape (`max_tokens` + sampling params), and `None` leaves the
+    /// name/host auto-detection untouched.
+    ///
+    /// Wired from `LLM_REASONING` (`auto` | `always` | `never`) so an operator can
+    /// correct a misclassified endpoint — e.g. a remote OpenAI-compatible gateway
+    /// serving a reasoning-*named* model that nonetheless only accepts the legacy
+    /// parameters (`LLM_REASONING=never`), or a proxy that hides the reasoning
+    /// nature of its model behind an opaque alias (`LLM_REASONING=always`).
+    pub fn with_reasoning_override(mut self, force: Option<bool>) -> Self {
+        if let Some(force) = force {
+            self.reasoning_model = force;
+        }
+        self
+    }
+
     /// Resolve caller options for the plain-completion ([`generate`](Self::generate))
     /// path. When the caller passes no options at all, the config-derived
     /// [`default_max_tokens`](Self::default_max_tokens) becomes the output cap
@@ -375,25 +425,46 @@ impl OpenAIAdapter {
 
     /// Build a request URL for `path`, appending `api-version=<v>` in Azure mode.
     ///
-    /// The api-version is added through `Url::query_pairs_mut`, so the query
+    /// `path` is appended to the base URL's **path segments**, not by raw string
+    /// concatenation. This matters when `base_url` already carries a query — e.g.
+    /// an Azure portal endpoint copied with a trailing `?api-version=...`: a naive
+    /// `{base_url}/{path}` would splice `chat/completions` into the *query* value
+    /// (`?api-version=…/chat/completions`), leaving the request path without
+    /// `/chat/completions` so every request 404s. Building on the parsed path
+    /// keeps the existing query and the route segment separate.
+    ///
+    /// The api-version is then added through `Url::query_pairs_mut`, so the query
     /// separator is chosen correctly even if `base_url` already carries a query
     /// (no malformed double-`?`) and the value is percent-encoded rather than
     /// interpolated raw. If `base_url` does not parse as a URL we fall back to a
     /// manual append that still picks `?` vs `&` from the existing query, so the
     /// api-version is never silently dropped (Azure 400s without it).
     fn endpoint_url(&self, path: &str) -> String {
+        if let Ok(mut url) = reqwest::Url::parse(&self.base_url) {
+            if let Ok(mut segments) = url.path_segments_mut() {
+                // Drop a trailing empty segment (a base_url ending in `/`) before
+                // extending so we never emit `//`. The constructor trims one
+                // trailing slash, but a bare-host base_url (`https://x.com`) still
+                // parses with a single empty segment.
+                segments
+                    .pop_if_empty()
+                    .extend(path.split('/').filter(|s| !s.is_empty()));
+            }
+            // A cannot-be-a-base URL (e.g. `mailto:`) has no path segments; that
+            // never happens for the http(s) endpoints we accept, so leave it.
+            if let Some(v) = &self.api_version {
+                url.query_pairs_mut().append_pair("api-version", v);
+            }
+            return url.into();
+        }
+        // base_url did not parse as a URL: fall back to a raw append that still
+        // chooses `?` vs `&` so the api-version is never silently dropped.
         let base = format!("{}/{path}", self.base_url);
         match &self.api_version {
-            Some(v) => match reqwest::Url::parse(&base) {
-                Ok(mut url) => {
-                    url.query_pairs_mut().append_pair("api-version", v);
-                    url.into()
-                }
-                Err(_) => {
-                    let sep = if base.contains('?') { '&' } else { '?' };
-                    format!("{base}{sep}api-version={v}")
-                }
-            },
+            Some(v) => {
+                let sep = if base.contains('?') { '&' } else { '?' };
+                format!("{base}{sep}api-version={v}")
+            }
             None => base,
         }
     }
@@ -1739,6 +1810,17 @@ mod tests {
             url.contains("api-version=2024-12-01-preview"),
             "api-version appended: {url}"
         );
+        // The route must stay in the PATH, not slide into the query value: a
+        // raw `{base}?foo=bar` + `/chat/completions` concat would leave the path
+        // at `.../gpt-4o-mini` and 404 every request.
+        let parsed = reqwest::Url::parse(&url).expect("endpoint_url produced a valid URL");
+        assert!(
+            parsed
+                .path()
+                .ends_with("/openai/deployments/gpt-4o-mini/chat/completions"),
+            "route stays in the path when base_url carries a query: {}",
+            parsed.path()
+        );
 
         // A value with a reserved character is percent-encoded, not interpolated raw.
         let odd = OpenAIAdapter::new(
@@ -1889,6 +1971,67 @@ mod tests {
     }
 
     #[test]
+    fn is_reasoning_model_detected_from_azure_deployment_segment() {
+        // Azure ignores the request-body model for routing (the deployment is in
+        // the URL) and the docs tell operators the value is inert, so a reasoning
+        // deployment is reachable with a non-reasoning LLM_MODEL. The deployment
+        // segment must still trigger detection, else Azure 400s on max_tokens +
+        // temperature for every call.
+        let by_deployment = OpenAIAdapter::new(
+            "gpt-4o-mini", // a non-reasoning placeholder, as .env.example ships
+            "sk-test",
+            Some("https://my-resource.openai.azure.com/openai/deployments/o3-prod".to_string()),
+        )
+        .unwrap()
+        .with_api_version("2024-12-01-preview");
+        assert!(by_deployment.is_reasoning_model());
+
+        // A non-reasoning deployment name with a non-reasoning model stays legacy.
+        let non_reasoning = OpenAIAdapter::new(
+            "gpt-4o-mini",
+            "sk-test",
+            Some("https://my-resource.openai.azure.com/openai/deployments/chat-prod".to_string()),
+        )
+        .unwrap()
+        .with_api_version("2024-12-01-preview");
+        assert!(!non_reasoning.is_reasoning_model());
+    }
+
+    #[test]
+    fn with_reasoning_override_forces_detection_either_way() {
+        // `never` un-fires a name/host match (remote gateway serving a
+        // reasoning-named model that only accepts legacy parameters).
+        let forced_off = OpenAIAdapter::new(
+            "gpt-5",
+            "sk-test",
+            Some("https://gateway.example.com/v1".to_string()),
+        )
+        .unwrap()
+        .with_reasoning_override(Some(false));
+        assert!(!forced_off.is_reasoning_model());
+
+        // `always` fires even for an opaque non-reasoning-looking alias.
+        let forced_on = OpenAIAdapter::new(
+            "my-alias",
+            "sk-test",
+            Some("https://gateway.example.com/v1".to_string()),
+        )
+        .unwrap()
+        .with_reasoning_override(Some(true));
+        assert!(forced_on.is_reasoning_model());
+
+        // `None` (auto) leaves auto-detection untouched.
+        let auto = OpenAIAdapter::new(
+            "gpt-5",
+            "sk-test",
+            Some("https://gateway.example.com/v1".to_string()),
+        )
+        .unwrap()
+        .with_reasoning_override(None);
+        assert!(auto.is_reasoning_model());
+    }
+
+    #[test]
     fn test_write_max_tokens_renames_key_for_reasoning_models() {
         let mut body = json!({"model": "gpt-5-mini"});
         let reasoning = OpenAIAdapter::new("gpt-5-mini", "test-key", None).unwrap();
@@ -1907,6 +2050,30 @@ mod tests {
         reasoning.write_max_tokens(&mut body, None);
         assert!(body.get("max_tokens").is_none());
         assert!(body.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn default_max_tokens_governs_option_less_generate_in_azure_mode() {
+        // The behaviour the Azure factory relies on (`.with_default_max_tokens`):
+        // an option-less generate() must send the configured ceiling, not the
+        // hardcoded 16384. Regression guard for the Azure factory previously
+        // omitting the setter, which made Azure ignore LLM_MAX_COMPLETION_TOKENS.
+        let azure = OpenAIAdapter::new(
+            "gpt-4o-mini",
+            "sk-test",
+            Some("https://res.openai.azure.com/openai/deployments/gpt-4o-mini".to_string()),
+        )
+        .unwrap()
+        .with_api_version("2024-12-01-preview")
+        .with_default_max_tokens(Some(4096));
+        assert_eq!(azure.resolve_options(None).max_tokens, Some(4096));
+
+        // Explicit caller options still win over the configured default.
+        let explicit = GenerationOptions {
+            max_tokens: Some(256),
+            ..GenerationOptions::default()
+        };
+        assert_eq!(azure.resolve_options(Some(explicit)).max_tokens, Some(256));
     }
 
     #[test]

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -460,9 +460,13 @@ impl OpenAIAdapter {
     /// The api-version is then added through `Url::query_pairs_mut`, so the query
     /// separator is chosen correctly even if `base_url` already carries a query
     /// (no malformed double-`?`) and the value is percent-encoded rather than
-    /// interpolated raw. If `base_url` does not parse as a URL we fall back to a
-    /// manual append that still picks `?` vs `&` from the existing query, so the
-    /// api-version is never silently dropped (Azure 400s without it).
+    /// interpolated raw. Any `api-version` already present on `base_url` (e.g. a
+    /// copied Azure portal "Target URI") is dropped first so the request never
+    /// carries duplicate/conflicting `api-version` params — the configured
+    /// `LLM_API_VERSION` wins, and other query params are preserved. If `base_url`
+    /// does not parse as a URL we fall back to a manual append that still picks
+    /// `?` vs `&` from the existing query, so the api-version is never silently
+    /// dropped (Azure 400s without it).
     fn endpoint_url(&self, path: &str) -> String {
         if let Ok(mut url) = reqwest::Url::parse(&self.base_url) {
             if let Ok(mut segments) = url.path_segments_mut() {
@@ -477,7 +481,19 @@ impl OpenAIAdapter {
             // A cannot-be-a-base URL (e.g. `mailto:`) has no path segments; that
             // never happens for the http(s) endpoints we accept, so leave it.
             if let Some(v) = &self.api_version {
-                url.query_pairs_mut().append_pair("api-version", v);
+                // Preserve every existing query pair EXCEPT a stray `api-version`,
+                // then append the configured one, so a base_url that already
+                // carries `api-version=...` yields exactly one (the configured
+                // value wins) rather than a duplicate Azure may reject.
+                let preserved: Vec<(String, String)> = url
+                    .query_pairs()
+                    .filter(|(k, _)| k != "api-version")
+                    .map(|(k, val)| (k.into_owned(), val.into_owned()))
+                    .collect();
+                url.query_pairs_mut()
+                    .clear()
+                    .extend_pairs(preserved)
+                    .append_pair("api-version", v);
             }
             return url.into();
         }
@@ -1844,6 +1860,32 @@ mod tests {
                 .ends_with("/openai/deployments/gpt-4o-mini/chat/completions"),
             "route stays in the path when base_url carries a query: {}",
             parsed.path()
+        );
+
+        // A base_url that already carries `api-version=...` (e.g. a copied Azure
+        // portal Target URI) must NOT yield a duplicate: the configured version
+        // wins and appears exactly once.
+        let dup = OpenAIAdapter::new(
+            "gpt-4o-mini",
+            "sk-test",
+            Some(
+                "https://res.openai.azure.com/openai/deployments/gpt-4o-mini?api-version=2023-05-15"
+                    .to_string(),
+            ),
+        )
+        .unwrap()
+        .with_api_version("2024-12-01-preview");
+        let url = dup.endpoint_url("chat/completions");
+        let parsed = reqwest::Url::parse(&url).expect("valid URL");
+        let versions: Vec<_> = parsed
+            .query_pairs()
+            .filter(|(k, _)| k == "api-version")
+            .map(|(_, v)| v.into_owned())
+            .collect();
+        assert_eq!(
+            versions,
+            vec!["2024-12-01-preview".to_string()],
+            "exactly one api-version, configured value wins: {url}"
         );
 
         // A value with a reserved character is percent-encoded, not interpolated raw.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,7 @@ for retries and the `cognee-llm` rustdoc for the adapter.
 | `LLM_API_KEY` / `OPENAI_TOKEN` | `llm_api_key` | _(empty)_ |
 | `LLM_ENDPOINT` / `OPENAI_URL` | `llm_endpoint` | _(empty)_ |
 | `LLM_API_VERSION` | `llm_api_version` | _(empty)_ |
+| `LLM_REASONING` | `llm_reasoning` | `auto` |
 | `LLM_TEMPERATURE` | `llm_temperature` | `0.0` |
 | `LLM_STREAMING` | `llm_streaming` | `false` |
 | `LLM_MAX_COMPLETION_TOKENS` / `LLM_MAX_TOKENS` | `llm_max_completion_tokens` | `16384` |
@@ -89,7 +90,26 @@ authenticates with the `api-key` header and appends an `?api-version=<v>` query.
 Set `LLM_PROVIDER=azure`, `LLM_API_KEY`, `LLM_API_VERSION` (e.g.
 `2024-12-01-preview`), and `LLM_ENDPOINT` to the **deployment** URL
 (`https://<resource>.openai.azure.com/openai/deployments/<deployment>`); the model
-in the request body is ignored by Azure since the deployment is in the URL.
+in the request body is ignored by Azure for **routing** since the deployment is in
+the URL. It is *not* inert for reasoning-model detection (below): `LLM_MODEL` still
+selects the parameter shape, so for an o-series/`gpt-5` deployment set `LLM_MODEL`
+to the underlying model name (the adapter also treats a `.../deployments/o3` style
+deployment segment as reasoning), or pin it explicitly with `LLM_REASONING`.
+
+### Reasoning-model parameters (`LLM_REASONING`)
+
+OpenAI reasoning families (`o1*`, `o3*`, `o4*`, `gpt-5*`) require a different
+request shape — `max_completion_tokens` instead of `max_tokens`, and no
+`temperature`/`top_p`/penalties. The adapter auto-detects this from the model
+name for any non-local endpoint (loopback and Ollama's port keep the legacy
+shape). `LLM_REASONING` overrides that detection:
+
+- `auto` (default) — name/host auto-detection as above.
+- `always` — force the reasoning shape (e.g. a proxy that hides a reasoning model
+  behind an opaque alias).
+- `never` — force the legacy `max_tokens`+`temperature` shape (e.g. a remote
+  OpenAI-compatible gateway serving a reasoning-*named* model that only accepts
+  the legacy parameters).
 
 Native Bedrock adapters are tracked separately in issue #17.
 


### PR DESCRIPTION
Follow-up to #41. Addresses the five defects from the high-effort code review, each verified against PR #41's head before it merged.

## Findings addressed

| # | Fix | Files |
|---|-----|-------|
| 1 | **`LLM_REASONING` override** (`auto`\|`always`\|`never`) via new `OpenAIAdapter::with_reasoning_override`, wired through `Settings` + HTTP server config. Escape hatch for a remote OpenAI-compatible gateway serving a reasoning-*named* model that only accepts the legacy `max_tokens`+`temperature` shape. | `openai.rs`, `context.rs`, `lib/config.rs`, `http-server/config.rs`, `builtins/llm.rs` |
| 2 | **`endpoint_url` path bug (must-fix)** — append the route to the base URL's path *segments* instead of `format!("{base}/{path}")`. A base URL carrying a query (Azure portal URI ending in `?api-version=...`) previously spliced `chat/completions` into the query value, dropping it from the path → every request 404'd. Test now asserts the path survives. | `openai.rs` |
| 3 | **Azure deployment reasoning detection** — also treat a reasoning-named `/deployments/<name>` segment as reasoning, since Azure ignores the body model (docs call it inert) so an o-series/gpt-5 deployment reached with a non-reasoning `LLM_MODEL` was undetected. Docs corrected. | `openai.rs`, docs |
| 4 | **Azure `max_completion_tokens`** — `AzureLlmFactory` now applies `.with_default_max_tokens(...)` like the OpenAI-compatible factory, so Azure honours `LLM_MAX_COMPLETION_TOKENS` on option-less `generate()` instead of the hardcoded 16384. | `builtins/llm.rs` |
| 5 | **Responses-client gating log** — `wire_responses_client` logs at `warn` (was `info`) when explicitly enabled for a non-allowlisted provider, naming the fix (`LLM_PROVIDER=custom`), since `POST /api/v1/responses` 500s until corrected. | `wiring.rs` |

## Tests
- New/updated unit tests in `openai.rs` (endpoint_url path preservation, Azure deployment-segment detection, `with_reasoning_override` both directions, Azure default-max-tokens), `context.rs` (`parse_reasoning_override`).
- `cargo test` for `cognee-llm` (34), `cognee-components` (10), `cognee` config (74) all pass; `cargo fmt` + `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)