### PR TITLE
chore(release): bump all Java version locations + clean up changelog generation

### DIFF
--- a/.github/workflows/release-open.yml
+++ b/.github/workflows/release-open.yml
@@ -156,7 +156,7 @@ jobs:
           {
             echo "Automated release PR for **${TAG}**, opened from issue #${ISSUE}."
             echo
-            echo "Merging this PR publishes to crates.io, npm, and the C-API GitHub Release."
+            echo "Merging this PR publishes to crates.io, npm, Maven Central, and the C-API GitHub Release."
             echo "Review the \`CHANGELOG.md\` diff below and the green PR checks first."
             echo
             echo "## Changelog"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+<!-- RELEASER: release-open.yml inserts the git-cliff-generated section directly
+     after the `## [Unreleased]` marker above, which lands it BEFORE any
+     hand-written prose below. When reviewing the release PR, move this
+     `### Breaking changes` block to the TOP of the new version's section —
+     ahead of Added/Changed/Fixed — so the breaking notes are the first thing a
+     reader sees. git-cliff only flags breaking *commits* (`feat!:` → a
+     **[BREAKING]** bullet); migration prose like the entries below is always
+     hand-written and always needs this manual reposition. -->
 
-- **Breaking (graph data):** `Entity`, `EntityType`, and `EdgeType` node/point
+### Breaking changes
+
+- **Umbrella crate renamed `cognee-lib` → `cognee`.** Depend on `cognee` instead
+  (`cargo add cognee`) and import from it (`use cognee::api::remember;` rather
+  than `use cognee_lib::api::remember;`). `cognee-lib` is still published as a
+  thin re-export shim so existing dependents keep compiling unchanged, but it is
+  deprecated and will not be maintained indefinitely. Every Cargo feature
+  forwards 1:1, so no feature flags need changing. See [#93].
+
+- **Graph data:** `Entity`, `EntityType`, and `EdgeType` node/point
   ids are now **deterministic and class-namespaced** —
   `uuid5(NAMESPACE_OID, "{ClassName}:{normalized_value}")` — matching upstream
   Python cognee's `DataPoint.id_for`. Previously entities/entity-types were
@@ -21,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   automatic migration is provided). See [#57] for details.
 
 [#57]: https://github.com/topoteretes/cognee-rs/issues/57
+[#93]: https://github.com/topoteretes/cognee-rs/pull/93
 
 ## [0.1.3](https://github.com/topoteretes/cognee-rs/compare/v0.1.0...v0.1.3) - 2026-07-02
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # One version section. `version`/`previous.version` are the git tag names
 # (vX.Y.Z); the heading shows the bare number and links to the tag-to-tag diff.
+#
+# Conventional-commit breaking markers (`feat!:` / `fix(x)!:` / a BREAKING CHANGE
+# trailer) set `commit.breaking`, which prefixes the bullet with **[BREAKING]**.
+# Without it a breaking commit renders as an ordinary bullet in its type's group
+# and the changelog never says the release breaks anything. Prose explaining the
+# migration still belongs in CHANGELOG.md by hand — this only guarantees the
+# commit itself is flagged.
 body = """
 {% if version %}\
 ## [{{ version | trim_start_matches(pat="v") }}]\
@@ -35,7 +42,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}
-- {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+- {% if commit.breaking %}**[BREAKING]** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}\
 {% endfor %}
 {% endfor %}
 """
@@ -55,21 +62,60 @@ tag_pattern = "v[0-9]*.[0-9]*.[0-9]*"
 topo_order = false
 sort_commits = "newest"
 
-# Conventional-commit prefix -> changelog section. First match wins; the final
-# catch-all keeps everything else under "Other".
+# Conventional-commit prefix -> changelog section. FIRST MATCH WINS, so every
+# skip rule below must precede the group rules.
+#
+# This changelog is user-facing: it answers "what changed for someone depending
+# on cognee?". Repo-internal churn (CI, cassettes, benchmarks, build plumbing,
+# intra-PR review fixups) is deliberately dropped — it is noise to a consumer and
+# it buries the entries that matter. `git log` remains the complete record.
+#
+# The skip rules are categorical, not per-commit, so they keep working as new
+# commits land. They are also deliberately blunt: a genuinely user-facing change
+# that happens to be typed `chore:`/`ci:` or to mention one of the plumbing
+# keywords WILL be dropped. Reviewing the generated section on the release PR is
+# still part of the flow (see docs/RELEASE.md) — re-type such a commit, or add
+# the entry to CHANGELOG.md by hand.
 commit_parsers = [
   { message = "^Merge ",          skip = true },
   { message = "^chore: release",  skip = true },
   { message = "^chore\\(release\\)", skip = true },
+
+  # ── Internal-only: never reaches the changelog ──────────────────────
+  # Whole types that describe repo upkeep rather than shipped behaviour.
+  { message = "^test",            skip = true },
+  { message = "^chore",           skip = true },
+  { message = "^ci",              skip = true },
+  { message = "^build",           skip = true },
+  { message = "^spike",           skip = true },
+
+  # Scopes that are purely benchmark / fixture / test-harness infrastructure,
+  # whatever type they carry (e.g. `perf(bench):`, `perf(fixtures):`).
+  { message = "^[a-z]+\\((bench|fixtures|ios-tests)\\)", skip = true },
+
+  # Intra-PR review fixups ("address PR #41 review findings", "apply review
+  # feedback", "address GraDKh review round 2"). The substantive change is
+  # already represented by its parent feat/fix bullet, so these only add noise.
+  # Anchored on a leading address/apply verb so a real fix that merely mentions
+  # review follow-ups in passing is NOT dropped.
+  { message = "(?i)^[a-z]+(\\([^)]*\\))?!?: *(address|apply) .*review", skip = true },
+
+  # Build/test plumbing keywords: recorded LLM cassettes, XCTest wiring, load
+  # harnesses, build.rs / cargo invocation and header-sync gate fixes. None of
+  # these change library behaviour.
+  #
+  # `^[^\n]*` restricts the match to the SUBJECT line. These parsers run against
+  # the full commit message, so an unanchored keyword also matches the body —
+  # which silently dropped real user-facing fixes whose bodies merely mentioned a
+  # cassette or build.rs. Rust's `regex` has `.`/`[^\n]` not crossing newlines
+  # and `^` not multiline by default, so this cannot leak past the first line.
+  { message = "^[^\\n]*(?i:cassette|xctest|xctunwrap|test bundle|load-harness|build\\.rs|--crate-type|header-sync|protoc)", skip = true },
+
+  # ── User-facing groups ──────────────────────────────────────────────
   { message = "^feat",            group = "Added" },
   { message = "^fix",             group = "Fixed" },
   { message = "^perf",            group = "Changed" },
   { message = "^refactor",        group = "Changed" },
   { message = "^doc",             group = "Documentation" },
-  { message = "^spike",           group = "Other" },
-  { message = "^ci",              group = "Other" },
-  { message = "^build",           group = "Other" },
-  { message = "^chore",           group = "Other" },
-  { message = "^test",            skip = true },
   { message = ".*",               group = "Other" },
 ]

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,7 +7,8 @@ Releasing cognee-rust is a **two-phase, release-PR-driven** flow:
 2. **Verify** — the normal PR CI builds everything and dry-run-packages the
    crates; you review the changelog and the green checks.
 3. **Publish** — merging the PR (with a required-reviewer approval on the publish
-   job) publishes to **crates.io + npm + the C-API GitHub Release**.
+   job) publishes to **crates.io + npm + Maven Central + the C-API GitHub
+   Release**.
 
 ## TL;DR — cut a release
 
@@ -40,6 +41,20 @@ commits, pushes, and opens a PR labelled `autorelease:pending`. The PAT (not
 
 A human reviews the changelog diff + green checks, approves the review, and merges.
 
+**What the changelog review must actually check** — `cliff.toml` drops
+repo-internal churn (CI, chores, cassettes, benchmark/fixture scopes, intra-PR
+review fixups, build plumbing) so the generated section is user-facing by
+default. Two things it cannot do for you:
+
+- **Reposition the breaking notes.** The generated section is inserted directly
+  after the `## [Unreleased]` marker, so any hand-written `### Breaking changes`
+  prose ends up *below* it. Move that block to the top of the new version's
+  section (see the `RELEASER:` comment in `CHANGELOG.md`).
+- **Catch a mis-typed commit.** The skip rules are categorical, so a user-facing
+  change committed as `chore:`/`ci:` — or whose subject happens to mention a
+  plumbing keyword — is silently dropped. Skim `git log <prev-tag>..HEAD` against
+  the generated bullets and hand-add anything missing.
+
 ### Phase 2 — `release-publish.yml` (trigger: the release PR is merged)
 Runs behind the **`release` environment** (required reviewers). Order:
 0. **Preflight** — `cargo owner --list -p cognee-models` and `npm whoami` (real
@@ -56,7 +71,19 @@ Runs behind the **`release` environment** (required reviewers). Order:
      ONNX Runtime for it (mirrors ts-prebuild dropping darwin-x64).
    - `ts-prebuild.yml` → prebuilt `.node` binaries + `@cognee/neon-*` and
      `@cognee/cognee-ts` npm packages (gated on `NPM_TOKEN`).
+   - `java-prebuild.yml` → 4 per-platform classifier jars (linux-x86_64,
+     linux-aarch_64, osx-aarch_64, windows-x86_64) + the main/sources/javadoc
+     jars, GPG-signed and uploaded as a bundle to the Central Portal as
+     `io.github.topoteretes:cognee:X.Y.Z` (gated on `MAVEN_CENTRAL_PASSWORD`).
+     `autoPublish=false` — the bundle lands in the Portal and **a human must
+     review and release it**, so Maven Central is the one target that is not
+     fully automatic. Its version comes solely from `java/pom.xml`, and Central
+     releases are immutable: re-deploying an existing version fails.
 3. **GitHub Release** — created/updated with the changelog section.
+
+`ios.yml` is **not** part of the release. It is a `main`/PR check only (cargo
+check for the iOS targets + a Swift parse) and ships no artifact; the Swift
+package is consumed from source.
 
 Publishing crates.io *before* the tag cascade means a crates.io failure aborts
 before any npm / C-API artifact ships.
@@ -69,6 +96,8 @@ before any npm / C-API artifact ships.
 | `capi/Cargo.toml` | `cargo set-version --manifest-path capi/Cargo.toml` |
 | `ts/cognee-ts-neon/Cargo.toml` | `cargo set-version --manifest-path …` |
 | `ts/package.json` + `@cognee/neon-*` pins + `ts/platform-packages/*/package.json` | node script |
+| `java/cognee-java-jni/Cargo.toml` | `cargo set-version --manifest-path …` (standalone crate, like ts-neon) |
+| `java/pom.xml` (`<project>` version) | python edit, anchored to the `io.github.topoteretes:cognee` coordinates so dependency/plugin `<version>` tags are untouched |
 | `python/` (`cognee-python`) | **automatic** — inherits `version.workspace`; `pyproject.toml` is `dynamic` |
 
 The Python binding is **not published to PyPI**; users build from source
@@ -81,6 +110,8 @@ The Python binding is **not published to PyPI**; users build from source
 | `RELEASE_PAT` | Repo secret. Fine-grained PAT scoped to this repo with **Contents: Read and write**, **Pull requests: Read and write**, **Issues: Read and write** (or a classic PAT with the `repo` scope). The owner only needs **write** access, not admin — the flow never pushes to `main` (it pushes a `release/*` branch and a tag; `main` advances via the PR merge). It must be a PAT rather than `GITHUB_TOKEN` so the opened PR triggers CI and the pushed tag cascades. | `release-open.yml` (open PR, push branch), `release-publish.yml` (push tag, create Release) |
 | `CARGO_REGISTRY_TOKEN` | **Environment** secret on `release`. crates.io token with publish rights for all `cognee-*` crates. | `release-publish.yml` preflight + publish |
 | `NPM_TOKEN` | Repo secret. npm token with publish rights to the `@cognee` org. | `release-verify.yml`, `ts-prebuild.yml`, `release-publish.yml` preflight |
+| `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` | Repo secrets. Central Portal user token for `io.github.topoteretes`. `MAVEN_CENTRAL_PASSWORD` doubles as the publish gate — absent, the Java deploy silently no-ops. | `java-prebuild.yml` |
+| `MAVEN_GPG_PRIVATE_KEY` / `MAVEN_GPG_PASSPHRASE` | Repo secrets. GPG key used to sign the Maven artifacts (Central requires signatures). | `java-prebuild.yml` |
 
 **One-time setup:** in **Settings → Environments**, create an environment named
 `release`, add the required reviewers who must approve each publish, and store
@@ -118,6 +149,10 @@ git push origin main v0.1.3
 2. Verify installs: `npm install @cognee/cognee-ts@X.Y.Z` and a `maturin develop`
    smoke build for the Python binding.
 3. Confirm the `cognee-*` crates are live on crates.io.
+4. **Release the Maven bundle** — `java-prebuild.yml` uploads with
+   `autoPublish=false`, so the deploy is not live until someone reviews and
+   releases it in the [Central Portal](https://central.sonatype.com/publishing).
+   Then confirm `io.github.topoteretes:cognee:X.Y.Z` resolves.
 
 ## Notes / tradeoffs
 
@@ -159,3 +194,9 @@ Release. If it fails partway:
   directly: `capi-release.yml` (`workflow_dispatch` with the tag) and/or
   `ts-prebuild.yml` (`workflow_dispatch`). Both are idempotent — they skip
   platforms/packages already published.
+- **The Java deploy failed** — re-run `java-prebuild.yml` via
+  `workflow_dispatch`. Unlike the others this is **not** idempotent against a
+  *released* Central version (releases are immutable, so a duplicate deploy
+  fails); if `java/pom.xml` was left at the previous version, fix the pom on
+  `main` first, then dispatch. A bundle that is merely *uploaded* (not yet
+  released in the Portal) can be dropped there and re-deployed.

--- a/scripts/release/assert-version.sh
+++ b/scripts/release/assert-version.sh
@@ -7,9 +7,13 @@
 # release where one crate lags the tag. This script is the gate: it runs on the
 # release PR (release-verify.yml) and can be run locally after set-version.sh.
 #
-# Checks the PACKAGE version of every crate in all three Cargo workspaces (root,
-# capi, ts-neon) and every npm package.json (+ its @cognee/neon-*
-# optionalDependencies pins). This is the one thing cargo cannot catch for us: a
+# Checks the PACKAGE version of every crate in all four Cargo workspaces (root,
+# capi, ts-neon, java-jni), every npm package.json (+ its @cognee/neon-*
+# optionalDependencies pins), and java/pom.xml's <project> version — the pom is
+# the sole source of the Maven Central coordinates in the tag-cascaded
+# java-prebuild.yml, and Central releases are immutable, so a stale version
+# there fails the deploy after crates.io has already shipped.
+# This is the one thing cargo cannot catch for us: a
 # stale intra-workspace *dependency requirement* already makes `cargo update` /
 # `cargo publish --dry-run` fail to resolve (a bumped crate no longer satisfies
 # the old `^x.y.z`), so ci.yml + publish-dry-run.yml cover that — this script
@@ -32,12 +36,13 @@ fail() { echo "  MISMATCH: $*" >&2; fails=$((fails + 1)); }
 
 # --- Cargo manifests: package version of every workspace member ----------------
 # Uses cargo metadata so inherited (version.workspace) members resolve correctly.
-# Covers all three workspaces: root (all cognee-* crates), capi, and ts-neon.
+# Covers all four workspaces: root (all cognee-* crates), capi, ts-neon, java-jni.
 python3 - "$VERSION" <<'PY' || fails=$((fails + 1))
 import json, subprocess, sys
 version = sys.argv[1]
 bad = []
-for manifest in ("Cargo.toml", "capi/Cargo.toml", "ts/cognee-ts-neon/Cargo.toml"):
+for manifest in ("Cargo.toml", "capi/Cargo.toml", "ts/cognee-ts-neon/Cargo.toml",
+                 "java/cognee-java-jni/Cargo.toml"):
     meta = json.loads(subprocess.check_output(
         ["cargo", "metadata", "--no-deps", "--format-version", "1",
          "--manifest-path", manifest]))
@@ -78,6 +83,23 @@ if (bad.length) {
 }
 console.log("  npm packages: all at", version);
 NODE
+
+# --- Java pom (Maven Central coordinates) --------------------------------------
+python3 - "$VERSION" "$ROOT/java/pom.xml" <<'PY' || fails=$((fails + 1))
+import re, sys
+version, pom = sys.argv[1], sys.argv[2]
+src = open(pom, encoding="utf-8").read()
+m = re.search(
+    r"<groupId>io\.github\.topoteretes</groupId>\s*"
+    r"<artifactId>cognee</artifactId>\s*<version>([^<]+)</version>",
+    src,
+)
+if not m:
+    sys.exit("  MISMATCH (maven): could not locate the <project> version in java/pom.xml")
+if m.group(1) != version:
+    sys.exit(f"  MISMATCH (maven):\n    - java/pom.xml <project> version={m.group(1)}")
+print("  maven pom: at", version)
+PY
 
 if [ "$fails" -gt 0 ]; then
   echo "assert-version: FAILED — ${fails} location group(s) not at ${VERSION}" >&2

--- a/scripts/release/set-version.sh
+++ b/scripts/release/set-version.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Set EVERY cognee-rust version location to a single X.Y.Z.
 #
-# cognee-rust ships from four separate manifests plus a set of npm package.json
-# files, and they must all carry the same version at release time. This script
+# cognee-rust ships from five separate Cargo manifests plus a set of npm
+# package.json files plus the Java pom, and they must all carry the same version
+# at release time. This script
 # is the single source of truth for that bump — the release-open workflow
 # (.github/workflows/release-open.yml) calls it, and it is safe to run by
 # hand for a local dry run.
@@ -18,9 +19,16 @@
 #   3. ts-neon crate   — ts/cognee-ts-neon/Cargo.toml [package] version.
 #   4. TS npm packages — ts/package.json version, its @cognee/neon-*
 #      optionalDependencies pins, and each ts/platform-packages/*/package.json.
+#   5. java-jni crate  — java/cognee-java-jni/Cargo.toml [package] version
+#      (standalone crate, mirrors ts-neon).
+#   6. Java pom        — java/pom.xml's <project> version. Load-bearing: the
+#      tag-cascaded java-prebuild.yml derives the jar version and the Maven
+#      Central coordinates from this file alone, and Central releases are
+#      IMMUTABLE — a missed bump here makes the deploy re-publish the previous
+#      version and fail, stranding Java users on the old release.
 #
-# Requires cargo-edit (`cargo install cargo-edit`) for `cargo set-version` and
-# node for the JSON edits.
+# Requires cargo-edit (`cargo install cargo-edit`) for `cargo set-version`,
+# node for the JSON edits, and python3 for the pom edit.
 #
 # Usage:
 #   scripts/release/set-version.sh 0.1.3
@@ -55,6 +63,10 @@ if ! cargo set-version --help >/dev/null 2>&1; then
 fi
 if ! command -v node >/dev/null 2>&1; then
   echo "error: node not found — required to bump the TS package.json files" >&2
+  exit 3
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 not found — required to bump java/pom.xml" >&2
   exit 3
 fi
 
@@ -109,5 +121,33 @@ for (const entry of fs.readdirSync(platDir, { withFileTypes: true })) {
   edit(rel, (pkg) => { pkg.version = version; });
 }
 NODE
+
+# 5. java-jni standalone crate.
+echo "-- java/cognee-java-jni/Cargo.toml"
+cargo set-version --manifest-path "$ROOT/java/cognee-java-jni/Cargo.toml" "$VERSION"
+
+# 6. Java pom — the <version> that is a direct child of <project>, anchored to
+#    the project coordinates so dependency/plugin <version> tags are never
+#    touched. Fails loudly if the anchor is gone (a silent skip here would ship
+#    a broken Maven Central deploy).
+echo "-- java/pom.xml"
+python3 - "$VERSION" "$ROOT/java/pom.xml" <<'PY'
+import re, sys
+version, pom = sys.argv[1], sys.argv[2]
+src = open(pom, encoding="utf-8").read()
+# <groupId>…</groupId><artifactId>cognee</artifactId><version>X.Y.Z</version>
+pat = re.compile(
+    r"(<groupId>io\.github\.topoteretes</groupId>\s*"
+    r"<artifactId>cognee</artifactId>\s*<version>)([^<]+)(</version>)"
+)
+new, n = pat.subn(lambda m: m.group(1) + version + m.group(3), src, count=1)
+if n != 1:
+    sys.exit(
+        "error: could not locate the <project> version in java/pom.xml — the "
+        "project coordinates changed; update set-version.sh before releasing"
+    )
+open(pom, "w", encoding="utf-8").write(new)
+print(f"   java/pom.xml -> {version}")
+PY
 
 echo "== Done. Review with: git diff --stat =="


### PR DESCRIPTION
Release-pipeline prep for **0.2.0**. Two independent problems, both found by dry-running the release flow against `main`.

## 1. The release PR would have opened red

`set-version.sh` never bumped `java/pom.xml` or `java/cognee-java-jni/Cargo.toml`, and `assert-version.sh` never checked them. But `java/scripts/check.sh` asserts a three-way parity — workspace `Cargo.toml` == jni crate == pom — and `ci.yml`'s `java-check` is a required gate. So a `release:0.2.0` label would have opened a **red** release PR with no automated remedy, forcing hand-edits on the release branch mid-release.

The jni crate's version is load-bearing at runtime as well: the pom ↔ cdylib `CARGO_PKG_VERSION` handshake compares them.

- `set-version.sh` bumps both. The pom edit is anchored to the `io.github.topoteretes:cognee` coordinates so dependency/plugin `<version>` tags are untouched, and it **exits non-zero if that anchor ever disappears** rather than silently skipping.
- `assert-version.sh` now covers four Cargo workspaces plus the pom.

Verified by a full 0.2.0 dry run: every version location bumped, `assert-version` clean, `java/scripts/check.sh` → `version ok (0.2.0)`. Then reverted.

## 2. Changelog generation: no breaking-change flag, lots of internal noise

`cliff.toml`'s template ignored `commit.breaking`, so the `cognee-lib` → `cognee` rename rendered as an ordinary "Added" bullet on a release whose entire justification is breaking changes. Now prefixed `**[BREAKING]**`.

Internal churn is dropped via **categorical** rules (not per-commit, so they keep working): whole types (`chore`/`ci`/`build`/`spike`/`test`), infrastructure scopes (`bench`/`fixtures`/`ios-tests`), intra-PR review fixups, and build/test plumbing keywords. For 0.2.0: **54 commits → 26 user-facing bullets**, and the `### Other` section disappears.

All 28 dropped commits were audited individually — 4 merge commits, 5 chores (cassette re-records, Maven plugin bump), 3 CI, 1 test, 3 bench/fixture-scoped, 5 review fixups, 7 build plumbing.

> [!IMPORTANT]
> The plumbing-keyword rule is anchored with `^[^\n]*` to confine it to the **subject line**. These parsers run against the *full commit message*, and an unanchored keyword silently dropped three real user-facing fixes (#88, #83, #70) whose bodies merely mentioned a cassette or `build.rs`. Caught by diffing every commit against the generated bullets.

## Docs

`docs/RELEASE.md` had **no mention of the Java/Maven Central leg at all**. Added: the `java-prebuild.yml` tag cascade, the Maven secrets, recovery steps, and that `autoPublish=false` makes Maven Central the one target requiring a **manual release in the Portal**. Also clarified `ios.yml` is check-only and ships nothing, and gave the changelog review an explicit checklist (reposition the breaking notes; watch for mis-typed commits the categorical rules drop).

`CHANGELOG.md` gains migration prose for the rename (it had none) under a `### Breaking changes` heading, which also resolves a duplicate `### Changed` collision with the generated section.

## Two judgment calls worth a look

- `ci(ort): mirror ONNX Runtime … pyke CDN 403s (#64)` — dropped as CI, but it genuinely unblocked users building from source. Arguably belongs in Fixed.
- `feat(llm): add ThrottleLlm load-harness instrument (#19)` — dropped as a dev instrument, though it does add a public type.

## Testing

- `scripts/check_all.sh` — passed (exit 0) on the base commit. No Rust changes here; this PR touches only shell, TOML, Markdown, and a workflow.
- Full `set-version.sh 0.2.0` → `assert-version.sh 0.2.0` → `java/scripts/check.sh` dry run, then reverted to 0.1.3.
- `git-cliff` preview diffed commit-by-commit against the generated bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxKe2CjjA536dfGbjWcWN9
