### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/topoteretes/cognee-rs/compare/v0.1.3...v0.2.0) - 2026-07-30
+
+### Added
+
+- Port HybridRetriever (HYBRID_COMPLETION) to Rust — Phase 1 core + default-off Phase 2 truth-subspace (#107)
+- Azure OpenAI support (Tier 3) (#41)
+- **[BREAKING]** Rename umbrella crate cognee-lib to cognee (#93)
+- Native Anthropic Messages API adapter (Tier 2)
+- Java SDK bindings (JNI) for cognee-rust (#82)
+- Batch multiple chunks per extraction request (#19) (#63)
+- Add iOS bindings with Swift async/await wrapper
+
+### Changed
+
+- Wrap bulk provenance writes in a transaction + configure connection pool (#35)
+- Remove now-unused summarization_batch_size knob
+- Bound summarization concurrency and add retry jitter
+- Extract cognee-components + pluggable adapter registry (#56)
+
+### Documentation
+
+- Correct cognee-cli install note and workspace tree root (#92)
+- Package is live on Maven Central; use version-agnostic install (#86)
+- Add Swift package README
+
+### Fixed
+
+- Harden connect_sqlite + review follow-ups from #35 (#103)
+- Accept single & repeated dataset params on GET /datasets/status (#101)
+- Apply llm_max_completion_tokens to recall/search (#67) (#97)
+- Single-database (relational + pgvector + pggraph) deploys (#95)
+- Give aux migrators their own tracking tables for shared-Postgres deploys (#89)
+- Reliably extract year-only temporal intervals (#90)
+- Require node descriptions in prompt so non-strict LLMs don't fail (#66) (#88)
+- Require KnowledgeGraph edges so extraction captures relationships (#83)
+- Litellm-parity for OpenAI-compatible adapter (custom endpoints) (#78)
+- Deterministic class-namespaced Entity/EntityType/EdgeType ids (#57) (#77)
+- Type remember() result & document snake_case parity (#46) (#70)
+- Npm publish path + capi-release platform/cross fixes (#62)
+
+
 <!-- RELEASER: release-open.yml inserts the git-cliff-generated section directly
      after the `## [Unreleased]` marker above, which lands it BEFORE any
      hand-written prose below. When reviewing the release PR, move this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- RELEASER: release-open.yml inserts the git-cliff-generated section directly
+     after the `## [Unreleased]` marker above, which lands it BEFORE any
+     hand-written prose below. When reviewing the release PR, move this
+     `### Breaking changes` block to the TOP of the new version's section —
+     ahead of Added/Changed/Fixed — so the breaking notes are the first thing a
+     reader sees. git-cliff only flags breaking *commits* (`feat!:` → a
+     **[BREAKING]** bullet); migration prose like the entries below is always
+     hand-written and always needs this manual reposition. -->
+
 ## [0.2.0](https://github.com/topoteretes/cognee-rs/compare/v0.1.3...v0.2.0) - 2026-07-30
+
+### Breaking changes
+
+- **Umbrella crate renamed `cognee-lib` → `cognee`.** Depend on `cognee` instead
+  (`cargo add cognee`) and import from it (`use cognee::api::remember;` rather
+  than `use cognee_lib::api::remember;`). `cognee-lib` is still published as a
+  thin re-export shim so existing dependents keep compiling unchanged, but it is
+  deprecated and will not be maintained indefinitely. Every Cargo feature
+  forwards 1:1, so no feature flags need changing. See [#93].
+
+- **Graph data:** `Entity`, `EntityType`, and `EdgeType` node/point
+  ids are now **deterministic and class-namespaced** —
+  `uuid5(NAMESPACE_OID, "{ClassName}:{normalized_value}")` — matching upstream
+  Python cognee's `DataPoint.id_for`. Previously entities/entity-types were
+  assigned random `uuid4` ids, so the same entity duplicated across `cognify`
+  runs instead of merging (issue [#57]), and database-backed edge dedup never
+  matched. Ontology/temporal/memify id sites were also brought onto the same
+  scheme. Graphs created before this change hold the old ids and will **not**
+  merge with newly-created nodes — re-run `cognify` on existing datasets (no
+  automatic migration is provided). See [#57] for details.
+
+[#57]: https://github.com/topoteretes/cognee-rs/issues/57
+[#93]: https://github.com/topoteretes/cognee-rs/pull/93
 
 ### Added
 
@@ -46,39 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deterministic class-namespaced Entity/EntityType/EdgeType ids (#57) (#77)
 - Type remember() result & document snake_case parity (#46) (#70)
 - Npm publish path + capi-release platform/cross fixes (#62)
-
-
-<!-- RELEASER: release-open.yml inserts the git-cliff-generated section directly
-     after the `## [Unreleased]` marker above, which lands it BEFORE any
-     hand-written prose below. When reviewing the release PR, move this
-     `### Breaking changes` block to the TOP of the new version's section —
-     ahead of Added/Changed/Fixed — so the breaking notes are the first thing a
-     reader sees. git-cliff only flags breaking *commits* (`feat!:` → a
-     **[BREAKING]** bullet); migration prose like the entries below is always
-     hand-written and always needs this manual reposition. -->
-
-### Breaking changes
-
-- **Umbrella crate renamed `cognee-lib` → `cognee`.** Depend on `cognee` instead
-  (`cargo add cognee`) and import from it (`use cognee::api::remember;` rather
-  than `use cognee_lib::api::remember;`). `cognee-lib` is still published as a
-  thin re-export shim so existing dependents keep compiling unchanged, but it is
-  deprecated and will not be maintained indefinitely. Every Cargo feature
-  forwards 1:1, so no feature flags need changing. See [#93].
-
-- **Graph data:** `Entity`, `EntityType`, and `EdgeType` node/point
-  ids are now **deterministic and class-namespaced** —
-  `uuid5(NAMESPACE_OID, "{ClassName}:{normalized_value}")` — matching upstream
-  Python cognee's `DataPoint.id_for`. Previously entities/entity-types were
-  assigned random `uuid4` ids, so the same entity duplicated across `cognify`
-  runs instead of merging (issue [#57]), and database-backed edge dedup never
-  matched. Ontology/temporal/memify id sites were also brought onto the same
-  scheme. Graphs created before this change hold the old ids and will **not**
-  merge with newly-created nodes — re-run `cognify` on existing datasets (no
-  automatic migration is provided). See [#57] for details.
-
-[#57]: https://github.com/topoteretes/cognee-rs/issues/57
-[#93]: https://github.com/topoteretes/cognee-rs/pull/93
+- Mirror ONNX Runtime downloads so builds no longer fail on upstream CDN 403s (#64)
 
 ## [0.1.3](https://github.com/topoteretes/cognee-rs/compare/v0.1.0...v0.1.3) - 2026-07-02
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.1.3"
+version = "0.2.0"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 authors = ["Topoteretes <support@cognee.ai>"]

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.1.3"
+version = "0.2.0"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
 authors = ["Topoteretes <support@cognee.ai>"]

--- a/crates/bindings-common/Cargo.toml
+++ b/crates/bindings-common/Cargo.toml
@@ -44,7 +44,7 @@ sqlite        = ["cognee/sqlite"]
 testing       = ["cognee/testing"]
 
 [dependencies]
-cognee = { path = "../lib", version = "0.1.3", default-features = false }
+cognee = { path = "../lib", version = "0.2.0", default-features = false }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/chunking/Cargo.toml
+++ b/crates/chunking/Cargo.toml
@@ -16,8 +16,8 @@ workspace = true
 
 [dependencies]
 async-trait.workspace = true
-cognee-models = { path = "../models", version = "0.1.3" }
-cognee-utils = { path = "../utils", version = "0.1.3" }
+cognee-models = { path = "../models", version = "0.2.0" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
@@ -32,7 +32,7 @@ tiktoken-rs = { workspace = true, optional = true }
 # pure chunking primitives (chunk_text, TokenCounter, …) stay wasm-clean.
 # See docs/spike-wasm-config1.md.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cognee-storage = { path = "../storage", version = "0.1.3" }
+cognee-storage = { path = "../storage", version = "0.2.0" }
 tokio.workspace = true
 
 [features]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -91,8 +91,8 @@ android-default = ["cognee/android-default"]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
-cognee = { path = "../lib", version = "0.1.3" }
-cognee-logging = { path = "../logging", version = "0.1.3" }
+cognee = { path = "../lib", version = "0.2.0" }
+cognee-logging = { path = "../logging", version = "0.2.0" }
 dirs.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cognee-lib/Cargo.toml
+++ b/crates/cognee-lib/Cargo.toml
@@ -96,4 +96,4 @@ android-default   = ["cognee/android-default"]
 testing           = ["cognee/testing"]
 
 [dependencies]
-cognee = { path = "../lib", version = "0.1.3", default-features = false }
+cognee = { path = "../lib", version = "0.2.0", default-features = false }

--- a/crates/cognify/Cargo.toml
+++ b/crates/cognify/Cargo.toml
@@ -21,20 +21,20 @@ image-loader = ["cognee-ingestion/image-loader"]
 audio-loader = ["cognee-ingestion/audio-loader"]
 
 [dependencies]
-cognee-models = { path = "../models", version = "0.1.3" }
-cognee-storage = { path = "../storage", version = "0.1.3" }
-cognee-chunking = { path = "../chunking", version = "0.1.3" }
-cognee-core = { path = "../core", version = "0.1.3" }
-cognee-ingestion = { path = "../ingestion", version = "0.1.3" }
-cognee-llm = { path = "../llm", version = "0.1.3" }
-cognee-graph = { path = "../graph", version = "0.1.3" }
-cognee-utils = { path = "../utils", version = "0.1.3" }
-cognee-embedding = { path = "../embedding", version = "0.1.3" }
-cognee-vector = { path = "../vector", version = "0.1.3" }
-cognee-ontology = { path = "../ontology", version = "0.1.3" }
-cognee-database = { path = "../database", version = "0.1.3" }
-cognee-session = { path = "../session", version = "0.1.3" }
-cognee-truth-subspace = { path = "../truth-subspace", version = "0.1.3" }
+cognee-models = { path = "../models", version = "0.2.0" }
+cognee-storage = { path = "../storage", version = "0.2.0" }
+cognee-chunking = { path = "../chunking", version = "0.2.0" }
+cognee-core = { path = "../core", version = "0.2.0" }
+cognee-ingestion = { path = "../ingestion", version = "0.2.0" }
+cognee-llm = { path = "../llm", version = "0.2.0" }
+cognee-graph = { path = "../graph", version = "0.2.0" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
+cognee-embedding = { path = "../embedding", version = "0.2.0" }
+cognee-vector = { path = "../vector", version = "0.2.0" }
+cognee-ontology = { path = "../ontology", version = "0.2.0" }
+cognee-database = { path = "../database", version = "0.2.0" }
+cognee-session = { path = "../session", version = "0.2.0" }
+cognee-truth-subspace = { path = "../truth-subspace", version = "0.2.0" }
 
 chrono.workspace = true
 uuid = { workspace = true, features = ["v4"] }

--- a/crates/components/Cargo.toml
+++ b/crates/components/Cargo.toml
@@ -34,12 +34,12 @@ mock-llm     = ["cognee-llm/mock"]
 testing      = ["cognee-vector/testing", "cognee-graph/testing"]
 
 [dependencies]
-cognee-database = { path = "../database", version = "0.1.3" }
-cognee-embedding = { path = "../embedding", version = "0.1.3" }
-cognee-graph = { path = "../graph", version = "0.1.3" }
-cognee-llm = { path = "../llm", version = "0.1.3" }
-cognee-storage = { path = "../storage", version = "0.1.3" }
-cognee-vector = { path = "../vector", version = "0.1.3" }
+cognee-database = { path = "../database", version = "0.2.0" }
+cognee-embedding = { path = "../embedding", version = "0.2.0" }
+cognee-graph = { path = "../graph", version = "0.2.0" }
+cognee-llm = { path = "../llm", version = "0.2.0" }
+cognee-storage = { path = "../storage", version = "0.2.0" }
+cognee-vector = { path = "../vector", version = "0.2.0" }
 async-trait.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,11 +19,11 @@ telemetry = ["cognee-telemetry/telemetry"]
 pipeline-run-registry = []
 
 [dependencies]
-cognee-database = { path = "../database", version = "0.1.3" }
-cognee-graph = { path = "../graph", version = "0.1.3" }
-cognee-models = { path = "../models", version = "0.1.3" }
-cognee-telemetry = { path = "../telemetry", version = "0.1.3" }
-cognee-vector = { path = "../vector", version = "0.1.3" }
+cognee-database = { path = "../database", version = "0.2.0" }
+cognee-graph = { path = "../graph", version = "0.2.0" }
+cognee-models = { path = "../models", version = "0.2.0" }
+cognee-telemetry = { path = "../telemetry", version = "0.2.0" }
+cognee-vector = { path = "../vector", version = "0.2.0" }
 
 async-trait.workspace = true
 chrono.workspace = true

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -19,8 +19,8 @@ sqlite   = ["sea-orm/sqlx-sqlite", "dep:log", "dep:tokio"]
 postgres = ["sea-orm/sqlx-postgres"]
 
 [dependencies]
-cognee-models     = { path = "../models", version = "0.1.3" }
-cognee-utils      = { path = "../utils", version = "0.1.3" }
+cognee-models     = { path = "../models", version = "0.2.0" }
+cognee-utils      = { path = "../utils", version = "0.2.0" }
 async-trait.workspace = true
 chrono.workspace  = true
 include_dir = "0.7"

--- a/crates/delete/Cargo.toml
+++ b/crates/delete/Cargo.toml
@@ -15,13 +15,13 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-cognee-core = { path = "../core", version = "0.1.3", features = ["pipeline-run-registry"] }
-cognee-database = { path = "../database", version = "0.1.3" }
-cognee-graph = { path = "../graph", version = "0.1.3" }
-cognee-models = { path = "../models", version = "0.1.3" }
-cognee-session = { path = "../session", version = "0.1.3" }
-cognee-storage = { path = "../storage", version = "0.1.3" }
-cognee-vector = { path = "../vector", version = "0.1.3" }
+cognee-core = { path = "../core", version = "0.2.0", features = ["pipeline-run-registry"] }
+cognee-database = { path = "../database", version = "0.2.0" }
+cognee-graph = { path = "../graph", version = "0.2.0" }
+cognee-models = { path = "../models", version = "0.2.0" }
+cognee-session = { path = "../session", version = "0.2.0" }
+cognee-storage = { path = "../storage", version = "0.2.0" }
+cognee-vector = { path = "../vector", version = "0.2.0" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/embedding/Cargo.toml
+++ b/crates/embedding/Cargo.toml
@@ -35,7 +35,7 @@ ort-tensorrt = ["ort/tensorrt"]
 
 [dependencies]
 async-trait = { workspace = true }
-cognee-utils = { path = "../utils", version = "0.1.3" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
 futures     = { workspace = true }
 tokio       = { workspace = true }
 serde       = { workspace = true }

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -45,8 +45,8 @@ sea-orm-migration = { version = "1.1", features = [
 ], optional = true }
 
 # Internal dependencies
-cognee-models = { path = "../models", version = "0.1.3" }
-cognee-utils = { path = "../utils", version = "0.1.3" }
+cognee-models = { path = "../models", version = "0.2.0" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
 
 [features]
 ladybug = ["dep:lbug"]

--- a/crates/http-server/Cargo.toml
+++ b/crates/http-server/Cargo.toml
@@ -102,34 +102,34 @@ hyper = { version = "1", features = ["server", "http1", "http2"] }
 # NOTE: cognee is intentionally NOT a direct dep here — adding it would
 # create a cycle when cognee's `server` feature pulls in cognee-http-server.
 # Concrete cognee types are wired via AppState in P1+.
-cognee-models = { path = "../models", version = "0.1.3" }
-cognee-observability = { path = "../observability", version = "0.1.3", optional = true }
+cognee-models = { path = "../models", version = "0.2.0" }
+cognee-observability = { path = "../observability", version = "0.2.0", optional = true }
 # Product-analytics client. Gated by the `telemetry` feature so a
 # `--no-default-features` build drops the dep entirely; the `emit` helper
 # in `telemetry.rs` compiles to a noop when absent.
-cognee-telemetry = { path = "../telemetry", version = "0.1.3", optional = true, features = ["telemetry"] }
-cognee-core = { path = "../core", version = "0.1.3", features = ["pipeline-run-registry"] }
+cognee-telemetry = { path = "../telemetry", version = "0.2.0", optional = true, features = ["telemetry"] }
+cognee-core = { path = "../core", version = "0.2.0", features = ["pipeline-run-registry"] }
 # Shared backend construction + adapter registry. Standalone wiring builds a
 # `ComponentRegistry::with_builtins()`; the enabled features here determine
 # which providers `with_builtins()` registers (onnx/ladybug/pgvector; mock-llm
 # is intentionally NOT enabled so a production server never honors MOCK_LLM).
-cognee-components = { path = "../components", version = "0.1.3", default-features = false, features = ["onnx", "ladybug", "pgvector"] }
-cognee-database = { path = "../database", version = "0.1.3", features = ["sqlite"] }
+cognee-components = { path = "../components", version = "0.2.0", default-features = false, features = ["onnx", "ladybug", "pgvector"] }
+cognee-database = { path = "../database", version = "0.2.0", features = ["sqlite"] }
 sea-orm = { version = "1", default-features = false, features = ["runtime-tokio-rustls", "with-chrono", "with-uuid", "with-json"] }
-cognee-storage = { path = "../storage", version = "0.1.3" }
-cognee-ingestion = { path = "../ingestion", version = "0.1.3" }
-cognee-cognify = { path = "../cognify", version = "0.1.3" }
-cognee-embedding = { path = "../embedding", version = "0.1.3", features = ["onnx"] }
-cognee-delete = { path = "../delete", version = "0.1.3" }
-cognee-ontology = { path = "../ontology", version = "0.1.3" }
-cognee-search = { path = "../search", version = "0.1.3" }
-cognee-session = { path = "../session", version = "0.1.3" }
-cognee-llm = { path = "../llm", version = "0.1.3" }
-cognee-graph = { path = "../graph", version = "0.1.3", features = ["ladybug"] }
-cognee-vector = { path = "../vector", version = "0.1.3", features = ["pgvector"] }
-cognee-logging = { path = "../logging", version = "0.1.3" }
-cognee-visualization = { path = "../visualization", version = "0.1.3" }
-cognee-utils = { path = "../utils", version = "0.1.3" }
+cognee-storage = { path = "../storage", version = "0.2.0" }
+cognee-ingestion = { path = "../ingestion", version = "0.2.0" }
+cognee-cognify = { path = "../cognify", version = "0.2.0" }
+cognee-embedding = { path = "../embedding", version = "0.2.0", features = ["onnx"] }
+cognee-delete = { path = "../delete", version = "0.2.0" }
+cognee-ontology = { path = "../ontology", version = "0.2.0" }
+cognee-search = { path = "../search", version = "0.2.0" }
+cognee-session = { path = "../session", version = "0.2.0" }
+cognee-llm = { path = "../llm", version = "0.2.0" }
+cognee-graph = { path = "../graph", version = "0.2.0", features = ["ladybug"] }
+cognee-vector = { path = "../vector", version = "0.2.0", features = ["pgvector"] }
+cognee-logging = { path = "../logging", version = "0.2.0" }
+cognee-visualization = { path = "../visualization", version = "0.2.0" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }

--- a/crates/ingestion/Cargo.toml
+++ b/crates/ingestion/Cargo.toml
@@ -18,13 +18,13 @@ workspace = true
 async-trait.workspace = true
 # `pipeline.rs` uses `DbPipelineWatcher` unconditionally, so it needs the
 # `pipeline-run-registry` module which `cognee-core` gates behind this feature.
-cognee-core = { path = "../core", version = "0.1.3", features = ["pipeline-run-registry"] }
-cognee-database = { path = "../database", version = "0.1.3" }
-cognee-graph = { path = "../graph", version = "0.1.3" }
-cognee-models = { path = "../models", version = "0.1.3" }
-cognee-storage = { path = "../storage", version = "0.1.3" }
-cognee-vector = { path = "../vector", version = "0.1.3" }
-cognee-utils = { path = "../utils", version = "0.1.3" }
+cognee-core = { path = "../core", version = "0.2.0", features = ["pipeline-run-registry"] }
+cognee-database = { path = "../database", version = "0.2.0" }
+cognee-graph = { path = "../graph", version = "0.2.0" }
+cognee-models = { path = "../models", version = "0.2.0" }
+cognee-storage = { path = "../storage", version = "0.2.0" }
+cognee-vector = { path = "../vector", version = "0.2.0" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
 md-5.workspace = true
 sha2.workspace = true
 uuid.workspace = true
@@ -51,7 +51,7 @@ calamine = { workspace = true, optional = true }
 mail-parser = { workspace = true, optional = true }
 quick-xml = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
-cognee-llm = { path = "../llm", version = "0.1.3", optional = true }
+cognee-llm = { path = "../llm", version = "0.2.0", optional = true }
 
 [features]
 default = []

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -142,26 +142,26 @@ testing = [
 ]
 
 [dependencies]
-cognee-chunking = { path = "../chunking", version = "0.1.3" }
-cognee-utils = { path = "../utils", version = "0.1.3" }
-cognee-cognify = { path = "../cognify", version = "0.1.3" }
-cognee-components = { path = "../components", version = "0.1.3", default-features = false }
-cognee-core = { path = "../core", version = "0.1.3", features = ["pipeline-run-registry"] }
-cognee-delete = { path = "../delete", version = "0.1.3" }
-cognee-database = { path = "../database", version = "0.1.3" }
-cognee-embedding = { path = "../embedding", version = "0.1.3" }
-cognee-graph = { path = "../graph", version = "0.1.3" }
-cognee-ingestion = { path = "../ingestion", version = "0.1.3" }
-cognee-llm = { path = "../llm", version = "0.1.3" }
-cognee-models = { path = "../models", version = "0.1.3" }
-cognee-observability = { path = "../observability", version = "0.1.3", optional = true }
-cognee-ontology = { path = "../ontology", version = "0.1.3" }
-cognee-search = { path = "../search", version = "0.1.3" }
-cognee-session = { path = "../session", version = "0.1.3" }
-cognee-storage = { path = "../storage", version = "0.1.3" }
-cognee-telemetry = { path = "../telemetry", version = "0.1.3" }
-cognee-vector = { path = "../vector", version = "0.1.3" }
-cognee-visualization = { path = "../visualization", version = "0.1.3", optional = true }
+cognee-chunking = { path = "../chunking", version = "0.2.0" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
+cognee-cognify = { path = "../cognify", version = "0.2.0" }
+cognee-components = { path = "../components", version = "0.2.0", default-features = false }
+cognee-core = { path = "../core", version = "0.2.0", features = ["pipeline-run-registry"] }
+cognee-delete = { path = "../delete", version = "0.2.0" }
+cognee-database = { path = "../database", version = "0.2.0" }
+cognee-embedding = { path = "../embedding", version = "0.2.0" }
+cognee-graph = { path = "../graph", version = "0.2.0" }
+cognee-ingestion = { path = "../ingestion", version = "0.2.0" }
+cognee-llm = { path = "../llm", version = "0.2.0" }
+cognee-models = { path = "../models", version = "0.2.0" }
+cognee-observability = { path = "../observability", version = "0.2.0", optional = true }
+cognee-ontology = { path = "../ontology", version = "0.2.0" }
+cognee-search = { path = "../search", version = "0.2.0" }
+cognee-session = { path = "../session", version = "0.2.0" }
+cognee-storage = { path = "../storage", version = "0.2.0" }
+cognee-telemetry = { path = "../telemetry", version = "0.2.0" }
+cognee-vector = { path = "../vector", version = "0.2.0" }
+cognee-visualization = { path = "../visualization", version = "0.2.0", optional = true }
 async-trait.workspace = true
 chrono.workspace = true
 dotenv.workspace = true

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -46,7 +46,7 @@ rand = { workspace = true }
 tracing.workspace = true
 
 # Shared tracing-key constants
-cognee-utils = { path = "../utils", version = "0.1.3" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
 
 # Content hashing (cassette mock, feature-gated)
 sha2 = { workspace = true, optional = true }

--- a/crates/models/Cargo.toml
+++ b/crates/models/Cargo.toml
@@ -15,7 +15,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-cognee-utils = { path = "../utils", version = "0.1.1" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
 chrono.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -28,7 +28,7 @@ telemetry = [
 ]
 
 [dependencies]
-cognee-utils = { path = "../utils", version = "0.1.3" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/ontology/Cargo.toml
+++ b/crates/ontology/Cargo.toml
@@ -15,7 +15,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-cognee-models = { path = "../models", version = "0.1.3" }
+cognee-models = { path = "../models", version = "0.2.0" }
 
 uuid = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -19,16 +19,16 @@ default = []
 telemetry = ["cognee-telemetry/telemetry"]
 
 [dependencies]
-cognee-embedding = { path = "../embedding", version = "0.1.3" }
-cognee-database = { path = "../database", version = "0.1.3" }
-cognee-graph = { path = "../graph", version = "0.1.3" }
-cognee-llm = { path = "../llm", version = "0.1.3" }
-cognee-models = { path = "../models", version = "0.1.3" }
-cognee-session = { path = "../session", version = "0.1.3", features = ["sea-orm-store"] }
-cognee-telemetry = { path = "../telemetry", version = "0.1.3" }
-cognee-truth-subspace = { path = "../truth-subspace", version = "0.1.3" }
-cognee-utils = { path = "../utils", version = "0.1.3" }
-cognee-vector = { path = "../vector", version = "0.1.3" }
+cognee-embedding = { path = "../embedding", version = "0.2.0" }
+cognee-database = { path = "../database", version = "0.2.0" }
+cognee-graph = { path = "../graph", version = "0.2.0" }
+cognee-llm = { path = "../llm", version = "0.2.0" }
+cognee-models = { path = "../models", version = "0.2.0" }
+cognee-session = { path = "../session", version = "0.2.0", features = ["sea-orm-store"] }
+cognee-telemetry = { path = "../telemetry", version = "0.2.0" }
+cognee-truth-subspace = { path = "../truth-subspace", version = "0.2.0" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
+cognee-vector = { path = "../vector", version = "0.2.0" }
 
 async-trait.workspace = true
 indexmap = "2"

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -24,8 +24,8 @@ sea-orm-store = ["dep:sea-orm", "dep:sea-orm-migration"]
 telemetry = ["cognee-telemetry/telemetry"]
 
 [dependencies]
-cognee-llm = { path = "../llm", version = "0.1.3" }
-cognee-telemetry = { path = "../telemetry", version = "0.1.3" }
+cognee-llm = { path = "../llm", version = "0.2.0" }
+cognee-telemetry = { path = "../telemetry", version = "0.2.0" }
 async-trait.workspace = true
 chrono.workspace = true
 thiserror.workspace = true

--- a/crates/truth-subspace/Cargo.toml
+++ b/crates/truth-subspace/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { workspace = true }
 # Vector-engine-backed persistence for load_centroids/upsert_centroids. This
 # edge is one-directional (truth-subspace -> vector) and cycle-free: cognee-vector
 # depends only on cognee-utils and does NOT depend on truth-subspace.
-cognee-vector = { path = "../vector", version = "0.1.3" }
+cognee-vector = { path = "../vector", version = "0.2.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/vector/Cargo.toml
+++ b/crates/vector/Cargo.toml
@@ -44,7 +44,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Telemetry constants
-cognee-utils = { path = "../utils", version = "0.1.3" }
+cognee-utils = { path = "../utils", version = "0.2.0" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/visualization/Cargo.toml
+++ b/crates/visualization/Cargo.toml
@@ -15,7 +15,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-cognee-graph = { path = "../graph", version = "0.1.3" }
+cognee-graph = { path = "../graph", version = "0.2.0" }
 dirs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/java/cognee-java-jni/Cargo.toml
+++ b/java/cognee-java-jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognee-java-jni"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.topoteretes</groupId>
   <artifactId>cognee</artifactId>
-  <version>0.1.3</version>
+  <version>0.2.0</version>
   <packaging>jar</packaging>
 
   <name>cognee</name>

--- a/ts/cognee-ts-neon/Cargo.toml
+++ b/ts/cognee-ts-neon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognee-ts-neon"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/cognee-ts",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Node.js bindings for the cognee AI-memory SDK",
   "license": "MIT OR Apache-2.0",
   "publishConfig": {
@@ -44,10 +44,10 @@
     "dotenv": "^16.6.1"
   },
   "optionalDependencies": {
-    "@cognee/neon-darwin-arm64": "0.1.3",
-    "@cognee/neon-linux-arm64-gnu": "0.1.3",
-    "@cognee/neon-linux-x64-gnu": "0.1.3",
-    "@cognee/neon-win32-x64-msvc": "0.1.3"
+    "@cognee/neon-darwin-arm64": "0.2.0",
+    "@cognee/neon-linux-arm64-gnu": "0.2.0",
+    "@cognee/neon-linux-x64-gnu": "0.2.0",
+    "@cognee/neon-win32-x64-msvc": "0.2.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",

--- a/ts/platform-packages/darwin-arm64/package.json
+++ b/ts/platform-packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-darwin-arm64",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Prebuilt cognee native addon for darwin-arm64 (aarch64-apple-darwin)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/linux-arm64-gnu/package.json
+++ b/ts/platform-packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-linux-arm64-gnu",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Prebuilt cognee native addon for linux-arm64-gnu (aarch64-unknown-linux-gnu)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/linux-x64-gnu/package.json
+++ b/ts/platform-packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-linux-x64-gnu",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Prebuilt cognee native addon for linux-x64-gnu (x86_64-unknown-linux-gnu)",
   "main": "index.js",
   "os": [

--- a/ts/platform-packages/win32-x64-msvc/package.json
+++ b/ts/platform-packages/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/neon-win32-x64-msvc",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Prebuilt cognee native addon for win32-x64-msvc (x86_64-pc-windows-msvc)",
   "main": "index.js",
   "os": [


### PR DESCRIPTION
Automated release PR for **v0.2.0**, opened from issue #110.

Merging this PR publishes to crates.io, npm, Maven Central, and the C-API GitHub Release.
Review the `CHANGELOG.md` diff below and the green PR checks first.

## Changelog

## [0.2.0](https://github.com/topoteretes/cognee-rs/compare/v0.1.3...v0.2.0) - 2026-07-30

### Added

- Port HybridRetriever (HYBRID_COMPLETION) to Rust — Phase 1 core + default-off Phase 2 truth-subspace (#107)
- Azure OpenAI support (Tier 3) (#41)
- **[BREAKING]** Rename umbrella crate cognee-lib to cognee (#93)
- Native Anthropic Messages API adapter (Tier 2)
- Java SDK bindings (JNI) for cognee-rust (#82)
- Batch multiple chunks per extraction request (#19) (#63)
- Add iOS bindings with Swift async/await wrapper

### Changed

- Wrap bulk provenance writes in a transaction + configure connection pool (#35)
- Remove now-unused summarization_batch_size knob
- Bound summarization concurrency and add retry jitter
- Extract cognee-components + pluggable adapter registry (#56)

### Documentation

- Correct cognee-cli install note and workspace tree root (#92)
- Package is live on Maven Central; use version-agnostic install (#86)
- Add Swift package README

### Fixed

- Harden connect_sqlite + review follow-ups from #35 (#103)
- Accept single & repeated dataset params on GET /datasets/status (#101)
- Apply llm_max_completion_tokens to recall/search (#67) (#97)
- Single-database (relational + pgvector + pggraph) deploys (#95)
- Give aux migrators their own tracking tables for shared-Postgres deploys (#89)
- Reliably extract year-only temporal intervals (#90)
- Require node descriptions in prompt so non-strict LLMs don't fail (#66) (#88)
- Require KnowledgeGraph edges so extraction captures relationships (#83)
- Litellm-parity for OpenAI-compatible adapter (custom endpoints) (#78)
- Deterministic class-namespaced Entity/EntityType/EdgeType ids (#57) (#77)
- Type remember() result & document snake_case parity (#46) (#70)
- Npm publish path + capi-release platform/cross fixes (#62)
