### PR TITLE
chore(scripts): add clean_all.sh; harden the offline iOS pipeline test

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,6 +45,20 @@ cargo test
 scripts/check_all.sh
 ```
 
+### Cleaning build artifacts (disk space)
+
+The repo has **four** Cargo workspaces, so `cargo clean` at the root only clears one of
+them (`ts/cognee-ts-neon/target` alone routinely exceeds 20 GB). Never hand-roll `rm -rf`
+over target dirs — use `bash scripts/clean_all.sh` (`--help` lists the flags, `--dry-run`
+reports sizes without deleting).
+
+Do not restate the flag/artifact list here or in the READMEs — it drifts. The canonical
+prose lives in
+[CONTRIBUTING.md § Cleaning build artifacts](../CONTRIBUTING.md#cleaning-build-artifacts)
+and the runtime source of truth is the script's own `--help`. When a new Cargo workspace or
+generated artifact dir is added, extend `CARGO_MANIFESTS` / `ALL_ARTIFACTS` in the script
+(and its header comment, which is what `--help` prints).
+
 ## Test Patterns
 
 - **Async tests:** `#[tokio::test]` for all async test functions (only async runtime used)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,42 @@ cargo update -p roaring@0.11.4 --precise 0.11.3         # one transitive dep
 # capi/ is its own workspace — run the same from inside capi/ if it drifts there.
 ```
 
+## Cleaning build artifacts
+
+This repo contains **four** Cargo workspaces, so a plain `cargo clean` at the root leaves
+most of the disk usage behind (the Neon `target/` alone routinely exceeds 20 GB). Use:
+
+```bash
+bash scripts/clean_all.sh                   # cargo clean all 4 workspaces
+bash scripts/clean_all.sh --all             # ...plus non-Cargo build outputs
+bash scripts/clean_all.sh --dry-run --all   # report sizes, delete nothing
+bash scripts/clean_all.sh --help            # authoritative flag/artifact list
+```
+
+| Workspace / crate | Cleaned by root `cargo clean`? |
+|---|---|
+| `Cargo.toml` (root — `crates/`, `examples/`, `python/`) | yes |
+| `capi/Cargo.toml` (separate workspace, decision D10) | **no** |
+| `ts/cognee-ts-neon/Cargo.toml` (standalone crate) | **no** |
+| `java/cognee-java-jni/Cargo.toml` (standalone crate) | **no** |
+
+`--all` adds the generated non-Cargo outputs (npm, tsc, the Neon `.node` binaries, Maven,
+`capi/build*`, `ios/.build`, wheels, `__pycache__`); run `--dry-run --all` for the exact
+list with sizes rather than trusting a copy of it here. Two things are deliberately **not**
+in `--all`, because nothing in `scripts/check_all.sh` or the per-binding check scripts
+brings them back:
+
+- **`target/models`** — downloaded ONNX/tokenizer files, the default `EMBEDDING_MODEL_PATH`
+  and the source `scripts/android-build-and-deploy.sh` stages models from. It is preserved
+  across the root `cargo clean` (stashed and restored); pass `--include-models` to drop it.
+- **`capi/CogneeSDK.xcframework`** — ~6.6 GB, 20–30 min to rebuild via
+  `capi/scripts/build_xcframework.sh`, and `ios/Package.swift` cannot resolve without it.
+  Pass `--xcframework` to drop it.
+
+Local databases and data stores (`cognee.db`, `.data_storage/`, `.cognee_system/`) are never
+removed — they can hold a developer's own knowledge graph. Docker layers from the
+`e2e-cross-sdk/` harness are separate — use `docker system prune`.
+
 ## Language bindings
 
 Each binding has its own check script (also invoked by `scripts/check_all.sh`):

--- a/README.md
+++ b/README.md
@@ -247,6 +247,20 @@ bash scripts/run_tests_with_openai.sh
 bash scripts/run_tests_with_openai.sh test_fact_extraction
 ```
 
+## Reclaiming disk space
+
+The bindings live in their own Cargo workspaces, so a root `cargo clean` leaves their
+`target/` dirs (tens of GB) behind. Clean all of them at once:
+
+```bash
+bash scripts/clean_all.sh                   # cargo clean every workspace
+bash scripts/clean_all.sh --dry-run --all   # report sizes, delete nothing
+bash scripts/clean_all.sh --help            # flags and what each one removes
+```
+
+See [CONTRIBUTING.md § Cleaning build artifacts](CONTRIBUTING.md#cleaning-build-artifacts)
+for what is kept back (downloaded models, the iOS xcframework) and why.
+
 ## Observability
 
 Cognee emits OpenTelemetry traces from every pipeline stage. To export them

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ signatures.
 
 ### Build & release
 - **[build/lbug-rebuilds.md](build/lbug-rebuilds.md)** — Ladybug rebuild troubleshooting.
+- **Reclaiming disk space** — `bash scripts/clean_all.sh` cleans all four Cargo workspaces (a root `cargo clean` misses the binding workspaces); see [CONTRIBUTING.md § Cleaning build artifacts](../CONTRIBUTING.md#cleaning-build-artifacts).
 - **[RELEASE.md](RELEASE.md)** — release runbook.
 
 ### Roadmap

--- a/ios/Tests/CogneeSDKTests/PipelineTests.swift
+++ b/ios/Tests/CogneeSDKTests/PipelineTests.swift
@@ -65,6 +65,24 @@ final class PipelineTests: XCTestCase {
         return "Title: \(title)\n\n\(content)\n\nReferences: \(refs)"
     }
 
+    // MARK: – Result types
+
+    /// Typed mirror of `CogneeAddResult` (cognee_sdk.h §D3):
+    /// `{"datasetName":"…","added":[…],"addedCount":N,"deduplicated":[…],"deduplicatedCount":M}`
+    private struct AddResult: Decodable {
+        let addedCount: Int
+        let deduplicatedCount: Int
+    }
+
+    /// Typed mirror of `CogneeCognifyResult` (cognee_sdk.h §D3):
+    /// `{"chunks":N,"entities":N,"edges":N,"summaries":N}`
+    private struct CognifyResult: Decodable {
+        let chunks: Int
+        let entities: Int
+        let edges: Int
+        let summaries: Int
+    }
+
     // MARK: – Tests
 
     /// Full offline pipeline: warm → add → cognify → search.
@@ -93,22 +111,53 @@ final class PipelineTests: XCTestCase {
         let inputsJSON = try textInputsJSON(memoryText)
         let addResult = try await cognee.add(inputsJSON: inputsJSON, dataset: "demo")
 
-        XCTAssertFalse(addResult.isEmpty,   "add() must return a non-empty JSON string")
-        XCTAssertNotEqual(addResult, "null", "add() must not return null")
+        // Decode CogneeAddResult and assert on numeric fields.
+        // On a fresh in-memory store the first add() must ingest ≥ 1 chunk with
+        // nothing deduplicated (the store was empty before warm()).
+        let addParsed = try JSONDecoder().decode(
+            AddResult.self,
+            from: try XCTUnwrap(addResult.data(using: .utf8), "add() returned non-UTF-8 data")
+        )
+        XCTAssertGreaterThan(addParsed.addedCount, 0,
+            "add() must ingest ≥ 1 chunk; got addedCount=\(addParsed.addedCount)")
+        XCTAssertEqual(addParsed.deduplicatedCount, 0,
+            "first add() on a fresh store must deduplicate 0 items")
 
         // ── 4. Cognify — replays cassette: graph extraction + summarisation ─
         let cognifyResult = try await cognee.cognify(dataset: "demo")
 
-        XCTAssertFalse(cognifyResult.isEmpty,    "cognify() must return a non-empty JSON string")
-        XCTAssertNotEqual(cognifyResult, "null",  "cognify() must not return null")
+        // Decode CogneeCognifyResult and assert on numeric fields.
+        // The cassette records 6 extracted nodes and 5 edges, so all counts ≥ 1.
+        let cognifyParsed = try JSONDecoder().decode(
+            CognifyResult.self,
+            from: try XCTUnwrap(cognifyResult.data(using: .utf8), "cognify() returned non-UTF-8 data")
+        )
+        XCTAssertGreaterThan(cognifyParsed.chunks, 0,
+            "cognify() must process ≥ 1 chunk")
+        XCTAssertGreaterThan(cognifyParsed.entities, 0,
+            "cognify() must extract ≥ 1 entity; cassette records 6 nodes")
+        XCTAssertGreaterThan(cognifyParsed.edges, 0,
+            "cognify() must extract ≥ 1 edge; cassette records 5 edges")
 
         // ── 5. Search — brute-force vector search over the stored chunks ────
         //     The mock graph store is a no-op so graph-based enrichment is
         //     skipped; the raw chunk hits are still returned.
         let searchResult = try await cognee.search(query: "Who was Alan Turing?")
 
-        XCTAssertFalse(searchResult.isEmpty,    "search() must return a non-empty JSON string")
-        XCTAssertNotEqual(searchResult, "null",  "search() must not return null")
+        // The mock graph store is a no-op, so only brute-force vector search
+        // runs — no LLM completion call is made.  The returned chunks must
+        // contain content from the Alan Turing text that was added.
+        XCTAssertFalse(searchResult.isEmpty,
+            "search() must return a non-empty JSON string")
+        XCTAssertNotEqual(searchResult, "null",
+            "search() must not return the JSON null literal")
+        XCTAssertTrue(
+            searchResult.lowercased().contains("turing") ||
+            searchResult.lowercased().contains("alan") ||
+            searchResult.lowercased().contains("mathematician"),
+            "search('Who was Alan Turing?') must return content about Alan Turing; " +
+            "got: \(searchResult.prefix(200))"
+        )
     }
 
     /// Smoke-test: SDK initialises without throwing.

--- a/ios/Tests/CogneeSDKTests/PipelineTests.swift
+++ b/ios/Tests/CogneeSDKTests/PipelineTests.swift
@@ -9,12 +9,68 @@
 //     -destination 'platform=iOS Simulator,name=iPhone 17' \
 //     2>&1 | grep -E 'Test|PASS|FAIL|error'
 
+import Foundation
 import XCTest
 @testable import CogneeSDK
 
 final class PipelineTests: XCTestCase {
 
     // MARK: – Helpers
+
+    /// Create a unique temp directory for one test's on-disk state and register
+    /// its removal in teardown.
+    ///
+    /// `configureMockMode` only mocks the LLM, embeddings, graph and vector
+    /// stores — the *relational* DB keeps its default `sqlite:./cognee.db?mode=rwc`
+    /// in the process working directory, which persists across runs. Tests that
+    /// assert fresh-store counts must redirect it, mirroring the isolation the
+    /// Rust bench command performs (`crates/cli/src/commands/bench.rs`).
+    private func makeIsolatedRoot() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("cognee-ios-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    /// Point every on-disk store at `root` so the test starts from an empty
+    /// store regardless of what earlier runs left behind. Must be called
+    /// **before** `warm()`.
+    private func isolateStores(_ cognee: Cognee, under root: URL) throws {
+        try cognee.configure("data_root_directory",
+                             value: root.appendingPathComponent("data").path)
+        try cognee.configure("system_root_directory",
+                             value: root.appendingPathComponent("system").path)
+        try cognee.configure("relational_db_url",
+                             value: "sqlite://\(root.path)/cognee.db?mode=rwc")
+    }
+
+    /// Decode `json`, reporting a failure instead of throwing.
+    ///
+    /// Deliberately non-fatal: a `try decode(...)` would abort the test at the
+    /// first malformed stage and skip every later stage, so a simultaneous
+    /// regression in cognify or search would go unreported. Returning `nil`
+    /// lets the caller skip that stage's assertions and keep exercising the
+    /// rest of the pipeline.
+    private func decodeOrFail<T: Decodable>(
+        _ type: T.Type,
+        from json: String,
+        _ label: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> T? {
+        guard let data = json.data(using: .utf8) else {
+            XCTFail("\(label) returned non-UTF-8 data", file: file, line: line)
+            return nil
+        }
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            XCTFail("\(label) returned JSON that does not decode as \(T.self): "
+                + "\(error) — raw: \(json.prefix(300))", file: file, line: line)
+            return nil
+        }
+    }
 
     /// Returns the filesystem path to the bundled demo cassette.
     private var cassettePath: String {
@@ -99,6 +155,12 @@ final class PipelineTests: XCTestCase {
         // ── 1. Create SDK and configure for offline mock mode ─────────────
         let cognee = try Cognee()
         try cognee.configureMockMode(cassettePath: path)
+        // Redirect the relational DB / data roots into a per-run temp dir. The
+        // count assertions below describe a *fresh* store; without this the
+        // second run in the same working directory finds the Turing payload
+        // already ingested (deduplicatedCount=1, cognify short-circuiting as
+        // already-completed) and every count assertion fails.
+        try isolateStores(cognee, under: try makeIsolatedRoot())
 
         // ── 2. Warm (builds in-memory stores using mock config) ────────────
         try await cognee.warm()
@@ -112,41 +174,43 @@ final class PipelineTests: XCTestCase {
         let addResult = try await cognee.add(inputsJSON: inputsJSON, dataset: "demo")
 
         // Decode CogneeAddResult and assert on numeric fields.
-        // On a fresh in-memory store the first add() must ingest ≥ 1 chunk with
-        // nothing deduplicated (the store was empty before warm()).
-        let addParsed = try JSONDecoder().decode(
-            AddResult.self,
-            from: try XCTUnwrap(addResult.data(using: .utf8), "add() returned non-UTF-8 data")
-        )
-        XCTAssertGreaterThan(addParsed.addedCount, 0,
-            "add() must ingest ≥ 1 chunk; got addedCount=\(addParsed.addedCount)")
-        XCTAssertEqual(addParsed.deduplicatedCount, 0,
-            "first add() on a fresh store must deduplicate 0 items")
+        // On a fresh store the first add() must ingest ≥ 1 item with nothing
+        // deduplicated (isolateStores guarantees the store is empty).
+        if let addParsed = decodeOrFail(AddResult.self, from: addResult, "add()") {
+            XCTAssertGreaterThan(addParsed.addedCount, 0,
+                "add() must ingest ≥ 1 chunk; got addedCount=\(addParsed.addedCount)")
+            XCTAssertEqual(addParsed.deduplicatedCount, 0,
+                "first add() on a fresh store must deduplicate 0 items")
+        }
 
         // ── 4. Cognify — replays cassette: graph extraction + summarisation ─
         let cognifyResult = try await cognee.cognify(dataset: "demo")
 
         // Decode CogneeCognifyResult and assert on numeric fields.
         // The cassette records 6 extracted nodes and 5 edges, so all counts ≥ 1.
-        let cognifyParsed = try JSONDecoder().decode(
-            CognifyResult.self,
-            from: try XCTUnwrap(cognifyResult.data(using: .utf8), "cognify() returned non-UTF-8 data")
-        )
-        XCTAssertGreaterThan(cognifyParsed.chunks, 0,
-            "cognify() must process ≥ 1 chunk")
-        XCTAssertGreaterThan(cognifyParsed.entities, 0,
-            "cognify() must extract ≥ 1 entity; cassette records 6 nodes")
-        XCTAssertGreaterThan(cognifyParsed.edges, 0,
-            "cognify() must extract ≥ 1 edge; cassette records 5 edges")
+        if let cognifyParsed = decodeOrFail(CognifyResult.self, from: cognifyResult, "cognify()") {
+            XCTAssertGreaterThan(cognifyParsed.chunks, 0,
+                "cognify() must process ≥ 1 chunk")
+            XCTAssertGreaterThan(cognifyParsed.entities, 0,
+                "cognify() must extract ≥ 1 entity; cassette records 6 nodes")
+            XCTAssertGreaterThan(cognifyParsed.edges, 0,
+                "cognify() must extract ≥ 1 edge; cassette records 5 edges")
+        }
 
         // ── 5. Search — brute-force vector search over the stored chunks ────
-        //     The mock graph store is a no-op so graph-based enrichment is
-        //     skipped; the raw chunk hits are still returned.
-        let searchResult = try await cognee.search(query: "Who was Alan Turing?")
+        //     `searchType: CHUNKS` is required for an offline content assertion:
+        //     the default GRAPH_COMPLETION calls `llm.generate`, and the cassette
+        //     holds only `structured_output` entries (KnowledgeGraph +
+        //     SummarizedContent), so that call misses and replays an *empty*
+        //     completion. GRAPH_COMPLETION also strips `context`/`graphs` from
+        //     the response unless verbose/onlyContext is set, leaving nothing to
+        //     match on. CHUNKS runs pure vector retrieval and returns the chunk
+        //     payloads (`result.data[].payload.text`), which do carry the prose.
+        let searchResult = try await cognee.search(
+            query: "Who was Alan Turing?",
+            optsJSON: #"{"searchType":"CHUNKS"}"#
+        )
 
-        // The mock graph store is a no-op, so only brute-force vector search
-        // runs — no LLM completion call is made.  The returned chunks must
-        // contain content from the Alan Turing text that was added.
         XCTAssertFalse(searchResult.isEmpty,
             "search() must return a non-empty JSON string")
         XCTAssertNotEqual(searchResult, "null",
@@ -155,7 +219,7 @@ final class PipelineTests: XCTestCase {
             searchResult.lowercased().contains("turing") ||
             searchResult.lowercased().contains("alan") ||
             searchResult.lowercased().contains("mathematician"),
-            "search('Who was Alan Turing?') must return content about Alan Turing; " +
+            "search('Who was Alan Turing?') must return chunk content about Alan Turing; " +
             "got: \(searchResult.prefix(200))"
         )
     }

--- a/scripts/clean_all.sh
+++ b/scripts/clean_all.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# clean_all.sh — reclaim disk space by cleaning EVERY Cargo workspace in the repo.
+#
+# Why this exists: `cargo clean` at the repo root only empties the root
+# workspace's target/. The bindings live in *separate* Cargo workspaces with
+# their own target/ dirs, so they survive a root clean — and they are usually
+# the biggest offenders (the Neon target/ alone regularly passes 20 GB):
+#
+#   Cargo.toml                      root workspace (crates/, examples/, python/)
+#   capi/Cargo.toml                 C API workspace          (decision D10)
+#   ts/cognee-ts-neon/Cargo.toml    Neon cdylib, standalone crate
+#   java/cognee-java-jni/Cargo.toml JNI cdylib, standalone crate
+#
+# Usage:
+#   bash scripts/clean_all.sh                   # cargo clean every workspace above
+#   bash scripts/clean_all.sh --all             # ...plus non-Cargo build outputs
+#   bash scripts/clean_all.sh --dry-run --all   # report sizes, delete nothing
+#
+# Flags:
+#   --all              also remove non-Cargo build outputs: ts/node_modules,
+#                      ts/lib, the Neon .node files (incl. platform-packages/),
+#                      java/target, capi/build*, ios/.build, python/dist,
+#                      *.egg-info and __pycache__ dirs.
+#   --include-models   also delete target/models. Kept by default: it holds
+#                      downloaded ONNX/tokenizer files (the default
+#                      EMBEDDING_MODEL_PATH) that no check script re-downloads.
+#   --xcframework      also delete capi/CogneeSDK.xcframework. Not in --all:
+#                      rebuilding it costs 20–30 min via
+#                      capi/scripts/build_xcframework.sh, and ios/Package.swift
+#                      cannot resolve without it.
+#   -n, --dry-run      report what would be freed, delete nothing.
+#
+# Not touched: local databases and data stores (cognee.db, .data_storage/,
+# .cognee_system/) — they can hold a developer's own knowledge graph. Docker
+# layers from e2e-cross-sdk/ are separate: use `docker system prune`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Absolute path to this file: the header block below is re-read for --help,
+# which must keep working after the `cd "$REPO_ROOT"` a few lines down (a
+# relative $BASH_SOURCE would no longer resolve from the new cwd).
+SELF="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+# Cargo workspaces / standalone crates, each with its own target/ dir.
+CARGO_MANIFESTS=(
+    "Cargo.toml"
+    "capi/Cargo.toml"
+    "ts/cognee-ts-neon/Cargo.toml"
+    "java/cognee-java-jni/Cargo.toml"
+)
+
+# Non-Cargo build outputs, removed only with --all. Every entry is gitignored
+# and reproducible from a check script or an npm/maven/maturin build. Globs are
+# expanded at array-definition time; unmatched ones stay literal and are
+# filtered by the `-e` test in the removal loop.
+ALL_ARTIFACTS=(
+    "ts/node_modules"                             # npm deps (ts/scripts/check.sh reinstalls)
+    "ts/lib"                                      # tsc output
+    "ts/cognee_ts_neon.node"                      # copied Neon cdylib (~470 MB)
+    "ts/platform-packages/"*"/cognee_ts_neon.node" # prebuilt per-platform cdylibs (~240 MB each)
+    "java/target"                                 # Maven output
+    "capi/build"                                  # cmake/example build dir
+    "capi/build-"*                                # per-platform variants
+    "ios/.build"                                  # SwiftPM (re-resolves on next build)
+    "python/dist"                                 # maturin/pip wheels
+    "python/"*.egg-info
+)
+
+# target/models holds downloaded embedding models: the default
+# EMBEDDING_MODEL_PATH / EMBEDDING_TOKENIZER_PATH (docs/configuration.md) and
+# the staging source for scripts/android-build-and-deploy.sh. `cargo clean`
+# removes ./target wholesale and nothing re-downloads them, so stash the dir
+# across the root clean unless --include-models is given.
+MODELS_DIR="target/models"
+MODELS_STASH=".tmp/clean_all-models"   # .tmp/ is gitignored and on the same fs
+
+ALL=0
+DRY_RUN=0
+INCLUDE_MODELS=0
+XCFRAMEWORK=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --all) ALL=1 ;;
+        --include-models) INCLUDE_MODELS=1 ;;
+        --xcframework) XCFRAMEWORK=1 ;;
+        -n | --dry-run) DRY_RUN=1 ;;
+        -h | --help)
+            # Print the header comment block (everything after the shebang up to
+            # the first line of code).
+            awk 'NR > 1 && /^#/ { sub(/^# ?/, ""); print; next } NR > 1 { exit }' "$SELF"
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument '$1' (try --help)" >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# size_kb PATH — apparent disk usage in KiB; 0 when the path is missing or
+# unmeasurable. `du` exits non-zero when any entry underneath is unreadable or
+# vanishes mid-walk (a concurrent cargo build is enough); under `set -e` with
+# `pipefail` that status would propagate out of the command substitution and
+# abort the script before anything is cleaned, so it is swallowed here.
+size_kb() {
+    [[ -e "$1" ]] || {
+        echo 0
+        return
+    }
+    local kb
+    kb=$(du -sk "$1" 2>/dev/null | awk 'NR == 1 { print $1 }') || kb=""
+    echo "${kb:-0}"
+}
+
+# human KIB — format a KiB count as KiB/MiB/GiB/TiB. Negative inputs (possible
+# when a `du` failure makes one measurement read as 0) clamp to zero rather than
+# printing a nonsensical "-2052 KiB".
+human() {
+    awk -v k="$1" 'BEGIN {
+        if (k < 0) k = 0
+        split("KiB MiB GiB TiB", u, " ")
+        i = 1
+        while (k >= 1024 && i < 4) { k /= 1024; i++ }
+        printf (i == 1 ? "%d %s\n" : "%.1f %s\n"), k, u[i]
+    }'
+}
+
+# restore_models — move a stashed target/models back into place. Runs from the
+# EXIT trap so an interrupted clean cannot lose the download.
+restore_models() {
+    [[ -d $MODELS_STASH ]] || return 0
+    mkdir -p target
+    rm -rf -- "$MODELS_DIR"
+    mv -- "$MODELS_STASH" "$MODELS_DIR"
+}
+trap restore_models EXIT
+# Recover a stash left behind by a previous run that was killed outright
+# (SIGKILL skips the trap above).
+restore_models
+
+freed_kb=0
+
+echo "================================================================"
+echo "=== Cargo workspaces ==="
+echo "================================================================"
+
+models_kb=$(size_kb "$MODELS_DIR")
+if [[ $INCLUDE_MODELS -eq 0 && $models_kb -gt 0 ]]; then
+    printf 'KEEP   %-34s %s  (--include-models to drop)\n' \
+        "$MODELS_DIR" "$(human "$models_kb")"
+fi
+
+for manifest in "${CARGO_MANIFESTS[@]}"; do
+    if [[ ! -f "$manifest" ]]; then
+        echo "SKIP  $manifest (not found)"
+        continue
+    fi
+    # Report the conventional target/ next to the manifest. A caller-set
+    # CARGO_TARGET_DIR redirects the real output elsewhere; `cargo clean`
+    # still honors it, only the size below reads as 0.
+    target_dir="$(dirname "$manifest")/target"
+    before=$(size_kb "$target_dir")
+
+    # Only the root workspace's target/ contains the model cache.
+    keep_models=0
+    if [[ "$manifest" == "Cargo.toml" && $INCLUDE_MODELS -eq 0 && -d $MODELS_DIR ]]; then
+        keep_models=1
+    fi
+
+    if [[ $DRY_RUN -eq 1 ]]; then
+        would=$before
+        if [[ $keep_models -eq 1 ]]; then
+            # Clamped: an unmeasurable target/ reads as 0, which would otherwise
+            # make the subtraction negative.
+            would=$((before > models_kb ? before - models_kb : 0))
+        fi
+        printf 'WOULD CLEAN  %-34s %s\n' "$manifest" "$(human "$would")"
+        freed_kb=$((freed_kb + would))
+        continue
+    fi
+
+    printf 'CLEAN  %-34s %s' "$manifest" "$(human "$before")"
+    if [[ $keep_models -eq 1 ]]; then
+        mkdir -p "$(dirname "$MODELS_STASH")"
+        rm -rf -- "$MODELS_STASH"
+        mv -- "$MODELS_DIR" "$MODELS_STASH"
+    fi
+    cargo clean --manifest-path "$manifest" --quiet
+    restore_models
+    after=$(size_kb "$target_dir")
+    freed_kb=$((freed_kb + (before > after ? before - after : 0)))
+    echo " -> $(human "$after")"
+done
+
+# Assemble the non-Cargo removal list from the flags that were passed.
+# Written as `if` blocks, not `[[ … ]] && …`: the latter evaluates to 1 when the
+# flag is off, and a false `&&` list as a top-level command aborts under `set -e`.
+EXTRAS=()
+if [[ $ALL -eq 1 ]]; then
+    EXTRAS+=("${ALL_ARTIFACTS[@]}")
+fi
+if [[ $XCFRAMEWORK -eq 1 ]]; then
+    EXTRAS+=("capi/CogneeSDK.xcframework")
+fi
+
+if [[ ${#EXTRAS[@]} -gt 0 ]]; then
+    echo ""
+    echo "================================================================"
+    echo "=== Other build artifacts ==="
+    echo "================================================================"
+    for path in "${EXTRAS[@]}"; do
+        # Unmatched globs stay literal in bash; skip those along with
+        # artifacts that were simply never built.
+        [[ -e "$path" ]] || continue
+        sz=$(size_kb "$path")
+        if [[ $DRY_RUN -eq 1 ]]; then
+            printf 'WOULD REMOVE  %-34s %s\n' "$path" "$(human "$sz")"
+        else
+            printf 'REMOVE  %-34s %s\n' "$path" "$(human "$sz")"
+            rm -rf -- "$path"
+        fi
+        freed_kb=$((freed_kb + sz))
+    done
+fi
+
+if [[ $ALL -eq 1 ]]; then
+    # Python bytecode caches are scattered; sweep them in one pass.
+    pycache_kb=0
+    while IFS= read -r d; do
+        sz=$(size_kb "$d")
+        pycache_kb=$((pycache_kb + ${sz:-0}))
+        [[ $DRY_RUN -eq 1 ]] || rm -rf -- "$d"
+    done < <(find python e2e-cross-sdk scripts -type d -name __pycache__ -prune 2>/dev/null)
+    if [[ $pycache_kb -gt 0 ]]; then
+        printf '%s  %-34s %s\n' \
+            "$([[ $DRY_RUN -eq 1 ]] && echo 'WOULD REMOVE' || echo 'REMOVE      ')" \
+            "__pycache__ dirs" "$(human "$pycache_kb")"
+        freed_kb=$((freed_kb + pycache_kb))
+    fi
+fi
+
+echo ""
+echo "================================================================"
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo "=== Dry run: $(human "$freed_kb") would be freed ==="
+else
+    echo "=== Freed $(human "$freed_kb") ==="
+fi
+echo "================================================================"
+
+if [[ $ALL -eq 0 ]]; then
+    echo "Cargo targets only. --all also drops node_modules, the Neon .node"
+    echo "files, java/target, capi/build*, ios/.build and python/dist."
+    echo "See --help for the full list; docker layers need 'docker system prune'."
+fi


### PR DESCRIPTION
## Why

`cargo clean` at the repo root only empties the root workspace's `target/`. The bindings live in three **separate** Cargo workspaces whose `target/` dirs survive it — and they hold most of the disk usage (`ts/cognee-ts-neon/target` alone measured **19.7 GiB** on my checkout).

| Manifest | Cleaned by root `cargo clean`? |
|---|---|
| `Cargo.toml` (root — `crates/`, `examples/`, `python/`) | yes |
| `capi/Cargo.toml` (separate workspace, decision D10) | **no** |
| `ts/cognee-ts-neon/Cargo.toml` (standalone crate) | **no** |
| `java/cognee-java-jni/Cargo.toml` (standalone crate) | **no** |

## `scripts/clean_all.sh`

- default: `cargo clean` all four workspaces, with per-workspace before/after sizes and a total-freed line
- `--all`: also the generated non-Cargo outputs — npm, tsc, the Neon `.node` binaries (including `ts/platform-packages/*/`, 240 MB that's easy to miss), Maven, `capi/build*`, `ios/.build`, wheels, `__pycache__`
- `--dry-run`, `--help`

Deliberately **preserved**, because nothing in `check_all.sh` or the per-binding check scripts brings them back:

- **`target/models`** — downloaded ONNX/tokenizer files, the default `EMBEDDING_MODEL_PATH`, and the source `android-build-and-deploy.sh` stages models from. Stashed across the root clean and restored from an `EXIT` trap, so even an interrupted or failing clean keeps them. `--include-models` opts out.
- **`capi/CogneeSDK.xcframework`** — ~6.6 GB and 20–30 min to rebuild, and `ios/Package.swift` cannot resolve without it. `--xcframework` opts in.

Local databases and data stores (`cognee.db`, `.data_storage/`, `.cognee_system/`) are never touched — they can hold a developer's own knowledge graph. Docker layers are out of scope (`docker system prune`).

Docs: `CONTRIBUTING.md § Cleaning build artifacts` is the canonical prose; `README.md`, `docs/README.md` and `.claude/CLAUDE.md` link to it instead of restating the flag list (that list had already drifted three ways across four files in a first draft), with the script's `--help` as the runtime source of truth.

## `ios/Tests/CogneeSDKTests/PipelineTests.swift`

This file had uncommitted work in progress in the tree; a code review over the combined diff turned up three problems, all fixed here:

1. **The search assertion could never pass offline.** The default `GRAPH_COMPLETION` calls `llm.generate`, but `demo_cassette.json` holds only two `structured_output` entries, so the call misses and the replay LLM returns an empty completion — and `prepare_search_result` strips `context`/`graphs` unless `verbose`/`onlyContext` is set. Switched to `{"searchType":"CHUNKS"}`: pure vector retrieval, and `index_data_points` puts the chunk text in the payload.
2. **No store isolation.** `configureMockMode` mocks the LLM, embeddings, graph and vector stores, but the relational DB stays at `sqlite:./cognee.db?mode=rwc` in the working directory, so a second run saw the payload already ingested (`deduplicatedCount=1`, cognify short-circuiting as already-completed) and every count assertion failed. Now redirects data/system roots and the DB URL into a per-run temp dir, mirroring `crates/cli/src/commands/bench.rs`.
3. **Fatal decodes hid downstream regressions.** `try JSONDecoder().decode(...)` aborted the test at the add() stage; a non-fatal `decodeOrFail` keeps cognify and search running.

## Testing

- `shellcheck scripts/clean_all.sh` clean; exercised on bash 3.2 (macOS)
- script behavior verified in a throwaway workspace: models survive a real `cargo clean` (and survive when `cargo clean` itself fails mid-run), build junk is removed, freed totals exclude preserved models, `--help` works from any cwd, unknown args exit 2
- specifically re-tested the two abort paths a review flagged: a `du` failure inside an unreadable subtree no longer kills the run before anything is cleaned
- Swift: `swiftc -parse` (the check `ios.yml` runs) plus a type-check against stub `CogneeSDK`/`XCTest` modules

**Not run:** `xcodebuild test` — needs Xcode (this machine has Command Line Tools only) and the 6.6 GB xcframework. The iOS assertions are reasoned from the Rust sources, not executed; worth a run by someone with the xcframework built before merge. No Rust code changed, so `check_all.sh` was not re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SePhkXEUpiSJ1CTg7t9ERb