### PR TITLE
fix(ci): unbreak the Windows release artifacts + refuse partial npm publishes

### DIFF
--- a/.github/workflows/capi-release.yml
+++ b/.github/workflows/capi-release.yml
@@ -74,7 +74,13 @@ jobs:
             archive_suffix: windows-x86_64
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    # 150, not 45. The windows-x86_64 leg never reached a real compile before —
+    # the wrong-linker bug (see the native build step) killed it ~4 minutes in, so
+    # 45 was only ever exercised by the faster Linux/macOS legs. ts-prebuild's
+    # win32 leg builds a comparable dependency graph (full cognee stack + ort +
+    # lbug's bundled C++) and needed >90 minutes, so fixing the linker without
+    # raising this would just swap a link error for a timeout.
+    timeout-minutes: 150
 
     steps:
       - name: Checkout
@@ -174,9 +180,19 @@ jobs:
         shell: bash
         run: ci/ort/prefetch.sh "${{ matrix.target }}" "${{ github.workspace }}/capi/target/ort-cache"
 
+      # NO `shell: bash` here. On Windows that selects Git Bash, which prepends
+      # C:\Program Files\Git\usr\bin to PATH — and that directory ships GNU
+      # coreutils' `link.exe` (the Unix hard-link tool), which SHADOWS the MSVC
+      # linker that ilammy/msvc-dev-cmd just put on PATH. rustc then invokes the
+      # wrong linker and every build script dies with:
+      #   /usr/bin/link: extra operand '...build_script_build...rcgu.o'
+      # This silently undid the MSVC setup above and broke the 0.2.0 windows-x86_64
+      # tarball. ts-prebuild.yml's equivalent step has always used the default
+      # shell (pwsh on Windows) — the Windows fixes were ported from there but the
+      # shell difference was missed. The default shell is bash on Linux/macOS, so
+      # dropping the override changes nothing for the other legs.
       - name: Build release library (native)
         if: "!matrix.cross"
-        shell: bash
         env:
           ORT_CACHE_DIR: ${{ github.workspace }}/capi/target/ort-cache
         run: cargo build --release --manifest-path capi/Cargo.toml --target ${{ matrix.target }}

--- a/.github/workflows/java-prebuild.yml
+++ b/.github/workflows/java-prebuild.yml
@@ -47,7 +47,11 @@ jobs:
     name: Build ${{ matrix.platform }}
     # Cap each leg so a stuck build (e.g. a hung native compile) fails fast
     # instead of running to the 6h/24h default and burning runner time.
-    timeout-minutes: 90
+    #
+    # 150, not 90: matches ts-prebuild.yml. At 0.2.0 the win32-x64-msvc leg was
+    # cancelled at ~91m while still legitimately compiling, so the four-jar gate
+    # correctly withheld the Maven Central bundle. See ts-prebuild.yml for detail.
+    timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ts-prebuild.yml
+++ b/.github/workflows/ts-prebuild.yml
@@ -38,7 +38,13 @@ jobs:
     name: Build ${{ matrix.platform }}
     # Cap each leg so a stuck build (e.g. a hung native compile) fails fast
     # instead of running to the 6h/24h default and burning runner time.
-    timeout-minutes: 90
+    #
+    # 150, not 90: at 0.2.0 the win32-x64-msvc leg was cancelled at 90m59s while
+    # still legitimately compiling (ort + lbug's bundled C++ + lancedb on a cold
+    # cache), which left @cognee/neon-win32-x64-msvc unpublished. It built fine at
+    # 0.1.3, so this is dependency-graph growth rather than a hang — the cap needs
+    # headroom above the real build time, not a tighter leash.
+    timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:
@@ -318,8 +324,22 @@ jobs:
           path: /tmp/neon-artifacts
           merge-multiple: false
 
+      # A missing artifact is a HARD FAILURE, not a warning.
+      #
+      # This used to `echo "WARNING: artifact missing"` and carry on, which is how
+      # 0.2.0 shipped broken: the win32-x64-msvc leg timed out, its .node was never
+      # produced, the platform publish logged "SKIP win32-x64-msvc: no .node built"
+      # — and then @cognee/cognee-ts@0.2.0 published anyway as `latest`, pinning an
+      # exact optionalDependency on @cognee/neon-win32-x64-msvc@0.2.0 that did not
+      # exist. Windows installs succeeded (the dep is *optional*) and then failed at
+      # runtime with no native addon. java-prebuild.yml already gets this right via
+      # its "Verify all four classifier jars are present" gate; this mirrors it.
+      #
+      # Publishing an incomplete platform set is never correct — better to ship
+      # nothing and re-dispatch than to leave a broken `latest` on the registry.
       - name: Place artifacts into platform package directories
         run: |
+          missing=0
           for PLATFORM in \
             linux-x64-gnu linux-arm64-gnu \
             darwin-arm64 \
@@ -330,9 +350,11 @@ jobs:
               cp "$SRC" "$DEST"
               echo "Placed $DEST"
             else
-              echo "WARNING: artifact missing for $PLATFORM" >&2
+              echo "::error::artifact missing for ${PLATFORM} — its build leg did not produce cognee_ts_neon.node. Refusing to publish an incomplete platform set."
+              missing=1
             fi
           done
+          [ "$missing" = 0 ] || exit 1
 
       # Publish each platform package.
       - name: Publish platform packages
@@ -366,6 +388,33 @@ jobs:
         env:
           COGNEE_SKIP_POSTINSTALL: "1"
         run: npm run build:ts
+
+      # Gate the main package on every platform pin being resolvable.
+      #
+      # ts/package.json pins each @cognee/neon-* optionalDependency to an EXACT
+      # version. If one of them is not on the registry, `npm install` still succeeds
+      # (optional deps fail soft) and then breaks at runtime when the addon can't be
+      # loaded. So the main package must not go live until all four are published —
+      # checked against the registry rather than the local artifacts, since a
+      # platform publish can also fail for registry-side reasons.
+      - name: Verify every platform package is on the registry
+        working-directory: ts
+        run: |
+          VER=$(node -p "require('./package.json').version")
+          missing=0
+          for PLATFORM in \
+            linux-x64-gnu linux-arm64-gnu \
+            darwin-arm64 \
+            win32-x64-msvc; do
+            PKG="@cognee/neon-${PLATFORM}"
+            if npm view "${PKG}@${VER}" version >/dev/null 2>&1; then
+              echo "ok ${PKG}@${VER}"
+            else
+              echo "::error::${PKG}@${VER} is not on the registry — @cognee/cognee-ts@${VER} pins it exactly and would install broken on that platform."
+              missing=1
+            fi
+          done
+          [ "$missing" = 0 ] || exit 1
 
       # Publish the main cognee-ts package (idempotent: skip if already on registry).
       - name: Publish cognee-ts


### PR DESCRIPTION
The 0.2.0 tag cascade lost **every Windows artifact**, for two unrelated reasons — and one of them let a broken package reach npm. Found while investigating why `capi-release`, `ts-prebuild` and `java-prebuild` all failed on `v0.2.0`.

## 1. `capi-release` used the wrong linker

The native build step ran under `shell: bash`, which on Windows is **Git Bash** — and that prepends `C:\Program Files\Git\usr\bin` to PATH, where GNU coreutils ships its own `link.exe` (the Unix hard-link tool). It shadowed the MSVC linker that `ilammy/msvc-dev-cmd` had just put on PATH:

```
"C:\Program Files\Git\usr\bin\link.exe" /NOLOGO ...
/usr/bin/link: extra operand '...build_script_build...rcgu.o'
Try '/usr/bin/link --help' for more information.
```

It died ~4 minutes in on the `quote` / `serde_core` build scripts, before any cognee code compiled — hence no `windows-x86_64` tarball on the v0.2.0 release.

`ts-prebuild`'s equivalent step has always used the default shell (pwsh). The Windows fixes in `capi-release` were ported from there, but the shell difference was missed, **silently undoing the MSVC setup directly above it**. Dropping the override is a no-op for the Linux/macOS legs, whose default shell is already bash.

Its timeout also goes **45 → 150**: that leg never reached a real compile, so 45 was only ever exercised by the much faster Linux/macOS legs. Fixing the linker alone would have swapped a link error for a timeout.

## 2. The win32 legs timed out by 59 seconds

`ts-prebuild` and `java-prebuild`'s `win32-x64-msvc` leg was cancelled at **90m59s** against a 90-minute cap, while still legitimately compiling (ort + lbug's bundled C++ + lancedb, cold cache).

It built fine at 0.1.3 — `@cognee/neon-win32-x64-msvc` has exactly one published version — so this is dependency-graph growth, not a hang. Both caps go to **150**.

## 3. `ts-prebuild` published anyway — the actual defect

A missing platform artifact was only a warning:

```
WARNING: artifact missing for win32-x64-msvc
SKIP win32-x64-msvc: no .node built
```

…so `@cognee/cognee-ts@0.2.0` went out as `latest` while pinning an **exact** `optionalDependency` on `@cognee/neon-win32-x64-msvc@0.2.0` that was never built. Because the dep is *optional*, Windows `npm install` **succeeds** and then fails at runtime with no native addon — the worst shape of failure.

`java-prebuild` already gets this right; its four-jar gate correctly withheld the Maven bundle instead of shipping an incomplete set. This mirrors it:

- a missing artifact is now `::error::` + `exit 1`, never a warning
- a **new gate** verifies all four `@cognee/neon-*` packages are actually on the registry at this version before the main package publishes — checked against the registry, not local artifacts, since a platform publish can also fail for registry-side reasons

Publishing an incomplete platform set is never correct. Shipping nothing and re-dispatching beats leaving a broken `latest`.

## Repairing 0.2.0 needs no version bump

The pin is exact and npm resolves optional deps at **install** time, so publishing the missing `@cognee/neon-win32-x64-msvc@0.2.0` **retroactively fixes the already-published `@cognee/cognee-ts@0.2.0`**. No 0.2.1, no republish, no deprecation.

Both publish loops skip versions already on the registry (`npm view ... && SKIP`), and `main` is already at 0.2.0, so re-dispatching `ts-prebuild` after this merges publishes *exactly* that one package and leaves the other three plus the main package untouched.

Plan once merged — all three are `workflow_dispatch` and idempotent:
1. `ts-prebuild` → publishes `@cognee/neon-win32-x64-msvc@0.2.0` only
2. `java-prebuild` → all four jars build → Maven bundle at 0.2.0 (still needs a manual release in the Central Portal)
3. `capi-release` with `tag=v0.2.0` → attaches the four tarballs to the existing release

## Testing

CI-only change; no Rust touched. All three workflows validated as parsing, and the timeout values confirmed:

```
capi-release     build            150
ts-prebuild      build-platform   150
java-prebuild    build-platform   150
```

The real proof is the dispatch run after merge — a Windows leg that compiles past the linker and completes inside the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxKe2CjjA536dfGbjWcWN9