### PR TITLE
fix(release): fail preflight on unreserved crate names instead of mid-publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -33,6 +33,11 @@ on:
         description: "Version to publish, e.g. 0.1.3 (must already be on main)"
         required: true
         type: string
+      allow_new_crates:
+        description: "Skip the 'every crate name already exists on crates.io' preflight. Only for a token you KNOW has the publish-new scope — otherwise the publish loop 403s partway and leaves a partial release."
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: release-publish
@@ -136,6 +141,54 @@ jobs:
           # entry is a dependency-free leaf that could be a brand-new,
           # not-yet-published crate, which would make a valid token look invalid.
           cargo owner --list cognee-models
+
+      # Publishing a brand-new crate NAME needs the `publish-new` token scope;
+      # updating an existing crate only needs `publish-update`. crates.io exposes
+      # no way to introspect a token's scopes, and `cargo owner --list` above only
+      # proves the token can read an *existing* crate — so a token holding just
+      # `publish-update` sails through both and then 403s partway down the publish
+      # loop, leaving a PARTIAL release: some crates live at the new version, the
+      # rest not, and no tag.
+      #
+      # That is exactly what happened cutting 0.2.0: 14 crates published, then
+      # `cognee-components` (a new name) failed with
+      #   403 Forbidden: this token does not have the required permissions
+      # and the release had to be finished with a re-issued token.
+      #
+      # Since the scope can't be probed, assert the property that makes it moot:
+      # every crate in publish-order.sh must ALREADY exist on crates.io, so every
+      # release publish is an update. New names get reserved once, out of band, at
+      # crate-creation time — the pattern already used for `cognee` itself, which
+      # sat as a 0.0.0 placeholder until 0.2.0 filled it in.
+      - name: Preflight — every crate name already exists on crates.io
+        env:
+          SKIP_CHECK: ${{ inputs.allow_new_crates }}
+        run: |
+          set -uo pipefail
+          if [ "${SKIP_CHECK:-false}" = "true" ]; then
+            echo "::warning::allow_new_crates=true — skipping the new-crate-name check. The token must hold publish-new or the publish loop will 403 partway and leave a partial release."
+            exit 0
+          fi
+          absent=""
+          while read -r crate; do
+            [ -n "$crate" ] || continue
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              -H 'User-Agent: cognee-release-preflight (github.com/topoteretes/cognee-rs)' \
+              "https://crates.io/api/v1/crates/${crate}")
+            case "$code" in
+              200) ;;
+              404) absent="${absent} ${crate}" ;;
+              *)   echo "::error::crates.io returned HTTP ${code} for '${crate}' — cannot verify it exists; aborting rather than risk a partial publish"
+                   exit 1 ;;
+            esac
+          done < <(bash scripts/split/publish-order.sh)
+          if [ -n "$absent" ]; then
+            echo "::error::These crate names are not on crates.io yet:${absent}"
+            echo "::error::Publishing them needs a token with the 'publish-new' scope, which cannot be verified up front — if it is missing, the publish loop 403s partway and leaves a PARTIAL release."
+            echo "::error::Fix: reserve each name once by publishing a 0.0.0 placeholder (how 'cognee' was reserved), then re-run. Or, if CARGO_REGISTRY_TOKEN definitely has publish-new, re-trigger via workflow_dispatch with allow_new_crates=true."
+            exit 1
+          fi
+          echo "all publishable crate names already exist on crates.io — every publish this run is an update"
 
       - name: Preflight — npm token
         env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -164,15 +164,35 @@ jobs:
         env:
           SKIP_CHECK: ${{ inputs.allow_new_crates }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
           if [ "${SKIP_CHECK:-false}" = "true" ]; then
             echo "::warning::allow_new_crates=true — skipping the new-crate-name check. The token must hold publish-new or the publish loop will 403 partway and leave a partial release."
             exit 0
           fi
+          # Materialize the crate list FIRST and require it to be non-empty.
+          # A safety check that silently verifies nothing is worse than no check:
+          # with process substitution a failing publish-order.sh (e.g. a
+          # `cargo metadata` error) makes the loop run zero iterations, leaves
+          # `absent` empty, and reports a clean bill of health for a release that
+          # is about to hit the very 403 this step exists to prevent. `set -e`
+          # plus the emptiness guard turn that into a hard failure.
+          crates="$(bash scripts/split/publish-order.sh)"
+          count="$(printf '%s\n' "$crates" | grep -c '[^[:space:]]' || true)"
+          if [ "${count:-0}" -eq 0 ]; then
+            echo "::error::scripts/split/publish-order.sh produced no crates — refusing to treat an empty list as 'every name exists'"
+            exit 1
+          fi
+          echo "checking ${count} crate name(s) against crates.io"
           absent=""
-          while read -r crate; do
-            [ -n "$crate" ] || continue
-            code=$(curl -s -o /dev/null -w '%{http_code}' \
+          # --max-time / --retry so a network stall fails the job instead of
+          # hanging it; no -f, so a 404 still yields a body-less 404 status
+          # rather than a non-zero exit that `set -e` would abort on.
+          # Word-split $crates directly rather than piping into `while read`:
+          # a pipeline would run the loop in a subshell and `absent` would be
+          # empty afterwards. Crate names never contain whitespace.
+          for crate in $crates; do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' \
+              --max-time 20 --retry 3 --retry-delay 2 --retry-connrefused \
               -H 'User-Agent: cognee-release-preflight (github.com/topoteretes/cognee-rs)' \
               "https://crates.io/api/v1/crates/${crate}")
             case "$code" in
@@ -181,7 +201,7 @@ jobs:
               *)   echo "::error::crates.io returned HTTP ${code} for '${crate}' — cannot verify it exists; aborting rather than risk a partial publish"
                    exit 1 ;;
             esac
-          done < <(bash scripts/split/publish-order.sh)
+          done
           if [ -n "$absent" ]; then
             echo "::error::These crate names are not on crates.io yet:${absent}"
             echo "::error::Publishing them needs a token with the 'publish-new' scope, which cannot be verified up front — if it is missing, the publish loop 403s partway and leaves a PARTIAL release."

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,7 +34,12 @@ commits, pushes, and opens a PR labelled `autorelease:pending`. The PAT (not
 ### Phase 1 verification — the PR checks (all pre-existing, plus one)
 - `ci.yml` — workspace build/test + `capi-check` (C library) + `ts-check` (Neon
   addon) + `python-check`. Runs on same-repo PRs, so the release branch qualifies.
-- `publish-dry-run.yml` — `cargo publish --dry-run` over every crate.
+- `publish-dry-run.yml` — `cargo publish --dry-run` over every crate. **Note it
+  deliberately SKIPS on `release/*` PRs**, so it is not part of this barrier: a
+  release branch bumps every internal `cognee-* = "^X.Y.Z"` requirement to a
+  version not yet on the index, which a per-crate dry run cannot resolve. It
+  gates normal PRs and `main`; the ordered real publish is the only thing that
+  exercises a release branch's dependency graph.
 - `release-verify.yml` (release branches only) — asserts every version location
   is consistent ([`assert-version.sh`](../scripts/release/assert-version.sh)) and
   runs an early `npm whoami` to confirm the npm token.
@@ -57,9 +62,11 @@ default. Two things it cannot do for you:
 
 ### Phase 2 — `release-publish.yml` (trigger: the release PR is merged)
 Runs behind the **`release` environment** (required reviewers). Order:
-0. **Preflight** — `cargo owner --list -p cognee-models` and `npm whoami` (real
+0. **Preflight** — `cargo owner --list cognee-models` and `npm whoami` (real
    authenticated calls; `cargo publish --dry-run` does **not** validate a token,
-   so this is the only way to fail before anything irreversible).
+   so this is the only way to fail before anything irreversible), plus an
+   assertion that **every crate name in `publish-order.sh` already exists on
+   crates.io** (see [New crates](#new-crates-must-be-reserved-first)).
 1. **crates.io** — `cargo publish` each crate in
    [`publish-order.sh`](../scripts/split/publish-order.sh) order (cargo waits for
    the index between dependents; already-published versions are skipped, so
@@ -103,12 +110,46 @@ before any npm / C-API artifact ships.
 The Python binding is **not published to PyPI**; users build from source
 (`cd python && maturin develop`, or `maturin build --release`).
 
+## New crates must be reserved first
+
+**Before a release that introduces a new `cognee-*` crate, publish a `0.0.0`
+placeholder for it.** Otherwise the release aborts in preflight.
+
+Why: publishing a brand-new crate *name* requires the crates.io **`publish-new`**
+token scope, while updating an existing crate only needs `publish-update`.
+crates.io offers no way to introspect a token's scopes, and `cargo owner --list`
+only proves the token can read a crate that already exists — so a token holding
+just `publish-update` passes every check and then **403s partway down the publish
+loop**, leaving some crates live at the new version, the rest not, and no tag.
+
+That is not hypothetical: cutting 0.2.0, 14 crates published and then
+`cognee-components` failed with `403 Forbidden: this token does not have the
+required permissions`, and the release had to be finished with a re-issued token.
+
+Since the scope cannot be probed, `release-publish.yml` asserts the property that
+makes it moot — every name in
+[`publish-order.sh`](../scripts/split/publish-order.sh) must already be on
+crates.io, so every release publish is an *update*. Reserving a name is a one-off
+action at crate-creation time, not release time; `cognee` itself sat as a `0.0.0`
+placeholder until 0.2.0 filled it in.
+
+```bash
+# From the new crate's directory, with version = "0.0.0" in its Cargo.toml:
+cargo publish -p cognee-<newcrate>
+# then restore the workspace-inherited version and commit
+```
+
+If `CARGO_REGISTRY_TOKEN` definitely holds `publish-new` and you would rather
+publish new names directly, re-trigger via `workflow_dispatch` with
+`allow_new_crates=true`. That only skips the check — if the scope is in fact
+missing, you get the partial release the check exists to prevent.
+
 ## Required secrets and setup
 
 | Secret | Scope | Used by |
 |---|---|---|
 | `RELEASE_PAT` | Repo secret. Fine-grained PAT scoped to this repo with **Contents: Read and write**, **Pull requests: Read and write**, **Issues: Read and write** (or a classic PAT with the `repo` scope). The owner only needs **write** access, not admin — the flow never pushes to `main` (it pushes a `release/*` branch and a tag; `main` advances via the PR merge). It must be a PAT rather than `GITHUB_TOKEN` so the opened PR triggers CI and the pushed tag cascades. | `release-open.yml` (open PR, push branch), `release-publish.yml` (push tag, create Release) |
-| `CARGO_REGISTRY_TOKEN` | **Environment** secret on `release`. crates.io token with publish rights for all `cognee-*` crates. | `release-publish.yml` preflight + publish |
+| `CARGO_REGISTRY_TOKEN` | **Environment** secret on `release`. crates.io token with publish rights for all `cognee-*` crates. Needs **`publish-update`**; also **`publish-new`** if you publish unreserved crate names (see [New crates](#new-crates-must-be-reserved-first)). Scope it to all crates or a pattern covering `cognee` **and** `cognee-*` — a list of literal names silently omits new ones. | `release-publish.yml` preflight + publish |
 | `NPM_TOKEN` | Repo secret. npm token with publish rights to the `@cognee` org. | `release-verify.yml`, `ts-prebuild.yml`, `release-publish.yml` preflight |
 | `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` | Repo secrets. Central Portal user token for `io.github.topoteretes`. `MAVEN_CENTRAL_PASSWORD` doubles as the publish gate — absent, the Java deploy silently no-ops. | `java-prebuild.yml` |
 | `MAVEN_GPG_PRIVATE_KEY` / `MAVEN_GPG_PASSPHRASE` | Repo secrets. GPG key used to sign the Maven artifacts (Central requires signatures). | `java-prebuild.yml` |
@@ -188,6 +229,15 @@ Release. If it fails partway:
   land the fix on `main` and re-trigger with
   `gh workflow run release-publish.yml -f version=X.Y.Z` (the `workflow_dispatch`
   path publishes from `main`, still behind the `release` approval gate).
+
+  If it failed with **`403 Forbidden: this token does not have the required
+  permissions`**, the token is missing a scope for that specific crate — almost
+  always `publish-new` on a brand-new name (see
+  [New crates](#new-crates-must-be-reserved-first)). Re-issue
+  `CARGO_REGISTRY_TOKEN` on the `release` environment with `publish-new` +
+  `publish-update` and a crate scope covering `cognee` and `cognee-*`, then
+  "Re-run failed jobs" — a re-run re-reads secrets, so no workflow change is
+  needed. Crates already published stay published; the loop skips them.
 - **Tag pushed but the npm / C-API cascade failed** (e.g. `ts-prebuild.yml` hit a
   transient npm error) — re-running `release-publish` will **not** re-fire the
   cascade (it skips the already-pushed tag). Instead re-run the failed workflow


### PR DESCRIPTION
Closes the gap that half-published 0.2.0.

## What went wrong

The publish loop got 14 crates in, then died on `cognee-components`:

```
error: failed to publish cognee-components v0.2.0 to registry at https://crates.io
Caused by:
  403 Forbidden: this token does not have the required permissions to perform this action
```

`CARGO_REGISTRY_TOKEN` held **`publish-update`** but not **`publish-new`**, and `cognee-components` was a brand-new crate name. Result: a partial release — 14 crates live at 0.2.0, 10 not, no tag — needing a re-issued token and a second trip through the environment approval gate.

## Why no preflight caught it

- `cargo owner --list cognee-models` only proves the token can **read** a crate that already exists.
- crates.io exposes **no way to introspect a token's scopes**.
- `cargo publish --dry-run` never validates a token at all.

So a `publish-update`-only token passes every check and fails only when it reaches the first *new* name — by which point earlier crates are irreversibly published.

## The fix

Since the scope can't be probed, assert the property that makes it moot: **every crate in `publish-order.sh` must already exist on crates.io**, so every release publish is an *update*. New names get reserved once, out of band, at crate-creation time — the pattern already used for `cognee` itself, which sat as a `0.0.0` placeholder until 0.2.0 filled it in.

The new preflight runs **before anything is published** and:
- walks `publish-order.sh` against the crates.io API
- treats any status other than 200/404 as a **hard failure**, rather than assuming the crate exists (a flaky 502 must not wave a new name through)
- names every offending crate and gives both remedies in the error

`allow_new_crates=true` on the `workflow_dispatch` path skips it, for a token known to hold `publish-new`.

## Verified against live crates.io

| case | result |
|---|---|
| all 24 current names | HTTP 200 → check passes, **no false positive on future releases** |
| `definitely-not-a-real-crate-xyzzy` | HTTP 404 → detected |
| `cognee-components`, `cognee-truth-subspace` | HTTP 200 — but **only because 0.2.0 published them**; before the release they were 404 |

That last row is the point: run against the pre-0.2.0 index, this check fails the run before a single crate goes out.

Step order confirmed — the check sits after the token probe and before the publish loop:

```
Preflight — crates.io token
Preflight — every crate name already exists on crates.io
Preflight — npm token
Publish each crate in topological order
```

## Docs

New "New crates must be reserved first" section in `docs/RELEASE.md` with the reservation command, plus two corrections found while writing it up:

- `publish-dry-run.yml` was listed as part of the release-PR verification barrier. It **deliberately skips on `release/*` PRs** — a release branch bumps every internal `cognee-* = "^X.Y.Z"` requirement to a version not yet on the index, which a per-crate dry run can't resolve. It gates normal PRs and `main`, never a release branch.
- The `CARGO_REGISTRY_TOKEN` row now spells out the required scopes and warns that scoping the token to a list of **literal** crate names silently omits new ones — a plausible way to end up back here.
- The recovery section now maps the `403 Forbidden` symptom straight to the cause and fix, noting a re-run re-reads secrets so no workflow change is needed.

## Testing

CI-only + docs; no Rust touched. `release-publish.yml` validated as parsing, both dispatch inputs registered, and the check body executed locally against real crates.io responses (results above).

It cannot be exercised end-to-end until the next release — by design, since the whole point is that it runs inside the approval-gated publish job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxKe2CjjA536dfGbjWcWN9