### PR TITLE
fix(capi): link the Apple frameworks the Rust staticlib needs

### DIFF
--- a/capi/CMakeLists.txt
+++ b/capi/CMakeLists.txt
@@ -61,9 +61,39 @@ add_dependencies(cognee_capi cognee_capi_cargo)
 # stdc++ is required because cognee-graph depends on lbug (C++ graph engine)
 set(COGNEE_SYSTEM_LIBS pthread dl m stdc++)
 
-# macOS requires CoreFoundation for iana_time_zone (used by chrono)
+# macOS: a Rust *staticlib* does not carry the `#[link]` / `cargo:rustc-link-lib`
+# directives its dependencies declare — rustc only acts on those when it drives
+# the final link itself (cdylib, bin). Because CMake links libcognee_capi.a with
+# clang instead, every Apple framework and system library the Rust side needs
+# must be named here, or the examples fail with undefined symbols such as
+# `_kSecValueData` / `_kSecClass` coming out of the security_framework objects
+# inside the archive.
+#
+# This list is the deduplicated output of
+#   cargo rustc --manifest-path capi/cognee-capi/Cargo.toml \
+#       --crate-type staticlib -- --print native-static-libs
+# minus the entries clang already links by default (-lSystem, -lc, -lm,
+# -lclang_rt.osx) and -lc++ (covered by `stdc++` above, which clang maps to
+# libc++ on Apple). Re-run that command and refresh this list whenever a
+# dependency that binds an Apple API is added, removed, or swapped out.
+#
+#   Security            — security-framework-sys, reached via rustls-native-certs
+#                         (reqwest -> hyper-rustls) reading the system trust store
+#   CoreFoundation      — core-foundation-sys: iana-time-zone (chrono) plus the
+#                         CF types the Security bindings pass around
+#   SystemConfiguration — whoami's SCDynamicStoreCopyComputerName, used for the
+#                         host name reported in telemetry
+#   Foundation, CoreML  — ort-sys (ONNX Runtime) and its CoreML execution provider
+#   iconv               — libc's Apple bindings declare `#[link(name = "iconv")]`
 if(APPLE)
-    list(APPEND COGNEE_SYSTEM_LIBS "-framework CoreFoundation")
+    list(APPEND COGNEE_SYSTEM_LIBS
+        "-framework Security"
+        "-framework CoreFoundation"
+        "-framework SystemConfiguration"
+        "-framework Foundation"
+        "-framework CoreML"
+        iconv
+    )
 endif()
 
 # Header include path

--- a/capi/README.md
+++ b/capi/README.md
@@ -23,6 +23,23 @@ cmake --build build
 
 Link with `-lcognee_capi` (and `-ldl -lm -lpthread` on Linux).
 
+When you link the **static** library (`libcognee_capi.a`) yourself, your build has to name
+the native libraries the Rust side depends on — a staticlib carries no link directives of
+its own. On macOS that is:
+
+```
+-lc++ -liconv -framework Security -framework CoreFoundation \
+-framework SystemConfiguration -framework Foundation -framework CoreML
+```
+
+`capi/CMakeLists.txt` does this for the bundled examples. The authoritative list for any
+given feature set comes from:
+
+```bash
+cargo rustc --manifest-path capi/cognee-capi/Cargo.toml \
+    --crate-type staticlib -- --print native-static-libs
+```
+
 ### Three-step pattern: init → warm → ops
 
 ```c


### PR DESCRIPTION
## Problem

`bash scripts/check_all.sh` has been failing on macOS/arm64 at the C API stage
(rc=2), and `bash capi/scripts/check.sh` fails the same way on its own. This is
pre-existing on `main` (reproduced at `0b02eba`), not caused by any in-flight work.

The CMake build of the C examples dies at link time:

```
Undefined symbols for architecture arm64:
  "_kSecValueData", referenced from:
      security_framework::item::ItemAddOptions::to_dictionary::…
        in libcognee_capi.a[5170](security_framework-….rcgu.o)
  "_kSecValueRef", "_kSecClass", "_kSecAttrAccount", …
ld: symbol(s) not found for architecture arm64
make[2]: *** [examples/example_sync_task] Error 1
```

## Root cause

Not a missing dependency — a property of Rust staticlibs.

`#[link(name = "Security", kind = "framework")]` attributes and
`cargo:rustc-link-lib=` lines from build scripts are only acted on when **rustc
drives the final link** (cdylib, bin, test). A `.a` is just an archive of object
files; it records none of that metadata. So any build that links
`libcognee_capi.a` itself has to name every native library the Rust side needs.

CMake links the examples with clang, and `capi/CMakeLists.txt` was only telling it
about `CoreFoundation`. `security-framework` arrives transitively via
`rustls-native-certs` (`reqwest` → `hyper-rustls`) reading the system trust store,
so its objects are in the archive and its Security-framework symbols go unresolved.

## Fix

Rather than guessing at the missing frameworks, take the list from the toolchain:

```bash
cargo rustc --manifest-path capi/cognee-capi/Cargo.toml \
    --crate-type staticlib -- --print native-static-libs
```

```
-lc++ -framework Foundation -framework CoreML -lclang_rt.osx -lc++
-framework Security -lc++ -framework CoreFoundation
-framework SystemConfiguration -framework CoreFoundation
-liconv -lSystem -lc -lm
```

Dropping what clang links by default (`-lSystem -lc -lm -lclang_rt.osx`) and
`-lc++` (already covered by the existing `stdc++` entry in `COGNEE_SYSTEM_LIBS`,
which clang maps to libc++ on Apple), what remains to add alongside the
`CoreFoundation` we already had is `Security`, `SystemConfiguration`,
`Foundation`, `CoreML` and `iconv`.

Everything stays inside the existing `if(APPLE)` guard, matching the style already
in the file, so **Linux and Windows builds are untouched**. No Rust, no Cargo
profile, no script changes.

Where each entry comes from (recorded in the CMake comment so the next dependency
bump that adds an Apple binding doesn't turn into the same archaeology):

| Entry | Source |
|---|---|
| `Security` | `security-framework-sys`, via `rustls-native-certs` (`reqwest` → `hyper-rustls`) |
| `CoreFoundation` | `core-foundation-sys`: `iana-time-zone` (chrono) + CF types the Security bindings pass around |
| `SystemConfiguration` | `whoami`'s `SCDynamicStoreCopyComputerName` (telemetry host name) |
| `Foundation`, `CoreML` | `ort-sys` (ONNX Runtime) and its CoreML execution provider |
| `iconv` | `libc`'s Apple bindings declare `#[link(name = "iconv")]` |

`capi/README.md` gets the same list, for downstream embedders who link the static
library by hand.

## Verification

- `bash capi/scripts/check.sh` → **rc=0** (was rc=2). All examples link, run and
  pass, including the slim (`--no-default-features --features sqlite,testing`) and
  `testing-panic` CMake configurations.
- `bash scripts/check_all.sh` → **rc=0**, `=== All checks passed! ===`. fmt,
  `cargo check --all-targets`, clippy `-D warnings`, the telemetry /
  no-default-features checks, the wasm32 drift guard, the telemetry noop test, and
  the C / Python / TS / Java binding checks all green.

### Environment note

`maturin` is not installed on this machine, so on a first pass
`python/scripts/check.sh` aborted immediately with `ERROR: maturin not found` and
`check_all.sh` stopped there. That is a local tooling prerequisite, not a repo
breakage, and it is downstream of and unrelated to this fix. The rc=0 run above
was done with `maturin` supplied from a throwaway venv (Python 3.12 — note that a
`python3 -m venv` resolving to the CommandLineTools 3.9 fails
`test_cognify_result_snake_case_fields`, which only reflects 3.9 not understanding
the PEP-604 `X | None` annotations in `cognee_py`'s stubs).

### Other pre-existing issues encountered, deliberately left alone
- One `capi` run saw `sdk_data_smoke` hang in `cg_sdk_delete_data` (main thread
  parked on the waiter condvar, every tokio worker idle). It did not reproduce:
  the binary passes standalone and on the subsequent full `check.sh` run. Flagging
  it as a possible flake worth watching; it is a runtime issue in the SDK and
  cannot be affected by a link-line change.
- Unrelated and untouched: `cargo build --workspace --all-targets` fails linking
  the `cognee-python` pyo3 test target (needs `-undefined dynamic_lookup`).
  `check_all.sh` uses `cargo check --all-targets`, which does not link, so it is
  not on this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SePhkXEUpiSJ1CTg7t9ERb
