### PR TITLE
fix: align the declared MSRV at 1.91 across all six sites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.89
+      - name: Install Rust 1.91
         uses: dtolnay/rust-toolchain@1.91.0
 
       - name: Install mold linker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,24 +81,42 @@ Plain unit tests that don't touch the LLM run with `cargo test`.
 
 ### MSRV & lockfiles
 
-The MSRV is **1.89**, declared via `rust-version` in `[workspace.package]` and pinned for
-local builds by `rust-toolchain.toml`. (On x86_64 the embedded qdrant `quantization` crate
-uses AVX-512 intrinsics stabilized in Rust 1.89; the aarch64 build skips that path, so a Mac
-may build on an older toolchain while CI on x86_64 will not.) `Cargo.lock` is intentionally
-**not committed** (see `.gitignore`); the edition-2024 MSRV-aware resolver (`resolver = "3"`)
-picks dependency versions compatible with 1.89 on a fresh resolve.
+The MSRV is **1.91**, declared via `rust-version` and pinned for local builds by
+`rust-toolchain.toml`. It must be stated in **every** workspace root, because the four of
+them are independent: `[workspace.package]` in `Cargo.toml` and `capi/Cargo.toml`, and the
+`[package]` sections of `ts/cognee-ts-neon/Cargo.toml` and `java/cognee-java-jni/Cargo.toml`.
+Keep them equal — see the resolution note below.
+
+(The hard floor from dependencies is lower: on x86_64 the embedded qdrant `quantization`
+crate uses AVX-512 intrinsics stabilized in Rust 1.89, and edition 2024 + resolver 3 would
+allow 1.85 in principle. The aarch64 build never compiles the AVX-512 path, so a Mac may
+build on an older toolchain while CI on x86_64 will not. 1.91 is the declared floor
+regardless, and the `msrv` CI lane builds against it.)
+
+`Cargo.lock` is intentionally **not committed** (see `.gitignore`); the edition-2024
+MSRV-aware resolver (`resolver = "3"`) picks dependency versions compatible with the declared
+`rust-version` on a fresh resolve.
+
+That last point is why the four declarations have to agree. The resolver caps each workspace
+at versions its own `rust-version` allows, so a workspace declaring a lower MSRV resolves an
+older graph. While `capi`/`ts` said 1.89 and root/`java` said 1.91, the two groups picked
+`cc 1.2.65` and `cc 1.4.0` respectively — and 175 of 836 external crates differed in version
+between them. `cc` sits in lbug's build-dependency closure, so that split alone forced a
+second full build of the bundled Ladybug C++ tree
+(see [docs/build/lbug-rebuilds.md](docs/build/lbug-rebuilds.md)).
 
 If `scripts/check_all.sh` fails with an error like
-`roaring@x.y.z requires rustc 1.90.0` (or any other "requires rustc > 1.89"), you have a
+`roaring@x.y.z requires rustc 1.92.0` (or any other "requires rustc > 1.91"), you have a
 **stale local lockfile** that pinned a version published with a higher MSRV — it is not a
-real breakage (a fresh resolve under the pinned toolchain selects a 1.89-compatible version).
+real breakage (a fresh resolve under the pinned toolchain selects a 1.91-compatible version).
 Recover by regenerating the lock or pinning the offending crate down, e.g.:
 
 ```bash
-# Regenerate fresh (uses the 1.89-aware resolver), or pin the specific crate:
+# Regenerate fresh (uses the 1.91-aware resolver), or pin the specific crate:
 cargo update                                            # whole workspace
 cargo update -p roaring@0.11.4 --precise 0.11.3         # one transitive dep
-# capi/ is its own workspace — run the same from inside capi/ if it drifts there.
+# capi/, ts/cognee-ts-neon/ and java/cognee-java-jni/ are their own workspaces —
+# run the same from inside whichever one drifted.
 ```
 
 ## Cleaning build artifacts

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ feedback, **`forget`** what's stale.
 ### Prerequisites
 
 - **Rust toolchain** — install [rustup](https://rustup.rs); the repo's pinned
-  toolchain (Rust 1.90, declared in `rust-toolchain.toml`) is selected
-  automatically. The workspace is edition 2024 / resolver 3; MSRV is 1.89.
+  toolchain (Rust 1.91, declared in `rust-toolchain.toml`) is selected
+  automatically. The workspace is edition 2024 / resolver 3; MSRV is 1.91.
 - An **LLM API key** (OpenAI-compatible). 
 
 Build the CLI from source with Cargo. 

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 version = "0.2.0"
-rust-version = "1.89"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 authors = ["Topoteretes <support@cognee.ai>"]
 description = "C API bindings for the cognee Rust SDK — AI memory pipeline (add → cognify → search)."

--- a/ts/cognee-ts-neon/Cargo.toml
+++ b/ts/cognee-ts-neon/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cognee-ts-neon"
 version = "0.2.0"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 description = "Neon (Node.js) native binding for the cognee Rust SDK."
 repository = "https://github.com/topoteretes/cognee-rs"


### PR DESCRIPTION
The MSRV was stated four different ways:

| Site | Said |
|---|---|
| `rust-toolchain.toml` | 1.91 (pin) |
| `Cargo.toml`, `java/cognee-java-jni/Cargo.toml` | 1.91 |
| `capi/Cargo.toml`, `ts/cognee-ts-neon/Cargo.toml` | **1.89** |
| `README.md` | pin is "Rust 1.90", MSRV 1.89 |
| `CONTRIBUTING.md` | 1.89 |
| `ci.yml:202` step label | "Install Rust 1.89" — while running `@1.91.0` |

1.91 is the real value everywhere it is actually enforced, so the rest are
corrected up to it. `capi` and `ts` declaring 1.89 was also a promise they could
not keep: both depend on path crates that declare 1.91 via
`[workspace.package]`.

## Why this is not cosmetic

Cargo's MSRV-aware resolver (`resolver = "3"`) caps each workspace at versions
its own `rust-version` allows, and no `Cargo.lock` is committed — so the
mismatch split the dependency graph in two. `capi`/`ts` resolved `cc 1.2.65`
while root/`java` resolved `cc 1.4.0`, and **175 of 836** external crates
differed in version between the groups.

`cc` sits in lbug's build-dependency closure, and per
`docs/build/lbug-rebuilds.md` a change there produces a fresh `lbug-<hash>`
`OUT_DIR` and a full rebuild of the bundled Ladybug C++ tree. The split alone
therefore forced a second complete C++ build — confirmed by observing four
distinct `lbug-<hash>` directories across the four workspaces.

## Verification

Lockfiles deleted first so the resolver ran fresh:

- `cargo check --all-targets` (capi) — ok, 2m58s
- `cargo build --release` (ts) — ok, 9m02s
- `cc` resolves to `1.4.0` in all four workspaces, root included (verified by
  re-resolving root and then restoring its lock)

## Note on the remaining 1.89 references

Those in `CONTRIBUTING.md` and `ci.yml` describe the *dependency-imposed* floor
— qdrant's `quantization` crate uses AVX-512 intrinsics stabilised in 1.89 on
x86_64 — which is a separate and still-accurate fact, not a declaration.
`CONTRIBUTING.md` now also records that the declaration must be repeated in each
of the four workspace roots, and why they have to agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SePhkXEUpiSJ1CTg7t9ERb