### PR TITLE
fix: remove the ladybug extension download from warm-up + make engine construction traceable

### DIFF
--- a/crates/graph/src/ladybug.rs
+++ b/crates/graph/src/ladybug.rs
@@ -590,10 +590,25 @@ impl GraphDBTrait for LadybugAdapter {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
         })?;
 
-        // Try to install and load JSON extension (optional)
-        // Ignore errors if extension is not available
-        let _ = conn.query("INSTALL json");
-        let _ = conn.query("LOAD EXTENSION json");
+        // No `INSTALL json` / `LOAD EXTENSION json` here, on purpose.
+        //
+        // Nothing in this repo issues a ladybug JSON query: node and edge
+        // properties are a plain `STRING` column (see the DDL below) and JSON is
+        // parsed on the Rust side via `serde_json` (`lbug_value_to_json`). The
+        // pair used to be run here "optionally", with both errors discarded.
+        //
+        // `INSTALL` fetches the extension over *plaintext HTTP* from
+        // extension.ladybugdb.com and `LOAD EXTENSION` then dlopens the result,
+        // so the two statements bought us an unconditional network round-trip on
+        // every first `initialize()` — cached under `$HOME/.lbug`, which CI never
+        // caches, and bounded only by a ~300s connect timeout — plus an MITM
+        // code-execution path, in exchange for a capability we never use. On a
+        // cold runner that stall is invisible: nothing here is instrumented, so
+        // it looks like a hung warm-up. It also contradicts this project's
+        // offline/edge target, where first-call network access is a defect.
+        //
+        // If a JSON query is ever genuinely needed, statically link the
+        // extension rather than downloading it at runtime.
 
         // Create Node table
         let create_node_table = r#"

--- a/crates/lib/src/component_manager.rs
+++ b/crates/lib/src/component_manager.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use tokio::sync::RwLock as TokioRwLock;
+use tracing::instrument;
 
 use cognee_components::ComponentRegistry;
 use cognee_database::DatabaseConnection;
@@ -126,31 +127,52 @@ impl ComponentManager {
         ctx
     }
 
+    // Each `init_*` below carries an INFO span so that engine construction —
+    // the bulk of a cold `warm()` — is visible in a trace.
+    //
+    // The spans go on these private constructors rather than on the public
+    // accessors because the accessors run `versioned_accessor!`, whose read-lock
+    // fast path returns a cached `Arc`. Instrumenting there would emit a span per
+    // cache *hit* — thousands per pipeline run, all ~0s — drowning the handful
+    // that represent real work. `init_*` runs only on the slow path: once per
+    // component per config version, which is exactly the event worth timing.
+
+    #[instrument(name = "cognee.component.storage", level = "info", skip_all, err)]
     async fn init_storage(&self) -> Result<Arc<dyn StorageTrait>, ComponentError> {
         let ctx = self.build_context().await;
         cognee_components::build_storage(&ctx).await
     }
 
+    #[instrument(name = "cognee.component.database", level = "info", skip_all, err)]
     async fn init_database(&self) -> Result<Arc<DatabaseConnection>, ComponentError> {
         let ctx = self.build_context().await;
         cognee_components::build_database(&ctx).await
     }
 
+    #[instrument(name = "cognee.component.graph_db", level = "info", skip_all, err)]
     async fn init_graph_db(&self) -> Result<Arc<dyn GraphDBTrait>, ComponentError> {
         let ctx = self.build_context().await;
         self.registry.build_graph(&ctx).await
     }
 
+    #[instrument(name = "cognee.component.vector_db", level = "info", skip_all, err)]
     async fn init_vector_db(&self) -> Result<Arc<dyn VectorDB>, ComponentError> {
         let ctx = self.build_context().await;
         self.registry.build_vector(&ctx).await
     }
 
+    #[instrument(
+        name = "cognee.component.embedding_engine",
+        level = "info",
+        skip_all,
+        err
+    )]
     async fn init_embedding_engine(&self) -> Result<Arc<dyn EmbeddingEngine>, ComponentError> {
         let ctx = self.build_context().await;
         self.registry.build_embedding(&ctx).await
     }
 
+    #[instrument(name = "cognee.component.llm", level = "info", skip_all, err)]
     async fn init_llm(&self) -> Result<Arc<dyn Llm>, ComponentError> {
         let ctx = self.build_context().await;
         self.registry.build_llm(&ctx).await

--- a/crates/lib/tests/component_warm_spans.rs
+++ b/crates/lib/tests/component_warm_spans.rs
@@ -1,0 +1,127 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Span coverage for engine construction (`ComponentManager::init_*`).
+//!
+//! A cold `warm()` spends most of its time building the six engines, and until
+//! these spans existed that stretch emitted nothing at all: a stall inside
+//! storage/database/graph construction produced zero bytes of output, so
+//! diagnosing one meant reconstructing timings from surrounding log lines
+//! instead of reading a trace (see the investigation on topoteretes/cognee-rs#115).
+//!
+//! Both tests are `#[serial]`. `SpanCapture` installs a process-global
+//! subscriber and fans every span out to all live capture stores, so two tests
+//! capturing at once in the same process see each other's spans. That is
+//! harmless for "is this span present?" but fatal for the count assertion below,
+//! and under a `cargo test` fallback (many tests per process, run in parallel)
+//! it happens every time. Serializing keeps the guards' lifetimes disjoint.
+
+use cognee::{ComponentManager, ConfigManager, PipelineContext, Settings};
+use cognee_test_utils::SpanCapture;
+use serial_test::serial;
+use tempfile::TempDir;
+
+/// A manager whose every on-disk artefact lands in a temp dir.
+///
+/// `Settings::default()` points at *relative* paths (`./.cognee_system`,
+/// `./.data_storage`, `sqlite:./cognee.db?mode=rwc`), so building the storage and
+/// database engines with the defaults writes into the crate directory and leaves
+/// `cognee.db{,-shm,-wal}` behind in the working tree. Redirect all of it.
+///
+/// The returned `TempDir` must stay alive for the duration of the test — dropping
+/// it deletes the directory out from under the engines.
+fn cm() -> (ComponentManager, TempDir) {
+    let dir = TempDir::new().expect("tempdir");
+    let root = dir.path();
+    let settings = Settings {
+        system_root_directory: root.join("system").to_string_lossy().into_owned(),
+        data_root_directory: root.join("data").to_string_lossy().into_owned(),
+        relational_db_url: format!(
+            "sqlite:{}?mode=rwc",
+            root.join("cognee.db").to_string_lossy()
+        ),
+        ..Settings::default()
+    };
+    (ComponentManager::new(ConfigManager::new(settings)), dir)
+}
+
+fn names(spans: &[cognee_test_utils::CapturedSpan]) -> Vec<String> {
+    spans.iter().map(|s| s.name.clone()).collect()
+}
+
+/// Every engine constructor emits its span. `llm` is included deliberately: it
+/// fails to build under default settings (no API key), and the `err` flag on the
+/// `#[instrument]` means the span must still be recorded — a failed engine build
+/// is exactly the case someone will be debugging.
+#[tokio::test]
+#[serial]
+async fn each_component_construction_emits_a_span() {
+    let capture = SpanCapture::install();
+    let (cm, _dir) = cm();
+
+    let _ = cm.storage().await;
+    let _ = cm.database().await;
+    let _ = cm.graph_db().await;
+    let _ = cm.vector_db().await;
+    let _ = cm.embedding_engine().await;
+    // Errors under default settings (strict LLM resolution, no key).
+    let llm = cm.llm().await;
+    assert!(
+        llm.is_err(),
+        "precondition: default settings have no LLM key, so this build must fail \
+         — the point of the assertion below is that the span fires anyway"
+    );
+
+    let spans = capture.spans();
+    let seen = names(&spans);
+    for component in [
+        "storage",
+        "database",
+        "graph_db",
+        "vector_db",
+        "embedding_engine",
+        "llm",
+    ] {
+        let expected = format!("cognee.component.{component}");
+        assert!(
+            spans.iter().any(|s| s.name == expected),
+            "missing span {expected}; saw: {seen:?}",
+        );
+    }
+}
+
+/// Regression guard for *where* the spans live.
+///
+/// They sit on the private `init_*` constructors, not the public accessors,
+/// because the accessors' `versioned_accessor!` fast path returns a cached `Arc`.
+/// Instrumenting there would emit a span per cache hit — thousands per pipeline
+/// run — burying the few that represent real work. If someone moves the
+/// `#[instrument]` up to the accessors, this test fails.
+#[tokio::test]
+#[serial]
+async fn cached_access_does_not_emit_a_second_span() {
+    let capture = SpanCapture::install();
+    let (cm, _dir) = cm();
+
+    // First call constructs; the next two must be served from the cache.
+    let first = cm.storage().await;
+    assert!(first.is_ok(), "storage must build under default settings");
+    let _ = cm.storage().await;
+    let _ = cm.storage().await;
+
+    let spans = capture.spans();
+    let count = spans
+        .iter()
+        .filter(|s| s.name == "cognee.component.storage")
+        .count();
+    assert_eq!(
+        count,
+        1,
+        "expected exactly one construction span across three accessor calls, \
+         got {count} — is #[instrument] on the accessor instead of init_*? \
+         saw: {:?}",
+        names(&spans),
+    );
+}

--- a/ts/__tests__/datasets.test.ts
+++ b/ts/__tests__/datasets.test.ts
@@ -602,7 +602,13 @@ describe("Phase-5 memory ops (Tier-B — skips without LLM creds)", () => {
       embedding_model_path: process.env.COGNEE_E2E_EMBED_MODEL_PATH,
     });
     await native.cogneeWarm(handle);
-  });
+    // 120s, matching the other Tier-B warm hooks (memory / recall / data-ops):
+    // this one builds a real ONNX embedding engine, which does not fit the 30s
+    // global default in jest.config.js. Latent today only because CI leaves
+    // COGNEE_E2E_EMBED_MODEL_PATH unset so the gate above skips the block —
+    // the moment those creds are set, this hook runs on a budget its siblings
+    // already judged insufficient.
+  }, 120_000);
 
   afterAll(() => {
     cleanupTmpDir(tmpDir);


### PR DESCRIPTION
Follow-ups from the #115 investigation into the flaky `datasets.test.ts` warm-up
timeout. Three stacked commits, deliberately separable — B can be reverted on its
own if the mechanism turns out to be wrong, without losing A's observability.

## A — `feat(lib)`: trace engine construction

A cold `warm()` spends most of its wall-clock building the six engines, and that
stretch emitted **nothing**. When the TS warm-up hook blew its 30s budget in CI,
steps 1–3 produced literally zero bytes, so locating the stall meant
reconstructing timings from surrounding log lines instead of reading a trace.

Adds an INFO span per engine:
`cognee.component.{storage,database,graph_db,vector_db,embedding_engine,llm}`.

The spans sit on the private `init_*` constructors, **not** the public
`PipelineContext` accessors. The accessors run `versioned_accessor!`, whose
read-lock fast path returns a cached `Arc` — instrumenting there would emit a span
per cache *hit*, thousands per pipeline run at ~0s each, burying the few that
represent real work. `init_*` runs only on the slow path: once per component per
config version. A test fails if anyone moves the attribute back up.

`err` is set so a *failed* engine build still records a span — precisely the case
someone will be debugging.

## B — `fix(graph)`: drop the ladybug JSON-extension install

`LadybugAdapter::initialize` ran `INSTALL json` / `LOAD EXTENSION json`, both with
errors discarded. Nothing in this repo issues a ladybug JSON query: properties are
a plain `STRING` column and JSON is parsed in Rust via `serde_json`. A repo-wide
search (Rust/TS/Python/fixtures/e2e) for `to_json(`, `json_extract`,
`json_merge`, `json_object`, `CAST AS JSON` and JSON column types finds nothing,
and no user-supplied Cypher reaches this backend — CYPHER/NATURAL_LANGUAGE search
are Neo4j-only and return `[]` on ladybug.

What it cost: `INSTALL` fetches over **plaintext HTTP** from
`extension.ladybugdb.com` and `LOAD EXTENSION` dlopens the result, so every first
`initialize()` made an unconditional network round-trip — cached under
`$HOME/.lbug`, which CI never caches, bounded only by httplib's ~300s connect
timeout, with nothing in `initialize()` instrumented to make a stall visible.

Measured locally, timing `initialize()` alone with `$HOME/.lbug` cleared between
runs:

| | cold cache | warm cache |
|---|---|---|
| before | **2226 ms** (downloads `libjson.lbug_extension`) | 32 ms |
| after | **22–25 ms** (no download, no cache dir created) | 22–25 ms |

To be precise about scope: 2.2s is the *floor* on a fast, responsive connection —
not the 30s+ CI stall. What this establishes is that an unconditional,
uninstrumented network download sat in `initialize()`, bounded by nothing we
control, which is what makes it a plausible source of that stall. Proving
causation would need the request black-holed (DROP), which I have not run.

Independent of the flake, this also contradicts the project's offline/edge target,
where first-call network access is a defect, and plaintext-HTTP-download-then-
`dlopen` is an MITM code-execution path.

Behaviour is otherwise unchanged: both statements already ignored their results,
so every offline dev run and every 404 has always exercised the post-failure path.

## C — `test(ts)`: budget the Tier-B warm hook

The Tier-B `beforeAll` builds a real ONNX embedding engine yet ran on the 30s
global default, while the three sibling Tier-B warm hooks doing the same work
(`memory`, `recall`, `data-ops`) all use 120s. Latent today — CI leaves
`COGNEE_E2E_EMBED_MODEL_PATH` unset so the gate skips the block — but it bites the
moment those creds are added.

**The Tier-A hook at line 58 is deliberately untouched**, even though it is the one
that actually timed out. It is mock-embedding by design (`embedding_provider:
"mock"` selects the mock engine regardless of env), its true Tier-A peers all run
on the 30s default, and every one passed even in the failing run. Raising it would
hand a Tier-A hook a Tier-B budget and retire the only detector for the stall B
addresses.

## Verification

- `cargo test -p cognee-graph --features ladybug` — 95 passed. (The `ladybug`
  feature is required; without it these files silently run zero tests.)
- The 2 new span tests pass, `#[serial]` because `SpanCapture`'s process-global
  subscriber fans spans to every live store, so concurrent captures in one process
  see each other's — harmless for presence, fatal for the count assertion.
- `npx jest __tests__/datasets.test.ts` — 31 passed, 1 skipped. Those 31 are
  exactly the tests that went red in CI.
- `scripts/check_all.sh` — exit 0, including the TS and Python binding checks that
  rebuild the addon with B in it.

## Not included

An upstream report to `lbug` that `OFFICIAL_EXTENSION_REPO` is `http://` — this PR
removes *our* exposure, but any `INSTALL <ext>` user is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxKe2CjjA536dfGbjWcWN9
