### PR TITLE
fix(core): pipeline task-context, batch-dispatch, and borrow_item fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      **[BREAKING]** bullet); migration prose like the entries below is always
      hand-written and always needs this manual reposition. -->
 
+### Breaking changes
+
+- **`cognee-core`: `PipelineContext::current_data` changed meaning.** It is now
+  pinned, once per data item, to the value that *entered* the pipeline, and is
+  never rebound as that item flows through the task chain. Previously the
+  executor overwrote it before every single-value task call, so a task at
+  position *k* saw the output of task *k-1* — that is, its own input, which it
+  already receives as an argument. Batch-dispatched (`*Batch`) tasks previously
+  got the run-level context, where the field was `None`; they now inherit the
+  same item value as every other task. This matches Python cognee, where
+  `PipelineContext(data_item=…)` is built once per data item in `run_tasks.py`
+  and never rebound per task.
+
+  The field's type is unchanged, so **this does not break compilation** — only
+  behaviour, and only for custom `Task` implementations. An out-of-tree task that
+  read `ctx.pipeline().current_data` expecting *its own* input must read its input
+  argument instead. A task that wanted the originating data item (the field's
+  documented purpose) now gets it at any depth in the chain.
+
 ## [0.2.0](https://github.com/topoteretes/cognee-rs/compare/v0.1.3...v0.2.0) - 2026-07-30
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   argument instead. A task that wanted the originating data item (the field's
   documented purpose) now gets it at any depth in the chain.
 
+  Pinning the value also keeps it reachable for the whole chain. This is an
+  `Arc` clone — nothing is duplicated — but the allocation is now released when
+  the item finishes rather than when its first task returns. Only pipelines
+  whose input value *owns* a large buffer are affected (`DataInput::Binary` is
+  the one to watch); those should stream the payload instead of materialising it
+  in the input value. Python behaves the same way, holding `data_item` on its
+  per-item context for the duration of the run.
+
 ## [0.2.0](https://github.com/topoteretes/cognee-rs/compare/v0.1.3...v0.2.0) - 2026-07-30
 
 ### Breaking changes

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -50,7 +50,7 @@ use cognee_vector::{VectorDB, VectorPoint};
 use serde::Serialize;
 use serde_json::json;
 use tokio::sync::Semaphore;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use url::Url;
 use uuid::Uuid;
 
@@ -1158,6 +1158,29 @@ pub async fn add_data_points(
             &structural_edges,
         )
         .await?;
+    } else if db.is_some() {
+        // A relational backend *is* configured, so the ledger row could have been
+        // written — the missing `user_id` is a genuine config inconsistency, not a
+        // deployment shape. Python degrades silently here
+        // (`add_data_points.py:123`); we make it loud.
+        warn!(
+            dataset_id = %input.dataset_id,
+            "Skipping provenance ledger write: a relational database is configured but \
+             user_id is None. Nodes and edges were written to the graph without a \
+             rollback/ownership record, so rollback and ownership tracking will not \
+             cover them."
+        );
+    } else {
+        // No relational backend at all: the ledger is not applicable to this
+        // deployment (embedded / unauthenticated use, where `db` and `user_id` are
+        // legitimately `None` in the public `cognify()` signature). Not a
+        // data-integrity problem, so this must not be a WARN — it would fire once
+        // per data item and flag every normal ingest.
+        debug!(
+            dataset_id = %input.dataset_id,
+            "No relational database configured; provenance ledger write not applicable. \
+             Nodes and edges are in the graph with no rollback/ownership record."
+        );
     }
 
     Ok(CognifyResult {

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -3407,4 +3407,91 @@ mod tests {
         let v = (*outputs[0]).as_any().downcast_ref::<i32>().unwrap();
         assert_eq!(*v, 15);
     }
+
+    // ── Retention characteristics of the per-item context ────────────────────
+
+    /// A payload that records when it is dropped, so a test can observe
+    /// whether the executor is still holding the pipeline input.
+    struct TrackedPayload {
+        _bytes: Vec<u8>,
+        dropped: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl Drop for TrackedPayload {
+        fn drop(&mut self) {
+            self.dropped
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    /// Pinning `current_data` per item necessarily keeps the pipeline input
+    /// alive for the whole task chain, even once no task needs it any more.
+    ///
+    /// This is deliberate and matches the reference implementation: Python
+    /// builds one `PipelineContext(data_item=data_item, ...)` per item in
+    /// `run_tasks.py` and holds it across the entire per-item run, so
+    /// `ctx.data_item` is reachable from the last task there too.
+    ///
+    /// The cost is one extra live copy of the input value per in-flight item
+    /// (so × `concurrency`). It matters for pipelines whose *input value*
+    /// owns a large buffer rather than a reference to one — e.g.
+    /// `DataInput::Binary { data: Vec<u8>, .. }`, which the bindings marshal
+    /// into. Such pipelines should stream rather than materialise the payload
+    /// in the input value; the executor cannot release it early without
+    /// giving up the documented `current_data` semantics.
+    #[tokio::test]
+    async fn per_item_context_keeps_the_input_alive_for_the_whole_chain() {
+        let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        // Task 0 consumes the payload and returns something small, so nothing
+        // downstream carries the payload forward. The only remaining strong
+        // reference is the one the per-item context holds.
+        let consume = TypedTask::<TrackedPayload, i32>::sync(|p: &TrackedPayload, _ctx| {
+            Ok(Box::new(p._bytes.len() as i32))
+        });
+
+        // Task 1 observes whether the payload is still alive.
+        let seen = Arc::new(std::sync::Mutex::new(None::<bool>));
+        let seen_in_task = Arc::clone(&seen);
+        let dropped_in_task = Arc::clone(&dropped);
+        let observe = TypedTask::<i32, i32>::sync(move |n: &i32, ctx| {
+            let already_dropped = dropped_in_task.load(std::sync::atomic::Ordering::SeqCst);
+            // lock poison is unrecoverable
+            *seen_in_task.lock().unwrap() = Some(already_dropped);
+            // The value is not merely alive, it is reachable as the original item.
+            let cd = ctx
+                .pipeline()
+                .current_data
+                .clone()
+                .expect("current_data is pinned per item by execute_one_item");
+            assert!(
+                (*cd).as_any().downcast_ref::<TrackedPayload>().is_some(),
+                "current_data should still be the original TrackedPayload"
+            );
+            Ok(Box::new(*n))
+        });
+
+        let pipeline = PipelineBuilder::new_with_task("retention", consume)
+            .add_task(observe)
+            .with_name("retention")
+            .build();
+
+        let input: Arc<dyn Value> = Arc::new(TrackedPayload {
+            _bytes: vec![0_u8; 4096],
+            dropped: Arc::clone(&dropped),
+        });
+
+        let ctx = stub_ctx_with_pipeline("retention").await;
+        let watcher = NoopWatcher;
+        execute(&pipeline, vec![input], ctx, &watcher)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            Some(false),
+            "the input must still be alive while a later task runs — that is \
+             what pinning current_data per item means"
+        );
+    }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -1,3 +1,66 @@
+//! Pipeline definition and the depth-first task executor.
+//!
+//! [`Pipeline`] (or the type-checked [`PipelineBuilder`]) describes an ordered
+//! chain of [`TaskInfo`]s; [`execute`] runs that chain over one or more input
+//! values, fanning out per data item and recursing through the chain with
+//! `execute_from`.
+//!
+//! # Batch dispatch bypasses executor services
+//!
+//! There are two dispatch paths through the executor, and they are **not**
+//! equivalent.
+//!
+//! Single-value tasks go through `execute_from` → `call_with_retry` and receive
+//! the executor's full set of services.
+//!
+//! When an upstream task yields an iterator or a stream, the executor
+//! accumulates its items into a buffer (sized by [`TaskInfo::with_batch_size`])
+//! and hands the buffer to `dispatch_batch`. If the consuming task is one of the
+//! `*Batch` [`Task`] variants, `dispatch_batch` calls it **directly** with the
+//! accumulated slice, skipping `call_with_retry` entirely. Such a task gets
+//! **none** of the following six services:
+//!
+//! 1. **Retries.** The configured [`RetryPolicy`] is never consulted; the batch
+//!    call is made exactly once and the first error fails the item.
+//! 2. **Per-task watcher events.** No `on_task` / `on_task_started` /
+//!    `on_task_completed` is emitted for the batch task, so it is invisible both
+//!    to watcher observers and to per-task status tracking.
+//! 3. **Provenance stamping.** The executor does not walk the batch task's
+//!    output with `stamp_tree_dyn`. (Items *inside* the incoming slice were
+//!    already stamped eagerly by the upstream `process_iter` / `process_stream`,
+//!    but anything the batch task newly creates stays unstamped unless the task
+//!    stamps it itself.)
+//! 4. **Rate limiting.** Neither [`Pipeline::with_rate_limiter`] nor
+//!    [`TaskInfo::with_rate_limiter`] is acquired — the effective limiter is
+//!    threaded only into `call_with_retry`. Batch calls are unthrottled.
+//! 5. **Progress-subtoken completion.** The per-task progress subtoken is only
+//!    completed by `execute_from`, so a batch task's slice of the progress bar
+//!    never advances. The task cannot compensate from inside, either: it is
+//!    handed the run-level [`TaskContext`], whose `progress` is the *root* token,
+//!    and [`ProgressToken::split`] has already zeroed the root's width — so
+//!    `ctx.progress.set(..)` from a batch task is a silent no-op.
+//! 6. **Cancellation observation.** The executor's only cancellation check sits
+//!    at the top of `execute_from`, *after* the empty-tasks base case. The batch
+//!    branch of `dispatch_batch` never checks, and neither do the `process_iter`
+//!    / `process_stream` accumulation loops — so a batch task can still be
+//!    entered, and further batches still accumulated, after the run has been
+//!    cancelled.
+//!
+//! What a batch task *does* get is the pre-accumulated slice and the run-level
+//! context; it is expected to handle its own error semantics.
+//!
+//! This is a **divergence from Python cognee**, where every task goes through
+//! `handle_task` and receives stamping, telemetry and spans regardless of
+//! batching (there, `batch_size` only controls how many items are gathered into
+//! the list handed to the task).
+//!
+//! Only the `*Batch` variants take this path. A **non-batch** task reached from
+//! `dispatch_batch` is executed one buffered item at a time through
+//! `execute_from`, so it keeps every service listed above.
+//!
+//! [`ProgressToken::split`]: crate::progress::ProgressToken::split
+//! [`TaskContext`]: crate::task_context::TaskContext
+
 // Mutex lock().unwrap() and invariant-guarded expect() are acceptable in this
 // pipeline runtime — lock poisoning is unrecoverable and the invariants are
 // upheld by construction.
@@ -127,10 +190,12 @@ pub struct Pipeline {
     /// `Pipeline` struct shape is stable across feature flips. The
     /// snapshot is only consumed when the `telemetry` feature is on.
     pub telemetry_settings: Option<serde_json::Map<String, serde_json::Value>>,
-    /// Pipeline-wide proactive rate limiter applied to every task call (both
-    /// single-value via `call_with_retry` and batch via `dispatch_batch`).
-    /// Individual tasks may override it via [`TaskInfo::rate_limiter`].
-    /// `None` means no throttling.
+    /// Pipeline-wide proactive rate limiter applied to every **single-value**
+    /// task call, via `call_with_retry`. Individual tasks may override it via
+    /// [`TaskInfo::rate_limiter`]. `None` means no throttling.
+    ///
+    /// Batch-dispatched (`*Batch`) task calls are **not** throttled — see
+    /// [`Pipeline::with_rate_limiter`].
     pub rate_limiter: Option<Arc<dyn RateLimiter>>,
 }
 
@@ -165,6 +230,18 @@ impl Pipeline {
         self
     }
 
+    /// Set the pipeline-wide default for how many items are accumulated from an
+    /// upstream iterator / stream before they are dispatched to the consuming
+    /// task. Individual tasks override it via [`TaskInfo::with_batch_size`].
+    ///
+    /// This sizes the accumulation buffer for **every** kind of consuming task,
+    /// not only `*Batch` variants — see [`TaskInfo::with_batch_size`] for what
+    /// that means for a non-batch consumer.
+    ///
+    /// When the consumer *is* a `*Batch` variant it is dispatched off the
+    /// executor's service path (no retries, watcher events, provenance stamping,
+    /// rate limiting, progress completion or cancellation checks); see
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn with_batch_size(mut self, size: usize) -> Self {
         assert!(size > 0, "batch_size must be > 0");
         self.batch_size = size;
@@ -192,10 +269,15 @@ impl Pipeline {
     /// Set a pipeline-wide proactive rate limiter. Individual tasks may override
     /// it via [`TaskInfo::with_rate_limiter`].
     ///
-    /// The limiter is acquired inside `call_with_retry` once per attempt (so
-    /// each retry is a fresh acquisition) and once per batch call in
-    /// `dispatch_batch`. Use this for LLM API quota throttling or per-host
-    /// crawl-rate control.
+    /// The limiter is acquired inside `call_with_retry`, once per attempt, so
+    /// each retry is a fresh acquisition. Use this for LLM API quota throttling
+    /// or per-host crawl-rate control.
+    ///
+    /// **Batch calls are not throttled today.** `dispatch_batch` invokes a
+    /// `*Batch` task directly without acquiring the limiter — the effective
+    /// limiter is threaded only into `call_with_retry` — so a pipeline whose LLM
+    /// work happens in a batch task gets no throttling from this setting. See
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     ///
     /// See [`crate::rate_limiter`] for the distinction between this,
     /// [`Pipeline::with_concurrency`] (item parallelism), and [`RetryPolicy`]
@@ -344,7 +426,15 @@ impl<I: Value, O: Value> PipelineBuilder<I, O> {
         self
     }
 
-    /// Set the default batch size (items accumulated before dispatching to a batch task).
+    /// Set the default number of items accumulated from an upstream iterator /
+    /// stream before they are dispatched to the consuming task.
+    ///
+    /// This sizes the accumulation buffer whatever kind the consuming task is,
+    /// not only for `*Batch` variants — see [`TaskInfo::with_batch_size`].
+    ///
+    /// When the consumer *is* a `*Batch` variant it is dispatched off the
+    /// executor's service path; see
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn with_batch_size(mut self, size: usize) -> Self {
         assert!(size > 0, "batch_size must be > 0");
         self.batch_size = size;
@@ -924,7 +1014,15 @@ async fn execute_one_item<'a>(
         .as_ref()
         .and_then(|f| f(Arc::clone(&input)));
 
-    let result = execute_from(&pipeline.tasks, input, 0, env).await;
+    // Pin `PipelineContext::current_data` to the **original** data item for the
+    // whole task chain (Python parity: `PipelineContext(data_item=data_item)` is
+    // built once per item in `run_tasks.py` and never rebound per task). Every
+    // dispatch site below — `execute_from`, `dispatch_batch`, `process_iter` /
+    // `process_stream` — inherits it through this per-item `ExecEnv`.
+    let item_ctx = ctx.with_current_data(Arc::clone(&input));
+    let item_env = env.with_ctx(&item_ctx);
+
+    let result = execute_from(&pipeline.tasks, input, 0, &item_env).await;
 
     // Best-effort status marking — don't shadow the pipeline result.
     if let Some(data_id) = &data_id {
@@ -1041,6 +1139,33 @@ struct ExecEnv<'a> {
     task_subtokens: &'a [ProgressToken],
     /// Pipeline-wide rate limiter; per-task limiters override it.
     rate_limiter: Option<&'a Arc<dyn RateLimiter>>,
+}
+
+impl<'a> ExecEnv<'a> {
+    /// Re-borrow this env against a different [`TaskContext`], keeping every
+    /// other (run-constant) field. Used by [`execute_one_item`] to install the
+    /// per-item context that carries `PipelineContext::current_data`.
+    ///
+    /// The returned env has the shorter lifetime `'b` of the borrowed context;
+    /// all other `&'a` fields shrink to `'b` by covariance.
+    fn with_ctx<'b>(&self, ctx: &'b Arc<TaskContext>) -> ExecEnv<'b>
+    where
+        'a: 'b,
+    {
+        ExecEnv {
+            policy: self.policy,
+            default_batch_size: self.default_batch_size,
+            pipeline_id: self.pipeline_id,
+            pipeline_name: self.pipeline_name,
+            total_tasks: self.total_tasks,
+            ctx,
+            watcher: self.watcher,
+            data_id_fn: self.data_id_fn,
+            run_info: self.run_info,
+            task_subtokens: self.task_subtokens,
+            rate_limiter: self.rate_limiter,
+        }
+    }
 }
 /// Depth-first pipeline executor.
 ///
@@ -1212,11 +1337,17 @@ fn execute_from<'a>(
 /// - Otherwise execute each item individually through `execute_from`, collecting
 ///   all outputs.
 ///
-/// **Design note:** batch-dispatched tasks bypass [`call_with_retry`] — there
-/// are no retries, no per-task watcher events, and no provenance stamping.
-/// Batch tasks receive pre-accumulated slices and are expected to handle their
-/// own error semantics. Only single-value tasks executed via [`execute_from`]
-/// get the full retry / watcher / provenance treatment.
+/// **Design note:** batch-dispatched tasks bypass [`call_with_retry`], and with
+/// it *six* executor services — there are no retries, no per-task watcher
+/// events, no provenance stamping, no rate-limiter acquisition, no
+/// progress-subtoken completion, and no cancellation check. Batch tasks receive
+/// pre-accumulated slices and are expected to handle their own error semantics.
+/// Only single-value tasks executed via [`execute_from`] get the full treatment.
+///
+/// This doc comment is the code-side summary; the authoritative version, with
+/// the reasoning for each of the six, is the module documentation:
+/// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
+/// Keep the two in sync.
 fn dispatch_batch<'a>(
     batch: Vec<Box<dyn Value>>,
     tail: &'a [TaskInfo],
@@ -1411,10 +1542,12 @@ async fn call_with_retry(
     let max_attempts = env.policy.max_attempts();
     let mut last_error: Option<TaskError> = None;
 
-    // Inject the task-specific progress subtoken and current data.
+    // Inject the task-specific progress subtoken. `current_data` is *not* set
+    // here: it is pinned to the original data item once per item in
+    // `execute_one_item` (Python's `ctx.data_item`), so overwriting it with this
+    // task's input would make it mean "previous task's output" instead.
     let subtoken = env.task_subtokens[task_index].clone();
-    let scoped_ctx = env.ctx.with_progress(subtoken);
-    let task_ctx = scoped_ctx.with_current_data(input.clone());
+    let task_ctx = env.ctx.with_progress(subtoken);
 
     // Resolve identity once (outside the retry loop) — per locked
     // decision 7, task lifecycle events fire once per task, not per
@@ -1728,6 +1861,26 @@ mod tests {
         })
     }
 
+    /// Like [`stub_ctx`], but with a `PipelineContext` attached so tasks can call
+    /// `ctx.pipeline()`. Uses the shared
+    /// [`PipelineContext::for_test`](crate::task_context::PipelineContext::for_test)
+    /// fixture rather than another hand-written struct literal.
+    async fn stub_ctx_with_pipeline(pipeline_name: &str) -> Arc<TaskContext> {
+        let pipeline_ctx = crate::task_context::PipelineContext::for_test(pipeline_name);
+        let ctx = stub_ctx().await;
+        Arc::new(TaskContext {
+            thread_pool: Arc::clone(&ctx.thread_pool),
+            database: Arc::clone(&ctx.database),
+            graph_db: Arc::clone(&ctx.graph_db),
+            vector_db: Arc::clone(&ctx.vector_db),
+            cancellation: ctx.cancellation.clone(),
+            progress: ctx.progress.clone(),
+            pipeline_ctx: Some(pipeline_ctx),
+            exec_status: Arc::clone(&ctx.exec_status),
+            pipeline_watcher: None,
+        })
+    }
+
     #[test]
     fn pipeline_run_info_elapsed_seconds_returns_none_before_completion() {
         let info = PipelineRunInfo {
@@ -1805,6 +1958,327 @@ mod tests {
         let result = (*outputs[0]).as_any().downcast_ref::<i32>().unwrap();
         assert_eq!(*result, 42);
         assert_eq!(counter.load(Ordering::SeqCst), 3);
+    }
+
+    /// Read `ctx.pipeline().current_data` as an `i32`, panicking if absent.
+    ///
+    /// Shared by every `current_data_*` test below. Panicking (rather than
+    /// returning `Option`) is deliberate: if a refactor threads the root `env`
+    /// into a dispatch site, `current_data` becomes `None`, and these tests must
+    /// then fail loudly instead of silently skipping their assertion.
+    fn observed_current_data(ctx: &Arc<TaskContext>) -> i32 {
+        ctx.pipeline()
+            .current_data
+            .as_ref()
+            .and_then(|v| (**v).as_any().downcast_ref::<i32>().copied())
+            .expect("current_data is pinned per item by execute_one_item")
+    }
+
+    /// `PipelineContext::current_data` must hold the **original** value that
+    /// entered the pipeline for this item, not the upstream task's output —
+    /// Python's `ctx.data_item` semantics. See `execute_one_item`.
+    #[tokio::test]
+    async fn current_data_is_the_original_item_not_the_previous_output() {
+        use std::sync::Mutex;
+
+        // Records what each task observed in `ctx.pipeline().current_data`.
+        let seen: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let record = |seen: Arc<Mutex<Vec<i32>>>| {
+            Task::sync_typed(
+                move |x: &i32, ctx: Arc<TaskContext>| -> Result<Box<i32>, TaskError> {
+                    seen.lock().unwrap().push(observed_current_data(&ctx));
+                    Ok(Box::new(*x + 1))
+                },
+            )
+        };
+
+        // Task 0 rewrites the value so a stale `current_data` would be visible
+        // to tasks 1 and 2 as `700` / `701` rather than the original `7`.
+        let rewrite = Task::sync_typed(|x: &i32, _ctx| -> Result<Box<i32>, TaskError> {
+            Ok(Box::new(*x * 100))
+        });
+
+        let pipeline = Pipeline::new("current_data pipeline")
+            .with_task(rewrite)
+            .with_task(record(Arc::clone(&seen)))
+            .with_task(record(Arc::clone(&seen)));
+
+        let ctx = stub_ctx_with_pipeline("test").await;
+
+        let inputs: Vec<Arc<dyn Value>> = vec![Arc::new(7_i32)];
+        let outputs = execute(&pipeline, inputs, ctx, &NoopWatcher).await.unwrap();
+
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![7, 7],
+            "tasks at index 1 and 2 must both see the original pipeline input"
+        );
+    }
+
+    /// Batch tasks are dispatched via `dispatch_batch` with the per-item env, so
+    /// they inherit the same `current_data` as single-value tasks.
+    #[tokio::test]
+    async fn current_data_is_inherited_by_batch_tasks() {
+        use std::sync::Mutex;
+
+        let seen: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_clone = Arc::clone(&seen);
+
+        // Fan the single input out into three items so the next task is reached
+        // through `process_iter` → `dispatch_batch`.
+        let fan_out = Task::sync_iter_typed(|x: &i32, _ctx| {
+            let x = *x;
+            Ok((0..3).map(move |i| Box::new(x + i)))
+        });
+        // Raw `sync_batch` rather than `sync_batch_typed`: the typed variant's
+        // `borrow_item` helper mis-downcasts real batch items (pre-existing,
+        // unrelated to this test).
+        let collect = Task::sync_batch(
+            move |items: &[Box<dyn Value>],
+                  ctx: Arc<TaskContext>|
+                  -> Result<Arc<dyn Value>, TaskError> {
+                seen_clone.lock().unwrap().push(observed_current_data(&ctx));
+                Ok(Arc::new(items.len() as i32) as Arc<dyn Value>)
+            },
+        );
+
+        let pipeline = Pipeline::new("batch current_data pipeline")
+            .with_task(fan_out)
+            .with_task(collect);
+
+        let ctx = stub_ctx_with_pipeline("test").await;
+        let inputs: Vec<Arc<dyn Value>> = vec![Arc::new(7_i32)];
+        execute(&pipeline, inputs, ctx, &NoopWatcher).await.unwrap();
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![7],
+            "the batch task must see the original pipeline input, not None"
+        );
+    }
+
+    /// The `process_stream` path must preserve `current_data` too: both the
+    /// batch task it dispatches to and the tail task after it see the original
+    /// pipeline input, never a streamed item and never `None`.
+    #[tokio::test]
+    async fn current_data_survives_process_stream_dispatch() {
+        use std::sync::Mutex;
+
+        let seen_batch: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_tail: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
+
+        // Stream out three values *different from* the pipeline input, so a
+        // `current_data` sourced from the streamed item would read 70/71/72.
+        let fan_out = Task::async_stream(|input: Arc<dyn Value>, _ctx| {
+            let x = *(*input).as_any().downcast_ref::<i32>().expect("i32 input");
+            let stream =
+                futures::stream::iter(0..3).map(move |i| Box::new(x * 10 + i) as Box<dyn Value>);
+            Ok(Box::pin(stream) as ValueStream)
+        });
+
+        // Raw `sync_batch` rather than `sync_batch_typed`: the typed variant's
+        // `borrow_item` helper mis-downcasts real batch items (pre-existing,
+        // unrelated to this test).
+        let seen_batch_c = Arc::clone(&seen_batch);
+        let collect = Task::sync_batch(
+            move |items: &[Box<dyn Value>],
+                  ctx: Arc<TaskContext>|
+                  -> Result<Arc<dyn Value>, TaskError> {
+                seen_batch_c
+                    .lock()
+                    .unwrap()
+                    .push(observed_current_data(&ctx));
+                Ok(Arc::new(items.len() as i32) as Arc<dyn Value>)
+            },
+        );
+
+        let seen_tail_c = Arc::clone(&seen_tail);
+        let tail = Task::sync_typed(
+            move |n: &i32, ctx: Arc<TaskContext>| -> Result<Box<i32>, TaskError> {
+                seen_tail_c
+                    .lock()
+                    .unwrap()
+                    .push(observed_current_data(&ctx));
+                Ok(Box::new(*n))
+            },
+        );
+
+        let pipeline = Pipeline::new("stream current_data pipeline")
+            .with_task(fan_out)
+            .with_task(collect)
+            .with_task(tail);
+
+        let ctx = stub_ctx_with_pipeline("test").await;
+        let inputs: Vec<Arc<dyn Value>> = vec![Arc::new(7_i32)];
+        execute(&pipeline, inputs, ctx, &NoopWatcher).await.unwrap();
+
+        assert_eq!(
+            *seen_batch.lock().unwrap(),
+            vec![7],
+            "a batch task fed by process_stream must see the original pipeline input"
+        );
+        assert_eq!(
+            *seen_tail.lock().unwrap(),
+            vec![7],
+            "the task after the batch must still see the original pipeline input"
+        );
+    }
+
+    /// With `concurrency > 1`, several items are in flight against the *same*
+    /// task objects. Each task invocation must see **its own** item's original
+    /// input — never another item's. This is the case that would misattribute
+    /// provenance / ownership across documents.
+    #[tokio::test]
+    async fn current_data_is_isolated_per_item_under_concurrency() {
+        use std::sync::Mutex;
+
+        const ITEMS: i32 = 6;
+
+        // Records (this task's input, observed current_data) pairs.
+        let pairs: Arc<Mutex<Vec<(i32, i32)>>> = Arc::new(Mutex::new(Vec::new()));
+
+        // Rewrite the value *and* await, so the items genuinely interleave: the
+        // sleeps are in reverse order, so completion order differs from start
+        // order and a shared context would cross items over.
+        let rewrite = Task::async_fn(|input: Arc<dyn Value>, _ctx| {
+            let x = *(*input).as_any().downcast_ref::<i32>().expect("i32 input");
+            Box::pin(async move {
+                sleep(Duration::from_millis((ITEMS + 1 - x) as u64 * 5)).await;
+                Ok(Arc::new(x * 100) as Arc<dyn Value>)
+            })
+        });
+
+        let pairs_c = Arc::clone(&pairs);
+        let record = Task::sync_typed(
+            move |x: &i32, ctx: Arc<TaskContext>| -> Result<Box<i32>, TaskError> {
+                pairs_c
+                    .lock()
+                    .unwrap()
+                    .push((*x, observed_current_data(&ctx)));
+                Ok(Box::new(*x))
+            },
+        );
+
+        let pipeline = Pipeline::new("per-item current_data pipeline")
+            .with_concurrency(4)
+            .with_task(rewrite)
+            .with_task(record);
+
+        let ctx = stub_ctx_with_pipeline("test").await;
+        let inputs: Vec<Arc<dyn Value>> =
+            (1..=ITEMS).map(|i| Arc::new(i) as Arc<dyn Value>).collect();
+        execute(&pipeline, inputs, ctx, &NoopWatcher).await.unwrap();
+
+        let recorded = pairs.lock().unwrap().clone();
+        assert_eq!(
+            recorded.len(),
+            ITEMS as usize,
+            "every item must be recorded"
+        );
+        for (task_input, observed) in &recorded {
+            assert_eq!(
+                *task_input,
+                observed * 100,
+                "task saw current_data={observed} while processing {task_input}: \
+                 that is a different item's original input"
+            );
+        }
+
+        // And every original input was observed exactly once.
+        let mut observed: Vec<i32> = recorded.iter().map(|(_, o)| *o).collect();
+        observed.sort_unstable();
+        assert_eq!(observed, (1..=ITEMS).collect::<Vec<_>>());
+    }
+
+    /// The enrichment re-dispatch path (`PassthroughSentinel` on a
+    /// `with_enriches()` task) forwards the original input through a second
+    /// `execute_from` call; that call must keep the per-item `current_data`.
+    #[tokio::test]
+    async fn current_data_survives_enrichment_passthrough() {
+        use std::sync::Mutex;
+
+        let seen: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
+
+        // Rewrite first, so `current_data` (7) is distinguishable from the value
+        // the passthrough forwards (700).
+        let rewrite = Task::sync_typed(|x: &i32, _ctx| -> Result<Box<i32>, TaskError> {
+            Ok(Box::new(*x * 100))
+        });
+
+        let enrich = TaskInfo::new(Task::Sync(Arc::new(|_input: Arc<dyn Value>, _ctx| {
+            Ok(Arc::new(crate::sentinels::PassthroughSentinel) as Arc<dyn Value>)
+        })))
+        .with_enriches();
+
+        let seen_c = Arc::clone(&seen);
+        let record = Task::sync_typed(
+            move |x: &i32, ctx: Arc<TaskContext>| -> Result<Box<i32>, TaskError> {
+                seen_c.lock().unwrap().push(observed_current_data(&ctx));
+                Ok(Box::new(*x))
+            },
+        );
+
+        let pipeline = Pipeline::new("enrichment current_data pipeline")
+            .with_task(rewrite)
+            .with_task(enrich)
+            .with_task(record);
+
+        let ctx = stub_ctx_with_pipeline("test").await;
+        let inputs: Vec<Arc<dyn Value>> = vec![Arc::new(7_i32)];
+        let outputs = execute(&pipeline, inputs, ctx, &NoopWatcher).await.unwrap();
+
+        // Sanity: the passthrough really did forward the rewritten value.
+        assert_eq!(*(*outputs[0]).as_any().downcast_ref::<i32>().unwrap(), 700);
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![7],
+            "the task after an enrichment passthrough must see the original input"
+        );
+    }
+
+    /// `Task::parallel` hands each sub-task `Arc::clone(&ctx)`, so every sub-task
+    /// must observe the same per-item `current_data`.
+    #[tokio::test]
+    async fn current_data_is_visible_to_parallel_subtasks() {
+        use std::sync::Mutex;
+
+        let seen: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let rewrite = Task::sync_typed(|x: &i32, _ctx| -> Result<Box<i32>, TaskError> {
+            Ok(Box::new(*x * 100))
+        });
+
+        let record = |seen: Arc<Mutex<Vec<i32>>>| {
+            Task::sync_typed(
+                move |x: &i32, ctx: Arc<TaskContext>| -> Result<Box<i32>, TaskError> {
+                    seen.lock().unwrap().push(observed_current_data(&ctx));
+                    Ok(Box::new(*x))
+                },
+            )
+        };
+
+        let par = TaskInfo::parallel(vec![
+            TaskInfo::new(record(Arc::clone(&seen))),
+            TaskInfo::new(record(Arc::clone(&seen))),
+        ]);
+
+        let pipeline = Pipeline::new("parallel current_data pipeline")
+            .with_task(rewrite)
+            .with_task(par);
+
+        let ctx = stub_ctx_with_pipeline("test").await;
+        let inputs: Vec<Arc<dyn Value>> = vec![Arc::new(7_i32)];
+        execute(&pipeline, inputs, ctx, &NoopWatcher).await.unwrap();
+
+        let mut observed = seen.lock().unwrap().clone();
+        observed.sort_unstable();
+        assert_eq!(
+            observed,
+            vec![7, 7],
+            "both parallel sub-tasks must see the original pipeline input"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -2032,9 +2032,10 @@ mod tests {
             let x = *x;
             Ok((0..3).map(move |i| Box::new(x + i)))
         });
-        // Raw `sync_batch` rather than `sync_batch_typed`: the typed variant's
-        // `borrow_item` helper mis-downcasts real batch items (pre-existing,
-        // unrelated to this test).
+        // Raw `sync_batch` rather than `sync_batch_typed`: this test only needs
+        // the item count and the context, so there is nothing to downcast and
+        // nothing to gain from the typed variant. (The typed batch constructors
+        // are exercised in `task.rs`.)
         let collect = Task::sync_batch(
             move |items: &[Box<dyn Value>],
                   ctx: Arc<TaskContext>|
@@ -2078,9 +2079,10 @@ mod tests {
             Ok(Box::pin(stream) as ValueStream)
         });
 
-        // Raw `sync_batch` rather than `sync_batch_typed`: the typed variant's
-        // `borrow_item` helper mis-downcasts real batch items (pre-existing,
-        // unrelated to this test).
+        // Raw `sync_batch` rather than `sync_batch_typed`: this test only needs
+        // the item count and the context, so there is nothing to downcast and
+        // nothing to gain from the typed variant. (The typed batch constructors
+        // are exercised in `task.rs`.)
         let seen_batch_c = Arc::clone(&seen_batch);
         let collect = Task::sync_batch(
             move |items: &[Box<dyn Value>],

--- a/crates/core/src/task.rs
+++ b/crates/core/src/task.rs
@@ -240,6 +240,13 @@ pub type AsyncStreamBatchFn = Arc<
 /// `&[Box<dyn Value>]` slice of items accumulated up to the task's `batch_size`.
 /// The pipeline executor detects which kind the next task is and routes
 /// accordingly.
+///
+/// **Batch variants are dispatched on a different path** and receive none of six
+/// executor services: retries, per-task watcher events, provenance stamping,
+/// rate limiting, progress-subtoken completion and cancellation checks. (This is
+/// a divergence from Python, which routes every task through `handle_task`
+/// regardless of batching.) See
+/// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
 pub enum Task {
     Sync(SyncFn),
     Async(AsyncFn),
@@ -344,6 +351,12 @@ impl Task {
     // ── Raw batch constructors (type-erased &[Box<dyn Value>] in) ─────────────
 
     /// Create a [`Task::SyncBatch`] from a raw closure.
+    ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn sync_batch<F>(f: F) -> Self
     where
         F: for<'a> Fn(&'a [Box<dyn Value>], Arc<TaskContext>) -> Result<Arc<dyn Value>, TaskError>
@@ -355,6 +368,12 @@ impl Task {
     }
 
     /// Create a [`Task::AsyncBatch`] from a raw closure returning a [`BoxFuture`].
+    ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn async_batch<F>(f: F) -> Self
     where
         F: for<'a> Fn(
@@ -369,6 +388,12 @@ impl Task {
     }
 
     /// Create a [`Task::SyncIterBatch`] from a raw closure returning a [`ValueIter`].
+    ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn sync_iter_batch<F>(f: F) -> Self
     where
         F: for<'a> Fn(&'a [Box<dyn Value>], Arc<TaskContext>) -> Result<ValueIter, TaskError>
@@ -380,6 +405,12 @@ impl Task {
     }
 
     /// Create a [`Task::AsyncStreamBatch`] from a raw closure returning a [`ValueStream`].
+    ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn async_stream_batch<F>(f: F) -> Self
     where
         F: for<'a> Fn(&'a [Box<dyn Value>], Arc<TaskContext>) -> Result<ValueStream, TaskError>
@@ -510,6 +541,12 @@ impl Task {
 
     /// Create a [`Task::SyncBatch`] from a typed closure receiving `&[&I]`.
     ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
+    ///
     /// ```rust,ignore
     /// Task::sync_batch_typed(|chunks: &[&DocumentChunk], ctx| {
     ///     Ok(Box::new(embed_all(chunks)))
@@ -531,6 +568,12 @@ impl Task {
     }
 
     /// Create a [`Task::AsyncBatch`] from a typed closure returning a `'static` future.
+    ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     ///
     /// Data needed inside the async block must be copied/cloned before it:
     ///
@@ -562,6 +605,12 @@ impl Task {
     }
 
     /// Create a [`Task::SyncIterBatch`] from a typed closure returning a concrete iterator.
+    ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn sync_iter_batch_typed<I, O, F, Iter>(f: F) -> Self
     where
         I: Value,
@@ -579,6 +628,12 @@ impl Task {
     }
 
     /// Create a [`Task::AsyncStreamBatch`] from a typed closure returning a concrete stream.
+    ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn async_stream_batch_typed<I, O, F, S>(f: F) -> Self
     where
         I: Value,
@@ -728,6 +783,9 @@ pub struct TaskInfo {
     pub name: Option<String>,
     /// Overrides the pipeline-level `batch_size` for this task.
     /// `None` → inherit `pipeline.batch_size`.
+    ///
+    /// Read by the executor for every kind of task, not only `*Batch` variants —
+    /// see [`TaskInfo::with_batch_size`].
     pub batch_size: Option<usize>,
     /// Template for a human-readable result summary recorded as a tracing span
     /// attribute when the `telemetry` feature is enabled.
@@ -771,6 +829,27 @@ impl TaskInfo {
         self
     }
 
+    /// Override how many items the executor accumulates from an upstream
+    /// iterator / stream before dispatching them to **this** task.
+    ///
+    /// This applies whatever kind this task is — not only to `*Batch` variants.
+    /// The executor reads the *consuming* task's `batch_size` unconditionally to
+    /// size its accumulation buffer:
+    ///
+    /// - a `*Batch` variant then receives the whole buffer as one slice;
+    /// - a non-batch variant receives the buffered items one at a time, after the
+    ///   buffer has filled.
+    ///
+    /// So setting this on a non-batch task is **not** a no-op: it changes how many
+    /// upstream items are held in memory at once, and therefore peak memory —
+    /// which matters on the edge targets this port serves.
+    ///
+    /// `None` (the default) inherits
+    /// [`Pipeline::with_batch_size`](crate::pipeline::Pipeline::with_batch_size).
+    ///
+    /// When this task *is* a `*Batch` variant it is additionally dispatched off
+    /// the executor's service path; see
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn with_batch_size(mut self, size: usize) -> Self {
         assert!(size > 0, "batch_size must be > 0");
         self.batch_size = Some(size);
@@ -807,9 +886,15 @@ impl TaskInfo {
 
     /// Set a per-task rate limiter, overriding the pipeline-level one.
     ///
-    /// When set, every attempt inside `call_with_retry` (and every batch call
-    /// in `dispatch_batch`) acquires a token from this limiter before calling
-    /// the task. `None` inherits the pipeline-level limiter.
+    /// When set, every attempt inside `call_with_retry` acquires a token from
+    /// this limiter before calling the task. `None` inherits the pipeline-level
+    /// limiter.
+    ///
+    /// **Batch calls are not throttled today.** If this task is a `*Batch`
+    /// variant, `dispatch_batch` invokes it directly without acquiring the
+    /// limiter — the effective limiter is threaded only into `call_with_retry` —
+    /// so setting this on a batch task currently has no effect. See
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn with_rate_limiter(mut self, rl: Arc<dyn RateLimiter>) -> Self {
         self.rate_limiter = Some(rl);
         self
@@ -970,6 +1055,12 @@ impl<I: Value, O: Value> TypedTask<I, O> {
     }
 
     /// Create a [`TypedTask::SyncBatch`] from a typed closure `&[&I] → Result<Box<O>, TaskError>`.
+    ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn sync_batch<F>(f: F) -> Self
     where
         F: for<'a> Fn(&'a [&'a I], Arc<TaskContext>) -> Result<Box<O>, TaskError>
@@ -981,6 +1072,12 @@ impl<I: Value, O: Value> TypedTask<I, O> {
     }
 
     /// Create a [`TypedTask::AsyncBatch`] from a typed closure returning a `'static` future.
+    ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn async_batch<F>(f: F) -> Self
     where
         F: for<'a> Fn(
@@ -995,6 +1092,12 @@ impl<I: Value, O: Value> TypedTask<I, O> {
     }
 
     /// Create a [`TypedTask::SyncIterBatch`] from a typed closure returning a concrete iterator.
+    ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn sync_iter_batch<F, Iter>(f: F) -> Self
     where
         F: for<'a> Fn(&'a [&'a I], Arc<TaskContext>) -> Result<Iter, TaskError>
@@ -1010,6 +1113,12 @@ impl<I: Value, O: Value> TypedTask<I, O> {
     }
 
     /// Create a [`TypedTask::AsyncStreamBatch`] from a typed closure returning a concrete stream.
+    ///
+    /// **No executor services:** a batch-dispatched task gets no retries, no
+    /// per-task watcher events, no provenance stamping, no rate-limiter
+    /// acquisition, no progress-subtoken completion and no cancellation check,
+    /// so it must handle its own error semantics. Full rationale:
+    /// [Batch dispatch bypasses executor services](crate::pipeline#batch-dispatch-bypasses-executor-services).
     pub fn async_stream_batch<F, S>(f: F) -> Self
     where
         F: for<'a> Fn(&'a [&'a I], Arc<TaskContext>) -> Result<S, TaskError>

--- a/crates/core/src/task.rs
+++ b/crates/core/src/task.rs
@@ -670,10 +670,33 @@ impl Task {
 
     /// Borrow-downcast a `Box<dyn Value>` item to `&I`.
     ///
-    /// Used inside typed batch constructors to downcast each slice element.
-    fn borrow_item<I: Value>(item: &dyn Value) -> &I {
+    /// Used inside typed batch constructors to downcast each element of the
+    /// `&[Box<dyn Value>]` slice the executor hands to a batch task.
+    ///
+    /// Takes `&Box<dyn Value>` rather than `&dyn Value` on purpose: the deref
+    /// to the inner trait object has to happen *here*, because every caller
+    /// iterates a `&[Box<dyn Value>]` and so holds a `&Box<dyn Value>`. With a
+    /// `&dyn Value` parameter that reference silently unsize-coerces to a
+    /// trait object pointing at the *`Box`* — which implements `Value` itself
+    /// via the blanket impl — and the downcast then tests the `Box`'s type
+    /// instead of its contents, returning `None` for every well-formed batch.
+    /// Centralising the deref makes that mistake unrepresentable at the call
+    /// sites. Compare [`Self::borrow_input`], which does the same for `Arc`.
+    ///
+    /// Panics on type mismatch — a mismatch means the pipeline was assembled
+    /// with incompatible task types (programming error).
+    #[allow(
+        clippy::borrowed_box,
+        reason = "the &Box is load-bearing: it forces the deref to the inner \
+                  dyn Value to happen here rather than at each call site, where \
+                  omitting it silently downcasts the Box instead of its contents"
+    )]
+    fn borrow_item<I: Value>(item: &Box<dyn Value>) -> &I {
         let type_name = std::any::type_name::<I>();
-        item.as_any()
+        // Explicit deref through Box to reach the inner `dyn Value`, then call
+        // `as_any` via vtable dispatch — see the note above.
+        (**item)
+            .as_any()
             .downcast_ref::<I>()
             .unwrap_or_else(|| panic!("Batch item type mismatch: expected {type_name}"))
     }
@@ -1448,5 +1471,136 @@ mod tests {
             assert!(labels.contains("Generator"));
             assert!(labels.contains("Async Generator"));
         }
+    }
+
+    // ── Typed batch constructors must observe their own items ────────────────
+    //
+    // Regression guard for `Task::borrow_item`, which downcast the
+    // `Box<dyn Value>` wrapper instead of its contents and therefore panicked
+    // with "Batch item type mismatch" on every non-empty batch — taking all
+    // four `*_batch_typed` constructors, and the four `TypedTask::*_batch`
+    // constructors that delegate to them, down with it.
+    //
+    // The defect survived because the pre-existing batch tests only assert
+    // `python_task_type()` labels and never read the slice. Every test below
+    // fails against the unfixed helper.
+
+    fn boxed_ints(values: &[i32]) -> Vec<Box<dyn Value>> {
+        values
+            .iter()
+            .map(|v| Box::new(*v) as Box<dyn Value>)
+            .collect()
+    }
+
+    /// Deref through the `Arc` before `as_any` — see `Task::borrow_input`.
+    fn arc_as_i32(value: &Arc<dyn Value>) -> i32 {
+        *(**value).as_any().downcast_ref::<i32>().unwrap()
+    }
+
+    /// Deref through the `Box` before `as_any` — the same hazard this fix is
+    /// about. Takes the box by value because that is what iter/stream outputs
+    /// yield; `&Box<dyn Value>` would be the shape `borrow_item` needs, but
+    /// here it would only earn a `clippy::borrowed_box` warning.
+    fn boxed_as_i32(value: Box<dyn Value>) -> i32 {
+        *(*value).as_any().downcast_ref::<i32>().unwrap()
+    }
+
+    #[tokio::test]
+    async fn sync_batch_typed_reads_its_items() {
+        let task = Task::sync_batch_typed(|items: &[&i32], _ctx| {
+            Ok(Box::new(items.iter().map(|v| **v).sum::<i32>()))
+        });
+        let batch = boxed_ints(&[1, 2, 4]);
+
+        let result = match task.call_batch(&batch, stub_ctx().await) {
+            TaskCall::Sync(r) => r.unwrap(),
+            _ => panic!("sync_batch should produce the Sync variant"),
+        };
+
+        assert_eq!(arc_as_i32(&result), 7);
+    }
+
+    #[tokio::test]
+    async fn async_batch_typed_reads_its_items() {
+        let task = Task::async_batch_typed(|items: &[&i32], _ctx| {
+            let sum: i32 = items.iter().map(|v| **v).sum();
+            Box::pin(async move { Ok(Box::new(sum)) })
+        });
+        let batch = boxed_ints(&[3, 5]);
+
+        let result = match task.call_batch(&batch, stub_ctx().await) {
+            TaskCall::Async(fut) => fut.await.unwrap(),
+            _ => panic!("async_batch should produce the Async variant"),
+        };
+
+        assert_eq!(arc_as_i32(&result), 8);
+    }
+
+    #[tokio::test]
+    async fn sync_iter_batch_typed_reads_its_items() {
+        let task = Task::sync_iter_batch_typed(|items: &[&i32], _ctx| {
+            let doubled: Vec<Box<i32>> = items.iter().map(|v| Box::new(**v * 2)).collect();
+            Ok(doubled.into_iter())
+        });
+        let batch = boxed_ints(&[1, 2, 3]);
+
+        let iter = match task.call_batch(&batch, stub_ctx().await) {
+            TaskCall::SyncIter(r) => r.unwrap(),
+            _ => panic!("sync_iter_batch should produce the SyncIter variant"),
+        };
+
+        let out: Vec<i32> = iter.map(boxed_as_i32).collect();
+        assert_eq!(out, vec![2, 4, 6]);
+    }
+
+    #[tokio::test]
+    async fn async_stream_batch_typed_reads_its_items() {
+        let task = Task::async_stream_batch_typed(|items: &[&i32], _ctx| {
+            let tripled: Vec<Box<i32>> = items.iter().map(|v| Box::new(**v * 3)).collect();
+            Ok(futures::stream::iter(tripled))
+        });
+        let batch = boxed_ints(&[1, 2]);
+
+        let stream = match task.call_batch(&batch, stub_ctx().await) {
+            TaskCall::AsyncStream(r) => r.unwrap(),
+            _ => panic!("async_stream_batch should produce the AsyncStream variant"),
+        };
+
+        let out: Vec<i32> = stream.map(boxed_as_i32).collect().await;
+        assert_eq!(out, vec![3, 6]);
+    }
+
+    #[tokio::test]
+    async fn typed_task_batch_reads_its_items_through_the_from_impl() {
+        // `TypedTask::sync_batch` erases via `From<TypedTask<I, O>> for Task`,
+        // which routes through `sync_batch_typed` and hence `borrow_item`.
+        let typed: TypedTask<i32, i32> = TypedTask::sync_batch(|items: &[&i32], _ctx| {
+            Ok(Box::new(items.iter().map(|v| **v).max().unwrap_or(0)))
+        });
+        let task = Task::from(typed);
+        let batch = boxed_ints(&[7, 42, 13]);
+
+        let result = match task.call_batch(&batch, stub_ctx().await) {
+            TaskCall::Sync(r) => r.unwrap(),
+            _ => panic!("sync_batch should produce the Sync variant"),
+        };
+
+        assert_eq!(arc_as_i32(&result), 42);
+    }
+
+    #[tokio::test]
+    async fn batch_typed_still_panics_on_a_genuine_type_mismatch() {
+        // The deref fix must not weaken the mismatch guard: a batch whose
+        // items really are the wrong type still has to panic.
+        let task = Task::sync_batch_typed(|items: &[&i32], _ctx| Ok(Box::new(items.len() as i32)));
+        let batch: Vec<Box<dyn Value>> = vec![Box::new("not an i32".to_string())];
+        let ctx = stub_ctx().await;
+
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            task.call_batch(&batch, ctx);
+        }))
+        .is_err();
+
+        assert!(panicked, "a genuinely mismatched batch item must panic");
     }
 }

--- a/crates/core/src/task_context.rs
+++ b/crates/core/src/task_context.rs
@@ -65,6 +65,26 @@ pub struct PipelineContext {
     /// An out-of-tree task that read `current_data` expecting its own input must
     /// switch to its input argument. Tasks that need the originating item — the
     /// reason this field exists — now get it at any depth in the chain.
+    ///
+    /// # Lifetime cost
+    ///
+    /// Pinning the value necessarily keeps it reachable until the item's chain
+    /// finishes. This is an `Arc` clone, so nothing is duplicated — but the
+    /// allocation is released at the end of `execute_one_item` rather than when
+    /// the first task returns, as it was before. With
+    /// [`Pipeline::with_concurrency`](crate::pipeline::Pipeline::with_concurrency)
+    /// above 1, that longer window makes overlap between in-flight items more
+    /// likely (the default is 1).
+    ///
+    /// It is only a concern for pipelines whose *input value* owns a large
+    /// buffer instead of a handle to one — `cognee_models::DataInput::Binary`,
+    /// which the bindings marshal into, is the case to watch. Those pipelines
+    /// should stream the payload rather than materialise it in the input value;
+    /// the executor cannot release it early without giving up the semantics
+    /// documented above. Python has the same characteristic, for the same
+    /// reason: its per-item `PipelineContext` holds `data_item` for the whole
+    /// run. Pinned by
+    /// `per_item_context_keeps_the_input_alive_for_the_whole_chain`.
     pub current_data: Option<Arc<dyn Value>>,
     /// Random per-invocation run id. Set by [`crate::pipeline::execute`] when
     /// it creates `PipelineRunInfo`. Used by tasks (via

--- a/crates/core/src/task_context.rs
+++ b/crates/core/src/task_context.rs
@@ -40,8 +40,31 @@ pub struct PipelineContext {
     pub tenant_id: Option<Uuid>,
     /// Dataset being processed.
     pub dataset_id: Option<Uuid>,
-    /// The data item currently being processed.
-    /// Set per-item by the executor before calling a task.
+    /// The data item currently being processed — the **original** value that
+    /// entered the pipeline for this item, not the upstream task's output.
+    ///
+    /// Set once per data item by the executor (`execute_one_item`) and
+    /// inherited unchanged by every task in the chain (including batch tasks).
+    /// Mirrors Python's `PipelineContext.data_item`, which is likewise built
+    /// once per item and never rebound per task.
+    ///
+    /// # Behavioural change (for custom [`crate::task::Task`] implementations)
+    ///
+    /// The meaning of this field **changed**, silently for callers — the type is
+    /// unchanged, so nothing fails to compile:
+    ///
+    /// - **Before:** rebound by the executor before *every* single-value task
+    ///   call, so at task *k* it held the output of task *k-1* — i.e. "this
+    ///   task's own input", which the task already receives as its argument.
+    ///   Batch-dispatched tasks were handed the run-level context, where the
+    ///   field was `None`.
+    /// - **Now:** pinned once per data item to the value that entered the
+    ///   pipeline, and never rebound. Batch tasks inherit that same item value
+    ///   instead of seeing `None`.
+    ///
+    /// An out-of-tree task that read `current_data` expecting its own input must
+    /// switch to its input argument. Tasks that need the originating item — the
+    /// reason this field exists — now get it at any depth in the chain.
     pub current_data: Option<Arc<dyn Value>>,
     /// Random per-invocation run id. Set by [`crate::pipeline::execute`] when
     /// it creates `PipelineRunInfo`. Used by tasks (via
@@ -75,6 +98,29 @@ impl PipelineContext {
         self.user_email
             .clone()
             .or_else(|| self.user_id.map(|id| id.to_string()))
+    }
+
+    /// Minimal in-crate test fixture: a named run with a random `pipeline_id`,
+    /// every optional identity field unset, and a fresh provenance visited-set.
+    ///
+    /// Exists so tests stop hand-writing the nine-field struct literal — there
+    /// are already ~10 such copies across this crate's tests, each of which has
+    /// to be touched whenever a field is added. New tests should use this and
+    /// mutate the two or three fields they actually care about. `#[cfg(test)]`
+    /// keeps it out of the public API surface.
+    #[cfg(test)]
+    pub(crate) fn for_test(pipeline_name: impl Into<String>) -> Self {
+        Self {
+            pipeline_id: Uuid::new_v4(),
+            pipeline_name: pipeline_name.into(),
+            user_id: None,
+            tenant_id: None,
+            dataset_id: None,
+            current_data: None,
+            run_id: None,
+            user_email: None,
+            provenance_visited: Arc::new(Mutex::new(HashSet::new())),
+        }
     }
 }
 /// Runtime dependencies and control tokens for a single pipeline task.
@@ -239,8 +285,6 @@ pub struct TaskContextBuilder {
     database: Option<Arc<DatabaseConnection>>,
     graph_db: Option<Arc<dyn GraphDBTrait>>,
     vector_db: Option<Arc<dyn VectorDB>>,
-    /// If set, the cancellation pair is created from an external handle.
-    cancellation: Option<(CancellationHandle, CancellationToken)>,
     progress: Option<ProgressToken>,
     pipeline_ctx: Option<PipelineContext>,
     exec_status: Option<Arc<dyn ExecStatusManager>>,
@@ -303,6 +347,12 @@ impl TaskContextBuilder {
 
     /// Build the context. Returns `(CancellationHandle, TaskContext)` so the
     /// caller keeps the handle while the task receives the token.
+    ///
+    /// The cancellation pair is always minted here. A builder field for
+    /// injecting an externally-created pair used to exist but had no setter and
+    /// was therefore unreachable, so it was removed deliberately; add a public
+    /// setter if a caller ever needs to cancel a run from outside the builder
+    /// (e.g. an HTTP cancel endpoint holding the handle).
     pub fn build(self) -> Result<(CancellationHandle, TaskContext), CoreError> {
         let thread_pool = self.thread_pool.ok_or(CoreError::MissingContextField {
             field: "thread_pool",
@@ -317,7 +367,7 @@ impl TaskContextBuilder {
             .vector_db
             .ok_or(CoreError::MissingContextField { field: "vector_db" })?;
 
-        let (handle, token) = self.cancellation.unwrap_or_else(cancellation_pair);
+        let (handle, token) = cancellation_pair();
 
         let ctx = TaskContext {
             thread_pool,


### PR DESCRIPTION
## What

Four scoped fixes to the pipeline task-context layer, plus the documentation and test-coverage follow-ups that a high-effort review of those fixes surfaced.

These came out of an audit comparing the Rust pipeline/task layer against the Python SDK's `PipelineContext` mechanism (Python's "context-free vs ctx-aware task" split). The audit's conclusion was that Rust needs **no architectural change** — its uniform `(input, ctx)` calling convention plus identity-through-values already delivers what Python's ctx machinery observably does, with fewer latent bugs. This PR lands only the small, real defects found along the way.

## `current_data` now means what its doc claimed

`PipelineContext::current_data` is set once per data item in `execute_one_item` — the item that **entered** the pipeline — instead of being overwritten with each task's own input in `call_with_retry`. That matches Python's `ctx.data_item`, and batch tasks now inherit the item value instead of seeing `None`.

Threaded via a new private `ExecEnv::with_ctx<'b>(&self, ctx: &'b Arc<TaskContext>) -> ExecEnv<'b> where 'a: 'b` — a field-by-field re-borrow. No `Clone` derive, no new parameter through the recursive executor.

The field is `pub` with **zero in-tree readers**, so the only consumers are out-of-tree custom `Task` impls. The type is unchanged, so they get no compile error — hence a `### Breaking changes` entry in `CHANGELOG.md` and a `# Behavioural change` section in the field's rustdoc.

## Batch-dispatch docs were wrong by omission

`dispatch_batch`'s design note listed **three** forfeited executor services. Verification found **six**. Batch tasks also:

- **never acquire the rate limiter** — `effective_rl` is threaded only into `call_with_retry`
- **never complete their progress subtoken** — and cannot compensate, because `ProgressToken::split()` zeroes the width of the root token `dispatch_batch` hands them, so `ctx.progress.set(1.0)` is a silent no-op
- **never observe cancellation** — the executor's only `is_cancelled()` sits *after* the empty-tasks base case, so a cancelled run whose last task is a batch variant drains its stream, keeps writing to the graph/vector store, and returns `Ok` with status `Completed`

**Those three code gaps are left for separate work.** This PR makes the documentation stop contradicting them: the canonical six-item list lives in a new `pipeline` module `//!` block, all 12 batch constructors and the `Task` enum link to that anchor, and the false "batch calls are throttled" promise is removed from both `with_rate_limiter` setters and the `Pipeline::rate_limiter` field.

Anchor resolution was verified in the generated HTML rather than trusting the build — rustdoc does not warn on bad fragments, so `cargo doc` alone would not have caught the original dangling links.

## `with_batch_size` was factually wrong

It claimed to be "only meaningful for `*Batch` variants". `execute_from` reads `rest.first().and_then(|next| next.batch_size)` **unconditionally** to size the upstream accumulation buffer, so setting it on a plain task silently changes peak memory instead of doing nothing — which matters on the edge/Android targets this port explicitly supports.

## Provenance-ledger warning was noisy for a supported config

`db` and `user_id` are `Option` in the public `cognify()` / `build_cognify_pipeline()` / `make_add_data_points_task()` signatures, so an embedded or unauthenticated caller saw a data-integrity `WARN` **per data item**. Now: `warn!` only when a relational backend is configured but `user_id` is absent (a genuine inconsistency — the row could have been written); `debug!` when there is no backend at all. Control flow and types unchanged.

## Dead field removed

`TaskContextBuilder.cancellation` had no public setter, so `build()` always minted a fresh pair. Removed, with a note recording that external-handle injection can return behind a setter if a caller ever needs to cancel a run from outside.

## `Task::borrow_item` panicked for every typed batch task

`borrow_item` took `&dyn Value`, but every caller iterates a `&[Box<dyn Value>]` and so passes `&Box<dyn Value>`. That reference silently unsize-coerces to a trait object pointing at the ***`Box`*** — which implements `Value` itself via the blanket `impl<T: Any + Send + Sync>` — so `downcast_ref` tested the `Box`'s type rather than its contents and returned `None` for every well-formed batch. **All four `*_batch_typed` constructors, and the four `TypedTask::*_batch` constructors that delegate to them, panicked with `Batch item type mismatch` on any non-empty batch.**

`borrow_input` already guards the identical hazard for `Arc` with an explicit `(**input)` deref and a comment explaining why; `borrow_item` was simply missing it.

Fixed **in the helper rather than at the four call sites**: the parameter is now `&Box<dyn Value>` and the deref happens once, centrally, which makes the omission unrepresentable at a call site instead of merely absent from the current four. That shape needs an `allow(clippy::borrowed_box)` — justified in the attribute's `reason`, since here the `&Box` is exactly the point.

Six tests added, since the pre-existing batch tests only assert `python_task_type()` label mapping and never read the slice — which is why this went unnoticed. One per typed batch variant, one covering the `From<TypedTask>` erasure path, and one pinning that a genuinely mismatched item **still** panics, so the deref cannot later be "fixed" into swallowing real type errors.

Verified load-bearing: against the unfixed helper all five item-reading tests fail with the exact `Batch item type mismatch: expected i32` panic.

## Retention cost of pinning `current_data` — measured, and kept

Pinning the value keeps the pipeline input reachable for the whole chain, where previously it was released when task 0 returned. A `Drop`-tracking test confirms this: the input is still alive, and still reachable as `current_data`, while a later task runs.

Kept anyway, on three grounds:

1. **It is parity-correct.** Python builds one `PipelineContext(data_item=..., ...)` per item in `run_tasks.py` and holds it across the entire per-item run, so `ctx.data_item` is reachable from the last task there too. Deleting the field would diverge from the reference implementation, not converge on it.
2. **The cost is a refcount, not a copy.** `Arc::clone` duplicates nothing — the single allocation is simply freed at the end of `execute_one_item` instead of at the end of the first task.
3. **The `× concurrency` multiplier does not apply today.** `Pipeline::concurrency` defaults to 1 and no production pipeline raises it; only tests do.

The narrow caveat that remains: it matters for pipelines whose *input value* owns a large buffer rather than a handle to one. `DataInput::Binary { data: Vec<u8>, .. }`, which the bindings marshal into, is the case to watch — those should stream the payload rather than materialise it in the input value. The executor cannot release it early without giving up the documented semantics. Recorded on the field and in the CHANGELOG, and pinned by `per_item_context_keeps_the_input_alive_for_the_whole_chain` so the behaviour is deliberate rather than incidental.

## Tests

Six `current_data` tests, all **proven load-bearing by revert**:

| Revert | Result |
|---|---|
| restore `with_current_data` in `call_with_retry` | 5 of 6 fail with **wrong-value** assertions (e.g. `left: [700, 701] right: [7, 7]`) — not merely `None` |
| point `execute_one_item` at the root `env` | all 6 fail |

Four are new, closing the gaps the review flagged: `process_stream`, per-item isolation under `concurrency > 1` (6 items at concurrency 4, reverse-ordered sleeps to force interleaving — the case that would misattribute provenance across documents), enrichment `PassthroughSentinel` re-dispatch, and `Task::parallel` sub-tasks.

These use raw `Task::sync_batch` / `Task::async_stream` — originally because `borrow_item` made the typed batch variants unusable, now simply because they don't need typing — and share one `#[cfg(test)] PipelineContext::for_test()` rather than adding an 11th hand-written struct literal.

## Verification

| Command | Result |
|---|---|
| `cargo check --all-targets` | clean |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo test -p cognee-core` | 124 passed, 13 ignored |
| `cargo test -p cognee-cognify --lib` | 215 passed |
| `cargo doc --no-deps -p cognee-core` | 3 warnings — unchanged from baseline, all pre-existing |

Debug mode throughout. `scripts/check_all.sh`: the Rust stages pass; the four binding checks (`capi`/`python`/`ts`/`java`) were still running against an earlier commit of this branch when it was opened. No public signature, type, or ABI changes here — the diff is doc comments, one `warn!`/`debug!` split, one private helper's parameter type, and `#[cfg(test)]` code — so the bindings are expected to be unaffected, but that is an expectation and not yet an observation.

## Known, deliberately not in this PR

- The cancellation / rate-limiter / progress **code** gaps described above.
- `DataPoint.topological_rank` — never written in Rust, while Python stamps it and its current visualization consumes it. The one confirmed data-parity gap, held back because it interacts with whether the Rust `visualize()` port should track Python's preprocessor rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhLXAF1dfLReC5CdyuiHMq
