### PR TITLE
perf: cut check_all.sh footprint from 76 GiB to ~44 GB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -749,12 +749,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Create venv and install dependencies
+      # Only maturin: python/scripts/check.sh runs `maturin develop --extras
+      # test`, which builds the extension and installs the test extra itself.
+      # Pre-installing the project here with `pip install -e ".[test]"` would
+      # both reintroduce the release-profile rebuild that command exists to
+      # avoid, and mask any breakage in check.sh's own bootstrap — CI would
+      # stay green against an environment this step had already prepared.
+      - name: Create venv and install maturin
         run: |
           python -m venv .venv
           source .venv/bin/activate
           pip install maturin
-          cd python && pip install -e ".[test]"
       - name: Run Python check
         run: |
           source .venv/bin/activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,11 +755,14 @@ jobs:
       # both reintroduce the release-profile rebuild that command exists to
       # avoid, and mask any breakage in check.sh's own bootstrap — CI would
       # stay green against an environment this step had already prepared.
+      # Bounded below at the same 1.5 python/pyproject.toml's dev extra
+      # requires, and below 2 so a major release cannot change `develop` /
+      # `--extras` behaviour under CI without a deliberate bump here.
       - name: Create venv and install maturin
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install maturin
+          pip install 'maturin>=1.5,<2'
       - name: Run Python check
         run: |
           source .venv/bin/activate

--- a/capi/CMakeLists.txt
+++ b/capi/CMakeLists.txt
@@ -35,6 +35,45 @@ else()
     set(CARGO_FEATURE_ARGS "")
 endif()
 
+# Re-enable lbug's internal consistency checks (KU_ASSERT / RUNTIME_CHECK).
+#
+# capi/Cargo.toml's [profile.dev] deliberately builds lbug's bundled Ladybug
+# tree as a Release C++ build (2.9 GiB -> 208 MiB), and Release defines NDEBUG.
+# lbug gates those checks on `defined(LBUG_RUNTIME_CHECKS) || !defined(NDEBUG)`
+# (lbug-src/src/include/common/assert.h), so they are off by default here.
+#
+# Defining LBUG_RUNTIME_CHECKS satisfies the first half of that condition
+# independently of NDEBUG, which re-arms the asserts while keeping the small
+# Release tree — cheaper than dropping to a Debug C++ build for the same
+# effect. Turning an assert failure into a thrown InternalException is what
+# makes a bad handle or index crossing the cg_sdk_* boundary stop at a precise
+# file and line instead of running into undefined behaviour.
+#
+# CXXFLAGS is the injection point because the `cmake` crate builds lbug from
+# lbug's own build.rs — this project never invokes that CMake run directly and
+# so cannot pass -DENABLE_RUNTIME_CHECKS=ON to it. Appending keeps any CXXFLAGS
+# the caller already set.
+#
+# Caveat: cargo fingerprints the lbug build-script unit on its build-dependency
+# closure, not on CXXFLAGS, so toggling this does NOT by itself force the C++
+# tree to rebuild. Run `cargo clean -p lbug --manifest-path capi/Cargo.toml`
+# (or a full clean) after flipping it.
+option(COGNEE_CAPI_LBUG_ASSERTS
+    "Define LBUG_RUNTIME_CHECKS so lbug's KU_ASSERT/RUNTIME_CHECK stay compiled in"
+    OFF)
+
+if(COGNEE_CAPI_LBUG_ASSERTS)
+    # string(STRIP) so an unset caller CXXFLAGS does not leave a leading space
+    # in the value; `cmake -E env` would pass it through verbatim.
+    string(STRIP "$ENV{CXXFLAGS} -DLBUG_RUNTIME_CHECKS" CARGO_CXXFLAGS)
+    set(CARGO_ASSERT_ENV "CXXFLAGS=${CARGO_CXXFLAGS}")
+    message(STATUS "cognee-capi: lbug runtime checks ENABLED (CXXFLAGS=${CARGO_CXXFLAGS})")
+else()
+    # `env` treats an empty list element as nothing to set, so this is a no-op
+    # and the caller's own CXXFLAGS pass through untouched.
+    set(CARGO_ASSERT_ENV "")
+endif()
+
 # Build Rust library via cargo.
 # CARGO_TARGET_DIR is forwarded explicitly so cargo writes artifacts into
 # capi/target/ (pinned above) regardless of the calling directory. Without
@@ -43,6 +82,7 @@ endif()
 add_custom_target(cognee_capi_cargo ALL
     COMMAND ${CMAKE_COMMAND} -E env
         CARGO_TARGET_DIR=${CARGO_TARGET_DIR}
+        ${CARGO_ASSERT_ENV}
         cargo build --manifest-path "${CMAKE_SOURCE_DIR}/cognee-capi/Cargo.toml"
         ${CARGO_NO_DEFAULT_ARGS}
         ${CARGO_FEATURE_ARGS}

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -36,6 +36,132 @@ uuid = { version = "1.21", features = ["v4", "v5", "serde"] }
 [profile.dev]
 panic = "abort"
 
+# Same graded debug-info split as the release profile below, and for a bigger
+# payoff: capi/CMakeLists.txt runs a bare `cargo build` (no --release) and
+# imports `${CARGO_TARGET_DIR}/debug/libcognee_capi.a`, so the Rust half of
+# every CMake build — and therefore every `scripts/check_all.sh` run — uses
+# this profile whatever -DCMAKE_BUILD_TYPE is set to. The release profile is
+# reached only by an explicit `cargo build --release`.
+#
+# Untuned, that cost 36.5 GiB per check_all.sh run. Measured from clean on
+# aarch64-apple-darwin:
+#
+#                            capi/target   capi/build   lbug C++   per example
+#   panic=abort only            27 GiB       9.5 GiB     2.9 GiB      510 MiB
+#   this config                 10 GiB       4.9 GiB     208 MiB      264 MiB
+#
+# capi/build is the CMake tree: 19 example binaries, each statically linking
+# libcognee_capi.a, so the archive's debug info is paid for 19 times over.
+#
+# `opt-level = 1` on dependencies is not a speed setting. The `cmake` crate
+# derives CMAKE_BUILD_TYPE from the OPT_LEVEL/DEBUG cargo exports to a build
+# script (cmake 0.1.58: opt-level 0 -> Debug; opt-level >= 1 with debug=false
+# -> Release; opt-level >= 1 with debug -> RelWithDebInfo), so this pairing is
+# what flips lbug's bundled Ladybug tree to a Release C++ build — the
+# 2.9 GiB -> 208 MiB row. See docs/build/lbug-rebuilds.md.
+#
+# Deliberate trade-off: Release and RelWithDebInfo both define NDEBUG, and lbug
+# gates its internal KU_ASSERT/RUNTIME_CHECK on
+# `defined(LBUG_RUNTIME_CHECKS) || !defined(NDEBUG)` (lbug-src assert.h), so
+# those checks are compiled out here — this profile was the last one in which
+# they still fired. To get them back without giving up the small tree,
+# configure with -DCOGNEE_CAPI_LBUG_ASSERTS=ON (see capi/CMakeLists.txt): that
+# defines LBUG_RUNTIME_CHECKS, satisfying the first half of the condition
+# independently of NDEBUG.
+#
+# panic = "abort" is untouched: it is the FFI safety floor, and neither
+# opt-level nor debug interacts with it.
+[profile.dev.package."*"]
+debug = 0
+opt-level = 1
+
+# First-party crates: full debug info AND an explicit opt-level 0 — both are
+# needed. Named package overrides *merge onto* the "*" glob rather than
+# replacing it, so `debug = true` alone would leave these at the glob's
+# opt-level 1, giving optimized-out locals and reordered lines when stepping
+# through cognee frames in a C example, plus optimization paid on every
+# incremental edit. These crates are path *dependencies* of cognee-capi rather
+# than members of this workspace, so the glob does catch them (unlike the root
+# workspace, whose members are exempt by definition).
+#
+# Hand-maintained, like the release list, because cargo has no prefix glob for
+# package overrides. A crate added to crates/ and pulled into this closure
+# silently falls under the glob instead — debug = 0, so no line tables at all —
+# and cargo warns only for specs matching *no* package, never for one matching
+# only the glob. Re-check this list when adding a crate to crates/.
+[profile.dev.package.cognee]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-bindings-common]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-chunking]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-cognify]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-components]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-core]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-database]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-delete]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-embedding]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-graph]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-ingestion]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-llm]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-logging]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-models]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-observability]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-ontology]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-search]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-session]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-storage]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-telemetry]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-truth-subspace]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-utils]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-vector]
+debug = true
+opt-level = 0
+[profile.dev.package.cognee-visualization]
+debug = true
+opt-level = 0
+
 [profile.release]
 # Full debug info for first-party code (see the per-package overrides below),
 # plus panic=abort.

--- a/python/scripts/check.sh
+++ b/python/scripts/check.sh
@@ -19,14 +19,17 @@ fi
 # architecture so it cannot shadow the freshly-built one.
 rm -f cognee_py/_native*.so
 
-maturin develop
-
-echo ""
-echo "================================================================"
-echo "=== Python: Installing test dependencies ==="
-echo "================================================================"
-
-pip install -e ".[test]"
+# --extras installs the [test] extra's dependencies as part of this same
+# dev-profile install, which is why there is no `pip install -e ".[test]"`
+# afterwards. That command looked free but was not: it handed the build to the
+# maturin PEP-517 backend, which defaults to --release, so the whole ~630-crate
+# graph was compiled a second time in a second profile — measured at 9.8 GiB of
+# target/release and ~4 minutes — purely to land two pure-Python wheels.
+#
+# Let maturin/pip resolve the specifiers rather than parsing pyproject.toml
+# here: they handle PEP 508 markers, quoting and spaces correctly, and this
+# script then needs no TOML parser (python < 3.11 has no stdlib tomllib).
+maturin develop --extras test
 
 echo ""
 echo "================================================================"


### PR DESCRIPTION
Profiled `scripts/check_all.sh` from a fully clean tree and fixed the two
changes that account for nearly all the recoverable waste.

## Baseline

33m24s wall, **76.4 GiB** on disk, **4,898 compilation units for 765 distinct
crates** — 6.4x average redundancy, with 248 crates compiled 8 times over.

| Tree | Size | Driver |
|---|---:|---|
| `target/debug` | 20 G | `maturin develop` (real codegen, not `cargo check` metadata) |
| `target/release` | 9.8 G | **`pip install -e ".[test]"`** — an entire second build |
| `capi/target/debug` | 25 G | dev profile, untuned |
| `capi/build/examples` | 9.5 G | 19 binaries x 510 MB, each statically linking the archive |
| `java/…/target` | 4.0 G | already tuned by #117 |
| `ts/…/target` | 2.8 G | release cdylib |
| `capi/target/check-slim` | 1.7 G | isolated `CARGO_TARGET_DIR` |

## 1. `capi`'s dev profile was untuned (-21 GiB)

#117 graded `[profile.release]`, but `capi/CMakeLists.txt` runs a bare
`cargo build` and imports `${CARGO_TARGET_DIR}/debug/`, so the Rust half of
every CMake build — and therefore every `check_all.sh` run — uses
**`[profile.dev]`**, which carried nothing but `panic = "abort"`. The release
profile is only reached by an explicit `cargo build --release`.

Measured from clean on aarch64-apple-darwin:

| | `capi/target` | `capi/build` | lbug C++ | per example |
|---|---:|---:|---:|---:|
| before | 27 GiB | 9.5 GiB | 2.9 GiB | 510 MiB |
| after | **10 GiB** | **4.9 GiB** | **208 MiB** | **264 MiB** |

`opt-level = 1` on dependencies is not a speed setting: the `cmake` crate
derives `CMAKE_BUILD_TYPE` from the `OPT_LEVEL`/`DEBUG` cargo exports to a build
script, so pairing it with `debug = 0` is what flips lbug's bundled Ladybug tree
to a Release C++ build (the 2.9 GiB -> 208 MiB row). Neither knob does it alone.

The 24 first-party overrides set **`opt-level = 0` explicitly** as well as
`debug = true` — named package overrides *merge onto* the `"*"` glob rather than
replacing it, so `debug = true` alone would have left them optimized.

### Assert opt-in

Release and RelWithDebInfo both define `NDEBUG`, and lbug gates its internal
`KU_ASSERT`/`RUNTIME_CHECK` on
`defined(LBUG_RUNTIME_CHECKS) || !defined(NDEBUG)` — so this profile, previously
the last one where they fired, no longer compiles them in.

Rather than accept that, `-DCOGNEE_CAPI_LBUG_ASSERTS=ON` puts
`-DLBUG_RUNTIME_CHECKS` on `CXXFLAGS`, satisfying the first half of the
condition independently of `NDEBUG`. Verified in the generated `CMakeCache.txt`:
`CMAKE_BUILD_TYPE` stays `Release` **and** `CMAKE_CXX_FLAGS` gains the define —
asserts back without giving up the 208 MiB tree.

Cargo fingerprints the lbug build-script unit on its build-dependency closure,
not on `CXXFLAGS`, so toggling the option needs `cargo clean -p lbug` to take
effect. Documented at the option.

## 2. The Python check built everything twice (-9.8 GiB, ~-4 min)

`maturin develop` builds the extension under the dev profile; the
`pip install -e ".[test]"` right after handed the build to the maturin PEP-517
backend, which **defaults to `--release`** — a second full codegen pass over the
~630-crate graph, producing `target/release/libcognee_py.dylib`. What it bought:
`pytest>=8` and `pytest-asyncio>=0.24`, two pure-Python wheels.

`maturin develop --extras test` installs them as part of the build already
running, with pip resolving the specifiers.

`ci.yml`'s python-check job also dropped its own `pip install -e ".[test]"`.
It pre-installed the project, so CI exercised an environment that step had
prepared rather than `check.sh`'s own bootstrap — the release rebuild still
happened there, and breakage in the script's setup would have stayed invisible
behind a green badge until it hit a developer's fresh venv.

## Considered and rejected

- **Dropping `cargo check` before `cargo clippy`** — not redundant. Clippy
  re-ran only **32 units in 13s**, exactly the workspace members, because
  dependencies are shared via `RUSTC_WORKSPACE_WRAPPER`.
- **A shared `CARGO_TARGET_DIR`** — measured 3.5% dedupe for ts+java and none
  once capi joins (`panic = "abort"` fingerprints every capi unit separately).

## Also noted, not changed

`cargo check --all-targets --features telemetry` is **vacuous**: `telemetry` is
already in `default` (`crates/lib/Cargo.toml:69`), so it compiles 0 units in
0.39s. It costs nothing, but it reads as a guard while guarding nothing.

## Known gap

`maturin develop` installs a **non-editable** copy of the pure-Python sources,
so editing `python/cognee_py/*.py` and rerunning pytest directly can import the
stale site-packages copy. The removed editable install used to mask this;
restoring editable behaviour without reintroducing the release rebuild is a
separate change.

## Verification

- `capi/scripts/check.sh` from clean, default options: rc=0, 11m9s
- `python/scripts/check.sh` with pytest deliberately uninstalled first: rc=0,
  127 passed / 95 skipped, `target/release` not recreated
- Assert opt-in confirmed via the generated `CMakeCache.txt`
- `shellcheck` clean; all four manifests parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SePhkXEUpiSJ1CTg7t9ERb