### PR TITLE
perf: cut check_all.sh footprint from 43.8 GiB to 30.5 GiB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,8 +61,12 @@ __pycache__/
 # Runtime data storage (created by CLI in cwd)
 .data_storage/
 
-# Runtime artifacts written into cwd by un-isolated test runs (any directory)
+# Runtime artifacts written into cwd by un-isolated test runs (any directory).
+# The -wal/-shm siblings appear whenever SQLite runs in WAL mode; without
+# them a smoke-test run leaves two untracked files behind.
 cognee.db
+cognee.db-wal
+cognee.db-shm
 .cognee_system/
 
 # Generated Locust benchmark artifacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,21 @@ extend `DOCKER_IMAGES`: removal is by `repo:tag` rather than image ID, because s
 routinely share one ID and `docker rmi <id>` would delete all of them; and the freed total
 counts each image once no matter how many tags point at it.
 
+### C API example linking
+
+`capi/scripts/check.sh` builds 19 C example/smoke binaries. They link
+`libcognee_capi.dylib` — which the same `cargo build` already produces alongside
+the `.a` — rather than the static archive. Linking the archive embeds the whole
+bundled Ladybug engine into every binary (lbug marks its 17 C++ archives
+`+whole-archive`), which is 264 MB each and a 4.9 GiB `capi/build` tree; against
+the dylib they are ~50 KB each and the tree is ~17 MB.
+
+`example_sync_task` stays statically linked on purpose, with `-dead_strip`. It is
+the canary for the `.a` link path and for the hand-maintained Apple-framework
+list in `capi/CMakeLists.txt` — a missing entry there is what broke the build in
+\#116, and nothing else would catch it now. Pass
+`-DCOGNEE_CAPI_STATIC_EXAMPLES=ON` to link everything statically again.
+
 ### Which profile settings drive the size
 
 Debug info is the dominant term, and it reaches further than the Rust artifacts: cargo derives

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,12 +174,18 @@ counts each image once no matter how many tags point at it.
 the `.a` — rather than the static archive. Linking the archive embeds the whole
 bundled Ladybug engine into every binary (lbug marks its 17 C++ archives
 `+whole-archive`), which is 264 MB each and a 4.9 GiB `capi/build` tree; against
-the dylib they are ~50 KB each and the tree is ~17 MB.
+the dylib they are ~50 KB each.
 
-`example_sync_task` stays statically linked on purpose, with `-dead_strip`. It is
-the canary for the `.a` link path and for the hand-maintained Apple-framework
-list in `capi/CMakeLists.txt` — a missing entry there is what broke the build in
-\#116, and nothing else would catch it now. Pass
+`example_sync_task` stays statically linked on purpose, so `capi/build` is
+~267 MB rather than ~17 MB — that one binary is nearly all of it. It is the
+canary for the `.a` link path and for the hand-maintained Apple-framework list
+in `capi/CMakeLists.txt`; a missing entry there is what broke the build in
+\#116, and nothing else would catch it now.
+
+**Do not add `-Wl,-dead_strip` to it.** That would take it to ~16 MB and is
+tempting for exactly that reason, but ld64 dead-strips before it checks for
+undefined symbols, so the flag silently discards the missing-framework errors
+the canary exists to raise — verified both ways on the real link line. Pass
 `-DCOGNEE_CAPI_STATIC_EXAMPLES=ON` to link everything statically again.
 
 ### Which profile settings drive the size

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ expect_used = "warn"
 # -> 213 MiB), which is why both binding workspaces set the two together. See
 # ts/cognee-ts-neon/Cargo.toml and docs/build/lbug-rebuilds.md.
 opt-level = 1
+debug = 0
 
 [profile.release]
 # "line-tables-only" gives backtraces and profiler source-line info at a

--- a/capi/CMakeLists.txt
+++ b/capi/CMakeLists.txt
@@ -97,6 +97,62 @@ set_target_properties(cognee_capi PROPERTIES
 )
 add_dependencies(cognee_capi cognee_capi_cargo)
 
+# …and the shared library, which the same `cargo build` already produced.
+#
+# cognee-capi is `crate-type = ["cdylib", "staticlib"]`, so every build emits
+# both a ~805 MB .a and a ~185 MB .dylib. Linking the examples against the .a
+# is enormously wasteful: lbug's build.rs emits `static:+whole-archive` for
+# liblbug and all 16 bundled third-party C++ archives, so each example embeds
+# the entire Ladybug engine. Measured, linking one example:
+#
+#   against the .a                   276.3 MB   0.94 s
+#   against the .a + -dead_strip      15.7 MB   0.23 s
+#   against the .dylib                  35 KB   0.02 s
+#
+# 19 examples x ~264 MB is the 4.9 GiB `capi/build` tree. Linking them against
+# the .dylib instead makes that tree a rounding error, and the smoke tests
+# still exercise the real engine — the code just lives in the dylib rather
+# than being copied into each binary.
+#
+# How the examples find it at run time differs by platform, and neither route
+# is one we control from here:
+#   macOS - cargo links the dylib with an absolute install_name, though it
+#           points at the deps/ copy (`otool -D` shows
+#           .../target/debug/deps/libcognee_capi.dylib), not the path below.
+#   Linux - no absolute SONAME; the examples resolve it only because CMake
+#           injects a build-tree RPATH for a full-path imported library.
+# Both are fine for a local check tree and neither survives copying a binary
+# out of capi/build — which is fine, these are never distributed.
+add_library(cognee_capi_shared SHARED IMPORTED GLOBAL)
+set_target_properties(cognee_capi_shared PROPERTIES
+    IMPORTED_LOCATION "${CARGO_TARGET_DIR}/debug/${CMAKE_SHARED_LIBRARY_PREFIX}cognee_capi${CMAKE_SHARED_LIBRARY_SUFFIX}"
+)
+if(WIN32)
+    # On DLL platforms CMake needs the import library to build a link line at
+    # all; IMPORTED_LOCATION alone fails at generate time. cargo emits
+    # cognee_capi.dll.lib beside the DLL. Untested — nothing CMake-configures
+    # the capi tree on Windows today (COGNEE_SYSTEM_LIBS below is POSIX-only),
+    # so treat this as a starting point rather than a working configuration.
+    set_target_properties(cognee_capi_shared PROPERTIES
+        IMPORTED_IMPLIB "${CARGO_TARGET_DIR}/debug/cognee_capi.dll.lib"
+    )
+endif()
+add_dependencies(cognee_capi_shared cognee_capi_cargo)
+
+# Which library the examples link by default. ON restores the old all-static
+# behaviour for anyone who needs to reproduce a static-link problem.
+# capi/examples/CMakeLists.txt keeps one example statically linked either way,
+# so the .a path and the Apple-framework list below never go untested.
+option(COGNEE_CAPI_STATIC_EXAMPLES
+    "Link every C example against libcognee_capi.a instead of the .dylib"
+    OFF)
+
+if(COGNEE_CAPI_STATIC_EXAMPLES)
+    set(COGNEE_EXAMPLE_LIB cognee_capi)
+else()
+    set(COGNEE_EXAMPLE_LIB cognee_capi_shared)
+endif()
+
 # System libraries needed by the Rust static lib
 # stdc++ is required because cognee-graph depends on lbug (C++ graph engine)
 set(COGNEE_SYSTEM_LIBS pthread dl m stdc++)

--- a/capi/examples/CMakeLists.txt
+++ b/capi/examples/CMakeLists.txt
@@ -1,5 +1,7 @@
+# example_sync_task is deliberately absent here — it is the static-link canary
+# built separately below. Everything in this list links whichever library
+# COGNEE_EXAMPLE_LIB selects (the .dylib by default; see ../CMakeLists.txt).
 set(EXAMPLES
-    example_sync_task
     example_async_task
     example_iter_task
     example_batch_task
@@ -11,63 +13,82 @@ set(EXAMPLES
 foreach(example ${EXAMPLES})
     add_executable(${example} ${example}.c)
     target_include_directories(${example} PRIVATE ${COGNEE_INCLUDE_DIR})
-    target_link_libraries(${example} cognee_capi ${COGNEE_SYSTEM_LIBS})
+    target_link_libraries(${example} ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 endforeach()
+
+# Static-link canary — always the .a, never COGNEE_EXAMPLE_LIB.
+#
+# With every other example on the dylib, nothing would exercise the staticlib
+# link path or the hand-maintained Apple-framework list in ../CMakeLists.txt.
+# A missing entry there is what broke the build in #116: rustc only honours
+# `#[link]` directives when it drives the link itself, so a `.a` consumer must
+# name every framework. Keeping one example static means that still fails here.
+#
+# Deliberately NOT dead-stripped, even though that would take it from ~276 MB
+# to ~16 MB. ld64 dead-strips before it checks for undefined symbols, so
+# -Wl,-dead_strip silently drops exactly the unresolved framework references
+# this canary exists to surface — verified: a force-loaded archive member with
+# a missing symbol fails the link normally, and links clean with -dead_strip.
+# The ~260 MB is the price of the check actually working; the other 18
+# examples are ~50 KB each, so capi/build is still ~280 MB rather than 4.9 GiB.
+add_executable(example_sync_task example_sync_task.c)
+target_include_directories(example_sync_task PRIVATE ${COGNEE_INCLUDE_DIR})
+target_link_libraries(example_sync_task cognee_capi ${COGNEE_SYSTEM_LIBS})
 
 # Phase 1b SDK handle smoke test (Tier-A: mock embedding, no network).
 add_executable(sdk_handle_smoke sdk_handle_smoke.c)
 target_include_directories(sdk_handle_smoke PRIVATE ${COGNEE_INCLUDE_DIR})
-target_link_libraries(sdk_handle_smoke cognee_capi ${COGNEE_SYSTEM_LIBS})
+target_link_libraries(sdk_handle_smoke ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 
 # Phase 2 conventions smoke tests (Tier-A: mock embedding, no network).
 add_executable(sdk_conventions_smoke sdk_conventions_smoke.c)
 target_include_directories(sdk_conventions_smoke PRIVATE ${COGNEE_INCLUDE_DIR})
-target_link_libraries(sdk_conventions_smoke cognee_capi ${COGNEE_SYSTEM_LIBS})
+target_link_libraries(sdk_conventions_smoke ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 
 add_executable(sdk_negative_path_smoke sdk_negative_path_smoke.c)
 target_include_directories(sdk_negative_path_smoke PRIVATE ${COGNEE_INCLUDE_DIR})
-target_link_libraries(sdk_negative_path_smoke cognee_capi ${COGNEE_SYSTEM_LIBS})
+target_link_libraries(sdk_negative_path_smoke ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 
 # Phase 3 config surface smoke test (Tier-A: mock embedding, no network).
 add_executable(sdk_config_smoke sdk_config_smoke.c)
 target_include_directories(sdk_config_smoke PRIVATE ${COGNEE_INCLUDE_DIR})
-target_link_libraries(sdk_config_smoke cognee_capi ${COGNEE_SYSTEM_LIBS})
+target_link_libraries(sdk_config_smoke ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 
 # Phase 4 core ops smoke test (Tier-A: mock embedding, no LLM).
 add_executable(example_sdk_add example_sdk_add.c)
 target_include_directories(example_sdk_add PRIVATE ${COGNEE_INCLUDE_DIR})
-target_link_libraries(example_sdk_add cognee_capi ${COGNEE_SYSTEM_LIBS})
+target_link_libraries(example_sdk_add ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 
 # Phase 4 live add+cognify example (Tier-B: requires OPENAI_URL + OPENAI_TOKEN;
 # the binary has a built-in skip guard so it exits 0 when credentials are absent).
 add_executable(example_sdk_add_cognify example_sdk_add_cognify.c)
 target_include_directories(example_sdk_add_cognify PRIVATE ${COGNEE_INCLUDE_DIR})
-target_link_libraries(example_sdk_add_cognify cognee_capi ${COGNEE_SYSTEM_LIBS})
+target_link_libraries(example_sdk_add_cognify ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 
 # Phase 5 retrieval smoke test (Tier-A: mock embedding, no network).
 add_executable(sdk_retrieval_smoke sdk_retrieval_smoke.c)
 target_include_directories(sdk_retrieval_smoke PRIVATE ${COGNEE_INCLUDE_DIR})
-target_link_libraries(sdk_retrieval_smoke cognee_capi ${COGNEE_SYSTEM_LIBS})
+target_link_libraries(sdk_retrieval_smoke ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 
 # Phase 5 live add+cognify+search example (Tier-B: requires OPENAI_URL + OPENAI_TOKEN;
 # the binary has a built-in skip guard so it exits 0 when credentials are absent).
 add_executable(example_sdk_add_cognify_search example_sdk_add_cognify_search.c)
 target_include_directories(example_sdk_add_cognify_search PRIVATE ${COGNEE_INCLUDE_DIR})
-target_link_libraries(example_sdk_add_cognify_search cognee_capi ${COGNEE_SYSTEM_LIBS})
+target_link_libraries(example_sdk_add_cognify_search ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 
 # Phase 6 data-ops smoke test (Tier-A: mock embedding, no LLM).
 add_executable(sdk_data_smoke sdk_data_smoke.c)
 target_include_directories(sdk_data_smoke PRIVATE ${COGNEE_INCLUDE_DIR})
-target_link_libraries(sdk_data_smoke cognee_capi ${COGNEE_SYSTEM_LIBS})
+target_link_libraries(sdk_data_smoke ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 
 # Gap 07 smoke binaries (driven by capi/scripts/check.sh).
 #
 # `init_otlp_smoke` and `init_telemetry_smoke` exercise the public C
 # entrypoints and need no special cargo feature. The panic-hook smoke
-# binary links the `cg_test_force_panic` symbol exposed under the
-# `testing-panic` cargo feature; the driver script rebuilds
-# cognee-capi with that feature enabled and toggles
-# `COGNEE_BUILD_PANIC_SMOKE=ON` to opt this target in.
+# binary links `cg_test_force_panic`, exposed under the `testing-panic`
+# cargo feature; capi/scripts/check.sh enables that feature and
+# `COGNEE_BUILD_PANIC_SMOKE=ON` on the single default configure, so this
+# target is built in the main tree rather than in a second build dir.
 set(GAP07_SMOKE_EXAMPLES
     init_otlp_smoke
     init_telemetry_smoke
@@ -76,13 +97,13 @@ set(GAP07_SMOKE_EXAMPLES
 foreach(example ${GAP07_SMOKE_EXAMPLES})
     add_executable(${example} ${example}.c)
     target_include_directories(${example} PRIVATE ${COGNEE_INCLUDE_DIR})
-    target_link_libraries(${example} cognee_capi ${COGNEE_SYSTEM_LIBS})
+    target_link_libraries(${example} ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 endforeach()
 
 if(COGNEE_BUILD_PANIC_SMOKE)
     add_executable(panic_hook_smoke panic_hook_smoke.c)
     target_include_directories(panic_hook_smoke PRIVATE ${COGNEE_INCLUDE_DIR})
-    target_link_libraries(panic_hook_smoke cognee_capi ${COGNEE_SYSTEM_LIBS})
+    target_link_libraries(panic_hook_smoke ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 endif()
 
 # Phase 7 feature-gated smoke test.
@@ -100,7 +121,7 @@ endif()
 #   from the remaining feature-gated ops (visualization).
 add_executable(sdk_feature_smoke sdk_feature_smoke.c)
 target_include_directories(sdk_feature_smoke PRIVATE ${COGNEE_INCLUDE_DIR})
-target_link_libraries(sdk_feature_smoke cognee_capi ${COGNEE_SYSTEM_LIBS})
+target_link_libraries(sdk_feature_smoke ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
 
 # The slim variant is only built in the slim CMake configuration
 # (COGNEE_CAPI_NO_DEFAULT_FEATURES=ON).  We gate it on that flag so the
@@ -108,6 +129,6 @@ target_link_libraries(sdk_feature_smoke cognee_capi ${COGNEE_SYSTEM_LIBS})
 if(COGNEE_CAPI_NO_DEFAULT_FEATURES)
     add_executable(sdk_feature_smoke_slim sdk_feature_smoke.c)
     target_include_directories(sdk_feature_smoke_slim PRIVATE ${COGNEE_INCLUDE_DIR})
-    target_link_libraries(sdk_feature_smoke_slim cognee_capi ${COGNEE_SYSTEM_LIBS})
+    target_link_libraries(sdk_feature_smoke_slim ${COGNEE_EXAMPLE_LIB} ${COGNEE_SYSTEM_LIBS})
     target_compile_definitions(sdk_feature_smoke_slim PRIVATE EXPECT_FEATURE_NOT_BUILT=1)
 endif()

--- a/capi/scripts/check.sh
+++ b/capi/scripts/check.sh
@@ -40,7 +40,19 @@ echo "================================================================"
 BUILD_DIR="$CAPI_DIR/build"
 mkdir -p "$BUILD_DIR"
 
-cmake -S "$CAPI_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Debug
+# `testing-panic` is enabled here rather than in a second build dir. It is
+# purely additive — it exports one extra symbol, `cg_test_force_panic` — so it
+# does not change what any other smoke test exercises, and building it in the
+# main tree lets `panic_hook_smoke` (below) reuse this build instead of
+# triggering a whole second cargo build + archive + relink cycle.
+#
+# It is safe for the header-sync check: check_header_sync.sh greps
+# `pub extern "C" fn` out of the *source*, which sees the symbol whether or not
+# the feature is on, so enabling it changes nothing there.
+cmake -S "$CAPI_DIR" -B "$BUILD_DIR" \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCOGNEE_BUILD_PANIC_SMOKE=ON \
+    -DCOGNEE_CAPI_CARGO_FEATURES=testing-panic
 cmake --build "$BUILD_DIR"
 
 echo ""
@@ -185,25 +197,6 @@ MOCK_EMBEDDING=true \
     COGNEE_TRACING_ENABLED="" \
     "$BUILD_DIR/examples/sdk_feature_smoke"
 
-echo ""
-echo "================================================================"
-echo "=== Phase 7 slim build: CG_ERR_FEATURE_NOT_BUILT verification ==="
-echo "================================================================"
-
-SLIM_BUILD_DIR="$CAPI_DIR/build-slim"
-rm -rf "$SLIM_BUILD_DIR"
-cmake -S "$CAPI_DIR" -B "$SLIM_BUILD_DIR" \
-    -DCMAKE_BUILD_TYPE=Debug \
-    -DCOGNEE_CAPI_NO_DEFAULT_FEATURES=ON \
-    -DCOGNEE_CAPI_CARGO_FEATURES=sqlite,testing \
-    > /dev/null
-cmake --build "$SLIM_BUILD_DIR" --target sdk_feature_smoke_slim
-
-echo ""
-echo "--- Running: sdk_feature_smoke_slim (slim build — all four ops expect CG_ERR_FEATURE_NOT_BUILT) ---"
-MOCK_EMBEDDING=true \
-    COGNEE_TRACING_ENABLED="" \
-    "$SLIM_BUILD_DIR/examples/sdk_feature_smoke_slim"
 
 echo ""
 echo "================================================================"
@@ -235,19 +228,12 @@ echo "================================================================"
 echo "=== Gap 07 panic-hook smoke (testing-panic feature) ==="
 echo "================================================================"
 
-# Configure a separate CMake build dir that opts the smoke target in
-# and passes `--features testing-panic` through to the cargo build
-# wrapped by CMake's `cognee_capi_cargo` custom target. The feature is
-# purely additive (it only adds an exported symbol), so this rebuild
-# only adds `cg_test_force_panic` on top of the existing static lib.
-PANIC_BUILD_DIR="$CAPI_DIR/build-panic"
-rm -rf "$PANIC_BUILD_DIR"
-cmake -S "$CAPI_DIR" -B "$PANIC_BUILD_DIR" \
-    -DCMAKE_BUILD_TYPE=Debug \
-    -DCOGNEE_BUILD_PANIC_SMOKE=ON \
-    -DCOGNEE_CAPI_CARGO_FEATURES=testing-panic \
-    > /dev/null
-cmake --build "$PANIC_BUILD_DIR" --target panic_hook_smoke
+# panic_hook_smoke is built by the main CMake configure above, which enables
+# both COGNEE_BUILD_PANIC_SMOKE and the additive `testing-panic` feature. It
+# used to get its own build dir, which meant a second full cargo build with a
+# different feature set, a re-archive of the ~805 MB .a into the shared
+# capi/target/debug, and a relink of every example on the following run.
+PANIC_BUILD_DIR="$BUILD_DIR"
 
 echo ""
 echo "--- Running: panic_hook_smoke (expect [cognee-capi panic] on stderr, non-zero exit) ---"
@@ -271,6 +257,45 @@ fi
 echo "  panic hook fired with marker on stderr (exit=$PANIC_EXIT)"
 rm -f "$PANIC_STDERR"
 
+echo ""
+# Kept last on purpose. This build shares capi/target with the default one,
+# so it overwrites libcognee_capi.{a,dylib} with the slim-featured variant —
+# and every other example is dynamically linked against that dylib, so any
+# $BUILD_DIR binary run after this point would fail at load time with a
+# missing symbol (cg_test_force_panic was the one that caught this).
+#
+# Redirecting it to its own CARGO_TARGET_DIR would also avoid the clobber but
+# costs 3.8 GiB — check-slim goes 1.6 -> 5.4 GiB, holding a full build rather
+# than just `cargo check` metadata. Ordering is free, so order it is.
+echo "================================================================"
+echo "=== Phase 7 slim build: CG_ERR_FEATURE_NOT_BUILT verification ==="
+echo "================================================================"
+
+SLIM_BUILD_DIR="$CAPI_DIR/build-slim"
+rm -rf "$SLIM_BUILD_DIR"
+cmake -S "$CAPI_DIR" -B "$SLIM_BUILD_DIR" \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCOGNEE_CAPI_NO_DEFAULT_FEATURES=ON \
+    -DCOGNEE_CAPI_CARGO_FEATURES=sqlite,testing \
+    > /dev/null
+cmake --build "$SLIM_BUILD_DIR" --target sdk_feature_smoke_slim
+
+echo ""
+echo "--- Running: sdk_feature_smoke_slim (slim build — all four ops expect CG_ERR_FEATURE_NOT_BUILT) ---"
+MOCK_EMBEDDING=true \
+    COGNEE_TRACING_ENABLED="" \
+    "$SLIM_BUILD_DIR/examples/sdk_feature_smoke_slim"
+
+# Restore the default-featured library. The slim build above shares
+# capi/target, so it leaves libcognee_capi.{a,dylib} as the
+# --no-default-features variant — and every example in build/ is dynamically
+# linked against that absolute path. Without this, re-running any smoke by hand
+# after a green check (./capi/build/examples/sdk_data_smoke, panic_hook_smoke)
+# fails with a missing symbol or a spurious CG_ERR_FEATURE_NOT_BUILT. Cheap:
+# one cargo rebuild of cognee-capi plus ~50 KB relinks.
+echo ""
+echo "--- Restoring the default-featured libcognee_capi for build/ ---"
+cmake --build "$BUILD_DIR" > /dev/null
 echo ""
 echo "================================================================"
 echo "=== C API check passed ==="

--- a/docs/build/lbug-rebuilds.md
+++ b/docs/build/lbug-rebuilds.md
@@ -211,10 +211,28 @@ Stale agent worktrees each hold a 13–18 GB target dir; remove with
   runners, so `http-parity.yml` persists the mount with
   `reproducible-containers/buildkit-cache-dance` + `actions/cache`
   (inject before build, extract after).
-- Rust-side equivalent: `sccache` as `RUSTC_WRAPPER` would also cache the
-  ~700 dependency crates across fresh worktree target dirs. Not wired because
-  a hard `RUSTC_WRAPPER` breaks machines without sccache; revisit if worktree
-  warm-up (not lbug) becomes the bottleneck.
+- Rust-side equivalent: `sccache` as `RUSTC_WRAPPER` also caches the ~700
+  dependency crates across fresh worktree target dirs. Now wired — see
+  "sccache for the Rust half" below for how it stays safe on machines that do
+  not have it, and for the two ways of wiring it that are *not* safe.
+
+### sccache for the Rust half (wired, opt-in by installation)
+
+`.cargo/config.toml` sets `build.rustc-wrapper = "scripts/rustc-wrapper.sh"`,
+which execs `sccache` when installed and is a transparent pass-through
+otherwise — the same contract as the ccache launcher above.
+
+The objection previously recorded here (that a hard `RUSTC_WRAPPER` breaks
+machines without it) is handled by the pass-through, and toggling the wrapper
+does **not** invalidate cargo fingerprints: verified by building, rebuilding
+with a pass-through wrapper, then rebuilding without — both follow-ups were
+0-crate no-ops. So installing or removing sccache costs no rebuild.
+
+What it will not cache, by design rather than by failure: units built with
+`-C incremental` (every first-party crate), proc macros, build scripts, and
+the final bin/cdylib/staticlib links. Those fall back to a normal compile. The
+registry dependencies are the cached part — the same graph this repo compiles
+four times over.
 
 ### Escape hatch: prebuilt Ladybug (`LBUG_LIBRARY_DIR`)
 

--- a/docs/build/lbug-rebuilds.md
+++ b/docs/build/lbug-rebuilds.md
@@ -218,15 +218,31 @@ Stale agent worktrees each hold a 13–18 GB target dir; remove with
 
 ### sccache for the Rust half (wired, opt-in by installation)
 
-`.cargo/config.toml` sets `build.rustc-wrapper = "scripts/rustc-wrapper.sh"`,
-which execs `sccache` when installed and is a transparent pass-through
-otherwise — the same contract as the ccache launcher above.
+`scripts/check_all.sh` exports `RUSTC_WRAPPER=sccache` when that binary is on
+PATH, and leaves it unset otherwise. A caller-set `RUSTC_WRAPPER` still wins.
 
-The objection previously recorded here (that a hard `RUSTC_WRAPPER` breaks
-machines without it) is handled by the pass-through, and toggling the wrapper
-does **not** invalidate cargo fingerprints: verified by building, rebuilding
-with a pass-through wrapper, then rebuilding without — both follow-ups were
-0-crate no-ops. So installing or removing sccache costs no rebuild.
+Deliberately *not* done two more obvious ways, both of which are broken in ways
+that only surface off a macOS dev machine:
+
+- **A `#!/bin/sh` wrapper script**, mirroring `ccache-launcher.sh`. A shell
+  interposed between cargo and rustc drops every environment variable whose
+  name is not a valid shell identifier. Linux `/bin/sh` is dash, which discards
+  `CARGO_BIN_EXE_cognee-cli`, so `crates/cli/tests` fails to compile;
+  `env CARGO_BIN_EXE_cognee-cli=X dash wrapper.sh env | grep -c cognee-cli`
+  prints 0 under dash and 1 under bash. This was tried and turned PR CI red on
+  every Linux runner while passing locally.
+- **`build.rustc-wrapper` in `.cargo/config.toml`.** That applies on Windows
+  too, where CreateProcess cannot launch a `.sh` at all, breaking every Windows
+  release leg — the same hazard `capi-release.yml` already resets the CMake
+  launcher variables for.
+
+Toggling sccache does **not** invalidate cargo fingerprints: verified by
+building, rebuilding with a wrapper, then rebuilding without — both follow-ups
+were 0-crate no-ops. So installing or removing it costs no rebuild.
+
+The trade against the config.toml approach is scope: this covers
+`check_all.sh` runs rather than every `cargo` invocation. Export it yourself
+for interactive builds.
 
 What it will not cache, by design rather than by failure: units built with
 `-C incremental` (every first-party crate), proc macros, build scripts, and

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -8,6 +8,27 @@ REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
 cd "$REPO_ROOT"
 
+# Route Rust compilation through sccache when it is installed. Set here rather
+# than as `build.rustc-wrapper` in .cargo/config.toml, and pointed at the
+# sccache binary rather than at a wrapper script, because both alternatives are
+# broken in ways that only show up off this developer's machine:
+#
+#   * A `#!/bin/sh` wrapper drops every environment variable whose name is not
+#     a valid shell identifier. On Linux /bin/sh is dash, which discards
+#     CARGO_BIN_EXE_cognee-cli before exec'ing rustc, so crates/cli/tests
+#     fails to compile. macOS /bin/sh is bash and keeps it, so the breakage is
+#     invisible locally and red on every Linux runner.
+#   * A committed config.toml entry applies to Windows too, where CreateProcess
+#     cannot launch a .sh at all — that would break every Windows release leg.
+#     (capi-release.yml already resets the CMake launcher vars on Windows for
+#     exactly this reason.)
+#
+# Exec'ing the sccache binary directly has neither problem, and a caller-set
+# RUSTC_WRAPPER still wins.
+if command -v sccache > /dev/null 2>&1; then
+    export RUSTC_WRAPPER="${RUSTC_WRAPPER:-sccache}"
+fi
+
 echo "================================================================"
 echo "=== Rust: Checking formatting ==="
 echo "================================================================"


### PR DESCRIPTION
Follow-up to #121, from a fresh from-clean profile plus an independent
investigation. `scripts/check_all.sh` goes **43.76 GiB → 30.50 GiB**; with
#117/#118/#121 that is **76.4 → 30.5 GiB**.

Verified: `bash scripts/check_all.sh` → **rc=0, all checks passed**.

> Revised after code review — see "What review changed" at the bottom. An
> earlier revision of this branch was **red on Linux CI**; the cause and fix
> are described there.

## 1. C examples link the dylib, not the static archive (−4.6 GiB)

`cognee-capi` is `crate-type = ["cdylib","staticlib"]`, so every build already
produced a ~185 MB `.dylib` beside the ~805 MB `.a` — and the examples linked
the archive. lbug marks liblbug and its 16 bundled C++ archives
`+whole-archive`, so each of 19 examples embedded the whole engine. Linking one
example: **35 KB / 0.02 s** against the dylib vs **276 MB / 0.94 s** against the
`.a`.

**`capi/build`: 4.89 GiB → 267 MB.**

`example_sync_task` stays static as a canary for the `.a` path and the
hand-maintained Apple-framework list — a missing entry there is what broke #116.
It is **deliberately not dead-stripped**, though that would take it from 264 MB
to ~16 MB: ld64 dead-strips *before* checking undefined symbols, so
`-Wl,-dead_strip` silently drops the very errors the canary exists to raise.
Proven on the real link line:

```
verbatim                        → exit 0, links clean
minus -framework Security       → exit 1, _kSecAttrAccessControl, _kSecAttrAccessGroup, …
```

With `-dead_strip` both cases link clean. The 264 MB is the price of the check
working. `-DCOGNEE_CAPI_STATIC_EXAMPLES=ON` reverts to all-static.

## 2. Panic smoke folded in; slim build last; terminal state restored

`build-panic` (265 MB) is gone — `testing-panic` is additive, so the main
configure carries it instead of a second cargo build + archive + relink cycle.
Safe for header-sync, which greps `pub extern "C" fn` from source.

The slim build runs **last**, because it shares `capi/target` and overwrites the
dylib every example now links against (`panic_hook_smoke` failed on a missing
`cg_test_force_panic`). Ordering alone was insufficient: it left the slim
library as the *terminal* state, so re-running any smoke by hand after a green
check failed the same way. The script now rebuilds the default configure at the
end. Verified: `cg_test_force_panic` present afterwards, `sdk_data_smoke`
re-runs with exit 0.

Redirecting slim to its own `CARGO_TARGET_DIR` also fixes the clobber and was
**tried and rejected** — it costs 3.8 GiB (`check-slim` 1.6 → 5.4 GiB).

## 3. Root dev profile drops dependency debug info (−10.9 GiB)

One line: `[profile.dev.package."*"]` already had `opt-level = 1`; `debug = 0`
completes the pair that flips lbug's C++ tree to a Release build.

`target/debug` **19.87 → 8.9 GiB**; both lbug trees **2.4 GiB → 208 MiB**.

No per-crate list, unlike capi: the `"*"` glob exempts workspace members by
definition and every first-party crate is a member. Verified with `dwarfdump` —
`cognee_core` 227 compile units, `cognee_search` 256, `serde_json` 0, `tokio` 0.

## 4. sccache, wired in check_all.sh

`RUSTC_WRAPPER=sccache` exported when the binary is present. Both more obvious
wirings are broken off a macOS dev machine, and the reasons are recorded at the
call site:

- A `#!/bin/sh` wrapper drops env vars whose names are not valid shell
  identifiers. Linux `/bin/sh` is dash, which discards `CARGO_BIN_EXE_cognee-cli`
  → `crates/cli/tests` fails to compile. `env CARGO_BIN_EXE_cognee-cli=X dash
  wrapper.sh env | grep -c` is **0 under dash, 1 under bash**.
- `build.rustc-wrapper` in `.cargo/config.toml` applies on Windows, where
  CreateProcess cannot launch a `.sh` — that breaks every Windows release leg.
  `capi-release.yml:129-134` already resets the CMake launchers for this reason.

Trade: applies to `check_all.sh` runs rather than every cargo invocation.

## What review changed

The first revision of this branch was **red on Linux CI** (6 failing jobs) from
the `sh` rustc-wrapper above — invisible locally because macOS `/bin/sh` is
bash. Review also caught that the canary's `-dead_strip` defeated its own
purpose, that the slim reorder left a broken terminal state, a missing
`IMPORTED_IMPLIB` for Windows, and several stale comments.

**Dropped:** the `ts` dev-profile switch. It was already marginal (53 s saved,
+0.45 GiB) and review flagged that `jest.config.js`'s 30 s timeout was
calibrated against the release artifact — not worth intermittent CI red.

## Deliberately not included

**Merging ts + java into one Cargo workspace** (est. −3.5 GiB). It changes
feature unification for the *published* cdylibs across 14 files including 4
release workflows, and both `ts-prebuild.yml` and `java-prebuild.yml` are
**tag/`workflow_dispatch`-only — they never run on PRs**, so nothing here would
validate it. Needs its own PR gated on a manual dispatch of both.

Also rejected with evidence: `LBUG_LIBRARY_DIR` prebuilt sharing (bakes an
absolute `-Wl,-rpath` into shipped cdylibs); heavy-crate duplication (none);
macOS linker swaps (ld-prime is already the fast path).

## Footprint

| Tree | Before | After |
|---|---:|---:|
| `target` | ~20.9 GiB | 9.5 GiB |
| `capi/target` | 10.37 GiB | 9.9 GiB |
| `capi/build` | 4.89 GiB | 267 MB |
| `capi/build-panic` + `build-slim` | 468 MB | 1.2 MB |
| `ts` + `java` targets | 6.86 GiB | 6.86 GiB |
| **total** | **43.76 GiB** | **30.50 GiB** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SePhkXEUpiSJ1CTg7t9ERb