### PR TITLE
perf(ci): build e2e binaries on the runner — HTTP Parity 39 → 9 min

### DIFF
--- a/.github/workflows/http-parity.yml
+++ b/.github/workflows/http-parity.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           workspaces: cognee-rust -> target
           shared-key: http-parity-release-v2
-          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/perf/e2e-prebuilt-binaries' }}  # TEMP: measurement only, revert before merge
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache ORT binary
         uses: actions/cache@v4

--- a/.github/workflows/http-parity.yml
+++ b/.github/workflows/http-parity.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           workspaces: cognee-rust -> target
           shared-key: http-parity-release-v2
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/perf/e2e-prebuilt-binaries' }}  # TEMP: measurement only, revert before merge
 
       - name: Cache ORT binary
         uses: actions/cache@v4

--- a/.github/workflows/http-parity.yml
+++ b/.github/workflows/http-parity.yml
@@ -68,16 +68,8 @@ jobs:
       - name: Stub cognee-rust/.env (required by docker-compose env_file)
         run: touch cognee-rust/.env
 
-      # Cargo.lock is gitignored (workspace policy: see .gitignore:6) but the
-      # rust-builder stage does `COPY cognee-rust/Cargo.lock ./`, so we
-      # materialize it on the host before docker build. `generate-lockfile`
-      # only resolves the dependency graph; it does not compile anything.
-      - name: Generate Cargo.lock (gitignored, required by Dockerfile COPY)
-        run: cargo generate-lockfile --manifest-path cognee-rust/Cargo.toml
-
-      # ubuntu-latest ships with ~14 GB free; lbug's C++ link step needs more
-      # headroom than that once cargo registry, target cache, and Docker
-      # layers are factored in. Mirror ci.yml's Test job cleanup.
+      # ubuntu-latest ships with ~14 GB free; the release build plus the cargo
+      # registry and target cache needs more headroom. Mirror ci.yml.
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
@@ -89,38 +81,81 @@ jobs:
           swap-storage: true
           docker-images: true
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      # ── ccache for lbug's bundled C++ build inside the image ─────────────
-      # The rust-builder stage compiles lbug's Ladybug C++ tree through ccache
-      # into a `--mount=type=cache,target=/ccache` BuildKit mount (see
-      # e2e-cross-sdk/Dockerfile and docs/build/lbug-rebuilds.md). BuildKit
-      # cache mounts live only inside the builder instance and are NOT part
-      # of exported layer caches, so on a fresh runner they start empty.
-      # buildkit-cache-dance injects the actions/cache-restored host dir into
-      # the mount before the build and extracts it back afterwards.
+      # ── Build the Rust binaries HERE, not inside the image ────────────────
+      # The Dockerfile used to carry a builder stage that recompiled ~741
+      # crates on every run — ~34 min of a ~39 min job — because its cargo
+      # target dir lived in a `--mount=type=cache` that never survives a fresh
+      # runner, and BuildKit layer caching was measured producing zero reuse
+      # here even at an identical commit. Building on the runner lets
+      # Swatinem/rust-cache persist the target dir instead, which is the one
+      # caching mechanism this repo has proven works.
       #
-      # Declaration order matters: post-steps run in reverse, so actions/cache
-      # (declared first) saves AFTER the dance post-step has extracted the
-      # mount contents back to ccache-mount/.
-      - name: Cache ccache (host side)
+      # Cold runs (first main run after a toolchain bump) cost about what the
+      # in-image build did; warm runs skip nearly all of it.
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install mold linker
+        uses: rui314/setup-mold@v1
+        with:
+          make-default: true
+
+      # cmake + protoc: lbug's bundled Ladybug C++ tree and the prost build.
+      - name: Install build deps
+        run: sudo apt-get update && sudo apt-get install -y cmake protobuf-compiler
+
+      # Restore-only, shared with ci.yml's lint job (the sole writer). ccache
+      # keys on compiler+flags+source content, so this workspace's resolution
+      # hits the same entries.
+      - name: ccache (lbug bundled C++, restore-only)
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: lbug-cxx
+          max-size: 1G
+          save: false
+
+      # Its own key: this is a --release tree, disjoint from the debug caches
+      # ci.yml keeps. Main-only save, matching the policy in ci.yml — branches
+      # restore main's copy rather than minting a duplicate.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cognee-rust -> target
+          shared-key: http-parity-release-v1
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Cache ORT binary
         uses: actions/cache@v4
         with:
-          path: ccache-mount
-          key: http-parity-ccache-${{ github.run_id }}
-          restore-keys: |
-            http-parity-ccache-
+          path: cognee-rust/target/ort-cache
+          key: ort-v2.0.0-rc.12-cpu-linux-x86_64
 
-      - name: Inject/extract ccache BuildKit cache mount
-        uses: reproducible-containers/buildkit-cache-dance@v3.4.0
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          cache-map: |
-            {
-              "ccache-mount": "/ccache"
-            }
+      - name: Build release binaries
+        working-directory: cognee-rust
+        env:
+          # ort-sys downloads the ONNX Runtime static library here; keeping it
+          # under target/ is what lets the cache above pick it up.
+          ORT_CACHE_DIR: ${{ github.workspace }}/cognee-rust/target/ort-cache
+          CARGO_INCREMENTAL: "0"
+        run: |
+          # One invocation for all three: separate `cargo build -p X` calls
+          # resolve features per-subgraph and build duplicate variants of
+          # shared deps (that cost 44 min before it was fixed). `bin` gates the
+          # http-server entry point; `dev-mock` gives the in-memory vector
+          # store the single-node harness needs.
+          cargo build --release \
+            -p cognee-cli \
+            -p cognee-http-server \
+            -p cognee-telemetry-emit \
+            --features cognee-http-server/bin,cognee-http-server/dev-mock
+          mkdir -p dist
+          cp target/release/cognee-cli \
+             target/release/cognee-http-server \
+             target/release/cognee-telemetry-emit \
+             dist/
+          ls -la dist/
+          # Fail loudly here rather than at container start if something did
+          # not link the way the harness image expects.
+          ldd dist/cognee-http-server || true
 
       # NOTE on layer caching — measured and rejected, do not re-add blindly.
       #

--- a/.github/workflows/http-parity.yml
+++ b/.github/workflows/http-parity.yml
@@ -144,9 +144,11 @@ jobs:
           # release profile is `debug = "line-tables-only"`, which is right for
           # shipped artifacts but is a large share of the target dir — and this
           # cache is the single biggest addition to a 10 GB repo quota that is
-          # already near its ceiling. An evicted cache costs a 54-min cold run
-          # instead of an 11-min warm one, so size here directly buys
-          # reliability of the speedup.
+          # already near its ceiling. An evicted cache costs a ~43-min cold run
+          # instead of a ~9-min warm one, so size here directly buys
+          # reliability of the speedup. (Measured with this setting on:
+          # cold 42.6 min / warm 9.1 min / cache 0.92 GB, versus 54.1 / 11.3 /
+          # 2.61 GB when the tree kept line-tables-only debug info.)
           #
           # The trade: backtraces out of the e2e harness lose line numbers.
           # That only affects this parity harness, never a released binary, and
@@ -170,9 +172,17 @@ jobs:
              target/release/cognee-telemetry-emit \
              dist/
           ls -la dist/
-          # Fail loudly here rather than at container start if something did
-          # not link the way the harness image expects.
-          ldd dist/cognee-http-server || true
+          # A real gate: catch a copy that silently did not happen here,
+          # rather than at container start.
+          for b in cognee-cli cognee-http-server cognee-telemetry-emit; do
+            test -x "dist/$b" || { echo "error: dist/$b missing or not executable" >&2; exit 1; }
+          done
+          # Informational only. This runs on the runner, so it cannot prove the
+          # harness image provides these libraries — the parity phases below are
+          # what verify that. It is here so a newly-introduced dynamic
+          # dependency is visible in the log instead of surfacing as an opaque
+          # container start failure.
+          ldd dist/cognee-http-server
 
       # NOTE on layer caching — measured and rejected, do not re-add blindly.
       #

--- a/.github/workflows/http-parity.yml
+++ b/.github/workflows/http-parity.yml
@@ -121,11 +121,7 @@ jobs:
         with:
           workspaces: cognee-rust -> target
           shared-key: http-parity-release-v1
-          # TEMPORARY (measurement only — revert before merge): lets this
-          # branch write the release cache so the cold-vs-warm delta is
-          # observable. Main-only, a branch never writes and so can never
-          # demonstrate the warm path.
-          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/perf/e2e-prebuilt-binaries' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache ORT binary
         uses: actions/cache@v4

--- a/.github/workflows/http-parity.yml
+++ b/.github/workflows/http-parity.yml
@@ -121,7 +121,11 @@ jobs:
         with:
           workspaces: cognee-rust -> target
           shared-key: http-parity-release-v1
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # TEMPORARY (measurement only — revert before merge): lets this
+          # branch write the release cache so the cold-vs-warm delta is
+          # observable. Main-only, a branch never writes and so can never
+          # demonstrate the warm path.
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/perf/e2e-prebuilt-binaries' }}
 
       - name: Cache ORT binary
         uses: actions/cache@v4

--- a/.github/workflows/http-parity.yml
+++ b/.github/workflows/http-parity.yml
@@ -117,10 +117,14 @@ jobs:
       # Its own key: this is a --release tree, disjoint from the debug caches
       # ci.yml keeps. Main-only save, matching the policy in ci.yml — branches
       # restore main's copy rather than minting a duplicate.
+      #
+      # v2 = the tree is now built with CARGO_PROFILE_RELEASE_DEBUG=0 (see the
+      # build step). Bumped rather than reused so a debug=0 build can never
+      # restore the older line-tables-only tree and thrash against it.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: cognee-rust -> target
-          shared-key: http-parity-release-v1
+          shared-key: http-parity-release-v2
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache ORT binary
@@ -136,6 +140,19 @@ jobs:
           # under target/ is what lets the cache above pick it up.
           ORT_CACHE_DIR: ${{ github.workspace }}/cognee-rust/target/ort-cache
           CARGO_INCREMENTAL: "0"
+          # Strip debug info for these three binaries only. The workspace
+          # release profile is `debug = "line-tables-only"`, which is right for
+          # shipped artifacts but is a large share of the target dir — and this
+          # cache is the single biggest addition to a 10 GB repo quota that is
+          # already near its ceiling. An evicted cache costs a 54-min cold run
+          # instead of an 11-min warm one, so size here directly buys
+          # reliability of the speedup.
+          #
+          # The trade: backtraces out of the e2e harness lose line numbers.
+          # That only affects this parity harness, never a released binary, and
+          # a harness failure is reproduced by re-running the phase rather than
+          # read off a stack trace.
+          CARGO_PROFILE_RELEASE_DEBUG: "0"
         run: |
           # One invocation for all three: separate `cargo build -p X` calls
           # resolve features per-subgraph and build duplicate variants of

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ e2e-cross-sdk/performance/locust/results/
 results/
 ghlogs/
 ios/.build/
+
+# Release binaries staged for the e2e-cross-sdk image (built on the CI
+# runner, copied in by e2e-cross-sdk/Dockerfile).
+dist/

--- a/e2e-cross-sdk/Dockerfile
+++ b/e2e-cross-sdk/Dockerfile
@@ -5,115 +5,33 @@
 #
 #   docker build -f cognee-rust/e2e-cross-sdk/Dockerfile .
 
-# ─── Stage 1: Rust CLI builder ──────────────────────────────────────────────
-# Use Debian Trixie for glibc 2.41 (ort-sys/ONNX Runtime requires glibc ≥ 2.38)
-FROM debian:trixie-slim AS rust-builder
-
-# Install Rust toolchain + system deps for pgvector/ort native builds
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates gcc g++ make ccache \
-    cmake clang libssl-dev pkg-config protobuf-compiler libprotobuf-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
-
-# ccache for lbug's bundled Ladybug C++ build (~1000 compiler calls per fresh
-# OUT_DIR; cargo relocates the OUT_DIR whenever lbug's build-dep closure
-# shifts in the resolved graph — see docs/build/lbug-rebuilds.md). The repo's
-# .cargo/config.toml + scripts/ccache-launcher.sh are not copied into this
-# image, so wire the CMake launcher directly; ccache is installed above.
-#   CCACHE_NOHASHDIR  — the release profile has debug=true; without it ccache
-#                       hashes the cwd (the shifting OUT_DIR) for -g builds.
-#   CCACHE_BASEDIR    — normalizes -I<OUT_DIR> paths for generated headers.
-#   COMPILERCHECK     — apt layer rebuilds change compiler mtimes; hash
-#                       compiler content instead.
-ENV CCACHE_DIR=/ccache \
-    CCACHE_BASEDIR=/build/cognee-rust \
-    CCACHE_NOHASHDIR=true \
-    CCACHE_COMPILERCHECK=content \
-    CMAKE_C_COMPILER_LAUNCHER=ccache \
-    CMAKE_CXX_COMPILER_LAUNCHER=ccache
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | sh -s -- -y --default-toolchain 1.93.0 --profile minimal
-
-WORKDIR /build/cognee-rust
-
-# Copy workspace. Only root-workspace members belong here — every path copied
-# is a cache-invalidation surface for the ~34-minute cargo build below, so
-# copying something the build never reads costs real CI time whenever it
-# changes.
+# ─── Stage 1: prebuilt Rust binaries (built on the runner, not here) ────────
 #
-# capi/ used to be copied and is deliberately not: it is its OWN cargo
-# workspace (capi/Cargo.toml declares `[workspace] members = ["cognee-capi"]`),
-# it is not listed in the root workspace's members, nothing in the root
-# workspace path-depends on it, and there is no [patch] pointing at it. The
-# three binaries built here never reference it. Its only effect was that
-# editing anything under capi/ — including capi/scripts/check.sh, which is not
-# even Rust — busted this layer and forced a full dependency rebuild.
-COPY cognee-rust/Cargo.toml cognee-rust/Cargo.lock ./
-COPY cognee-rust/crates/ crates/
-COPY cognee-rust/examples/ examples/
-COPY cognee-rust/python/ python/
-# Harness-only crate that drives cognee::telemetry::send_telemetry
-# directly. Source lives under e2e-cross-sdk/bin/telemetry_emit.rs;
-# manifest lives under e2e-cross-sdk/telemetry-emit/Cargo.toml. Both
-# are needed at workspace resolution time because the workspace root
-# Cargo.toml lists `e2e-cross-sdk/telemetry-emit` as a member.
-COPY cognee-rust/e2e-cross-sdk/telemetry-emit/ e2e-cross-sdk/telemetry-emit/
-COPY cognee-rust/e2e-cross-sdk/bin/telemetry_emit.rs e2e-cross-sdk/bin/telemetry_emit.rs
-
-# Build all three release binaries in ONE cargo invocation.
+# The Rust CLI/server/telemetry binaries used to be compiled by a builder stage
+# in this file. They are now built on the CI runner and copied in from
+# cognee-rust/dist/ — see .github/workflows/http-parity.yml.
 #
-# Splitting these across three `cargo build -p X` calls cost ~44 min of pure
-# waste per CI run. Each invocation resolves features for only its own
-# subgraph, so shared dependencies land on different feature sets and cargo
-# builds an *additional* variant of each rather than reusing the one already in
-# the (shared) target mount. Measured on run 31029376437: 1689s + 1350s +
-# 1309s = 72.5 min, with the second and third steps compiling 162 and 281
-# crates — the third rebuilding base-of-graph crates (proc-macro2, syn, serde,
-# tokio) for a binary that is a few hundred lines. Concretely, proc-macro2
-# resolves to `default,proc-macro,span-locations` under cognee-cli but
-# `default,proc-macro` under cognee-telemetry-emit, and that difference
-# cascades through syn into every proc-macro consumer.
+# Why: the builder stage recompiled ~741 crates on every run (~34 min of a
+# ~39 min job). Its cargo target dir lived in a `--mount=type=cache`, which
+# never survives a fresh runner, and BuildKit layer caching was measured
+# producing ZERO reuse here even at an identical commit — so nothing carried
+# over between runs. Building on the runner instead lets Swatinem/rust-cache
+# persist the target dir, which is machinery this repo has proven works.
 #
-# One invocation means one feature resolution, so every dependency is compiled
-# exactly once. Consequence to be aware of: resolver = "3" unifies features
-# across all selected packages, so cognee-cli here is built with
-# cognee-vector/testing + cognee-components/testing enabled (via the
-# http-server `dev-mock` feature). That only *registers* the mock vector
-# provider in ComponentRegistry::with_builtins(); it stays inert unless
-# VECTOR_DB_PROVIDER=mock is selected, which the CLI side of the harness does
-# not do.
+# Portability: the runner builds on ubuntu-24.04 (glibc 2.39, ort-sys needs
+# >= 2.38) and the harness below runs Debian Trixie (glibc 2.41). Old -> new is
+# the compatible direction for both glibc and libstdc++ (lbug's bundled C++).
+# There is no OpenSSL to satisfy: reqwest is `default-features = false` with
+# `rustls-tls`, and the resolved graph for these three binaries contains no
+# openssl-sys or native-tls.
 #
-# `bin` gates the http-server standalone entry point; `dev-mock` enables the
-# in-memory vector store (the harness is single-node with no Postgres, so
-# pgvector — the only other option — cannot connect and the server fails to
-# start). Both must be package-qualified because -p selects three packages.
-#
-# The `cp`s stay inside this RUN: target/ is a cache mount, so nothing under
-# it survives into the image layer.
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/build/cognee-rust/target \
-    --mount=type=cache,target=/ccache \
-    cargo build --release \
-        -p cognee-cli \
-        -p cognee-http-server \
-        -p cognee-telemetry-emit \
-        --features cognee-http-server/bin,cognee-http-server/dev-mock \
-    && cp target/release/cognee-cli /usr/local/bin/cognee-cli-rust \
-    && cp target/release/cognee-http-server /usr/local/bin/cognee-http-server \
-    && cp target/release/cognee-telemetry-emit /usr/local/bin/cognee-telemetry-emit
-
-# Download ONNX embedding models (needed by Rust CLI for cognify)
-RUN mkdir -p /opt/models \
-    && curl -fL "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/onnx/model_quantized.onnx" \
-       -o /opt/models/BGE-Small-v1.5-model_quantized.onnx \
-    && curl -fL "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/tokenizer.json" \
-       -o /opt/models/bge-small-tokenizer.json
+# To build the image outside CI, produce the binaries first:
+#   cargo build --release -p cognee-cli -p cognee-http-server \
+#     -p cognee-telemetry-emit \
+#     --features cognee-http-server/bin,cognee-http-server/dev-mock
+#   mkdir -p dist && cp target/release/cognee-cli \
+#     target/release/cognee-http-server \
+#     target/release/cognee-telemetry-emit dist/
 
 
 # ─── Stage 2: Python CLI builder ────────────────────────────────────────────
@@ -160,24 +78,29 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 
 # ─── Stage 3: Test harness ──────────────────────────────────────────────────
-# Must use Trixie to match glibc of the Rust binary (2.41)
+# Trixie (glibc 2.41) runs the runner-built binaries, which link against
+# ubuntu-24.04's glibc 2.39 — see the stage-1 note.
 FROM python:3.12-slim-trixie AS harness
 
+# curl/ca-certificates are for the ONNX model fetch below; they used to come
+# from the deleted rust-builder stage.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    sqlite3 \
+    sqlite3 curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Rust CLI binary
-COPY --from=rust-builder /usr/local/bin/cognee-cli-rust /usr/local/bin/cognee-cli-rust
+# Prebuilt Rust binaries. `cognee-cli` is renamed on the way in so it does not
+# collide with the Python CLI symlinked below as cognee-cli-python.
+COPY cognee-rust/dist/cognee-cli /usr/local/bin/cognee-cli-rust
+COPY cognee-rust/dist/cognee-http-server /usr/local/bin/cognee-http-server
+COPY cognee-rust/dist/cognee-telemetry-emit /usr/local/bin/cognee-telemetry-emit
 
-# Copy Rust HTTP server binary
-COPY --from=rust-builder /usr/local/bin/cognee-http-server /usr/local/bin/cognee-http-server
-
-# Copy harness-only telemetry emit binary (cross-SDK parity test)
-COPY --from=rust-builder /usr/local/bin/cognee-telemetry-emit /usr/local/bin/cognee-telemetry-emit
-
-# Copy ONNX models
-COPY --from=rust-builder /opt/models/ /opt/models/
+# ONNX embedding models (needed by the Rust CLI for cognify). Fetched here
+# rather than in the deleted builder stage; ~30 MB, a few seconds.
+RUN mkdir -p /opt/models \
+    && curl -fL "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/onnx/model_quantized.onnx" \
+       -o /opt/models/BGE-Small-v1.5-model_quantized.onnx \
+    && curl -fL "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/tokenizer.json" \
+       -o /opt/models/bge-small-tokenizer.json
 
 # Copy Python virtualenv. The venv was created with `uv venv --relocatable`
 # in stage 2, so script shebangs already use a sh-shim that resolves the

--- a/e2e-cross-sdk/Dockerfile
+++ b/e2e-cross-sdk/Dockerfile
@@ -25,7 +25,9 @@
 # `rustls-tls`, and the resolved graph for these three binaries contains no
 # openssl-sys or native-tls.
 #
-# To build the image outside CI, produce the binaries first:
+# To build the image outside CI, produce the binaries first — run these from
+# the cognee-rust repo root, so they land in cognee-rust/dist/ as the COPYs
+# below expect (the build context is the monorepo root above it):
 #   cargo build --release -p cognee-cli -p cognee-http-server \
 #     -p cognee-telemetry-emit \
 #     --features cognee-http-server/bin,cognee-http-server/dev-mock
@@ -96,10 +98,14 @@ COPY cognee-rust/dist/cognee-telemetry-emit /usr/local/bin/cognee-telemetry-emit
 
 # ONNX embedding models (needed by the Rust CLI for cognify). Fetched here
 # rather than in the deleted builder stage; ~30 MB, a few seconds.
+# --retry: these are build-time network fetches, so a transient DNS hiccup or
+# 5xx from the CDN would otherwise fail the whole image build.
 RUN mkdir -p /opt/models \
-    && curl -fL "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/onnx/model_quantized.onnx" \
+    && curl -fL --retry 3 --retry-delay 2 --retry-connrefused \
+       "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/onnx/model_quantized.onnx" \
        -o /opt/models/BGE-Small-v1.5-model_quantized.onnx \
-    && curl -fL "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/tokenizer.json" \
+    && curl -fL --retry 3 --retry-delay 2 --retry-connrefused \
+       "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/tokenizer.json" \
        -o /opt/models/bge-small-tokenizer.json
 
 # Copy Python virtualenv. The venv was created with `uv venv --relocatable`


### PR DESCRIPTION
Moves the e2e Rust build out of the Docker image and onto the runner, where `Swatinem/rust-cache` can actually persist the target dir. **HTTP Parity: 39.0 → 9.1 min warm.**

## Measured

Every number from a real run on this branch; cold and warm measured as separate dispatches.

| | wall clock | build step | cache |
|---|---|---|---|
| Baseline (build inside the image) | 39.0 min | 2034 s | — |
| Runner build, `debug = "line-tables-only"` — cold | 54.1 min | 2837 s | 2.61 GB |
| Runner build, `debug = "line-tables-only"` — warm | 11.3 min | 249 s | 2.61 GB |
| **Runner build, `debug = 0` — cold** | **42.6 min** | 2161 s | **0.92 GB** |
| **Runner build, `debug = 0` — warm** | **9.1 min** | **211 s** | **0.92 GB** |

- **Warm is the common case** — main writes the cache, branches restore it: **39.0 → 9.1 min (−77%)**.
- **Cold is 42.6 min**, ~3.6 min worse than today. It happens after a Rust toolchain bump or a cache eviction, and #130's Mon+Thu warm-up bounds that window to under a day.

## Why the build moved out of the image

The `rust-builder` stage recompiled ~741 crates on **every** run — roughly 34 min of a 39 min job — and nothing carried over, by either available mechanism:

- its cargo target dir lived in a `--mount=type=cache`, which never survives a fresh runner;
- BuildKit layer caching was measured in #129 producing **zero reuse at an identical commit** (2085 s cold vs 2034 s warm, with even trivial apt/rustup layers missing), for reasons still unexplained.

Building on the runner puts the target dir behind `Swatinem/rust-cache` instead — the one caching mechanism this repo has demonstrated works. What remains in the image is the Python venv, the ONNX model fetch and harness assembly: Phase-1a is now **111 s** covering image build, container start *and* the tests.

This is deliberately **not** cargo-chef. Chef's entire benefit is Docker layer caching, which is the thing measured broken here.

## Portability, verified not assumed

The runner builds on `ubuntu-24.04` (glibc 2.39, clearing ort-sys's ≥ 2.38) and the harness runs Trixie (glibc 2.41). Old → new is the compatible direction for glibc and libstdc++ alike.

`ldd` on the built server (printed by the build step, so a surprise dep fails on the runner rather than at container start):

```
linux-vdso.so.1 · libstdc++.so.6 · libgcc_s.so.1 · libm.so.6 · libc.so.6
```

Nothing exotic, and no OpenSSL to satisfy — `reqwest` is `default-features = false` with `rustls-tls`, and the resolved graph for these three binaries contains no `openssl-sys` or `native-tls`. All four runs passed every parity phase, so the ubuntu-built binaries demonstrably execute in the Trixie harness.

## Why `debug = 0`

Scoped to these three harness binaries only; the workspace release profile keeps `debug = "line-tables-only"` for everything shipped.

It was added to fix a real objection: at 2.61 GB the cache was the largest single addition to a 10 GB repo quota already at its ceiling, and **an evicted cache costs a 42-min cold run instead of a 9-min warm one** — so cache size directly buys reliability of the speedup. Stripping debug info cut it to **0.92 GB (−65%)**, dropped the cold build by 11 min, and made the cache save 3.5× faster (50 s → 14 s).

The trade is that harness backtraces lose line numbers. That never affects a released binary, and a harness failure is reproduced by re-running the phase.

Cache key is `v2` deliberately: had it stayed `v1`, a `debug=0` build could have restored the `line-tables-only` tree and thrashed against it, producing a meaningless measurement.

## Also removed

Everything that existed only for the deleted stage: the `Cargo.lock` materialisation step, the buildx setup, the `buildkit-cache-dance`, and the `COPY`s of `crates/`, `examples/`, `python/` and the manifests. That shrinks the build context and removes most of what used to invalidate the image build.

## Known and not addressed here

**The runner build is slower than the identical in-image build was** — 2161 s vs 2034 s (2837 s before `debug=0`). Close enough not to block this, but unexplained. The plausible candidate is a lower ccache hit rate: the Dockerfile tuned `CCACHE_NOHASHDIR`/`CCACHE_BASEDIR` for lbug's shifting `OUT_DIR`, and the runner relies on the repo's launcher config instead. Untested.

**`e2e-cross-sdk/.dockerignore` is inert.** Docker resolves `.dockerignore` at the *context root* (the monorepo root), not next to the Dockerfile — confirmed by `docker buildx build --check` reporting `load .dockerignore → transferring context: 2B`, i.e. an empty one. So its `cognee-rust/target/` exclusion has never applied and local builds ship the whole target dir as context. The fix is renaming it to `Dockerfile.dockerignore`, which BuildKit picks up per-Dockerfile. Kept out of this PR on purpose: changing context size would confound the measurements above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SePhkXEUpiSJ1CTg7t9ERb
