### PR TITLE
fix(bindings): close the relational pool on teardown so SQLite releases its WAL sidecars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ ts/cognee.db
 # under older Node versions produces churn (lockfileVersion 1 vs 3).
 ts/package-lock.json
 
+# Python virtualenvs — `python/scripts/check.sh` needs maturin on PATH, and both
+# CI and the documented local flow create one at the repo root.
+.venv/
+.venv*/
+
 # Python cache
 __pycache__/
 *.pyc

--- a/capi/cognee-capi/src/sdk.rs
+++ b/capi/cognee-capi/src/sdk.rs
@@ -466,6 +466,9 @@ pub unsafe extern "C" fn cg_sdk_close(sdk: *mut CgSdk) {
     // SAFETY: non-null, and the caller guarantees the pointer is live for this
     // call (same contract as every other `cg_sdk_*` entry point).
     let state = unsafe { &(*sdk).state };
+    // `cg_sdk_new` initialises the runtime idempotently, so a live handle always
+    // has one; the `None` arm is unreachable in practice and only avoids building
+    // a runtime for the sake of shutting it down.
     if let Some(rt) = crate::runtime::global_runtime() {
         state.close_blocking(&rt.handle());
     }

--- a/capi/cognee-capi/src/sdk.rs
+++ b/capi/cognee-capi/src/sdk.rs
@@ -436,11 +436,56 @@ pub unsafe extern "C" fn cg_sdk_clone(sdk: *const CgSdk) -> *mut CgSdk {
     Box::into_raw(Box::new(CgSdk { state }))
 }
 
+/// Close the SDK handle: release the resources it opened (relational connection
+/// pool and, with it, a SQLite database's `-wal`/`-shm` sidecars) and mark the
+/// handle closed.
+///
+/// **Blocking**, and deterministic: when this returns, the pool is closed and the
+/// sidecar files are gone. Dropping the handle is not enough on its own — sqlx's
+/// pool destructor lets its connections tear down concurrently, and SQLite only
+/// unlinks the sidecars when the *last* connection closes, so relying on the drop
+/// is a race that orphans the files (issue #132).
+///
+/// Call this when you are done with **every** clone of the handle and no async op
+/// is in flight. It affects the shared inner state, so it closes the handle for
+/// every `cg_sdk_clone` of it as well, and any op started afterwards fails with
+/// `CG_ERR_SDK_RUNTIME` ("cognee handle is closed"). An op that is already in
+/// flight may fail on its next query.
+///
+/// Idempotent, and a no-op on a handle that was never warmed (nothing is open) or
+/// on a null pointer. You must still call `cg_sdk_destroy` to free the pointer.
+///
+/// # Safety
+/// `sdk` must be a pointer previously returned by `cg_sdk_new` or `cg_sdk_clone`,
+/// or null, and must not be destroyed concurrently on another thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cg_sdk_close(sdk: *mut CgSdk) {
+    if sdk.is_null() {
+        return;
+    }
+    // SAFETY: non-null, and the caller guarantees the pointer is live for this
+    // call (same contract as every other `cg_sdk_*` entry point).
+    let state = unsafe { &(*sdk).state };
+    if let Some(rt) = crate::runtime::global_runtime() {
+        state.close_blocking(&rt.handle());
+    }
+}
+
 /// Destroy a `CgSdk` handle.
 ///
 /// Drops the `Arc<HandleState>`. In-flight async ops keep their own clones of
 /// the state, so callbacks may fire **after** this call — do not access `sdk`
 /// from any callback registered before destruction.
+///
+/// When this drops the **last** reference to the inner state — no surviving
+/// `cg_sdk_clone` handle, no in-flight op — it first releases the resources that
+/// state holds, because a plain drop would leave a SQLite database's
+/// `-wal`/`-shm` sidecars orphaned on disk (issue #132). That case is
+/// unobservable to the caller (nothing else can still use the state), so the
+/// contract above is unchanged: a clone or an in-flight op still keeps the handle
+/// alive and working, and this call still frees only the pointer. It is *not* a
+/// close — for a deterministic teardown that always releases, call `cg_sdk_close`
+/// first, which is also the only way to release while clones are still alive.
 ///
 /// No-op if `sdk` is null.
 ///
@@ -451,7 +496,17 @@ pub unsafe extern "C" fn cg_sdk_clone(sdk: *const CgSdk) -> *mut CgSdk {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cg_sdk_destroy(sdk: *mut CgSdk) {
     if !sdk.is_null() {
-        drop(unsafe { Box::from_raw(sdk) });
+        let sdk = unsafe { Box::from_raw(sdk) };
+        // `strong_count == 1` means this box owns the only reference, so nothing
+        // can observe the release; it cannot race upwards either, since a new
+        // clone could only be made through this very pointer. When the count is
+        // higher, someone else is still using the state and we must not touch it.
+        if Arc::strong_count(&sdk.state) == 1
+            && let Some(rt) = crate::runtime::global_runtime()
+        {
+            sdk.state.release_blocking(&rt.handle());
+        }
+        drop(sdk);
     }
 }
 

--- a/capi/examples/sdk_handle_smoke.c
+++ b/capi/examples/sdk_handle_smoke.c
@@ -9,6 +9,9 @@
  *   4. cg_sdk_warm               — warms the services bundle via waiter.
  *   5. cg_sdk_owner_id           — returns a quoted UUID via waiter.
  *   6. cg_sdk_clone + cg_sdk_destroy — ref-counting sanity.
+ *   7. cg_sdk_close              — releases the SQLite `-wal`/`-shm` sidecars
+ *      synchronously and closes the handle for good (issue #132); and
+ *      cg_sdk_destroy releases them when it drops the last reference.
  *
  * Environment:
  *   MOCK_EMBEDDING=true   — set via the JSON settings overlay in this test.
@@ -23,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h> /* getpid, for the process-unique temp dirs in step 8 */
 
 #include "cognee_sdk.h"
 
@@ -47,6 +51,15 @@ static int g_failures = 0;
             g_failures++;                                           \
         }                                                           \
     } while (0)
+
+/** Whether a path exists and is readable (used for the WAL sidecar checks). */
+static int file_exists(const char* path)
+{
+    FILE* f = fopen(path, "rb");
+    if (!f) return 0;
+    fclose(f);
+    return 1;
+}
 
 /** Run an async op through the waiter.  Returns the op's CgErrorCode.
  *  Sets *out_result (caller must cg_string_destroy) on CG_OK. */
@@ -171,7 +184,74 @@ int main(void)
     }
     cg_sdk_destroy(sdk2);
 
-    /* ── 8. Cleanup ──────────────────────────────────────────────────────── */
+    /* ── 8. cg_sdk_close releases the SQLite sidecars (issue #132) ───────── */
+    /*
+     * A warmed handle runs its relational database in WAL mode, which creates
+     * `<db>-wal` and `<db>-shm` next to the file. Dropping the handle does not
+     * reliably remove them — sqlx's pool destructor lets its connections tear
+     * down concurrently and SQLite only unlinks the sidecars when the *last*
+     * connection closes — so they used to be orphaned until process exit.
+     * `cg_sdk_close` must leave nothing behind, synchronously, and must mark the
+     * handle closed. A second handle repeats the check for the `cg_sdk_destroy`
+     * path, which releases when it drops the last reference.
+     */
+    {
+        int failures_before = g_failures;
+        for (int use_close = 1; use_close >= 0; use_close--) {
+            char sys_dir[256];
+            char db_url[512];
+            char wal[512];
+            char shm[512];
+            snprintf(sys_dir, sizeof(sys_dir), "/tmp/cg_smoke_handle_%d_%d_sys",
+                     (int)getpid(), use_close);
+            snprintf(db_url, sizeof(db_url), "sqlite:%s/cognee.db?mode=rwc", sys_dir);
+            snprintf(wal, sizeof(wal), "%s/cognee.db-wal", sys_dir);
+            snprintf(shm, sizeof(shm), "%s/cognee.db-shm", sys_dir);
+
+            char settings_buf[2048];
+            snprintf(settings_buf, sizeof(settings_buf),
+                     "{"
+                     "  \"embedding_provider\": \"mock\","
+                     "  \"llm_api_key\": \"dummy-key-for-smoke-test\","
+                     "  \"vector_db_provider\": \"mock\","
+                     "  \"system_root_directory\": \"%s\","
+                     "  \"data_root_directory\": \"%s/data\","
+                     "  \"relational_db_url\": \"%s\""
+                     "}",
+                     sys_dir, sys_dir, db_url);
+
+            CgSdk* sdk_wal = cg_sdk_new(settings_buf);
+            ASSERT(sdk_wal != NULL, "cg_sdk_new(temp dirs) must return non-NULL");
+            if (!sdk_wal) continue;
+
+            rc = run_via_waiter(sdk_wal, cg_sdk_warm, NULL);
+            ASSERT_EQ(rc, CG_OK, "warm on the temp-dir handle must succeed");
+            ASSERT(file_exists(wal) && file_exists(shm),
+                   "a warmed handle must have both WAL sidecars on disk");
+
+            if (use_close) {
+                cg_sdk_close(sdk_wal);
+                ASSERT(!file_exists(wal), "cg_sdk_close must remove -wal");
+                ASSERT(!file_exists(shm), "cg_sdk_close must remove -shm");
+                /* Closed for good: an op afterwards must fail, not reopen. */
+                rc = run_via_waiter(sdk_wal, cg_sdk_warm, NULL);
+                ASSERT(rc != CG_OK, "warm after cg_sdk_close must fail");
+                ASSERT(!file_exists(wal), "a failed op must not reopen the database");
+                cg_sdk_close(sdk_wal); /* idempotent */
+                cg_sdk_destroy(sdk_wal);
+            } else {
+                /* No explicit close: destroying the last reference releases. */
+                cg_sdk_destroy(sdk_wal);
+                ASSERT(!file_exists(wal), "cg_sdk_destroy (last ref) must remove -wal");
+                ASSERT(!file_exists(shm), "cg_sdk_destroy (last ref) must remove -shm");
+            }
+        }
+        if (g_failures == failures_before) {
+            printf("sdk sidecar release        OK  (cg_sdk_close + last-ref destroy)\n");
+        }
+    }
+
+    /* ── 9. Cleanup ──────────────────────────────────────────────────────── */
     cg_sdk_destroy(sdk_env);
     cg_shutdown();
 

--- a/capi/include/cognee_sdk.h
+++ b/capi/include/cognee_sdk.h
@@ -301,11 +301,42 @@ void cg_sdk_owner_id(const CgSdk* sdk, CgSdkResultCallback callback, void* user_
 CgSdk* cg_sdk_clone(const CgSdk* sdk);
 
 /**
+ * Close the handle: release the resources it opened and mark it closed.
+ *
+ * Releases the relational connection pool and, with it, a SQLite database's
+ * `-wal`/`-shm` sidecar files.  Dropping the handle is not enough on its own:
+ * sqlx's pool destructor lets its connections tear down concurrently, and
+ * SQLite only unlinks the sidecars when the *last* connection closes, so
+ * relying on the drop is a race that orphans the files (issue #132).
+ *
+ * **Blocking and deterministic**: when this returns the pool is closed and the
+ * sidecars are gone, so the directory holding them can be deleted.
+ *
+ * Call it when you are done with **every** clone of the handle and no async op
+ * is in flight.  It acts on the shared inner state, so it also closes every
+ * `cg_sdk_clone` of this handle, and any op started afterwards fails with
+ * `CG_ERR_SDK_RUNTIME` ("cognee handle is closed").  An op already in flight may
+ * fail on its next query.
+ *
+ * Idempotent; a no-op on a never-warmed handle or a NULL pointer.  You must
+ * still call `cg_sdk_destroy` to free the pointer.
+ */
+void cg_sdk_close(CgSdk* sdk);
+
+/**
  * Destroy a `CgSdk` handle.
  *
  * Drops the Arc reference.  In-flight async ops keep their own Arc clones,
  * so callbacks registered before this call may still fire afterwards.  Do
  * not access `sdk` from any callback after calling this.
+ *
+ * When this drops the **last** reference to the inner state (no surviving
+ * clone, no in-flight op) it first releases that state's resources, since a
+ * plain drop would orphan a SQLite database's `-wal`/`-shm` sidecars (issue
+ * #132).  That case is unobservable — nothing else can still use the state — so
+ * the contract above is unchanged.  It is *not* a close: for a deterministic
+ * teardown, or to release while clones are still alive, call `cg_sdk_close`
+ * first.
  *
  * No-op if `sdk` is NULL.
  */

--- a/crates/bindings-common/Cargo.toml
+++ b/crates/bindings-common/Cargo.toml
@@ -54,3 +54,6 @@ uuid       = { workspace = true }
 tokio      = { workspace = true }
 async-trait = { workspace = true }
 base64      = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/bindings-common/src/handle.rs
+++ b/crates/bindings-common/src/handle.rs
@@ -12,6 +12,7 @@
 //! C-specific wrappers (`CgSdk`) stay in `cognee-capi` (Phase 1 Part B).
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Mutex as TokioMutex;
 use uuid::Uuid;
@@ -63,6 +64,12 @@ pub struct HandleState {
     /// keeps the DB-free in-memory derivation; the closed cloud build attaches
     /// an impl that persists the `users` row.
     bootstrap: Option<Arc<dyn DefaultUserBootstrap>>,
+    /// Set by [`HandleState::close`] (the *explicit* teardown). Once set,
+    /// [`HandleState::services`] fails instead of re-warming, so a use-after-close
+    /// surfaces as a clear error rather than silently reopening the database.
+    /// [`HandleState::release`] deliberately leaves this alone — see the two
+    /// methods' docs.
+    closed: AtomicBool,
 }
 
 impl HandleState {
@@ -97,6 +104,7 @@ impl HandleState {
             owner_id: TokioMutex::new(None),
             tenant_id: None,
             bootstrap: None,
+            closed: AtomicBool::new(false),
         }
     }
 
@@ -125,6 +133,14 @@ impl HandleState {
     /// config version advanced. On the (re)build path the resolved owner id is
     /// written back into `owner_id`.
     pub async fn services(&self) -> Result<Arc<CogneeServices>, SdkError> {
+        // A handle closed through the explicit teardown must not silently reopen
+        // the database on the next op. This is the single choke point every op
+        // goes through, which is why the guard lives here and not in each binding.
+        if self.is_closed() {
+            return Err(SdkError::Runtime(
+                "cognee handle is closed (close() was called); create a new handle".to_string(),
+            ));
+        }
         let current_ver = self.cm.config().version();
 
         // Fast path: cache hit at the current version.
@@ -170,64 +186,129 @@ impl HandleState {
         Ok(svc)
     }
 
-    /// Release the resources this handle opened, now rather than at `Drop`.
+    /// Whether [`close`](Self::close) has been called on this handle.
     ///
-    /// Dropping the handle is **not** a close: the relational pool's destructor
-    /// only flags the pool closed and lets its connections tear down
-    /// concurrently, which for SQLite leaves the `-wal`/`-shm` sidecars orphaned
-    /// on disk (see `cognee::database::close` for the full mechanism and
-    /// topoteretes/cognee-rs#132 for the measurements). A binding with an explicit
-    /// teardown entry point calls this from it — the Java binding does, from
-    /// `Cognee.close()` — so the files are gone by the time that entry point
-    /// returns. Bindings whose only teardown is a GC finalizer (Python, TS) have
-    /// no such entry point yet and are still subject to the drop race.
+    /// Bindings use this for a cheap synchronous guard before dispatching an op,
+    /// so a use-after-close reports itself without building a future first.
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    /// Whether this handle currently holds built services — i.e. whether a
+    /// teardown would have anything to release.
     ///
-    /// Non-poisoning and idempotent: the cached service bundle and the resolved
-    /// owner id are cleared too, so a later op on the same handle re-warms from
-    /// scratch against a fresh connection instead of failing. What it does *not*
-    /// do is wait for concurrent operations — an op that is mid-flight when this
-    /// runs holds its own `Arc<CogneeServices>` and will see a closed pool on its
-    /// next query, so bindings should only close once their own contract says the
-    /// handle is done.
+    /// Cheap and non-blocking, for use from a synchronous finalizer that wants to
+    /// skip the teardown entirely (and, with it, spinning up a runtime to drive
+    /// it) for a handle that never warmed. A contended lock reports `true`: the
+    /// safe direction is to attempt the release rather than skip a real one.
+    pub fn has_open_resources(&self) -> bool {
+        match self.services.try_lock() {
+            Ok(guard) => guard.is_some(),
+            Err(_) => true,
+        }
+    }
+
+    /// Release the resources this handle opened, leaving it usable.
+    ///
+    /// Dropping a handle is **not** a close: the relational pool's destructor only
+    /// flags the pool closed and lets its connections tear down concurrently,
+    /// which for SQLite leaves the `-wal`/`-shm` sidecars orphaned on disk (see
+    /// `cognee::database::close` for the mechanism, topoteretes/cognee-rs#132 for
+    /// the measurements). So every teardown path has to call one of these two
+    /// methods, and which one depends on whether the user asked:
+    ///
+    /// - `release` is for the **implicit** paths — a GC finalizer (`Drop for
+    ///   PyCognee`, neon's `Finalize`) reclaiming a handle the program dropped on
+    ///   the floor. The user never said "close", so this only gives the resources
+    ///   back: the handle stays warm-able, and anything still holding a clone of
+    ///   the state (a sub-handle like `cognee.datasets`, an in-flight op) keeps
+    ///   working — it just re-warms against a fresh connection.
+    /// - [`close`](Self::close) is for the **explicit** paths (`Cognee.close()`,
+    ///   `cg_sdk_close`). It additionally marks the handle closed, so later ops
+    ///   fail with a clear error instead of silently reopening the database.
+    ///
+    /// Both are idempotent. Neither waits for concurrent operations: an op that is
+    /// mid-flight holds its own `Arc<CogneeServices>` and will see a closed pool on
+    /// its next query, so a binding should only tear down when its own contract
+    /// says the handle is done.
+    pub async fn release(&self) {
+        self.teardown(false).await;
+    }
+
+    /// Release the handle's resources **and** mark it closed: every later op fails
+    /// with an explicit "handle is closed" error rather than re-warming.
+    ///
+    /// This is the explicit user-facing teardown — see [`release`](Self::release)
+    /// for how the two differ and why both exist.
     pub async fn close(&self) {
+        self.teardown(true).await;
+    }
+
+    /// Shared body of [`release`](Self::release) / [`close`](Self::close).
+    async fn teardown(&self, mark_closed: bool) {
+        // Mark first: a concurrent op then fails fast in `services()` instead of
+        // racing to warm a pool that is about to be closed underneath it.
+        if mark_closed {
+            self.closed.store(true, Ordering::Release);
+        }
         // Clear the cached bundle: it holds an `Arc` clone of the connection, and
-        // dropping it is what makes the close non-poisoning — the next
-        // `services()` rebuilds instead of handing out the closed pool. The lock
-        // is held across the close so a concurrent `services()` cannot slip a
-        // freshly built pool into the cache in between and have it closed
-        // underneath it. Lock order (services → owner id → the manager's caches)
-        // is the same one `services()` takes, so this cannot deadlock.
+        // dropping it is what lets `release` leave the handle re-warmable rather
+        // than holding a closed pool. The lock is held across the close so a
+        // concurrent `services()` cannot slip a freshly built pool into the cache
+        // in between and have it closed underneath it. Lock order (services →
+        // owner id → the manager's caches) is the same one `services()` takes, so
+        // this cannot deadlock.
         let mut guard = self.services.lock().await;
         drop(guard.take());
         *self.owner_id.lock().await = None;
         self.cm.close().await;
     }
 
-    /// Blocking wrapper around [`close`](Self::close) for a synchronous binding
-    /// teardown hook (the JNI `destroy`), which cannot `.await`.
+    /// Blocking [`close`](Self::close), for a synchronous binding teardown hook
+    /// (the JNI `destroy`, `cg_sdk_close`, Python's `close()`) that cannot
+    /// `.await`.
+    ///
+    /// See [`release_blocking`](Self::release_blocking) for how the thread is
+    /// handled.
+    pub fn close_blocking(self: &Arc<Self>, rt: &tokio::runtime::Handle) {
+        self.teardown_blocking(rt, true);
+    }
+
+    /// Blocking [`release`](Self::release), for a synchronous finalizer
+    /// (`Drop for PyCognee`) that cannot `.await`.
     ///
     /// `rt` is the binding's own runtime handle, used when the calling thread has
     /// no runtime of its own — the normal case, since teardown runs on the
-    /// embedder's thread (a Java `close()` call or the `Cleaner` thread). Teardown
-    /// invoked from *inside* the async runtime is also possible, though — a Java
-    /// `CompletableFuture` continuation runs on a worker thread — and blocking a
-    /// worker outright would stall the runtime, so that case hands the thread over
-    /// to the blocking pool first and still closes before returning.
-    pub fn close_blocking(self: &Arc<Self>, rt: &tokio::runtime::Handle) {
+    /// embedder's thread (a Java `close()` call or the `Cleaner` thread, a Python
+    /// interpreter thread running a `__del__`). Teardown invoked from *inside* the
+    /// async runtime is also possible, though — a Java `CompletableFuture`
+    /// continuation runs on a worker thread — and blocking a worker outright would
+    /// stall the runtime, so that case hands the thread over to the blocking pool
+    /// first and still finishes before returning.
+    pub fn release_blocking(self: &Arc<Self>, rt: &tokio::runtime::Handle) {
+        self.teardown_blocking(rt, false);
+    }
+
+    fn teardown_blocking(self: &Arc<Self>, rt: &tokio::runtime::Handle, mark_closed: bool) {
         use tokio::runtime::{Handle, RuntimeFlavor};
 
         match Handle::try_current() {
-            Err(_) => rt.block_on(self.close()),
+            Err(_) => rt.block_on(self.teardown(mark_closed)),
             Ok(current) if current.runtime_flavor() == RuntimeFlavor::MultiThread => {
-                tokio::task::block_in_place(|| current.block_on(self.close()));
+                tokio::task::block_in_place(|| current.block_on(self.teardown(mark_closed)));
             }
             Ok(current) => {
                 // A current-thread runtime cannot hand the thread off
-                // (`block_in_place` panics there), so the close cannot be awaited
-                // here without deadlocking the very runtime that has to drive it.
-                // Spawn it instead: the pool closes moments later.
+                // (`block_in_place` panics there), so the teardown cannot be
+                // awaited here without deadlocking the very runtime that has to
+                // drive it. Spawn it instead: the pool closes moments later. The
+                // closed flag is still set synchronously, so a use-after-close is
+                // reported even before the spawned teardown lands.
+                if mark_closed {
+                    self.closed.store(true, Ordering::Release);
+                }
                 let this = Arc::clone(self);
-                current.spawn(async move { this.close().await });
+                current.spawn(async move { this.teardown(mark_closed).await });
             }
         }
     }

--- a/crates/bindings-common/src/handle.rs
+++ b/crates/bindings-common/src/handle.rs
@@ -170,6 +170,68 @@ impl HandleState {
         Ok(svc)
     }
 
+    /// Release the resources this handle opened, now rather than at `Drop`.
+    ///
+    /// Dropping the handle is **not** a close: the relational pool's destructor
+    /// only flags the pool closed and lets its connections tear down
+    /// concurrently, which for SQLite leaves the `-wal`/`-shm` sidecars orphaned
+    /// on disk (see `cognee::database::close` for the full mechanism and
+    /// topoteretes/cognee-rs#132 for the measurements). A binding with an explicit
+    /// teardown entry point calls this from it — the Java binding does, from
+    /// `Cognee.close()` — so the files are gone by the time that entry point
+    /// returns. Bindings whose only teardown is a GC finalizer (Python, TS) have
+    /// no such entry point yet and are still subject to the drop race.
+    ///
+    /// Non-poisoning and idempotent: the cached service bundle and the resolved
+    /// owner id are cleared too, so a later op on the same handle re-warms from
+    /// scratch against a fresh connection instead of failing. What it does *not*
+    /// do is wait for concurrent operations — an op that is mid-flight when this
+    /// runs holds its own `Arc<CogneeServices>` and will see a closed pool on its
+    /// next query, so bindings should only close once their own contract says the
+    /// handle is done.
+    pub async fn close(&self) {
+        // Clear the cached bundle: it holds an `Arc` clone of the connection, and
+        // dropping it is what makes the close non-poisoning — the next
+        // `services()` rebuilds instead of handing out the closed pool. The lock
+        // is held across the close so a concurrent `services()` cannot slip a
+        // freshly built pool into the cache in between and have it closed
+        // underneath it. Lock order (services → owner id → the manager's caches)
+        // is the same one `services()` takes, so this cannot deadlock.
+        let mut guard = self.services.lock().await;
+        drop(guard.take());
+        *self.owner_id.lock().await = None;
+        self.cm.close().await;
+    }
+
+    /// Blocking wrapper around [`close`](Self::close) for a synchronous binding
+    /// teardown hook (the JNI `destroy`), which cannot `.await`.
+    ///
+    /// `rt` is the binding's own runtime handle, used when the calling thread has
+    /// no runtime of its own — the normal case, since teardown runs on the
+    /// embedder's thread (a Java `close()` call or the `Cleaner` thread). Teardown
+    /// invoked from *inside* the async runtime is also possible, though — a Java
+    /// `CompletableFuture` continuation runs on a worker thread — and blocking a
+    /// worker outright would stall the runtime, so that case hands the thread over
+    /// to the blocking pool first and still closes before returning.
+    pub fn close_blocking(self: &Arc<Self>, rt: &tokio::runtime::Handle) {
+        use tokio::runtime::{Handle, RuntimeFlavor};
+
+        match Handle::try_current() {
+            Err(_) => rt.block_on(self.close()),
+            Ok(current) if current.runtime_flavor() == RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(|| current.block_on(self.close()));
+            }
+            Ok(current) => {
+                // A current-thread runtime cannot hand the thread off
+                // (`block_in_place` panics there), so the close cannot be awaited
+                // here without deadlocking the very runtime that has to drive it.
+                // Spawn it instead: the pool closes moments later.
+                let this = Arc::clone(self);
+                current.spawn(async move { this.close().await });
+            }
+        }
+    }
+
     /// Resolve the owner id, warming lazily if necessary.
     pub async fn owner_id(&self) -> Result<Uuid, SdkError> {
         // `services()` guarantees `owner_id` is populated on its build path.

--- a/crates/bindings-common/tests/handle_close.rs
+++ b/crates/bindings-common/tests/handle_close.rs
@@ -1,0 +1,138 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression test for issue #132: a warmed handle must release its SQLite
+//! `-wal`/`-shm` sidecars when it is closed, not at process exit.
+//!
+//! Dropping the handle is not enough: sqlx's pool destructor only flags the pool
+//! closed and lets its connections tear down concurrently, so whether SQLite ever
+//! sees a "last connection" close — the precondition for unlinking the sidecars —
+//! is a race. Every binding's teardown therefore goes through
+//! [`HandleState::close`], and a caller that deletes the enclosing directory
+//! right after closing (a JUnit `@TempDir`, a CLI scratch dir) must find nothing
+//! left behind.
+
+use std::path::{Path, PathBuf};
+
+use cognee::config::Settings;
+use cognee_bindings_common::HandleState;
+
+/// A handle with every store rooted under `dir`, exactly as the binding test
+/// suites configure one, plus its database path.
+///
+/// Built from `Settings::default()` rather than the environment so the test is
+/// hermetic in both directions: it neither needs credentials (CI's no-secrets
+/// lane) nor picks up a developer's `.env` provider. Warming still resolves the
+/// LLM strictly, so it needs a non-empty key — a dummy suffices, since
+/// `OpenAIAdapter::new` performs no network I/O — and the mock embedding provider
+/// keeps warm off the network and away from any ONNX download.
+fn handle_under(dir: &Path) -> (std::sync::Arc<HandleState>, PathBuf) {
+    let db_path = dir.join("cognee.db");
+    let settings = Settings {
+        llm_api_key: "sk-test".to_owned(),
+        embedding_provider: "mock".to_owned(),
+        data_root_directory: dir.join("data").to_string_lossy().into_owned(),
+        system_root_directory: dir.join("sys").to_string_lossy().into_owned(),
+        relational_db_url: format!("sqlite://{}?mode=rwc", db_path.display()),
+        ..Settings::default()
+    };
+    (
+        std::sync::Arc::new(HandleState::from_settings(settings)),
+        db_path,
+    )
+}
+
+/// The `-wal` / `-shm` sidecar paths for a SQLite database file.
+fn sidecars(db: &Path) -> (PathBuf, PathBuf) {
+    let name = db
+        .file_name()
+        .expect("the database path has a file name")
+        .to_string_lossy()
+        .to_string();
+    (
+        db.with_file_name(format!("{name}-wal")),
+        db.with_file_name(format!("{name}-shm")),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn close_releases_sqlite_sidecars_and_leaves_the_handle_reusable() {
+    let dir = tempfile::tempdir().unwrap();
+    let (state, db_path) = handle_under(dir.path());
+    let (wal, shm) = sidecars(&db_path);
+
+    // Constructing a handle opens nothing, so there is nothing to release yet.
+    assert!(
+        !wal.exists() && !shm.exists(),
+        "constructing a handle must not open the database",
+    );
+
+    state.services().await.expect("warm");
+    assert!(
+        wal.exists() && shm.exists(),
+        "a warmed handle runs the relational database in WAL mode",
+    );
+
+    state.close().await;
+
+    // No polling: the sidecars are gone before `close` resolves.
+    assert!(
+        !wal.exists(),
+        "-wal must be released by close(), got a leak"
+    );
+    assert!(
+        !shm.exists(),
+        "-shm must be released by close(), got a leak"
+    );
+
+    // Closing clears the caches rather than poisoning them, so the same handle
+    // can still be used — it just warms cold again.
+    state.services().await.expect("re-warm after close");
+    assert!(wal.exists(), "re-warming reopens the database");
+
+    // Idempotent.
+    state.close().await;
+    state.close().await;
+    assert!(!wal.exists() && !shm.exists(), "close must be idempotent");
+}
+
+/// `close_blocking` is what the synchronous binding teardown hooks call, and both
+/// of its deterministic branches must leave nothing behind by the time they
+/// return: from a thread with no runtime of its own (a Java `close()` call, the
+/// common case) and from inside the runtime itself (a `CompletableFuture`
+/// continuation, which must not simply block a worker).
+#[tokio::test(flavor = "multi_thread")]
+async fn close_blocking_releases_the_sidecars_on_either_thread() {
+    let handle = tokio::runtime::Handle::current();
+
+    // (a) Off-runtime caller.
+    let dir = tempfile::tempdir().unwrap();
+    let (state, db_path) = handle_under(dir.path());
+    let (wal, shm) = sidecars(&db_path);
+    state.services().await.expect("warm");
+    assert!(wal.exists() && shm.exists());
+    let off_thread = {
+        let state = std::sync::Arc::clone(&state);
+        let handle = handle.clone();
+        std::thread::spawn(move || state.close_blocking(&handle))
+    };
+    off_thread.join().expect("closing thread");
+    assert!(
+        !wal.exists() && !shm.exists(),
+        "close_blocking from an off-runtime thread must release the sidecars",
+    );
+
+    // (b) Caller already inside the runtime.
+    let dir = tempfile::tempdir().unwrap();
+    let (state, db_path) = handle_under(dir.path());
+    let (wal, shm) = sidecars(&db_path);
+    state.services().await.expect("warm");
+    assert!(wal.exists() && shm.exists());
+    state.close_blocking(&handle);
+    assert!(
+        !wal.exists() && !shm.exists(),
+        "close_blocking from a runtime worker must release the sidecars",
+    );
+}

--- a/crates/bindings-common/tests/handle_close.rs
+++ b/crates/bindings-common/tests/handle_close.rs
@@ -57,8 +57,9 @@ fn sidecars(db: &Path) -> (PathBuf, PathBuf) {
     )
 }
 
+/// The explicit teardown: releases the sidecars *and* closes the handle for good.
 #[tokio::test(flavor = "multi_thread")]
-async fn close_releases_sqlite_sidecars_and_leaves_the_handle_reusable() {
+async fn close_releases_sqlite_sidecars_and_marks_the_handle_closed() {
     let dir = tempfile::tempdir().unwrap();
     let (state, db_path) = handle_under(dir.path());
     let (wal, shm) = sidecars(&db_path);
@@ -68,6 +69,7 @@ async fn close_releases_sqlite_sidecars_and_leaves_the_handle_reusable() {
         !wal.exists() && !shm.exists(),
         "constructing a handle must not open the database",
     );
+    assert!(!state.is_closed());
 
     state.services().await.expect("warm");
     assert!(
@@ -87,15 +89,52 @@ async fn close_releases_sqlite_sidecars_and_leaves_the_handle_reusable() {
         "-shm must be released by close(), got a leak"
     );
 
-    // Closing clears the caches rather than poisoning them, so the same handle
-    // can still be used — it just warms cold again.
-    state.services().await.expect("re-warm after close");
-    assert!(wal.exists(), "re-warming reopens the database");
+    // A closed handle stays closed: ops report it instead of reopening the DB.
+    assert!(state.is_closed());
+    // `CogneeServices` is not `Debug`, so match rather than `expect_err`.
+    let err = match state.services().await {
+        Ok(_) => panic!("an op after close() must fail"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("closed"),
+        "the error should name the cause, got: {err}"
+    );
+    assert!(
+        !wal.exists(),
+        "a failed op after close() must not reopen the database"
+    );
 
     // Idempotent.
     state.close().await;
     state.close().await;
     assert!(!wal.exists() && !shm.exists(), "close must be idempotent");
+}
+
+/// The implicit teardown (what a GC finalizer calls): releases the sidecars but
+/// leaves the handle usable, because the user never asked for a close — anything
+/// still holding a clone of the state, like a Python `cognee.datasets` sub-handle
+/// that outlived its parent, has to keep working.
+#[tokio::test(flavor = "multi_thread")]
+async fn release_frees_the_sidecars_without_closing_the_handle() {
+    let dir = tempfile::tempdir().unwrap();
+    let (state, db_path) = handle_under(dir.path());
+    let (wal, shm) = sidecars(&db_path);
+
+    state.services().await.expect("warm");
+    assert!(wal.exists() && shm.exists());
+
+    state.release().await;
+    assert!(!wal.exists() && !shm.exists(), "release must free both");
+    assert!(!state.is_closed(), "release must not close the handle");
+
+    // Still usable: it just warms cold again against a fresh connection.
+    state.services().await.expect("re-warm after release");
+    assert!(wal.exists(), "re-warming reopens the database");
+
+    state.release().await;
+    state.release().await;
+    assert!(!wal.exists() && !shm.exists(), "release must be idempotent");
 }
 
 /// `close_blocking` is what the synchronous binding teardown hooks call, and both
@@ -135,4 +174,23 @@ async fn close_blocking_releases_the_sidecars_on_either_thread() {
         !wal.exists() && !shm.exists(),
         "close_blocking from a runtime worker must release the sidecars",
     );
+
+    // (c) `release_blocking` — the finalizer path — is blocking too, and leaves
+    // the handle open.
+    let dir = tempfile::tempdir().unwrap();
+    let (state, db_path) = handle_under(dir.path());
+    let (wal, shm) = sidecars(&db_path);
+    state.services().await.expect("warm");
+    assert!(wal.exists() && shm.exists());
+    let off_thread = {
+        let state = std::sync::Arc::clone(&state);
+        let handle = handle.clone();
+        std::thread::spawn(move || state.release_blocking(&handle))
+    };
+    off_thread.join().expect("releasing thread");
+    assert!(
+        !wal.exists() && !shm.exists(),
+        "release_blocking must release the sidecars",
+    );
+    assert!(!state.is_closed());
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -17,6 +17,51 @@ use commands::{
 };
 use tracing::error;
 
+/// How long to wait for the relational pool to close on exit. See
+/// [`close_components`].
+const CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Close the relational connection pool before the process exits.
+///
+/// Exiting without closing leaves a SQLite database's `-wal`/`-shm` sidecars
+/// behind: dropping the pool only flags it closed and lets its connections tear
+/// down concurrently, and SQLite unlinks the sidecars only when the *last*
+/// connection closes (issue #132). The next `cognee` invocation recovers them, so
+/// nothing is corrupt, but the files linger next to the database and a caller
+/// that wraps the CLI in a temporary directory cannot clean up after it.
+///
+/// Each command owns (and drops) its own runtime, so this builds a small
+/// current-thread one purely to drive the close — a pool drain, not I/O.
+///
+/// Bounded by [`CLOSE_TIMEOUT`] because the close waits for connections to come
+/// back: if a command's runtime was dropped while one was still checked out, its
+/// pool permit is never released and the wait would never finish. Timing out
+/// costs only the sidecars we were trying to remove, whereas hanging would cost
+/// the caller their exit code, so this is deliberately best-effort.
+fn close_components(cm: &ComponentManager) {
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(error) => {
+            tracing::debug!(%error, "could not build a runtime to close the database");
+            return;
+        }
+    };
+    rt.block_on(async {
+        if tokio::time::timeout(CLOSE_TIMEOUT, cm.close())
+            .await
+            .is_err()
+        {
+            tracing::debug!(
+                "closing the relational database timed out after {CLOSE_TIMEOUT:?}; \
+                 its WAL sidecars may be left for the next run to recover"
+            );
+        }
+    });
+}
+
 fn run(settings: Settings) -> Result<(), CliError> {
     let cli = Cli::parse();
 
@@ -24,23 +69,33 @@ fn run(settings: Settings) -> Result<(), CliError> {
     let config = ConfigManager::new(settings);
     let cm = Arc::new(ComponentManager::new(config));
 
-    match cli.command {
-        Commands::Add(args) => add::run(args, Arc::clone(&cm)),
-        Commands::Cognify(args) => cognify::run(args, Arc::clone(&cm)),
-        Commands::AddAndCognify(args) => add_and_cognify::run(args, Arc::clone(&cm)),
-        Commands::Memify(args) => memify::run(args, Arc::clone(&cm)),
-        Commands::Search(args) => search::run(args, Arc::clone(&cm)),
-        Commands::Remember(args) => remember::run(args, Arc::clone(&cm)),
-        Commands::Recall(args) => recall::run(args, Arc::clone(&cm)),
-        Commands::Forget(args) => forget::run(args, Arc::clone(&cm)),
-        Commands::Improve(args) => improve::run(args, Arc::clone(&cm)),
-        Commands::Delete(args) => delete::run(args, Arc::clone(&cm)),
+    let result = dispatch(cli.command, &cm);
+
+    // Release the database before returning, whether the command succeeded or
+    // not — a failed run has usually opened it too.
+    close_components(&cm);
+
+    result
+}
+
+fn dispatch(command: Commands, cm: &Arc<ComponentManager>) -> Result<(), CliError> {
+    match command {
+        Commands::Add(args) => add::run(args, Arc::clone(cm)),
+        Commands::Cognify(args) => cognify::run(args, Arc::clone(cm)),
+        Commands::AddAndCognify(args) => add_and_cognify::run(args, Arc::clone(cm)),
+        Commands::Memify(args) => memify::run(args, Arc::clone(cm)),
+        Commands::Search(args) => search::run(args, Arc::clone(cm)),
+        Commands::Remember(args) => remember::run(args, Arc::clone(cm)),
+        Commands::Recall(args) => recall::run(args, Arc::clone(cm)),
+        Commands::Forget(args) => forget::run(args, Arc::clone(cm)),
+        Commands::Improve(args) => improve::run(args, Arc::clone(cm)),
+        Commands::Delete(args) => delete::run(args, Arc::clone(cm)),
         Commands::Config(args) => config::run(args),
-        Commands::RunSequence(args) => run_sequence::run(args, Arc::clone(&cm)),
+        Commands::RunSequence(args) => run_sequence::run(args, Arc::clone(cm)),
         #[cfg(feature = "visualization")]
-        Commands::Visualize(args) => visualize::run(args, Arc::clone(&cm)),
+        Commands::Visualize(args) => visualize::run(args, Arc::clone(cm)),
         #[cfg(feature = "bench")]
-        Commands::Bench(args) => bench::run(args, Arc::clone(&cm)),
+        Commands::Bench(args) => bench::run(args, Arc::clone(cm)),
     }
 }
 

--- a/crates/database/src/connection.rs
+++ b/crates/database/src/connection.rs
@@ -314,6 +314,38 @@ fn sqlite_parent_dir_is_writable(path: &std::path::Path) -> bool {
     }
 }
 
+/// Close the relational connection pool, releasing SQLite's `-wal`/`-shm`
+/// sidecars deterministically.
+///
+/// **Dropping a [`DatabaseConnection`] is not a close.** sqlx's pool destructor
+/// only flags the pool closed and then lets every pooled connection tear itself
+/// down independently, each on its own sqlite worker thread, concurrently and in
+/// no defined order. SQLite removes the `-wal`/`-shm` sidecars only when the
+/// *last* connection to the file closes, and only if that close can take an
+/// exclusive lock on the shared-memory index: when two connections close at the
+/// same instant neither can take it, so neither runs the final
+/// checkpoint-and-unlink and the sidecars are orphaned on disk — observable as
+/// `<db>-wal`/`<db>-shm` files that outlive the last handle by minutes
+/// (topoteretes/cognee-rs#132). With a single pooled connection the drop path
+/// happens to clean up; with more than one it is a race, which is why relying on
+/// `Drop` is not enough.
+///
+/// [`sea_orm::DatabaseConnection::close_by_ref`] runs sqlx's real close: pooled
+/// connections are closed one at a time and checked-out ones are awaited, so
+/// exactly one connection observes itself as the last and the sidecars are gone
+/// before this future resolves.
+///
+/// Idempotent, and safe to call while other `Arc` clones of the connection are
+/// still alive: they observe a closed pool and fail their next query rather than
+/// silently reconnecting. Callers that may be reused (e.g.
+/// `ComponentManager::close`) drop their cached connection so the next access
+/// builds a fresh one.
+pub async fn close(db: &DatabaseConnection) -> Result<(), DatabaseError> {
+    db.close_by_ref()
+        .await
+        .map_err(|e| DatabaseError::ConnectionError(e.to_string()))
+}
+
 /// Run all pending migrations on an existing connection.
 pub async fn initialize(db: &DatabaseConnection) -> Result<(), DatabaseError> {
     Migrator::up(db, None)

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -16,7 +16,7 @@ pub use ops::tutorial_seeder::{
     TUTORIAL_BASICS_ID, TUTORIAL_PYTHON_DEV_ID, seed_tutorials_if_first_call,
 };
 
-pub use connection::{connect, initialize, sqlite_url_is_in_memory};
+pub use connection::{close, connect, initialize, sqlite_url_is_in_memory};
 
 /// Generic backend-label helper shared by the concrete public fn below and the
 /// transaction-scoped internals in `ops::graph_storage` (a `DatabaseTransaction`

--- a/crates/database/tests/connection_pool.rs
+++ b/crates/database/tests/connection_pool.rs
@@ -357,3 +357,57 @@ async fn writable_file_in_read_only_dir_connects_without_wal() {
     // Restore so tempdir cleanup can remove the directory.
     std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
 }
+
+/// Closing the pool must remove the WAL sidecars, deterministically, and for a
+/// pool that actually has several connections open.
+///
+/// Dropping the connection cannot be asserted instead: sqlx's pool destructor
+/// only flags the pool closed and lets each connection tear down concurrently on
+/// its own worker thread, so whether any of them observes itself as the last
+/// connection — the precondition for SQLite unlinking `-wal`/`-shm` — is a race
+/// (issue #132). `close` closes them one at a time, so it is not.
+#[tokio::test(flavor = "multi_thread")]
+async fn close_releases_wal_sidecars() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("closing.db");
+    let wal = path.with_file_name("closing.db-wal");
+    let shm = path.with_file_name("closing.db-shm");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+
+    let db = std::sync::Arc::new(connect(&url).await.expect("connect"));
+    db.execute(Statement::from_string(
+        DatabaseBackend::Sqlite,
+        "CREATE TABLE t (x INTEGER)",
+    ))
+    .await
+    .unwrap();
+
+    // Force the pool past one connection: the single-connection drop path
+    // happens to clean up, so a one-connection pool would not exercise the bug.
+    let mut queries = Vec::new();
+    for _ in 0..8 {
+        let db = std::sync::Arc::clone(&db);
+        queries.push(tokio::spawn(async move {
+            db.query_one(Statement::from_string(DatabaseBackend::Sqlite, "SELECT 1"))
+                .await
+                .unwrap();
+        }));
+    }
+    for q in queries {
+        q.await.unwrap();
+    }
+    assert!(
+        db.get_sqlite_connection_pool().size() > 1,
+        "the concurrent queries should have opened more than one connection",
+    );
+    assert!(
+        wal.exists() && shm.exists(),
+        "WAL mode creates both sidecars"
+    );
+
+    cognee_database::close(&db).await.expect("close");
+
+    // No polling: the files are gone before `close` resolves.
+    assert!(!wal.exists(), "-wal must be removed by close");
+    assert!(!shm.exists(), "-shm must be removed by close");
+}

--- a/crates/http-server/src/lifecycle.rs
+++ b/crates/http-server/src/lifecycle.rs
@@ -57,4 +57,19 @@ pub async fn on_shutdown(state: &crate::state::AppState) {
             aborted.len()
         );
     }
+
+    // Close the relational pool last, once the work that uses it has stopped.
+    //
+    // Exiting without closing leaves a SQLite database's `-wal`/`-shm` sidecars
+    // on disk: dropping the pool only flags it closed and lets its connections
+    // tear down concurrently, and SQLite unlinks the sidecars only when the
+    // *last* connection closes (issue #132). The next start recovers them, so
+    // nothing is corrupt, but a server whose data directory is ephemeral (a
+    // container, a test harness) leaves litter behind and looks like it crashed.
+    if let Some(lib) = state.lib.as_ref() {
+        match cognee_database::close(&lib.database).await {
+            Ok(()) => tracing::info!("relational database closed"),
+            Err(e) => tracing::warn!("closing the relational database failed (non-fatal): {e}"),
+        }
+    }
 }

--- a/crates/lib/src/component_manager.rs
+++ b/crates/lib/src/component_manager.rs
@@ -206,6 +206,33 @@ impl ComponentManager {
         *guard = Some((current_ver, new.clone()));
         Ok(new)
     }
+
+    /// Release the cached components that hold OS resources beyond their own
+    /// memory, instead of waiting for `Drop`.
+    ///
+    /// Today that means the relational connection pool: dropping it does not
+    /// close it, so a SQLite database can leave its `-wal`/`-shm` sidecars
+    /// orphaned on disk long after the manager is gone (see
+    /// [`cognee_database::close`] for the mechanism). The other components
+    /// (storage, graph, vector, embedding, LLM, transcriber) expose no explicit
+    /// shutdown and release everything on drop, so they are left untouched.
+    ///
+    /// The connection is **taken out of the cache** before it is closed, so this
+    /// leaves the manager reusable — just cold: the next `database()` builds a
+    /// fresh pool rather than handing out the closed one. Calling this twice is a
+    /// no-op the second time, and calling it on a manager that never opened the
+    /// database does nothing at all.
+    ///
+    /// A close failure is logged rather than returned: the caller is tearing the
+    /// manager down and has no remedy, and the pool is unusable either way.
+    pub async fn close(&self) {
+        let cached = self.database.write().await.take();
+        if let Some((_, db)) = cached
+            && let Err(e) = cognee_database::close(&db).await
+        {
+            tracing::warn!(error = %e, "failed to close the relational connection pool");
+        }
+    }
 }
 
 // Versioned accessor helper macro — avoids repeating the double-checked

--- a/java/README.md
+++ b/java/README.md
@@ -83,8 +83,12 @@ try (Cognee cognee = new Cognee(Map.of("data_root_directory", "./data"))) {
 
 `Cognee` is `AutoCloseable` — use try-with-resources so the native handle is
 released promptly (a `Cleaner` is a leak backstop, but `close()` is the primary
-path). Settings keys are the canonical snake_case `Settings` field names; absent
-keys fall back to environment variables and then compiled-in defaults.
+path). `close()` blocks until the relational connection pool is closed, so a
+SQLite database's `-wal`/`-shm` sidecars are already gone when it returns and the
+directory holding them can be deleted; the flip side is that an operation still
+in flight may fail on its next query, so join your futures before closing.
+Settings keys are the canonical snake_case `Settings` field names; absent keys
+fall back to environment variables and then compiled-in defaults.
 
 ## Operation surface
 

--- a/java/cognee-java-jni/src/handle.rs
+++ b/java/cognee-java-jni/src/handle.rs
@@ -118,6 +118,17 @@ pub extern "system" fn Java_ai_cognee_internal_Native_newHandle<'l>(
 }
 
 /// `ai.cognee.internal.Native.destroy(long handle)`
+///
+/// Closes the handle's relational connection pool **before** dropping the state,
+/// blocking until it is closed. Dropping alone is not a close: SQLite would keep
+/// its `-wal`/`-shm` sidecars on disk until process exit (issue #132), so
+/// `Cognee.close()` has to return with the files already gone — a Java caller's
+/// next act is often to delete the directory they live in.
+///
+/// Each `Cognee` owns its own handle (there is no Java-level handle clone), so
+/// the only other references that can exist here are the `Arc` clones held by
+/// in-flight async ops. Those are ops started before `close()` and not yet
+/// awaited, which the Java contract already treats as a use-after-close.
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_ai_cognee_internal_Native_destroy<'l>(
     mut env: JNIEnv<'l>,
@@ -129,9 +140,13 @@ pub extern "system" fn Java_ai_cognee_internal_Native_destroy<'l>(
             // SAFETY: `handle` came from `newHandle`; the Java op/close RW-lock
             // ensures no op is in flight here and `Cleanable.clean()` runs this
             // at most once, so `destroy` runs exactly once with no live borrow.
-            unsafe {
-                drop(Box::from_raw(handle as *mut Arc<HandleState>));
+            let state = unsafe { Box::from_raw(handle as *mut Arc<HandleState>) };
+            // A runtime that failed to build means no op ever ran, so there is
+            // nothing open to close.
+            if let Ok(rt) = crate::runtime::runtime() {
+                state.close_blocking(rt.handle());
             }
+            drop(state);
         }
     })
 }

--- a/java/src/main/java/ai/cognee/Cognee.java
+++ b/java/src/main/java/ai/cognee/Cognee.java
@@ -357,6 +357,17 @@ public final class Cognee implements AutoCloseable {
         return Native.version();
     }
 
+    /**
+     * Release the native handle and the resources it opened.
+     *
+     * <p>Blocks until the relational connection pool is closed, so once this
+     * returns the database's SQLite {@code -wal}/{@code -shm} sidecars are gone
+     * and the directory holding them can be deleted. Idempotent.
+     *
+     * <p>Any operation still in flight (started before {@code close()} and not
+     * yet joined) may therefore fail on its next query: closing releases the
+     * connections those operations are using. Join your futures first.
+     */
     @Override
     public void close() {
         lifecycleLock.writeLock().lock();

--- a/java/src/test/java/ai/cognee/CogneeLifecycleTest.java
+++ b/java/src/test/java/ai/cognee/CogneeLifecycleTest.java
@@ -1,8 +1,11 @@
 package ai.cognee;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -17,6 +20,31 @@ class CogneeLifecycleTest {
         cognee.close();
         cognee.close(); // idempotent
         assertThrows(IllegalStateException.class, () -> cognee.dispatch(h -> h));
+    }
+
+    /**
+     * Regression test for issue #132: {@code close()} must return with the SQLite
+     * {@code -wal}/{@code -shm} sidecars already gone. They used to survive until
+     * the JVM exited — a connection leak, and a race against {@code @TempDir}
+     * cleanup, which walks this very directory as soon as the test returns.
+     */
+    @Test
+    void closeReleasesSqliteSidecars(@TempDir Path dir) {
+        Path db = dir.resolve("cognee.db");
+        Path wal = dir.resolve("cognee.db-wal");
+        Path shm = dir.resolve("cognee.db-shm");
+
+        try (Cognee cognee = new Cognee(TestConfig.underTempDir(dir))) {
+            // Constructing a handle opens nothing; an op is what opens the DB.
+            assertFalse(Files.exists(db), "construction must not open the database");
+            cognee.warm().join();
+            assertTrue(Files.exists(wal) && Files.exists(shm),
+                    "a warmed handle runs the relational database in WAL mode");
+        }
+
+        // No waiting, no polling: close() is synchronous about this.
+        assertFalse(Files.exists(wal), "close() must release cognee.db-wal");
+        assertFalse(Files.exists(shm), "close() must release cognee.db-shm");
     }
 
     @Test

--- a/python/README.md
+++ b/python/README.md
@@ -43,6 +43,28 @@ async def main():
 asyncio.run(main())
 ```
 
+### Closing the handle
+
+`close()` releases what the handle opened — most visibly the relational
+connection pool, which for SQLite means the `-wal`/`-shm` sidecar files next to
+the database. It blocks until that is done, so the directory holding them can be
+deleted as soon as it returns, and it is idempotent. Operations attempted after
+it raise `CogneeRuntimeError` rather than silently reopening the database.
+
+Both context-manager forms close on exit:
+
+```python
+with Cognee(settings) as cognee:
+    ...
+
+async with Cognee(settings) as cognee:
+    await cognee.warm()
+```
+
+A handle that is garbage-collected without an explicit `close()` still gives its
+resources back, so a forgotten handle does not leak for the life of the process —
+but only `close()` is deterministic about *when*.
+
 Set environment variables before running:
 
 ```bash

--- a/python/cognee_py/_native.pyi
+++ b/python/cognee_py/_native.pyi
@@ -612,6 +612,43 @@ class Cognee:
         """Return the owner UUID string (warms the handle lazily)."""
         ...
 
+    # -- Lifecycle ------------------------------------------------------------
+
+    def close(self) -> None:
+        """Close the handle, releasing the resources it opened.
+
+        Blocking: when it returns, the relational connection pool is closed and
+        a SQLite database's ``-wal``/``-shm`` sidecars are gone, so the
+        directory holding them can be deleted. Idempotent. Any operation started
+        afterwards raises ``CogneeRuntimeError``.
+
+        Also available as a context manager (``with`` / ``async with``).
+        """
+        ...
+
+    @property
+    def closed(self) -> bool:
+        """Whether :meth:`close` has been called on this handle."""
+        ...
+
+    def __enter__(self) -> "Cognee": ...
+
+    def __exit__(
+        self,
+        exc_type: Optional[type] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[Any] = None,
+    ) -> bool: ...
+
+    async def __aenter__(self) -> "Cognee": ...
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[Any] = None,
+    ) -> bool: ...
+
     # -- Core pipeline --------------------------------------------------------
 
     async def add(

--- a/python/src/sdk.rs
+++ b/python/src/sdk.rs
@@ -216,4 +216,109 @@ impl PyCognee {
             Ok(id.to_string())
         })
     }
+
+    /// Close the handle, releasing the resources it opened.
+    ///
+    /// Blocking and deterministic: when this returns, the relational connection
+    /// pool is closed and a SQLite database's ``-wal``/``-shm`` sidecar files are
+    /// gone, so the directory holding them can be deleted. Dropping the handle is
+    /// not enough on its own — the pool's destructor lets its connections tear
+    /// down concurrently, and SQLite only unlinks the sidecars when the *last*
+    /// connection closes, so relying on the drop orphans the files.
+    ///
+    /// Idempotent, and a no-op on a handle that was never warmed. Any operation
+    /// started afterwards raises ``CogneeRuntimeError`` instead of silently
+    /// reopening the database — including operations on a surface obtained
+    /// earlier, such as ``cognee.datasets``.
+    ///
+    /// Usable as a context manager, which closes on exit:
+    ///
+    /// .. code-block:: python
+    ///
+    ///     with Cognee(settings) as cognee:
+    ///         ...
+    ///
+    ///     async with Cognee(settings) as cognee:
+    ///         await cognee.warm()
+    fn close(&self, py: Python<'_>) {
+        let rt = pyo3_async_runtimes::tokio::get_runtime();
+        // Release the GIL while blocking: the teardown is pure Rust and needs no
+        // interpreter, and holding the GIL would stall every other Python thread
+        // for the duration of the close.
+        py.allow_threads(|| self.inner.close_blocking(rt.handle()));
+    }
+
+    /// Enter the synchronous context manager (returns ``self``).
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    /// Exit the synchronous context manager: closes the handle.
+    ///
+    /// Returns ``False`` so an exception raised inside the ``with`` body
+    /// propagates.
+    #[pyo3(signature = (_exc_type=None, _exc_value=None, _traceback=None))]
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        _exc_type: Option<&Bound<'_, PyAny>>,
+        _exc_value: Option<&Bound<'_, PyAny>>,
+        _traceback: Option<&Bound<'_, PyAny>>,
+    ) -> bool {
+        self.close(py);
+        false
+    }
+
+    /// Enter the async context manager (awaitable, returns ``self``).
+    fn __aenter__<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let this = slf.into_pyobject(py)?.unbind();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(this) })
+    }
+
+    /// Exit the async context manager: closes the handle without blocking the
+    /// event loop (the teardown is awaited on the tokio runtime).
+    ///
+    /// Resolves to ``False`` so an exception raised inside the ``async with``
+    /// body propagates.
+    #[pyo3(signature = (_exc_type=None, _exc_value=None, _traceback=None))]
+    fn __aexit__<'py>(
+        &self,
+        py: Python<'py>,
+        _exc_type: Option<&Bound<'_, PyAny>>,
+        _exc_value: Option<&Bound<'_, PyAny>>,
+        _traceback: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let handle = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            handle.close().await;
+            Ok(false)
+        })
+    }
+
+    /// Whether :meth:`close` has been called on this handle.
+    #[getter]
+    fn closed(&self) -> bool {
+        self.inner.is_closed()
+    }
+}
+
+impl Drop for PyCognee {
+    /// Give the resources back when the handle is garbage-collected without an
+    /// explicit :meth:`close`.
+    ///
+    /// This is the *implicit* teardown, so it releases without closing: a surface
+    /// the caller kept a reference to (``d = cognee.datasets; del cognee``) shares
+    /// this handle's state and has to keep working — it simply re-warms against a
+    /// fresh connection. Blocking here is what makes the release deterministic:
+    /// spawning it would race with interpreter shutdown, which is exactly when a
+    /// handle nobody closed tends to be collected, and the sidecars would survive.
+    fn drop(&mut self) {
+        // Nothing was ever opened (a handle that never warmed) → nothing to give
+        // back, and in particular no reason to build a tokio runtime here.
+        if !self.inner.has_open_resources() {
+            return;
+        }
+        let rt = pyo3_async_runtimes::tokio::get_runtime();
+        self.inner.release_blocking(rt.handle());
+    }
 }

--- a/python/tests/test_sdk_handle.py
+++ b/python/tests/test_sdk_handle.py
@@ -177,3 +177,103 @@ async def test_warm_with_settings_override(tmp_path):
     cognee = _isolated_cognee(tmp_path, ', "llm_model": "gpt-4o-mini"')
     result = await cognee.warm()
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: close() / context managers / GC release (issue #132)
+# ---------------------------------------------------------------------------
+
+def _sidecars(tmp_path):
+    """The WAL sidecar paths for the handle built by ``_isolated_cognee``."""
+    return tmp_path / "cognee.db-wal", tmp_path / "cognee.db-shm"
+
+
+def test_close_is_a_noop_on_a_never_warmed_handle(tmp_path):
+    """Constructing opens nothing, so close() has nothing to release."""
+    cognee = _isolated_cognee(tmp_path)
+    assert cognee.closed is False
+    cognee.close()
+    cognee.close()  # idempotent
+    assert cognee.closed is True
+    wal, shm = _sidecars(tmp_path)
+    assert not wal.exists() and not shm.exists()
+
+
+@SKIP_IF_NO_WARM
+@pytest.mark.asyncio
+async def test_close_releases_sqlite_sidecars(tmp_path):
+    """close() must return with the -wal/-shm files already gone.
+
+    Dropping the handle is not enough: the pool's destructor lets its
+    connections tear down concurrently, and SQLite only unlinks the sidecars
+    when the last connection closes (issue #132).
+    """
+    wal, shm = _sidecars(tmp_path)
+    cognee = _isolated_cognee(tmp_path)
+    await cognee.warm()
+    assert wal.exists() and shm.exists(), "a warmed handle runs the DB in WAL mode"
+
+    cognee.close()
+
+    # No waiting, no polling.
+    assert not wal.exists(), "close() must release cognee.db-wal"
+    assert not shm.exists(), "close() must release cognee.db-shm"
+
+
+@SKIP_IF_NO_WARM
+@pytest.mark.asyncio
+async def test_operations_after_close_raise(tmp_path):
+    """A closed handle reports itself instead of silently reopening the DB."""
+    wal, _ = _sidecars(tmp_path)
+    cognee = _isolated_cognee(tmp_path)
+    await cognee.warm()
+    cognee.close()
+
+    with pytest.raises(cp.CogneeRuntimeError, match="closed"):
+        await cognee.warm()
+    assert not wal.exists(), "a failed op must not reopen the database"
+
+
+@SKIP_IF_NO_WARM
+def test_sync_context_manager_closes(tmp_path):
+    """`with Cognee(...)` closes the handle on exit."""
+    wal, shm = _sidecars(tmp_path)
+    with _isolated_cognee(tmp_path) as cognee:
+        assert cognee.closed is False
+    assert cognee.closed is True
+    assert not wal.exists() and not shm.exists()
+
+
+@SKIP_IF_NO_WARM
+@pytest.mark.asyncio
+async def test_async_context_manager_closes(tmp_path):
+    """`async with Cognee(...)` warms inside the block and closes on exit."""
+    wal, shm = _sidecars(tmp_path)
+    async with _isolated_cognee(tmp_path) as cognee:
+        await cognee.warm()
+        assert wal.exists() and shm.exists()
+    assert cognee.closed is True
+    assert not wal.exists() and not shm.exists()
+
+
+@SKIP_IF_NO_WARM
+@pytest.mark.asyncio
+async def test_garbage_collection_releases_sidecars(tmp_path):
+    """A handle nobody closed must still release its sidecars when collected.
+
+    This is the implicit teardown (``Drop``), which releases without closing —
+    it is not a substitute for close(), but it keeps a forgotten handle from
+    leaking the files for the life of the process.
+    """
+    import gc
+
+    wal, shm = _sidecars(tmp_path)
+    cognee = _isolated_cognee(tmp_path)
+    await cognee.warm()
+    assert wal.exists() and shm.exists()
+
+    del cognee
+    gc.collect()
+
+    assert not wal.exists(), "GC must release cognee.db-wal"
+    assert not shm.exists(), "GC must release cognee.db-shm"

--- a/ts/README.md
+++ b/ts/README.md
@@ -38,6 +38,37 @@ const recall = await c.recall("What does the fox do?");
 console.log(recall.searchResponse?.result?.data);
 ```
 
+### Closing the handle
+
+`close()` releases what the handle opened — most visibly the relational
+connection pool, which for SQLite means the `-wal`/`-shm` sidecar files next to
+the database. It is synchronous, so the directory holding them can be deleted as
+soon as it returns, and it is idempotent. Operations attempted afterwards reject
+with a "handle is closed" error rather than silently reopening the database.
+
+The handle is a disposable, so `using` closes it at the end of the scope
+(TypeScript 5.2+ / Node 20.11+):
+
+```ts
+using c = new Cognee(settings);
+await c.warm();
+// closed here
+```
+
+```ts
+const c = new Cognee(settings);
+try {
+  await c.warm();
+} finally {
+  c.close();
+}
+```
+
+A handle that is garbage-collected without an explicit `close()` still gives its
+resources back, so a forgotten handle does not leak for the life of the process —
+but only `close()` is deterministic about *when*, which matters if the process is
+about to exit.
+
 Fully-annotated runnable examples are available in the [`examples/`](examples/) directory.
 
 | Example | npm script | What it covers |

--- a/ts/__tests__/sdk_handle.test.ts
+++ b/ts/__tests__/sdk_handle.test.ts
@@ -18,6 +18,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
+import { Cognee } from "../src/cognee";
 import { native } from "../src/native";
 
 /** RFC-4122 UUIDv5 (SHA-1) of `name` under the OID namespace. */
@@ -105,5 +106,86 @@ describe("Phase-1 SDK handle & facade", () => {
     // No cogneeWarm() — cogneeOwnerId warms on demand.
     const ownerId = await native.cogneeOwnerId(handle);
     expect(ownerId).toBe(uuid5Oid(email));
+  });
+
+  // ── close() and the WAL sidecars (issue #132) ──────────────────────────────
+  //
+  // A warmed handle runs its relational database in WAL mode, which creates
+  // `<db>-wal`/`<db>-shm`. Letting the handle be garbage-collected does not
+  // reliably remove them: the pool's destructor lets its connections tear down
+  // concurrently and SQLite only unlinks the sidecars when the *last* connection
+  // closes. `close()` must be deterministic about it.
+  describe("close()", () => {
+    let closeDir: string;
+    let closeDb: string;
+
+    beforeEach(() => {
+      closeDir = fs.mkdtempSync(path.join(os.tmpdir(), "cognee-sdk-close-"));
+      closeDb = path.join(closeDir, "cognee.db");
+    });
+
+    afterEach(() => {
+      try {
+        fs.rmSync(closeDir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    });
+
+    function closeSettings() {
+      return {
+        ...makeSettings(),
+        system_root_directory: closeDir,
+        data_root_directory: path.join(closeDir, "data"),
+        relational_db_url: `sqlite:${closeDb}?mode=rwc`,
+      };
+    }
+
+    const wal = () => `${closeDb}-wal`;
+    const shm = () => `${closeDb}-shm`;
+
+    it("releases the WAL sidecars synchronously", async () => {
+      const c = new Cognee(closeSettings());
+      await c.warm();
+      expect(fs.existsSync(wal())).toBe(true);
+      expect(fs.existsSync(shm())).toBe(true);
+
+      c.close();
+
+      // No waiting, no polling.
+      expect(fs.existsSync(wal())).toBe(false);
+      expect(fs.existsSync(shm())).toBe(false);
+    });
+
+    it("is idempotent and rejects ops afterwards", async () => {
+      const c = new Cognee(closeSettings());
+      await c.warm();
+      c.close();
+      c.close();
+
+      await expect(c.warm()).rejects.toThrow(/closed/);
+      // A failed op must not reopen the database.
+      expect(fs.existsSync(wal())).toBe(false);
+    });
+
+    it("is a no-op on a handle that was never warmed", () => {
+      const c = new Cognee(closeSettings());
+      expect(() => c.close()).not.toThrow();
+      expect(fs.existsSync(wal())).toBe(false);
+    });
+
+    it("is wired to Symbol.dispose so `using` closes the handle", async () => {
+      // Exercised without `using` syntax so the test compiles on the repo's
+      // ES2020 target; `using` calls exactly this method.
+      const c = new Cognee(closeSettings());
+      await c.warm();
+      expect(fs.existsSync(wal())).toBe(true);
+      expect(typeof (c as unknown as Record<symbol, unknown>)[Symbol.dispose]).toBe(
+        "function"
+      );
+      c[Symbol.dispose]();
+      expect(fs.existsSync(wal())).toBe(false);
+      expect(fs.existsSync(shm())).toBe(false);
+    });
   });
 });

--- a/ts/cognee-ts-neon/src/lib.rs
+++ b/ts/cognee-ts-neon/src/lib.rs
@@ -59,6 +59,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("cogneeNew", sdk::cognee_new)?;
     cx.export_function("cogneeWarm", sdk::cognee_warm)?;
     cx.export_function("cogneeOwnerId", sdk::cognee_owner_id)?;
+    cx.export_function("cogneeClose", sdk::cognee_close)?;
 
     // Pipeline ops (Phase 3): add / cognify / add-and-cognify.
     cx.export_function("cogneeAdd", sdk_ops::cognee_add)?;

--- a/ts/cognee-ts-neon/src/runtime.rs
+++ b/ts/cognee-ts-neon/src/runtime.rs
@@ -12,6 +12,17 @@ pub fn runtime() -> &'static tokio::runtime::Runtime {
         .expect("cognee-ts-neon: runtime not initialised – call init() first")
 }
 
+/// The global tokio runtime if one has been initialised, else `None`.
+///
+/// Unlike [`runtime`] this never panics, and unlike [`ensure_runtime`] it never
+/// builds one. Teardown paths (`cogneeClose`, the `Finalize` release) use it:
+/// they need the runtime only to drive a teardown, so if there is none there was
+/// also nothing to tear down, and spinning one up just to shut down would be
+/// backwards.
+pub fn try_runtime() -> Option<&'static tokio::runtime::Runtime> {
+    RUNTIME.get()
+}
+
 /// Initialise the global tokio runtime on first use and return a reference to
 /// it. Unlike [`init`], this is idempotent and never errors when the runtime is
 /// already set — it is the entry point the `CogneeHandle` path uses so callers

--- a/ts/cognee-ts-neon/src/sdk.rs
+++ b/ts/cognee-ts-neon/src/sdk.rs
@@ -21,15 +21,41 @@ pub use cognee_bindings_common::HandleState;
 
 use crate::errors::throw_sdk_error;
 use crate::json::stringify_js;
-use crate::runtime::{ensure_runtime, runtime};
+use crate::runtime::{ensure_runtime, runtime, try_runtime};
 
 /// The boxed SDK handle. Survives across JS calls (held by a `JsBox`).
 pub struct CogneeHandle {
     pub state: Arc<HandleState>,
 }
 
-// Default no-op finalize is fine: the `Arc`s drop when the `JsBox` is GC'd.
-impl Finalize for CogneeHandle {}
+impl Finalize for CogneeHandle {
+    /// Give the resources back when V8 collects a handle the program never
+    /// closed.
+    ///
+    /// Dropping the `Arc`s is not enough: the relational pool's destructor lets
+    /// its connections tear down concurrently, so a SQLite database's
+    /// `-wal`/`-shm` sidecars end up orphaned on disk (issue #132). This is the
+    /// *implicit* teardown, so it releases without closing — anything still
+    /// holding a clone of the state (an in-flight op) keeps working and simply
+    /// re-warms.
+    ///
+    /// `finalize` runs on the JavaScript thread during garbage collection, where
+    /// blocking would stall the event loop, so the teardown is handed to the
+    /// tokio runtime instead. That makes it best-effort: a process that exits
+    /// promptly afterwards may not give the task time to run, which is why
+    /// [`Cognee.close()`](cognee_close) exists and is the documented path.
+    fn finalize<'a, C: Context<'a>>(self, _cx: &mut C) {
+        // Nothing was ever opened → nothing to release, and no reason to touch
+        // the runtime (which may not even be initialised).
+        if !self.state.has_open_resources() {
+            return;
+        }
+        if let Some(rt) = try_runtime() {
+            let state = self.state;
+            rt.spawn(async move { state.release().await });
+        }
+    }
+}
 
 impl CogneeHandle {
     /// Build the handle from settings (sync, no I/O).
@@ -146,6 +172,30 @@ pub fn cognee_owner_id(mut cx: FunctionContext) -> JsResult<JsPromise> {
     });
 
     Ok(promise)
+}
+
+/// `cogneeClose(handle)`
+///
+/// Close the handle: release the relational connection pool and, with it, a
+/// SQLite database's `-wal`/`-shm` sidecar files, then mark the handle closed.
+///
+/// **Synchronous and blocking** — deliberately. The point of a close is that the
+/// files are gone when it returns (a caller's next act is often to delete the
+/// directory they live in), and a synchronous close is also what `Symbol.dispose`
+/// requires. The work is a pool drain, measured in microseconds, not a network
+/// round-trip. Dropping the handle instead is a race that orphans the files
+/// (issue #132).
+///
+/// Idempotent, and a no-op on a handle that was never warmed. Any op started
+/// afterwards rejects with a "handle is closed" error rather than silently
+/// reopening the database.
+pub fn cognee_close(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let handle = cx.argument::<JsBox<CogneeHandle>>(0)?;
+    let state = Arc::clone(&handle.state);
+    if let Some(rt) = try_runtime() {
+        state.close_blocking(rt.handle());
+    }
+    Ok(cx.undefined())
 }
 
 /// `Settings` populated from the environment (defaults + env overlay).

--- a/ts/cognee-ts-neon/src/sdk.rs
+++ b/ts/cognee-ts-neon/src/sdk.rs
@@ -192,6 +192,9 @@ pub fn cognee_owner_id(mut cx: FunctionContext) -> JsResult<JsPromise> {
 pub fn cognee_close(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let handle = cx.argument::<JsBox<CogneeHandle>>(0)?;
     let state = Arc::clone(&handle.state);
+    // `cogneeNew` ensures the runtime, so a live handle always has one; the
+    // `None` arm is unreachable in practice and only avoids building a runtime
+    // for the sake of shutting it down.
     if let Some(rt) = try_runtime() {
         state.close_blocking(rt.handle());
     }

--- a/ts/src/cognee.ts
+++ b/ts/src/cognee.ts
@@ -458,6 +458,52 @@ export class Cognee {
     }
   }
 
+  /**
+   * Close the handle, releasing the resources it opened.
+   *
+   * Synchronous and blocking: when it returns, the relational connection pool is
+   * closed and a SQLite database's `-wal`/`-shm` sidecar files are gone, so the
+   * directory holding them can be deleted. Letting the handle be
+   * garbage-collected is not equivalent — the pool's destructor lets its
+   * connections tear down concurrently and SQLite only unlinks the sidecars when
+   * the last connection closes, so the files can be orphaned until the process
+   * exits.
+   *
+   * Idempotent, and a no-op on a handle that was never warmed. Any operation
+   * started afterwards rejects with a "handle is closed" error instead of
+   * silently reopening the database.
+   *
+   * The handle is also a disposable, so `using` closes it at end of scope:
+   *
+   * ```ts
+   * using c = new Cognee(settings);
+   * await c.warm();
+   * ```
+   */
+  close(): void {
+    try {
+      native.cogneeClose(this._handle);
+    } catch (e) {
+      throw wrapNativeError(e);
+    }
+  }
+
+  /**
+   * `Symbol.dispose` — lets `using c = new Cognee(...)` close the handle when
+   * the scope ends (TypeScript 5.2+ / Node 20.11+).
+   *
+   * The type comes from the `ESNext.Disposable` lib, which is types-only, so this
+   * changes nothing about the emitted JavaScript or the supported Node range: on
+   * a runtime without `Symbol.dispose` the computed key degrades to the harmless
+   * string `"undefined"`, and `using` is unavailable there anyway.
+   *
+   * There is deliberately no `Symbol.asyncDispose`: {@link close} is synchronous,
+   * so `await using` would buy nothing over `using`.
+   */
+  [Symbol.dispose](): void {
+    this.close();
+  }
+
   // ── Pipeline ops ──────────────────────────────────────────────────────────
 
   /**

--- a/ts/src/native.ts
+++ b/ts/src/native.ts
@@ -90,6 +90,10 @@ export interface NativeBindings {
   cogneeNew(settings?: object | string): NativeBox;
   cogneeWarm(handle: NativeBox): Promise<void>;
   cogneeOwnerId(handle: NativeBox): Promise<string>;
+  // Sync and blocking on purpose: a close has to have finished when it returns
+  // (the caller may delete the directory the DB lives in), and `Symbol.dispose`
+  // cannot await. The work is a connection-pool drain, not I/O over a network.
+  cogneeClose(handle: NativeBox): void;
 
   // Pipeline ops (Phase 3). All async (build engines + run the pipeline).
   //

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "ESNext.Disposable"],
     "strict": true,
     "esModuleInterop": true,
     "outDir": "lib",


### PR DESCRIPTION
Fixes #132.

## Root cause: dropping a pool is not closing it

The leak is **not** a retained reference and **not** the 600 s idle timeout — the
issue's two leading candidates are both refuted by measurement:

- After the handle is dropped, `Arc::strong_count` reaches **0** for both
  `CogneeServices` and `Arc<DatabaseConnection>`.
- `lsof` on the process shows **no open descriptor** anywhere under the
  database's directory while the `-wal`/`-shm` files are still sitting there.

The files are orphans. sqlx's `PoolInner::drop` only *flags* the pool closed and
then lets each pooled connection tear itself down on its own sqlite worker
thread — concurrently, in no defined order. SQLite unlinks `-wal`/`-shm` only
when the **last** connection to the file closes, and only if that close can take
an exclusive lock on the shared-memory index; when two connections close at the
same instant neither can, so neither runs the final checkpoint-and-unlink.
`Pool::close` (sqlx-core `pool/inner.rs:97-115`) pops and closes idle
connections **one at a time** and awaits the checked-out ones, so exactly one
connection observes itself as last.

A matrix over the drop path at the `cognee-database` layer (temp file, WAL, 5 s
poll for the sidecars) shows it is a race, not a fixed condition:

| scenario | result |
|---|---|
| migrations only, 1 pooled connection | **leaked** (still present at 5 s) |
| 8 concurrent queries | **leaked** (still present at 5 s) |
| 2 concurrent queries | released after 51 ms |
| migrations + 8 concurrent queries | released after 55 ms |
| migrations + 8 queries, explicit `close()` | released after **28 µs** |
| 8 queries, explicit `close()` | released after **11 µs** |

That race is also why the HTTP server leaks only intermittently, and why one TS
"before" run came up clean while five runs of the same binary leaked 10 files.

## Measurements, per surface

Same method everywhere: run something that opens the database, then count
orphaned `*-wal`/`*-shm` files under its directory **after the process exits**.

| surface | before | after |
|---|---|---|
| **Java** (`mvn test`, tempdir cleanup disabled) | **18** — all 9 databases the suite opens leave both files | **0** |
| **C API** (`sdk_handle_smoke`) | **4**, and 6 failed assertions | **0**, all pass |
| **Python** (script warms, then exits) | **2** per run, both with and without `close()` | **0** in both modes |
| **TS** (node script warms, then exits) | **10** across 5 runs, both modes | **0** across 5 runs, both modes |
| **CLI** (`cognee-cli add`) | **2** | **0** |
| **HTTP server** (start, `/health`, SIGTERM) | **2** in 1 of 3 runs — intermittent | **0** in 3 of 3, close logged each time |

A green suite proves nothing here on its own: the Java suite was green while
leaking all 18 files, so every number above comes from counting files, and each
"before" column was produced by disabling the new teardown and rebuilding.

## Two tiers of teardown

The right behaviour depends on who asked, so `HandleState` has both:

- **`release()`** — the *implicit* path, for a GC finalizer reclaiming a handle
  the program dropped on the floor. Gives the resources back and nothing else:
  the handle stays warm-able, so a sub-handle that outlived its parent
  (`d = cognee.datasets; del cognee`) keeps working and simply re-warms against
  a fresh connection.
- **`close()`** — the *explicit* path (`Cognee.close()`, `cg_sdk_close`, …). Also
  marks the handle closed, so a later op fails with `cognee handle is closed`
  instead of silently reopening the database. The guard lives in `services()`,
  the one choke point every op passes through, rather than in each binding.

Both have blocking wrappers for synchronous teardown hooks (which hand the
thread to the blocking pool if they are themselves called from inside the
runtime), and `has_open_resources()` lets a finalizer skip the work — and the
runtime it would otherwise need — for a handle that never warmed.

Underneath: `cognee_database::close` is the documented primitive (with the WAL
mechanism written down next to the pragmas that create the sidecars), and
`ComponentManager::close` evicts the connection from its version-keyed cache
*before* closing it, which is what keeps `release` non-poisoning.

## Per surface

- **Java** — `Cognee.close()` blocks until the pool is closed (the JNI `destroy`
  calls the blocking close before dropping the state). Javadoc and README note
  the flip side: an op still in flight may fail, so join your futures first.
- **Python** — new `close()`, a `closed` property, and **both** context-manager
  protocols (`with` and `async with`). `Drop for PyCognee` releases, and blocks
  while doing it: spawning would race interpreter shutdown, which is exactly
  when a handle nobody closed tends to be collected. Type stubs and README
  updated.
- **TS** — new `cogneeClose` native export and `Cognee.close()`, plus
  `Symbol.dispose` so `using c = new Cognee(...)` works. `ESNext.Disposable` is
  types-only, so the supported Node range is unchanged; there is deliberately no
  `asyncDispose`, since the close is synchronous. `Finalize` now releases
  instead of being a no-op.
- **C API** — new `cg_sdk_close`, declared in `cognee_sdk.h` (header-sync check
  passes). **`cg_sdk_destroy` keeps its contract**: clones and in-flight ops may
  still outlive it, and it only releases when it drops the *last* reference —
  a case nothing can observe, since no clone and no op can still be using the
  state. Closing unconditionally inside `destroy` would break the documented
  `cg_sdk_clone` sharing model, so the fix is additive, exactly as suggested.
- **CLI** — closes after the command, on success *or* failure. Each command owns
  its own runtime, so this builds a small current-thread one purely to drive the
  close, bounded by a 5 s timeout: the close waits for connections to come back,
  and a runtime dropped while one was still checked out never releases its pool
  permit. Losing the sidecars beats hanging the caller's exit code.
- **HTTP server** — closes in `on_shutdown`, after the pipeline registry and the
  in-flight cloud syncs that use it have stopped.

## Tests

Each fails on the pre-fix teardown and passes after:

- `cognee-database` → `close_releases_wal_sidecars` (multi-connection pool; no
  polling, the files are gone before `close` resolves)
- `cognee-bindings-common` → `handle_close.rs`: `close` releases + marks closed +
  ops afterwards fail; `release` frees but leaves the handle usable; both
  blocking wrappers on both thread kinds
- Java → `CogneeLifecycleTest.closeReleasesSqliteSidecars`
- C API → step 8 of `sdk_handle_smoke` (`cg_sdk_close` *and* last-ref destroy)
- Python → 6 cases in `test_sdk_handle.py` (close, ops-after-close, both context
  managers, GC release, never-warmed no-op)
- TS → 4 cases in `sdk_handle.test.ts` (release, idempotence + rejection,
  never-warmed no-op, `Symbol.dispose`)

## Verified locally

Java 28 tests; `capi/scripts/check.sh` (full cmake build + every smoke test);
`python/scripts/check.sh` under **Python 3.11**, matching CI — 203 passed, 25
skipped; TS 209 passed, 13 skipped; `cargo fmt --check`, `cargo clippy
--all-targets -D warnings`, `cargo check --all-targets`, the `bindings/`
workspace, and `capi/scripts/check_header_sync.sh`.

Two local-environment notes, both reproduced as pre-existing on an unmodified
tree: under the system Python 3.9 one stub test fails on a PEP 604 `X | None`
annotation in the untouched `types.py` (CI uses 3.11), and `ts/__tests__/search.test.ts`
times out when this machine's `.env` supplies expired LLM credentials — it
passes with that file moved aside, which is CI's state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SePhkXEUpiSJ1CTg7t9ERb
