### PR TITLE
test(graph): give the Postgres graph suites per-test databases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -731,10 +731,12 @@ jobs:
     services:
       postgres:
         # Stock Postgres, not pgvector/pgvector — the graph path needs no
-        # extensions. `POSTGRES_DB` is the graph database directly, which is why
-        # no `CREATE DATABASE` step is needed: a service container creates
-        # exactly one database, so naming it here matches the URL the test file
-        # already documents.
+        # extensions. `POSTGRES_DB` is no longer the database the tests write to:
+        # it is the one the URL connects *through* to reach the server, from
+        # where each case creates a throwaway database of its own and drops it
+        # again. Still no `CREATE DATABASE` step needed — the suite does that
+        # itself, and the default `postgres` superuser has the `CREATEDB` right
+        # `create_temp_postgres_db` requires.
         image: postgres:16
         env:
           POSTGRES_USER: postgres
@@ -762,6 +764,9 @@ jobs:
         uses: rui314/setup-mold@v1
         with:
           make-default: true
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -792,31 +797,44 @@ jobs:
       # a target/ whose ort-sys build-script output points into an empty
       # ort-cache — the link failure described at the top of this file.
 
-      # `--nocapture` is load-bearing here. A skipped `pggraph_test!` case still
-      # reports `ok`, so the printed `PGGRAPH_TEST_URL not set — skipping` line
-      # is the only signal that separates a real run from a green no-op. The
-      # logs are kept so the guard step below can assert on them.
+      # `--success-output immediate` is load-bearing, and is this lane's
+      # replacement for the `--nocapture` it used to pass libtest. A skipped
+      # `pggraph_test!` case still reports `ok`, so the printed
+      # `PGGRAPH_TEST_URL not set — skipping` line is the only signal separating
+      # a real run from a green no-op — and nextest captures a *passing* test's
+      # output by default, which would swallow precisely that line and disarm the
+      # guard below. `--color never` keeps the logs parseable regardless of what
+      # nextest infers about the terminal. The logs are kept for the guard step.
       #
-      # Keep this as `cargo test`, NOT `cargo nextest`. Every case shares the
-      # single `cognee_test_graph` database and wipes it on entry; that is only
-      # safe because `cargo test` runs the binary in one process where the
-      # `#[serial]` attributes actually serialize. nextest runs each test in its
-      # own process, where an in-process lock cannot help and the schema
-      # mutations would race. Switch to `cognee_test_utils::create_temp_postgres_db`
-      # first if this lane ever needs nextest for parity with the other lanes.
+      # This lane runs nextest like every other test lane in the repo. It used to
+      # insist on `cargo test`, and had to: all 34 cases shared the single
+      # `cognee_test_graph` database and wiped it on entry, which was only safe
+      # because `cargo test` runs the whole binary in one process, where the
+      # `#[serial]` attributes could actually serialize. nextest gives each test
+      # its own process, where an in-process lock cannot help — and it duly
+      # failed 33 of 59 cases with `relation "graph_edge" does not exist`. Each
+      # case now provisions its own throwaway database via
+      # `cognee_test_utils::create_temp_postgres_db` and drops it again, so there
+      # is no shared state left to race on and no `#[serial]` anywhere.
+      #
+      # Deliberately no `NEXTEST_PROFILE: ci`: that profile retries a failed test
+      # once, and a lane whose whole premise is that the races are gone must not
+      # paper over a residual one.
       - name: Run PgGraphAdapter integration tests
         run: |
           set -o pipefail
-          cargo test -p cognee-graph --features postgres,testing \
-            --test pg_graph_integration -- --nocapture 2>&1 | tee pggraph-integration.log
+          cargo nextest run -p cognee-graph --features postgres,testing \
+            --test pg_graph_integration --success-output immediate --color never \
+            2>&1 | tee pggraph-integration.log
 
       # The shared-DB migration and legacy-purge cases live inline in the crate,
       # not in the integration file, so they need their own invocation.
       - name: Run PgGraphAdapter inline (lib) tests
         run: |
           set -o pipefail
-          cargo test -p cognee-graph --features postgres,testing \
-            --lib -- --nocapture 2>&1 | tee pggraph-lib.log
+          cargo nextest run -p cognee-graph --features postgres,testing \
+            --lib --success-output immediate --color never \
+            2>&1 | tee pggraph-lib.log
 
       # Without this, a future change that stops the URL reaching the test
       # process (renamed env var, service container failing to bind) would leave

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -226,6 +226,9 @@ jobs:
         with:
           make-default: true
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
@@ -245,27 +248,32 @@ jobs:
       # No ORT cache step — see the ci.yml twin: `cognee-graph` pulls in no
       # `ort-sys`, and an unguarded writer here can poison the shared ORT key.
 
-      # `--nocapture` plus the guard step below: a skipped case still reports
-      # `ok`, so the printed skip line is the only thing separating a real run
-      # from a green no-op. Keep as `cargo test`, not nextest — see the ci.yml
-      # twin for both rationales.
+      # `--success-output immediate` plus the guard step below: a skipped case
+      # still reports `ok`, so the printed skip line is the only thing separating
+      # a real run from a green no-op, and nextest would otherwise capture and
+      # discard it on a passing test. nextest is safe here now that each case owns
+      # its own throwaway database — see the ci.yml twin for the full history.
       #
       # Note there is deliberately no retry here, unlike `test-no-secrets`'s
       # `NEXTEST_PROFILE: ci`: a transient failure starting the Postgres service
       # container should be visible rather than absorbed, since a silently
       # retried infrastructure problem is how this suite went unexecuted for so
-      # long. Fork contributors who hit one can push an empty commit to re-run.
+      # long — and a retry would equally mask a race, which is the exact class of
+      # bug the per-test databases exist to rule out. Fork contributors who hit
+      # one can push an empty commit to re-run.
       - name: Run PgGraphAdapter integration tests
         run: |
           set -o pipefail
-          cargo test -p cognee-graph --features postgres,testing \
-            --test pg_graph_integration -- --nocapture 2>&1 | tee pggraph-integration.log
+          cargo nextest run -p cognee-graph --features postgres,testing \
+            --test pg_graph_integration --success-output immediate --color never \
+            2>&1 | tee pggraph-integration.log
 
       - name: Run PgGraphAdapter inline (lib) tests
         run: |
           set -o pipefail
-          cargo test -p cognee-graph --features postgres,testing \
-            --lib -- --nocapture 2>&1 | tee pggraph-lib.log
+          cargo nextest run -p cognee-graph --features postgres,testing \
+            --lib --success-output immediate --color never \
+            2>&1 | tee pggraph-lib.log
 
       - name: Assert the suite really executed
         run: bash scripts/ci/assert_pggraph_suite_ran.sh pggraph-integration.log pggraph-lib.log

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -57,4 +57,14 @@ testing = []
 tempfile.workspace = true
 serial_test.workspace = true
 cognee-test-utils = { path = "../test-utils" }
+# `create_temp_postgres_db` (used by the Postgres graph suites for their per-test
+# databases) opens its maintenance connection through `cognee_database::connect`,
+# which needs an sqlx driver at *runtime* — sea-orm returns "URL scheme not
+# supported" without one. `cognee-database` declares no default features, and
+# `cognee-test-utils` pulls it in bare, so the driver would otherwise arrive only
+# by feature unification with this crate's own `postgres` feature. That happens to
+# hold today (one shared sea-orm 1.1), but it is invisible and would break the
+# moment the two crates resolve to different sea-orm versions, with a runtime
+# error rather than a compile one. Spell it out instead.
+cognee-database = { path = "../database", features = ["postgres"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -1553,6 +1553,15 @@ mod shared_db_migration_tests {
         let outcome = tokio::spawn(body(tmp.url().to_string())).await;
         tmp.cleanup().await;
         if let Err(join_err) = outcome {
+            // A `JoinError` here can only be a panic: the task is never aborted
+            // and its handle is awaited immediately, so there is no cancellation
+            // path. Assert that rather than leaning on it — `into_panic()` panics
+            // on a cancelled task, which would replace the real failure with a
+            // confusing one.
+            assert!(
+                join_err.is_panic(),
+                "the {what} task was cancelled instead of panicking, which this helper never does: {join_err}"
+            );
             std::panic::resume_unwind(join_err.into_panic());
         }
     }

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -1499,6 +1499,9 @@ mod migrator {
 // are skipped otherwise. They live inline (rather than under `tests/`) so they
 // can reuse the crate's own optional `sea-orm`/`sea-orm-migration` dependencies
 // without forcing a heavy dev-dependency onto the default (feature-off) build.
+// (`cognee-database` is now a dev-dependency, but only to pin down the sqlx
+// driver these tests' throwaway databases need at runtime — see the note on it
+// in Cargo.toml; sea-orm itself still comes from this crate.)
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 #[allow(
@@ -1510,10 +1513,48 @@ mod shared_db_migration_tests {
     use super::PgGraphAdapter;
     use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
     use sea_orm_migration::prelude::*;
-    use serial_test::serial;
 
     fn test_url() -> Option<String> {
         std::env::var("PGGRAPH_TEST_URL").ok()
+    }
+
+    /// Run `body` against a throwaway database of this test's own, dropped again
+    /// afterwards — even if `body` panics.
+    ///
+    /// Both cases below are about two migrators *coexisting inside one database*,
+    /// so the isolation is at the database level and nothing inside it is reset.
+    /// That replaces a `reset()` helper which dropped `graph_node`, `graph_edge`
+    /// and both `seaql_migrations*` tables on the way in and out: destructive
+    /// enough to wreck a developer's own database, and useless as mutual
+    /// exclusion under `cargo nextest`, where each test runs in its own process
+    /// and the `#[serial]` attribute these carried could not serialize anything.
+    ///
+    /// Not reaching a live Postgres is reported the same way as in the
+    /// integration suite: a missing URL prints a skip line and returns; anything
+    /// else — failing to create the database, connect, or migrate — panics with
+    /// the underlying error rather than masquerading as "not configured".
+    ///
+    /// `body` runs on a spawned task so a failed assertion surfaces as a
+    /// `JoinError` instead of unwinding past the drop. `TempPostgresDb::cleanup`
+    /// is `async`, so it cannot be a `Drop` impl; without this the database would
+    /// leak on every red run. The panic is re-raised unchanged afterwards.
+    async fn with_temp_db<F, Fut>(what: &str, body: F)
+    where
+        F: FnOnce(String) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let Some(base_url) = test_url() else {
+            eprintln!("PGGRAPH_TEST_URL not set — skipping {what}");
+            return;
+        };
+        let tmp = cognee_test_utils::create_temp_postgres_db(&base_url)
+            .await
+            .expect("PGGRAPH_TEST_URL is set, so CREATE DATABASE must succeed on that server");
+        let outcome = tokio::spawn(body(tmp.url().to_string())).await;
+        tmp.cleanup().await;
+        if let Err(join_err) = outcome {
+            std::panic::resume_unwind(join_err.into_panic());
+        }
     }
 
     /// A stand-in for the downstream relational / auth migrator. It writes its
@@ -1568,22 +1609,6 @@ mod shared_db_migration_tests {
         }
     }
 
-    /// Drop every table and bookkeeping table so each run starts clean.
-    async fn reset(db: &DatabaseConnection) {
-        for stmt in [
-            "DROP TABLE IF EXISTS graph_edge CASCADE",
-            "DROP TABLE IF EXISTS graph_node CASCADE",
-            "DROP TABLE IF EXISTS rel_baseline_marker CASCADE",
-            "DROP TABLE IF EXISTS rel_auth_marker CASCADE",
-            "DROP TABLE IF EXISTS seaql_migrations CASCADE",
-            "DROP TABLE IF EXISTS seaql_migrations_pggraph CASCADE",
-        ] {
-            db.execute(Statement::from_string(db.get_database_backend(), stmt))
-                .await
-                .unwrap();
-        }
-    }
-
     /// Count rows in a bookkeeping table. Returns 0 **only** when the table does
     /// not exist; any other DB error panics so it fails the test rather than
     /// masquerading as an empty table (`table` is a fixed test literal, so
@@ -1614,88 +1639,82 @@ mod shared_db_migration_tests {
 
     /// The relational migrator and the graph adapter migrator must coexist in
     /// one Postgres DB without colliding on the default `seaql_migrations` table.
+    ///
+    /// The database is this test's own, but *both* migrators still run inside
+    /// that one database — sharing it is the thing under test.
     #[tokio::test]
-    #[serial]
     async fn pggraph_coexists_with_relational_migrator_in_shared_db() {
-        let Some(url) = test_url() else {
-            eprintln!("PGGRAPH_TEST_URL not set — skipping shared-DB migration test");
-            return;
-        };
+        with_temp_db("shared-DB migration test", |url| async move {
+            let db = Database::connect(&url).await.unwrap();
 
-        let db = Database::connect(&url).await.unwrap();
-        reset(&db).await;
+            // 1. Relational / auth migrator runs first and populates the default
+            //    `seaql_migrations` with versions the graph migrator does not own.
+            RelationalMigrator::up(&db, None)
+                .await
+                .expect("relational migrator should succeed");
+            assert_eq!(version_count(&db, "seaql_migrations").await, 2);
 
-        // 1. Relational / auth migrator runs first and populates the default
-        //    `seaql_migrations` with versions the graph migrator does not own.
-        RelationalMigrator::up(&db, None)
-            .await
-            .expect("relational migrator should succeed");
-        assert_eq!(version_count(&db, "seaql_migrations").await, 2);
+            // 2. Initialising the graph adapter against the SAME database must
+            //    succeed. Before the fix it aborted with "Migration file of version
+            //    'm20260914_000002_auth' is missing ...".
+            let adapter = PgGraphAdapter::new(&url).await;
+            assert!(
+                adapter.is_ok(),
+                "PgGraphAdapter init must not collide with the relational \
+                 seaql_migrations table; got: {:?}",
+                adapter.err()
+            );
 
-        // 2. Initialising the graph adapter against the SAME database must
-        //    succeed. Before the fix it aborted with "Migration file of version
-        //    'm20260914_000002_auth' is missing ...".
-        let adapter = PgGraphAdapter::new(&url).await;
-        assert!(
-            adapter.is_ok(),
-            "PgGraphAdapter init must not collide with the relational \
-             seaql_migrations table; got: {:?}",
-            adapter.err()
-        );
-
-        // 3. The graph migrator tracks its version in its OWN table and leaves
-        //    the relational bookkeeping untouched.
-        assert_eq!(version_count(&db, "seaql_migrations").await, 2);
-        assert_eq!(version_count(&db, "seaql_migrations_pggraph").await, 1);
-
-        reset(&db).await;
+            // 3. The graph migrator tracks its version in its OWN table and leaves
+            //    the relational bookkeeping untouched.
+            assert_eq!(version_count(&db, "seaql_migrations").await, 2);
+            assert_eq!(version_count(&db, "seaql_migrations_pggraph").await, 1);
+        })
+        .await;
     }
 
     /// Upgrade path: a legacy graph row left in the default `seaql_migrations`
     /// by an older build must be purged so the core migrator no longer chokes.
+    ///
+    /// Also runs in a database of its own, and again both migrators share it —
+    /// the legacy row and the purge are only meaningful in one database.
     #[tokio::test]
-    #[serial]
     async fn pggraph_purges_legacy_row_from_default_table_on_upgrade() {
-        let Some(url) = test_url() else {
-            eprintln!("PGGRAPH_TEST_URL not set — skipping legacy-purge test");
-            return;
-        };
+        with_temp_db("legacy-purge test", |url| async move {
+            let db = Database::connect(&url).await.unwrap();
 
-        let db = Database::connect(&url).await.unwrap();
-        reset(&db).await;
-
-        // Simulate an older build that recorded the graph version into the
-        // DEFAULT `seaql_migrations` table (aux-ran-before-core ordering).
-        db.execute(Statement::from_string(
-            db.get_database_backend(),
-            "CREATE TABLE seaql_migrations (version VARCHAR PRIMARY KEY, applied_at BIGINT NOT NULL)",
-        ))
-        .await
-        .unwrap();
-        db.execute(Statement::from_string(
-            db.get_database_backend(),
-            "INSERT INTO seaql_migrations (version, applied_at) \
-             VALUES ('m20250101_000001_create_graph_tables', 0)",
-        ))
-        .await
-        .unwrap();
-
-        // Upgraded build initialises the graph adapter.
-        PgGraphAdapter::new(&url)
+            // Simulate an older build that recorded the graph version into the
+            // DEFAULT `seaql_migrations` table (aux-ran-before-core ordering).
+            db.execute(Statement::from_string(
+                db.get_database_backend(),
+                "CREATE TABLE seaql_migrations (version VARCHAR PRIMARY KEY, applied_at BIGINT NOT NULL)",
+            ))
             .await
-            .expect("graph adapter should initialise on upgrade");
-
-        // The stale graph row is gone, so the core/relational migrator can now
-        // run against the default table without aborting.
-        assert_eq!(
-            version_count(&db, "seaql_migrations").await,
-            0,
-            "legacy graph row must be purged from the default seaql_migrations"
-        );
-        RelationalMigrator::up(&db, None)
+            .unwrap();
+            db.execute(Statement::from_string(
+                db.get_database_backend(),
+                "INSERT INTO seaql_migrations (version, applied_at) \
+                 VALUES ('m20250101_000001_create_graph_tables', 0)",
+            ))
             .await
-            .expect("core migrator must not choke after legacy row is purged");
+            .unwrap();
 
-        reset(&db).await;
+            // Upgraded build initialises the graph adapter.
+            PgGraphAdapter::new(&url)
+                .await
+                .expect("graph adapter should initialise on upgrade");
+
+            // The stale graph row is gone, so the core/relational migrator can now
+            // run against the default table without aborting.
+            assert_eq!(
+                version_count(&db, "seaql_migrations").await,
+                0,
+                "legacy graph row must be purged from the default seaql_migrations"
+            );
+            RelationalMigrator::up(&db, None)
+                .await
+                .expect("core migrator must not choke after legacy row is purged");
+        })
+        .await;
     }
 }

--- a/crates/graph/tests/pg_graph_integration.rs
+++ b/crates/graph/tests/pg_graph_integration.rs
@@ -30,27 +30,32 @@ fn test_url() -> Option<String> {
     std::env::var("PGGRAPH_TEST_URL").ok()
 }
 
-/// Provision a throwaway database and an adapter migrated onto it.
+/// Provision a throwaway database for one case.
 ///
 /// `None` means one thing only: no URL was configured, so the caller should
-/// skip. Once a URL *is* set, a failure to provision, connect or migrate is a
-/// real defect and panics with the underlying error — these used to be
-/// `.ok()?`-ed into the same `None`, so an adapter regression (a migrator
-/// collision, say) surfaced as "PGGRAPH_TEST_URL not set" and sent whoever
-/// read the CI log hunting for a broken service container instead.
+/// skip. Once a URL *is* set, a failure to provision is a real defect and panics
+/// with the underlying error; the same goes for the connect/migrate step in the
+/// macro below. These used to be `.ok()?`-ed into the same `None`, so an adapter
+/// regression (a migrator collision, say) surfaced as "PGGRAPH_TEST_URL not set"
+/// and sent whoever read the CI log hunting for a broken service container
+/// instead.
+///
+/// This deliberately stops at the database and does **not** build the adapter:
+/// everything that can panic after `CREATE DATABASE` has to run inside the
+/// macro's cleanup guard, or that panic strands the database. `CREATE DATABASE`
+/// is the last fallible step inside the helper, so an `Err` here means no
+/// database exists yet and there is nothing to drop.
 ///
 /// The database is empty by construction, so the old `delete_graph()` "clean
 /// slate" wipe is gone: it is no longer needed, and it is what made the shared
 /// database unsafe to point at anything real in the first place.
-async fn make_adapter() -> Option<(TempPostgresDb, PgGraphAdapter)> {
+async fn temp_db() -> Option<TempPostgresDb> {
     let base_url = test_url()?;
-    let tmp = create_temp_postgres_db(&base_url)
-        .await
-        .expect("PGGRAPH_TEST_URL is set, so CREATE DATABASE must succeed on that server");
-    let db = PgGraphAdapter::new(tmp.url())
-        .await
-        .expect("PGGRAPH_TEST_URL is set, so the adapter must connect and migrate");
-    Some((tmp, db))
+    Some(
+        create_temp_postgres_db(&base_url)
+            .await
+            .expect("PGGRAPH_TEST_URL is set, so CREATE DATABASE must succeed on that server"),
+    )
 }
 
 /// Register a shared-suite case as a test with a database of its own.
@@ -59,22 +64,33 @@ async fn make_adapter() -> Option<(TempPostgresDb, PgGraphAdapter)> {
 /// in-process serial guard does nothing under `cargo nextest`, where every test
 /// gets its own process.
 ///
-/// The case body runs on a spawned task so a failed assertion arrives as a
-/// `JoinError` rather than unwinding straight out of the test function.
-/// `TempPostgresDb::cleanup` is `async` and so cannot live in a `Drop` impl, so
-/// without catching the panic here every red case would strand its database on
-/// the server — across 32 cases that turns one failing run into a manual cleanup
-/// chore. The panic is re-raised unchanged afterwards, so libtest/nextest still
-/// report the original failure and message.
+/// **Everything fallible runs inside the spawned task**, adapter construction
+/// included, so a panic arrives as a `JoinError` instead of unwinding straight
+/// out of the test function. `TempPostgresDb::cleanup` is `async` and so cannot
+/// live in a `Drop` impl; without catching the panic here a red case would
+/// strand its database on the server, and across 32 cases that turns one failing
+/// run into a manual cleanup chore. Building the adapter *outside* the guard
+/// would have left exactly that hole on the connect/migrate path — the one
+/// failure this suite most exists to catch. The panic is re-raised unchanged
+/// afterwards, so libtest/nextest still report the original failure and message.
+///
+/// The one leak this cannot cover is a test hard-killed rather than unwound
+/// (nextest's `slow-timeout` terminate-after, or a `SIGKILL`), which no async
+/// cleanup can survive; the databases are uniquely named, so the fallback is
+/// dropping stragglers by hand.
 macro_rules! pggraph_test {
     ($name:ident) => {
         #[tokio::test]
         async fn $name() {
-            let Some((tmp, db)) = make_adapter().await else {
+            let Some(tmp) = temp_db().await else {
                 eprintln!("PGGRAPH_TEST_URL not set — skipping {}", stringify!($name));
                 return;
             };
+            let url = tmp.url().to_string();
             let outcome = tokio::spawn(async move {
+                let db = PgGraphAdapter::new(&url)
+                    .await
+                    .expect("PGGRAPH_TEST_URL is set, so the adapter must connect and migrate");
                 common::$name(&db).await;
                 // Hand the pooled connections back before the database is
                 // dropped, so cleanup does not have to lean on `WITH (FORCE)`.

--- a/crates/graph/tests/pg_graph_integration.rs
+++ b/crates/graph/tests/pg_graph_integration.rs
@@ -99,6 +99,15 @@ macro_rules! pggraph_test {
             .await;
             tmp.cleanup().await;
             if let Err(join_err) = outcome {
+                // A `JoinError` here can only be a panic: the task is never
+                // aborted and its handle is awaited immediately, so there is no
+                // cancellation path. Assert that rather than leaning on it —
+                // `into_panic()` panics on a cancelled task, which would replace
+                // the real failure with a confusing one.
+                assert!(
+                    join_err.is_panic(),
+                    "the case task was cancelled instead of panicking, which this harness never does: {join_err}"
+                );
                 std::panic::resume_unwind(join_err.into_panic());
             }
         }

--- a/crates/graph/tests/pg_graph_integration.rs
+++ b/crates/graph/tests/pg_graph_integration.rs
@@ -11,48 +11,80 @@
 //!   PGGRAPH_TEST_URL="postgres://user:pass@localhost:5432/cognee_test_graph"
 //!
 //! Tests are skipped automatically when the variable is absent.
-//! All tests run serially (shared DB state).
+//!
+//! Each case provisions its **own throwaway database** on that server and drops
+//! it again afterwards, so nothing is shared and nothing is wiped. The URL's own
+//! database is only ever used to reach the server — pointing `PGGRAPH_TEST_URL`
+//! at a database you actually keep data in is safe. The role it names needs
+//! `CREATEDB`; see [`cognee_test_utils::create_temp_postgres_db`] for the full
+//! rationale.
 #![cfg(feature = "postgres")]
 
 mod common;
 
-use cognee_graph::{GraphDBTrait, PgGraphAdapter};
-use serial_test::serial;
+use cognee_graph::PgGraphAdapter;
+use cognee_test_utils::{TempPostgresDb, create_temp_postgres_db};
 
 /// Read the connection URL or return `None` to skip.
 fn test_url() -> Option<String> {
     std::env::var("PGGRAPH_TEST_URL").ok()
 }
 
-/// Create an adapter and wipe the graph for a clean slate.
+/// Provision a throwaway database and an adapter migrated onto it.
 ///
 /// `None` means one thing only: no URL was configured, so the caller should
-/// skip. Once a URL *is* set, a failure to connect, migrate or wipe is a real
-/// defect and panics with the underlying error — previously these were
+/// skip. Once a URL *is* set, a failure to provision, connect or migrate is a
+/// real defect and panics with the underlying error — these used to be
 /// `.ok()?`-ed into the same `None`, so an adapter regression (a migrator
 /// collision, say) surfaced as "PGGRAPH_TEST_URL not set" and sent whoever
 /// read the CI log hunting for a broken service container instead.
-async fn make_adapter() -> Option<PgGraphAdapter> {
-    let url = test_url()?;
-    let db = PgGraphAdapter::new(&url)
+///
+/// The database is empty by construction, so the old `delete_graph()` "clean
+/// slate" wipe is gone: it is no longer needed, and it is what made the shared
+/// database unsafe to point at anything real in the first place.
+async fn make_adapter() -> Option<(TempPostgresDb, PgGraphAdapter)> {
+    let base_url = test_url()?;
+    let tmp = create_temp_postgres_db(&base_url)
+        .await
+        .expect("PGGRAPH_TEST_URL is set, so CREATE DATABASE must succeed on that server");
+    let db = PgGraphAdapter::new(tmp.url())
         .await
         .expect("PGGRAPH_TEST_URL is set, so the adapter must connect and migrate");
-    db.delete_graph()
-        .await
-        .expect("delete_graph must succeed against a live Postgres");
-    Some(db)
+    Some((tmp, db))
 }
 
+/// Register a shared-suite case as a test with a database of its own.
+///
+/// No `#[serial]`: the cases share no state any more, which is the point — an
+/// in-process serial guard does nothing under `cargo nextest`, where every test
+/// gets its own process.
+///
+/// The case body runs on a spawned task so a failed assertion arrives as a
+/// `JoinError` rather than unwinding straight out of the test function.
+/// `TempPostgresDb::cleanup` is `async` and so cannot live in a `Drop` impl, so
+/// without catching the panic here every red case would strand its database on
+/// the server — across 32 cases that turns one failing run into a manual cleanup
+/// chore. The panic is re-raised unchanged afterwards, so libtest/nextest still
+/// report the original failure and message.
 macro_rules! pggraph_test {
     ($name:ident) => {
         #[tokio::test]
-        #[serial]
         async fn $name() {
-            let Some(db) = make_adapter().await else {
+            let Some((tmp, db)) = make_adapter().await else {
                 eprintln!("PGGRAPH_TEST_URL not set — skipping {}", stringify!($name));
                 return;
             };
-            common::$name(&db).await;
+            let outcome = tokio::spawn(async move {
+                common::$name(&db).await;
+                // Hand the pooled connections back before the database is
+                // dropped, so cleanup does not have to lean on `WITH (FORCE)`.
+                drop(db);
+            })
+            .await;
+            tmp.cleanup().await;
+            if let Err(join_err) = outcome {
+                std::panic::resume_unwind(join_err.into_panic());
+            }
         }
     };
 }

--- a/scripts/ci/assert_pggraph_suite_ran.sh
+++ b/scripts/ci/assert_pggraph_suite_ran.sh
@@ -5,7 +5,7 @@
 #
 # Every `pggraph_test!` case (crates/graph/tests/pg_graph_integration.rs) and
 # both inline `shared_db_migration_tests` cases return early — still reporting
-# `ok` — when their Postgres URL is absent, so libtest's exit status proves
+# `ok` — when their Postgres URL is absent, so the runner's exit status proves
 # nothing on its own. Run with the URL unset, both binaries print the exact
 # same "32 passed" / "24 passed" summaries as a real run, just in 0.00s. This
 # script is what separates the two.
@@ -14,6 +14,20 @@
 # mirrored lane in .github/workflows/community.yml. It lives here rather than
 # inline in both YAML files so the two copies cannot drift, and so it can be
 # tested against captured logs without a CI round-trip.
+#
+# Both runners are understood. The CI lanes run `cargo nextest`; a developer
+# reproducing a failure locally will usually reach for `cargo test`, and the two
+# print entirely different summaries. Every pattern below therefore accepts
+# either format, so the same script validates either log:
+#
+#   libtest   test result: ok. 32 passed; 0 failed; ...
+#             test <path>::<name> ... ok
+#   nextest       Summary [   2.30s] 32 tests run: 32 passed, 0 skipped
+#                 PASS [   0.05s] cognee-graph <path>::<name>
+#
+# Note the nextest lanes pass `--success-output immediate`: nextest captures a
+# passing test's output by default, which would swallow the skip line that check
+# 1 below exists to find.
 #
 # Usage: assert_pggraph_suite_ran.sh <integration-log> <lib-log>
 
@@ -80,20 +94,39 @@ fi
 # ── 2. A plausible number of integration cases actually ran ─────────────────
 # Absence of a skip marker is not presence of a test. Both targets are behind
 # `#[cfg(feature = "postgres")]`, so dropping `--features postgres,testing`
-# compiles them down to zero cases: libtest then prints "running 0 tests",
-# exits 0, and emits no skip line — indistinguishable from success without
-# this check.
-passed="$(sed -nE 's/^test result: ok\. ([0-9]+) passed;.*/\1/p' "$INTEGRATION_LOG" | head -1)"
+# compiles them down to zero cases: the runner then reports 0 tests, exits 0,
+# and emits no skip line — indistinguishable from success without this check.
+#
+# nextest's whole-run summary is checked FIRST, and the order is load-bearing.
+# nextest gives every test its own libtest process, and `--success-output
+# immediate` echoes each one's captured stdout — so a nextest log is full of
+# per-test `test result: ok. 1 passed;` lines. Reading libtest's pattern first
+# picks one of those up and concludes that a single test ran, failing a perfectly
+# good 32-case run. `Summary [` is emitted only by nextest, so trying it first is
+# unambiguous either way round.
+#
+# A log carrying neither summary falls through to the emptiness check below,
+# which fails closed — the safe direction, and the reason this stayed an
+# assertion instead of being relaxed when the lanes moved to nextest.
+passed="$(sed -nE 's/^[[:space:]]*Summary \[[^]]*\] [0-9]+ tests run: ([0-9]+) passed.*/\1/p' "$INTEGRATION_LOG" | head -1)"
+if [[ -z "$passed" ]]; then
+  passed="$(sed -nE 's/^test result: ok\. ([0-9]+) passed;.*/\1/p' "$INTEGRATION_LOG" | head -1)"
+fi
 [[ -n "$passed" ]] ||
-  fail "no libtest summary line in $INTEGRATION_LOG — the integration binary did not run to completion."
+  fail "no libtest or nextest summary line in $INTEGRATION_LOG — the integration binary did not run to completion."
 ((passed >= MIN_INTEGRATION_TESTS)) ||
   fail "only $passed integration tests ran, expected at least $MIN_INTEGRATION_TESTS — the postgres/testing features have probably stopped applying, which compiles the suite down to nothing."
 
 # ── 3. Both inline cases ran by name ────────────────────────────────────────
 # The lib target holds 20-odd unrelated unit tests, so a count floor would not
 # notice these two disappearing.
+#
+# `PASS \[` is matched unanchored rather than at line start: nextest prefixes a
+# retried case with `TRY n `, and the leading indentation is cosmetic. The names
+# are fixed `[a-z_]` literals from the array above, so embedding them in the
+# pattern needs no escaping.
 for test_name in "${INLINE_TESTS[@]}"; do
-  grep -qF -- "$test_name ... ok" "$LIB_LOG" ||
+  grep -qE "($test_name \.\.\. ok|PASS \[[^]]*\][[:space:]].*$test_name([[:space:]]|\$))" "$LIB_LOG" ||
     fail "inline test $test_name did not run (or did not pass) — see $LIB_LOG."
 done
 


### PR DESCRIPTION
## Why

The 34 Postgres graph cases — 32 in `crates/graph/tests/pg_graph_integration.rs`, 2 inline in
`crates/graph/src/pg_graph_adapter.rs` — all shared the single `cognee_test_graph` database and
wiped it on entry, kept apart only by an in-process `#[serial]`. That works under `cargo test`,
which runs a binary in one process, and cannot work under `cargo nextest`, which every other test
lane in this repo uses: one process per test, where the attribute serializes nothing.

Nothing was failing, but the trap was live. Verified on `origin/main` before touching anything:

```
$ cargo nextest run -p cognee-graph --features postgres,testing     # ×3, on main
Summary [   0.321s] 59 tests run: 26 passed, 33 failed, 0 skipped
Summary [   0.213s] 59 tests run: 26 passed, 33 failed, 0 skipped
Summary [   2.088s] 59 tests run: 29 passed, 30 failed, 0 skipped

thread 'test_add_and_get_node' panicked at crates/graph/tests/pg_graph_integration.rs:42:10:
delete_graph must succeed against a live Postgres: QueryError("Failed to truncate graph:
  ... relation \"graph_edge\" does not exist")
```

Exactly the failure mode the `ci.yml` comment predicted, and exactly the kind that reproduces
nowhere else.

## What changed

**Per-test databases.** Both suites now provision a throwaway database through the helper that
exists for this (`cognee_test_utils::create_temp_postgres_db`) and drop it again, following
`pg_shared_db_single_stack.rs` and `provenance_batch.rs`. `#[serial]` is gone from both, and so is
the `delete_graph()` "clean slate" wipe — a fresh database is empty by construction, and that wipe
is what made pointing `PGGRAPH_TEST_URL` at a database you actually use unsafe. `POSTGRES_DB` in the
service container is now only the database the URL connects *through* to reach the server.

**The two coexistence cases still test coexistence.** They get their own database, but both the
relational migrator and the graph migrator still run *inside that one database*, sharing
`seaql_migrations` bookkeeping — that is the whole point of them. What went away is the `reset()`
helper that dropped `graph_node`, `graph_edge` and both `seaql_migrations*` tables on the way in and
out.

**Cleanup is panic-safe** — this is the one place I deliberately went beyond the two existing
callers, which accept leaks on panic. Everything fallible, adapter construction included, runs on a
spawned task, so a panic arrives as a `JoinError`, the database is dropped, and the panic is
re-raised unchanged (same failure, same message, same reporting). `TempPostgresDb::cleanup` is
`async` and so cannot be a `Drop` impl, which is why the tolerated-leak approach exists at all;
across 32 cases, one red run would otherwise leave 32 databases behind.

The second commit is a review follow-up, and worth calling out because the first commit got this
wrong: `make_adapter` originally created the database and *then* built the adapter, both **outside**
the guard — so the connect/migrate panic, the one failure this suite most exists to catch and the one
#128 deliberately made loud, was exactly the path that still leaked. `temp_db` now stops at the
database and the adapter is built inside the spawned task, matching the inline `with_temp_db` helper
that never had the hole. `CREATE DATABASE` is the last fallible step inside
`create_temp_postgres_db`, so an `Err` from `temp_db` means there is nothing yet to drop.

Verified both ways: breaking 3 case bodies → 3 failures, 0 databases left; and forcing a failure at
the adapter step itself (pointing it at a dead address) → 32 panics on that line, 0 databases left,
where the first commit would have stranded 32. The one leak that cannot be closed this way, now
documented in the macro, is a test hard-killed rather than unwound (nextest's `slow-timeout`
terminate-after, or a `SIGKILL`) — no async cleanup survives that.

**`None` still means exactly one thing.** No URL configured → skip. Every real failure — creating
the database, connecting, migrating — panics with its own error, preserving the #128 distinction.

**Both CI lanes move to nextest**, which was the payoff, and the stale "Keep this as `cargo test`,
NOT `cargo nextest`" comment is replaced with what is now true (in `ci.yml` and its `community.yml`
mirror).

## Decisions worth flagging

**`--success-output immediate` is load-bearing.** nextest captures a *passing* test's output, which
would have swallowed the `PGGRAPH_TEST_URL not set — skipping` line that the guard exists to find —
a silent disarming of the guard, not a visible break. It is this lane's replacement for the
`--nocapture` it used to pass libtest. `--color never` keeps the logs parseable regardless of what
nextest infers about the terminal.

**Deliberately no `NEXTEST_PROFILE: ci`.** That profile retries a failed test once. A lane whose
entire premise is that the races are gone must not paper over a residual one — and `community.yml`
already argued the same for infrastructure failures.

**The guard script now reads either runner's format**, so it also validates a local `cargo test`
log. One subtlety cost a debugging round and is now commented in the script: the nextest summary
must be tried **first**. Under `--success-output immediate` the log carries a per-test
`test result: ok. 1 passed;` line from every single-test libtest process, so matching libtest's
pattern first concludes that one test ran and fails a healthy 32-case run.

Exercised offline against captured logs — no CI round-trips — in all four runner combinations:

| variant | expected | got |
|---|---|---|
| real nextest logs | pass | pass |
| real libtest logs | pass | pass |
| mixed (libtest integration + nextest lib, and vice versa) | pass | pass |
| every case skipped (URL unset) | fail | fail — skip marker |
| skip marker only in the lib log | fail | fail — skip marker |
| zero tests ran (`-E` filter matching nothing) | fail | fail — count floor |
| missing lib log | fail | fail — no evidence |
| empty integration log | fail | fail — no evidence |
| inline case absent from the lib log | fail | fail — named inline test |

**One new dev-dependency: `cognee-database` with `postgres`.** `create_temp_postgres_db` opens its
maintenance connection through `cognee_database::connect`, which needs an sqlx driver at *runtime* —
sea-orm returns "URL scheme not supported" without one. `cognee-database` declares no default
features and `cognee-test-utils` pulls it in bare, so today the driver arrives only by feature
unification with this crate's own `postgres` feature. That holds (one shared sea-orm 1.1) but is
invisible, and would break as a runtime error rather than a compile error the moment the two resolve
to different sea-orm versions. Spelled out instead, with the reasoning in `Cargo.toml`.

## Cost

Per-test databases are not free. Measured against a live `postgres:16`, 32 integration cases:

| invocation | time |
|---|---|
| before: shared DB, `cargo test` (forced serial) | 5.07 s |
| after: `nextest -j1` — the serial floor | 10.3 s |
| after: `nextest -j4` — ≈ the 4-core CI runner | 5.02 s |
| after: `nextest -j20` — this dev box | 2.30 s |

A database costs ~165 ms per case (`CREATE` + migrate + `DROP`). Parallelism pays for it: CI comes
out a wash, a developer box 2.2× faster. Per-test rather than per-binary granularity is worth that —
per-binary would have kept the 32 cases sharing state and left the wipe in place, which is the
problem, not the cost.

The runner beat the local estimate comfortably — the real lane came in at **1.487 s for all 32
cases**, ~0.18 s each including provisioning, against a service container on the same host. The
whole lane runs in 3m57s.

## Verification

`cargo nextest run -p cognee-graph --features postgres,testing` — **18 runs, all green, zero leaked
databases**:

- 10 unloaded (~2.3 s each);
- 8 with the scheduler starved — whole suite pinned to core 0 with `taskset -c 0` against 4
  competing busy loops on that same core, stretching each run from 2.3 s to ~14 s. This is the
  technique that caught the PR #109 timing bug; a single green run proves nothing here.

Leak count after every run, and after the deliberate-failure runs:
`psql -lqt | grep -cE 'cognee_test_[0-9a-f]{32}'` → `0`.

Also green: both `cargo test` invocations (the suites stay runnable either way), the full CI lane
simulated locally end-to-end including the guard step, and `scripts/check_all.sh`.

## CI evidence

All checks green on both commits — latest: [run
31407123288](https://github.com/topoteretes/cognee-rs/actions/runs/31407123288), 18 pass, where the
Postgres graph lane reports `Summary [1.401s] 32 tests run: 32 passed`, both inline cases by name,
and `PgGraph suite verified: 32 integration tests ran against a live Postgres, both inline migration
tests passed, no skip markers.` The `community.yml` mirror reports `skipping`, its expected result on
an in-repo PR.

Full per-case output, quoted from the first run
([31395257587](https://github.com/topoteretes/cognee-rs/actions/runs/31395257587)) — every case
executing by name on the runner, under nextest:

```
    Starting 32 tests across 1 binary
        PASS [   0.213s] ( 1/32) cognee-graph::pg_graph_integration test_add_and_get_node
        PASS [   0.213s] ( 2/32) cognee-graph::pg_graph_integration test_add_and_has_edge
        PASS [   0.228s] ( 3/32) cognee-graph::pg_graph_integration test_add_nodes_batch
        PASS [   0.230s] ( 4/32) cognee-graph::pg_graph_integration test_add_edges_batch
        PASS [   0.169s] ( 5/32) cognee-graph::pg_graph_integration test_delete_node
        PASS [   0.175s] ( 6/32) cognee-graph::pg_graph_integration test_delete_graph
        PASS [   0.163s] ( 7/32) cognee-graph::pg_graph_integration test_delete_nodes_batch
        PASS [   0.166s] ( 8/32) cognee-graph::pg_graph_integration test_edge_upsert_same_key
        PASS [   0.172s] ( 9/32) cognee-graph::pg_graph_integration test_get_connections
        PASS [   0.172s] (10/32) cognee-graph::pg_graph_integration test_get_filtered_graph_data
        PASS [   0.177s] (11/32) cognee-graph::pg_graph_integration test_get_edges
        PASS [   0.173s] (12/32) cognee-graph::pg_graph_integration test_get_graph_data
        PASS [   0.181s] (13/32) cognee-graph::pg_graph_integration test_get_id_filtered_graph_data
        PASS [   0.188s] (14/32) cognee-graph::pg_graph_integration test_get_neighborhood_depth1
        PASS [   0.203s] (15/32) cognee-graph::pg_graph_integration test_get_graph_data_surfaces_created_at
        PASS [   0.211s] (16/32) cognee-graph::pg_graph_integration test_get_graph_metrics
        PASS [   0.171s] (17/32) cognee-graph::pg_graph_integration test_get_neighborhood_empty_seeds
        PASS [   0.168s] (18/32) cognee-graph::pg_graph_integration test_get_neighborhood_multiple_seeds
        PASS [   0.170s] (19/32) cognee-graph::pg_graph_integration test_get_neighbors
        PASS [   0.157s] (20/32) cognee-graph::pg_graph_integration test_get_nodes_batch
        PASS [   0.175s] (21/32) cognee-graph::pg_graph_integration test_has_edges
        PASS [   0.194s] (22/32) cognee-graph::pg_graph_integration test_get_nodeset_subgraph_and
        PASS [   0.181s] (23/32) cognee-graph::pg_graph_integration test_has_edges_batch_equivalence
        PASS [   0.192s] (24/32) cognee-graph::pg_graph_integration test_get_nodeset_subgraph_or
        PASS [   0.178s] (25/32) cognee-graph::pg_graph_integration test_has_node
        PASS [   0.176s] (26/32) cognee-graph::pg_graph_integration test_node_delete_cascades_edges
        PASS [   0.181s] (27/32) cognee-graph::pg_graph_integration test_initialize_is_empty
        PASS [   0.176s] (28/32) cognee-graph::pg_graph_integration test_node_truth_state_missing_and_invalid
        PASS [   0.179s] (29/32) cognee-graph::pg_graph_integration test_node_truth_state_round_trip
        PASS [   0.177s] (30/32) cognee-graph::pg_graph_integration test_properties_json_round_trip
        PASS [   0.193s] (31/32) cognee-graph::pg_graph_integration test_node_truth_state_preserves_other_properties
        PASS [   0.193s] (32/32) cognee-graph::pg_graph_integration test_node_upsert_same_id
     Summary [   1.487s] 32 tests run: 32 passed, 0 skipped
```

Both inline coexistence cases, and the guard confirming the lane really executed rather than
skipping itself green:

```
        PASS [   0.141s] (23/24) cognee-graph pg_graph_adapter::shared_db_migration_tests::pggraph_purges_legacy_row_from_default_table_on_upgrade
        PASS [   0.143s] (24/24) cognee-graph pg_graph_adapter::shared_db_migration_tests::pggraph_coexists_with_relational_migrator_in_shared_db
     Summary [   0.170s] 24 tests run: 24 passed, 0 skipped

PgGraph suite verified: 32 integration tests ran against a live Postgres, both inline migration tests passed, no skip markers.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)