### PR TITLE
feat(bench): align metrics with the Python bench

### DIFF
--- a/crates/cli/src/commands/bench.rs
+++ b/crates/cli/src/commands/bench.rs
@@ -1,9 +1,9 @@
 //! `cognee-cli bench` — the performance orchestrator driver.
 //!
 //! Ports Python's `bench_cognee.py`: runs the full
-//! `prune → setup → add → cognify → search` pipeline once, times each phase,
-//! and writes a result JSON with the exact Python schema so the shared
-//! orchestrator/reporter can drive either SDK unchanged.
+//! `prune → setup → add → cognify → search → dataset delete` pipeline once,
+//! times each phase, and writes a result JSON with the exact Python schema so
+//! the shared orchestrator/reporter can drive either SDK unchanged.
 //!
 //! Exit-code policy (Python parity): once the run completes and the result
 //! file is written, exit `0` even if individual phases failed (failures are
@@ -15,6 +15,7 @@ use std::time::Instant;
 
 use cognee::add::AddPipeline;
 use cognee::api::prune::{PruneTarget, prune_data, prune_system};
+use cognee::api::{DatasetDb, DatasetManager};
 use cognee::cognify::{ChunkStrategy, CognifyConfig, TokenCounterKind, cognify};
 use cognee::core::RayonThreadPool;
 use cognee::database::{IngestDb, PipelineRunRepository, SeaOrmPipelineRunRepository, ops};
@@ -65,6 +66,7 @@ struct BenchResult {
     prune_time_s: f64,
     db_setup_time_s: f64,
     search_time: f64,
+    dataset_delete_time_s: f64,
     status: BenchStatus,
     success: bool,
     config: BenchConfig,
@@ -81,6 +83,7 @@ struct BenchStatus {
     add: String,
     cognify: String,
     search: String,
+    dataset_delete: String,
 }
 
 const PHASE_OK: &str = "success";
@@ -175,8 +178,9 @@ fn finish_phase_telemetry(_profile_dir: Option<&str>, _phase: &str) {}
 /// workload. The timer starts *after* the profiler/telemetry are armed and
 /// stops *before* the flamegraph/telemetry artifacts are written, so the
 /// returned elapsed is workload-only — not inflated by profiler startup or
-/// report generation. Centralizes the bracketing so the three phases (add /
-/// cognify / search) cannot drift out of sync. Returns `(elapsed_secs, result)`.
+/// report generation. Centralizes the bracketing so the measured phases (add /
+/// cognify / search / dataset delete) cannot drift out of sync. Returns
+/// `(elapsed_secs, result)`.
 async fn timed_phase(
     profile_dir: Option<&str>,
     phase: &str,
@@ -429,6 +433,7 @@ async fn run_phases(
         add: PHASE_OK.to_string(),
         cognify: PHASE_OK.to_string(),
         search: PHASE_OK.to_string(),
+        dataset_delete: PHASE_OK.to_string(),
     };
 
     // ── Prune ────────────────────────────────────────────────────────────
@@ -533,11 +538,49 @@ async fn run_phases(
         status.search = format!("failed: {msg}");
     }
 
+    // ── Extra retrievers (profiling only, untimed) ───────────────────────
+    // Not part of the reported contract — see `phase_search_retrievers`. A
+    // failure here is warned about but deliberately does NOT touch `status`:
+    // these queries do not exist in the Python bench, so letting them fail the
+    // run would make `success` mean different things across the two SDKs.
+    // `cfg!` rather than `#[cfg]` so both configurations stay type-checked; the
+    // branch const-folds away in a non-profiling build, where `--profile-dir`
+    // is documented as ignored and no flamegraph would be written anyway.
+    if cfg!(feature = "profiling") && profile_dir.is_some() {
+        eprintln!("Profiling: running the extra no-LLM retrievers...");
+        let (t_retrievers, retriever_res) = timed_phase(
+            profile_dir,
+            "search_retrievers",
+            phase_search_retrievers(cm, owner_id, dataset_name),
+        )
+        .await;
+        match retriever_res {
+            Ok(()) => info!("search_retrievers took {t_retrievers:.3}s (not reported)"),
+            Err(msg) => warn!("Extra retrievers FAILED (not reported): {msg}"),
+        }
+    }
+
+    // ── Dataset delete (populated) ───────────────────────────────────────
+    // Runs last, so it measures deletion with nodes, edges and vectors all
+    // present — the meaningful case, and what Python's Phase 4 measures.
+    eprintln!("Phase 4: Deleting the populated dataset...");
+    let (t_dataset_delete, dataset_delete_res) = timed_phase(
+        profile_dir,
+        "dataset_delete",
+        phase_dataset_delete(cm, owner_id, dataset_name),
+    )
+    .await;
+    if let Err(msg) = dataset_delete_res {
+        warn!("Dataset delete FAILED: {msg}");
+        status.dataset_delete = format!("failed: {msg}");
+    }
+
     let success = status.prune == PHASE_OK
         && status.db_setup == PHASE_OK
         && status.add == PHASE_OK
         && status.cognify == PHASE_OK
-        && status.search == PHASE_OK;
+        && status.search == PHASE_OK
+        && status.dataset_delete == PHASE_OK;
 
     BenchResult {
         memories_count: n,
@@ -547,6 +590,7 @@ async fn run_phases(
         prune_time_s: round3(t_prune),
         db_setup_time_s: round3(t_db_setup),
         search_time: t_search,
+        dataset_delete_time_s: round3(t_dataset_delete),
         status,
         success,
         config,
@@ -738,19 +782,13 @@ fn bench_search_request(
     }
 }
 
-/// Exercise retrieval across representative query types so the search phase is
-/// actually profiled, not just the one graph-completion path.
-///
-/// Runs the no-LLM retrievers (`Chunks`, `Summaries`, pure vector fetch) and the
-/// LLM one (`GraphCompletion`). Under the mocked LLM the completion call is
-/// near-free, so the no-LLM retrievers are what surface the real retrieval cost
-/// (vector KNN plus chunk/summary materialization) in `search.svg`. Per-query
-/// wall times are logged. The phase aggregate is what `search_time` reports.
-async fn phase_search(
+/// The query text both SDKs benchmark against.
+const BENCH_QUERY: &str = "What is in the document";
+
+/// Build the search orchestrator used by the search phases.
+async fn bench_search_orchestrator(
     cm: &Arc<ComponentManager>,
-    owner_id: Uuid,
-    dataset_name: &str,
-) -> Result<(), String> {
+) -> Result<cognee::search::SearchOrchestrator, String> {
     let vector_db = cm.vector_db().await.map_err(|e| e.to_string())?;
     let embedding_engine = cm.embedding_engine().await.map_err(|e| e.to_string())?;
     let graph_db = cm.graph_db().await.map_err(|e| e.to_string())?;
@@ -762,7 +800,7 @@ async fn phase_search(
         .map_err(|e| e.to_string())?;
     let session_manager = Arc::new(SessionManager::new(Arc::new(session_store)));
     let search_history_db = Arc::clone(&database) as Arc<dyn cognee::database::SearchHistoryDb>;
-    let orchestrator = SearchBuilder::new(
+    Ok(SearchBuilder::new(
         vector_db,
         embedding_engine,
         graph_db,
@@ -771,19 +809,56 @@ async fn phase_search(
     )
     .with_session_manager(session_manager)
     .with_dataset_resolver(Arc::clone(&database) as Arc<dyn IngestDb>)
-    .build();
+    .build())
+}
 
-    let query_text = "What is in the document";
-    // No-LLM retrievers first (Chunks/Summaries) so retrieval cost is visible,
-    // then the LLM path (GraphCompletion). Labels feed the per-query log lines.
+/// The measured search phase: the single graph-completion query Python times.
+///
+/// Python's `bench_cognee.py` Phase 3 is one
+/// `cognee.search(query_text=..., only_context=True)` call, so this is one
+/// `GraphCompletion` request with `only_context`. Keep it that way — the whole
+/// point of `search_time` is that the Python and Rust nightly arms report the
+/// same unit of work. Extra retrievers belong in `phase_search_retrievers`.
+async fn phase_search(
+    cm: &Arc<ComponentManager>,
+    owner_id: Uuid,
+    dataset_name: &str,
+) -> Result<(), String> {
+    let orchestrator = bench_search_orchestrator(cm).await?;
+    let request = bench_search_request(
+        BENCH_QUERY,
+        SearchType::GraphCompletion,
+        dataset_name,
+        owner_id,
+    );
+    orchestrator
+        .search(&request)
+        .await
+        .map_err(|e| format!("graph_completion: {e}"))?;
+    Ok(())
+}
+
+/// Extra retrieval paths, run only under `--profile-dir` and never reported.
+///
+/// The no-LLM retrievers (`Chunks`, `Summaries`) surface the real retrieval
+/// cost — vector KNN plus chunk/summary materialization — that the completion
+/// path hides, especially under a mocked LLM where the completion call is
+/// near-free. That makes them worth a flamegraph, but folding them into
+/// `search_time` would make it incomparable with Python's single query, so they
+/// get their own `search_retrievers.svg` and their elapsed is discarded.
+async fn phase_search_retrievers(
+    cm: &Arc<ComponentManager>,
+    owner_id: Uuid,
+    dataset_name: &str,
+) -> Result<(), String> {
+    let orchestrator = bench_search_orchestrator(cm).await?;
     let queries = [
         ("chunks", SearchType::Chunks),
         ("summaries", SearchType::Summaries),
-        ("graph_completion", SearchType::GraphCompletion),
     ];
 
     for (label, search_type) in queries {
-        let request = bench_search_request(query_text, search_type, dataset_name, owner_id);
+        let request = bench_search_request(BENCH_QUERY, search_type, dataset_name, owner_id);
         let t = Instant::now();
         orchestrator
             .search(&request)
@@ -791,6 +866,54 @@ async fn phase_search(
             .map_err(|e| format!("{label}: {e}"))?;
         info!("search[{label}] took {:.3}s", t.elapsed().as_secs_f64());
     }
+    Ok(())
+}
+
+/// `datasets.empty_dataset(dataset)` — delete the populated dataset.
+///
+/// Mirrors Python's Phase 4, which resolves the dataset by name and calls
+/// `datasets_api.empty_dataset(dataset.id, user)`. Both sides delete the
+/// dataset's relational rows, graph nodes/edges and vectors.
+///
+/// They are NOT byte-for-byte the same unit of work, so do not read a small
+/// `dataset_delete_time_s` gap as an SDK difference. Rust's
+/// `DatasetManager::empty_dataset` hardcodes `DeleteMode::Hard`, which makes
+/// `DeleteService::execute` additionally run `sweep_orphan_nodes` /
+/// `sweep_orphan_edge_types`; Python's `empty_dataset` has no equivalent (its
+/// degree-one sweep lives in `legacy_delete`, off the `delete_data` path). The
+/// sweep runs after this dataset's own nodes are already deleted, so on a
+/// single-dataset bench it scans a near-empty graph and costs a small
+/// near-constant amount rather than scaling with the corpus — but it is
+/// Rust-side-only overhead, so compare the two series by trend, not level.
+async fn phase_dataset_delete(
+    cm: &Arc<ComponentManager>,
+    owner_id: Uuid,
+    dataset_name: &str,
+) -> Result<(), String> {
+    let database = cm.database().await.map_err(|e| e.to_string())?;
+
+    // Python guards this with `if found:` — a failed add leaves nothing to
+    // delete, and the phase still reports its (near-zero) elapsed rather than
+    // failing a run that has already recorded the real failure in `add`.
+    let Some(dataset) = ops::datasets::get_dataset_by_name(&database, dataset_name, owner_id, None)
+        .await
+        .map_err(|e| e.to_string())?
+    else {
+        warn!("dataset '{dataset_name}' not found — nothing to delete");
+        return Ok(());
+    };
+
+    // Shared with `cognee-cli delete` / `forget` so the benchmark cannot drift
+    // into measuring a differently-wired deletion than the commands it mirrors.
+    let delete_service = super::build_delete_service(cm)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let datasets = DatasetManager::new(Arc::clone(&database) as Arc<dyn DatasetDb>);
+    datasets
+        .empty_dataset(dataset.id, owner_id, &delete_service)
+        .await
+        .map_err(|e| e.to_string())?;
     Ok(())
 }
 

--- a/crates/cli/src/commands/delete.rs
+++ b/crates/cli/src/commands/delete.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use cognee::PipelineContext;
 use cognee::api::DatasetRef;
-use cognee::database::{IngestDb, PipelineRunRepository, SeaOrmPipelineRunRepository};
-use cognee::delete::{DeleteMode, DeleteRequest, DeleteScope, DeleteService};
+use cognee::database::IngestDb;
+use cognee::delete::{DeleteMode, DeleteRequest, DeleteScope};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -37,40 +37,15 @@ pub fn run(args: DeleteArgs, cm: Arc<cognee::ComponentManager>) -> Result<(), Cl
         .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
 
     runtime.block_on(async {
-        let storage = cm
-            .storage()
-            .await
-            .map_err(|e| CliError::Runtime(format!("{e}")))?;
         let database = cm
             .database()
-            .await
-            .map_err(|e| CliError::Runtime(format!("{e}")))?;
-        let graph_db = cm
-            .graph_db()
-            .await
-            .map_err(|e| CliError::Runtime(format!("{e}")))?;
-        let vector_db = cm
-            .vector_db()
             .await
             .map_err(|e| CliError::Runtime(format!("{e}")))?;
 
         let request =
             build_request_async(args, owner_id, database.clone() as Arc<dyn IngestDb>).await?;
 
-        // Python parity (gap 08-05): wire the pipeline-runs repository so a
-        // dataset deletion writes a fresh `INITIATED` row for every pipeline
-        // registered against it. Without this a subsequent re-cognify would
-        // be short-circuited by `check_pipeline_run_qualification` (08-08).
-        let pipeline_run_repo: Arc<dyn PipelineRunRepository> =
-            Arc::new(SeaOrmPipelineRunRepository::new(database.clone()));
-
-        let service = DeleteService::new(
-            storage,
-            database.clone() as Arc<dyn cognee::database::DeleteDb>,
-        )
-        .with_graph_db(graph_db)
-        .with_vector_db(vector_db)
-        .with_pipeline_run_repo(pipeline_run_repo);
+        let service = super::build_delete_service(&cm).await?;
 
         if enforce_acl {
             return Err(CliError::Validation(

--- a/crates/cli/src/commands/forget.rs
+++ b/crates/cli/src/commands/forget.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use cognee::api::{DatasetRef, ForgetTarget, forget};
-use cognee::database::{DeleteDb, IngestDb, PipelineRunRepository, SeaOrmPipelineRunRepository};
-use cognee::delete::DeleteService;
+use cognee::database::IngestDb;
 use cognee::{ComponentManager, PipelineContext};
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -42,30 +41,12 @@ pub fn run(args: ForgetArgs, cm: Arc<ComponentManager>) -> Result<(), CliError> 
         .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
 
     runtime.block_on(async {
-        let storage = cm
-            .storage()
-            .await
-            .map_err(|e| CliError::Runtime(format!("{e}")))?;
         let database = cm
             .database()
             .await
             .map_err(|e| CliError::Runtime(format!("{e}")))?;
-        let graph_db = cm
-            .graph_db()
-            .await
-            .map_err(|e| CliError::Runtime(format!("{e}")))?;
-        let vector_db = cm
-            .vector_db()
-            .await
-            .map_err(|e| CliError::Runtime(format!("{e}")))?;
 
-        let pipeline_run_repo: Arc<dyn PipelineRunRepository> =
-            Arc::new(SeaOrmPipelineRunRepository::new(database.clone()));
-
-        let delete_service = DeleteService::new(storage, database.clone() as Arc<dyn DeleteDb>)
-            .with_graph_db(graph_db)
-            .with_vector_db(vector_db)
-            .with_pipeline_run_repo(pipeline_run_repo);
+        let delete_service = super::build_delete_service(&cm).await?;
 
         // Build the ForgetTarget from the (already-validated) flags.
         let target = if args.all {

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -16,3 +16,52 @@ pub mod run_sequence;
 pub mod search;
 #[cfg(feature = "visualization")]
 pub mod visualize;
+
+use std::sync::Arc;
+
+use cognee::database::{DeleteDb, PipelineRunRepository, SeaOrmPipelineRunRepository};
+use cognee::delete::DeleteService;
+use cognee::{ComponentManager, PipelineContext};
+
+use crate::error::CliError;
+
+/// Build the `DeleteService` shared by every deletion path in the CLI.
+///
+/// `delete`, `forget` and the `bench` dataset-delete phase must wire the same
+/// backends or they stop doing (and, for the benchmark, measuring) the same
+/// thing. Two parts are easy to omit and quietly change behaviour:
+///
+/// - the graph and vector backends — without them a deletion drops relational
+///   rows only, which for the benchmark would turn a populated-dataset delete
+///   into a metadata-row delete;
+/// - the pipeline-runs repository — without it a deletion writes no fresh
+///   `INITIATED` row, so a later re-cognify is short-circuited by
+///   `check_pipeline_run_qualification`.
+pub(crate) async fn build_delete_service(
+    cm: &Arc<ComponentManager>,
+) -> Result<DeleteService, CliError> {
+    let storage = cm
+        .storage()
+        .await
+        .map_err(|e| CliError::Runtime(format!("{e}")))?;
+    let database = cm
+        .database()
+        .await
+        .map_err(|e| CliError::Runtime(format!("{e}")))?;
+    let graph_db = cm
+        .graph_db()
+        .await
+        .map_err(|e| CliError::Runtime(format!("{e}")))?;
+    let vector_db = cm
+        .vector_db()
+        .await
+        .map_err(|e| CliError::Runtime(format!("{e}")))?;
+
+    let pipeline_run_repo: Arc<dyn PipelineRunRepository> =
+        Arc::new(SeaOrmPipelineRunRepository::new(Arc::clone(&database)));
+
+    Ok(DeleteService::new(storage, database as Arc<dyn DeleteDb>)
+        .with_graph_db(graph_db)
+        .with_vector_db(vector_db)
+        .with_pipeline_run_repo(pipeline_run_repo))
+}

--- a/crates/cli/tests/cli_bench.rs
+++ b/crates/cli/tests/cli_bench.rs
@@ -74,7 +74,7 @@ fn test_bench_mock_offline_smoke() {
     let raw = fs::read_to_string(&output).expect("result file written");
     let v: serde_json::Value = serde_json::from_str(&raw).expect("result is valid JSON");
 
-    // All six metric keys present and numeric / >= 0.
+    // All seven metric keys present and numeric / >= 0.
     for key in [
         "add_time_s",
         "cognify_time_s",
@@ -82,6 +82,7 @@ fn test_bench_mock_offline_smoke() {
         "prune_time_s",
         "db_setup_time_s",
         "search_time",
+        "dataset_delete_time_s",
     ] {
         let n = v[key]
             .as_f64()
@@ -110,7 +111,14 @@ fn test_bench_mock_offline_smoke() {
 
     // Status block: every phase "success".
     let status = &v["status"];
-    for phase in ["prune", "db_setup", "add", "cognify", "search"] {
+    for phase in [
+        "prune",
+        "db_setup",
+        "add",
+        "cognify",
+        "search",
+        "dataset_delete",
+    ] {
         assert_eq!(
             status[phase].as_str(),
             Some("success"),

--- a/docs/performance/cpu-profiling.md
+++ b/docs/performance/cpu-profiling.md
@@ -44,9 +44,13 @@ once the graph is large. That is the reason for the committed Moby-Dick fixture.
 | graph size | 150 nodes / 100 edges | 1189 nodes / 2667 edges |
 | add (wall) | 3.0 s | 8.5 s |
 | cognify (wall) | 0.86 s | 5.76 s |
-| search (wall) | 0.25 s | 0.35 s |
+| search (wall) † | 0.25 s | 0.35 s |
 | cognify on-CPU fraction | 11% | 26% |
 | top cognify hotspot | token-count update (53 ms) | graph.query (982 ms / 1061 calls) |
+
+† Measured when the timed `search` phase still ran `Chunks` + `Summaries` +
+`GraphCompletion`. It now times `GraphCompletion` alone — see the search note
+below.
 
 ## Method
 
@@ -93,8 +97,17 @@ Cypher execution per graph element.
 
 **search: 0.35 s wall, about 63% on-CPU (249 ms busy).** Small in absolute terms.
 `cognee.search` (123 ms) and retrieval (`get_context`, `graph_search`) split it.
-Retrieval is now visible because the bench exercises the no-LLM retrievers
-(`Chunks`, `Summaries`) alongside `GraphCompletion`.
+
+> **These search figures predate the phase split and are not reproducible as
+> written.** They were measured when the timed `search` phase ran `Chunks`,
+> `Summaries` and `GraphCompletion` together. The phase now times only the
+> single `GraphCompletion` query the Python bench times, so `search.svg` /
+> `search.telemetry.json` cover that query alone and come out well under
+> 0.35 s. The two no-LLM retrievers moved to a separate phase and now produce
+> `search_retrievers.svg` / `search_retrievers.telemetry.json` — that is where
+> the `Chunks`/`Summaries` retrieval cost went, and it is emitted only on a
+> `--features bench,profiling` build invoked with `--profile-dir`. Re-measure
+> both phases before quoting numbers here again.
 
 ## What is inside `graph.query`
 
@@ -153,6 +166,10 @@ MOCK_LLM=true MOCK_EMBEDDING=deterministic \
 ```
 
 Artifacts land in `target/perf-profiles/large/`: `<phase>.svg` (flamegraph) and
-`<phase>.telemetry.json` (wall-clock breakdown). `--min-graph-nodes 1189` asserts
+`<phase>.telemetry.json` (wall-clock breakdown), for phases `add`, `cognify`,
+`search`, `search_retrievers` and `dataset_delete`. `search` covers the one
+`GraphCompletion` query the benchmark reports as `search_time`;
+`search_retrievers` covers the untimed `Chunks`/`Summaries` queries and is
+written only on a `profiling` build. `--min-graph-nodes 1189` asserts
 the recorded baseline so a stale cassette fails loudly instead of profiling an
 empty graph.

--- a/docs/performance/mock-benchmark.md
+++ b/docs/performance/mock-benchmark.md
@@ -2,7 +2,7 @@
 
 This guide ties together the record/replay mock LLM, the deterministic mock
 embeddings, and the `cognee-cli bench` driver into a single offline workflow: a
-benchmark of the full `add → cognify → search` pipeline that runs with **no API
+benchmark of the full `add → cognify → search → dataset delete` pipeline that runs with **no API
 key**.
 
 For the design rationale (why we mock both the LLM and the embeddings, and the
@@ -112,12 +112,14 @@ the shared orchestrator can drive either SDK unchanged:
   "prune_time_s": 0.0,
   "db_setup_time_s": 0.0,
   "search_time": 0.0,
+  "dataset_delete_time_s": 0.0,
   "status": {                 // per-phase: "success" or "failed: <msg>"
     "prune": "success",
     "db_setup": "success",
     "add": "success",
     "cognify": "success",
-    "search": "success"
+    "search": "success",
+    "dataset_delete": "success"
   },
   "success": true,
   "config": {
@@ -132,8 +134,9 @@ the shared orchestrator can drive either SDK unchanged:
 }
 ```
 
-The ingest/prune/db-setup phase times are rounded to 3 decimals (Python
-`round(x, 3)` parity); `search_time` is reported unrounded, matching Python. Once a run
+The ingest/prune/db-setup/dataset-delete phase times are rounded to 3 decimals
+(Python `round(x, 3)` parity); `search_time` is reported unrounded, matching
+Python. Once a run
 completes and the result file is written the process exits `0` even if individual
 phases failed — failures are captured in `status` / `success`. The process exits
 nonzero only for catastrophic errors (bad arguments, unreadable corpus,

--- a/docs/performance/python-approach.md
+++ b/docs/performance/python-approach.md
@@ -1,7 +1,7 @@
 # Mock-LLM Percentile Benchmark — Python Approach & Rust Porting Strategy
 
 This document explains, in detail, how the Python `cognee` repository benchmarks
-the `add → cognify → search` pipeline with **mocked LLM and embedding backends**,
+the `add → cognify → search → dataset delete` pipeline with **mocked LLM and embedding backends**,
 why that design is valuable, and how we intend to port it to `cognee-rust`.
 
 It is the design-rationale document behind the offline mock benchmark. The
@@ -18,7 +18,7 @@ The Python reference lives in the sibling checkout at `../cognee` (i.e.
 | File | Role |
 |---|---|
 | [`statistics_percentile_report.py`](../../../cognee/cognee/tests/performance/statistics_percentile_report.py) | **Orchestrator / reporter.** Runs the bench N times, computes percentiles, prints a table, emits a Chart.js HTML report. |
-| [`statistics_percentile/bench_cognee.py`](../../../cognee/cognee/tests/performance/statistics_percentile/bench_cognee.py) | **Bench driver.** One full pipeline run (prune → setup → add → cognify → search), phase-timed, writes a JSON result. |
+| [`statistics_percentile/bench_cognee.py`](../../../cognee/cognee/tests/performance/statistics_percentile/bench_cognee.py) | **Bench driver.** One full pipeline run (prune → setup → add → cognify → search → dataset delete), phase-timed, writes a JSON result. |
 | [`statistics_percentile/memories.json`](../../../cognee/cognee/tests/performance/statistics_percentile/memories.json) | Input corpus: array of `{title, content, references}` memories. |
 | [`statistics_percentile/mock_memories.json`](../../../cognee/cognee/tests/performance/statistics_percentile/mock_memories.json) | Hand-authored mock responses: per-title `knowledge_graph` + `summary`. |
 
@@ -58,17 +58,24 @@ Two details matter for the port:
   to avoid rate limits (`if i != 1 and not args.mock_llm: time.sleep(60)`,
   line ~363). In `--mock-llm` mode the sleep is skipped — runs are back-to-back.
 
-The required JSON contract (what the bench must emit) — `build_report` reads each
-key with `r[metric]` (not `.get`), so **all of these must be present**:
+The JSON contract (what the bench emits) — the metric keys both SDKs produce:
 
 ```
 add_time_s, cognify_time_s, total_ingest_time_s,
-search_time, prune_time_s, db_setup_time_s
+search_time, prune_time_s, db_setup_time_s,
+dataset_delete_time_s
 ```
 
 plus `config` (`llm_model`, `embedding_model`, `embedding_dimensions`),
 `status` (object: phase → `"success"` | `"failed: …"`), `success` (bool), and
 `memories_count`. `wall_time_s` is added by the orchestrator, not the bench.
+
+`build_report` first filters `METRICS` down to the keys **run 1** actually
+emitted, then reads every run with `r[metric]` (not `.get`). So a metric no run
+emits is simply skipped — that is how the cloud-only `tenant_*` metrics coexist
+with the local ones — but a key present in run 1 and missing later raises. A
+bench must therefore emit its metric set *consistently across runs*, not
+necessarily completely.
 
 ### 2.2 Bench driver — `bench_cognee.py`
 
@@ -78,7 +85,21 @@ One pipeline run, timing each phase with `time.time()`:
 2. `setup` — DB setup, timed as `db_setup_time_s`.
 3. `add` — `cognee.add(text_list)`, timed as `add_time_s`.
 4. `cognify` — `cognee.cognify(...)`, timed as `cognify_time_s`.
-5. `search` — one `cognee.search(...)`, timed as `search_time`.
+5. `search` — one `cognee.search(query_text=..., only_context=True)`, timed as
+   `search_time`. Exactly one query: the Rust bench mirrors this so the two
+   `search_time` series measure the same unit of work.
+6. `dataset delete` — `datasets.empty_dataset(...)` over the *populated*
+   dataset (it runs after cognify and search, so nodes, edges and vectors are
+   all present), timed as `dataset_delete_time_s`.
+
+   Caveat on this one metric: the Rust bench reaches `empty_dataset` with
+   `DeleteMode::Hard`, which also runs an orphan-node/edge-type sweep that
+   Python's `empty_dataset` never performs (Python's degree-one sweep sits in
+   `legacy_delete`, reachable only from `delete_data`). The sweep runs after
+   the dataset's own nodes are gone, so on a single-dataset bench it scans a
+   near-empty graph — a small near-constant Rust-side overhead, not something
+   that scales with the corpus. Compare the two `dataset_delete_time_s` series
+   by trend rather than by absolute level.
 
 Each phase is wrapped in try/except so a failure is recorded in `status` rather
 than aborting the run. Results are serialized to `--output`.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -13,8 +13,8 @@ This directory holds the offline (zero-API) benchmark harness for the
   cassette lookup hashes — are stable across runs.
 - `fixtures/cassette.json` — recorded LLM responses for that corpus
   (`LlmCassette`, version 1, recorded against `gpt-4o-mini`). Committed so that
-  anyone — and CI — can replay the full `add → cognify → search` pipeline with
-  **no API key**.
+  anyone — and CI — can replay the full
+  `add → cognify → search → dataset delete` pipeline with **no API key**.
 - `run_mock_bench.sh` — drives the shared Python percentile orchestrator against
   the Rust `cognee-cli bench` in offline `--mock-llm` mode (deterministic mock
   embeddings + the committed cassette). See the script header for env-var


### PR DESCRIPTION
## Why

The nightly performance report drives both SDKs through the same Python orchestrator (`statistics_percentile_report.py`), but the Rust arm reported a different metric set and a different unit of work for `search_time`. The two columns could not be read side by side — which is the entire point of running both.

This is step 1 of bringing the Rust nightly arms to parity with the Python ones; the follow-up (Slack section formatting in `topoteretes/cognee`) depends on nothing here.

## What changed

**`dataset_delete_time_s` + `status.dataset_delete`** — mirrors Python's Phase 4, deleting the populated dataset after cognify and search. `statistics_percentile_report.py` already listed the key in `METRICS`, so the percentile table, HTML report and MotherDuck views pick it up with **no change on the cognee side**.

**Timed search phase reduced to one query** — one `GraphCompletion` + `only_context` request, matching `bench_cognee.py`. `Chunks` / `Summaries` move to an untimed `search_retrievers` phase gated on a `profiling` build with `--profile-dir`.

**Shared `commands::build_delete_service`** — `delete`, `forget` and the benchmark built the same `DeleteService` three times over. For the benchmark, drifting wiring would silently change what it measures.

## Reviewer notes — expected changes in the nightly

- **`search_time` steps down** for the Rust arms the night this lands (three queries → one). Not a regression.
- **`dataset_delete_time_s` is not level-comparable with Python.** Rust's `DatasetManager::empty_dataset` hardcodes `DeleteMode::Hard`, so `DeleteService::execute` also runs `sweep_orphan_nodes` / `sweep_orphan_edge_types`; Python's `empty_dataset` has no equivalent (its degree-one sweep lives in `legacy_delete`, off the `delete_data` path). The sweep runs after this dataset's nodes are already gone, so it scans a near-empty graph — small and near-constant, not corpus-scaling — but it is Rust-side-only. Documented at the call site and in `python-approach.md`. Compare by trend, not level.
- **Retriever coverage narrows.** No automated build enables `profiling`, so `Chunks`/`Summaries` errors no longer turn a bench run red, where the old three-query loop's `?` fed them into `status.search`. Accepted deliberately: failing on queries Python does not run would make `success` mean different things per SDK, and the search crate has its own integration tests for those retrievers.

Two review findings were left unaddressed on purpose: `phase_dataset_delete` discards its `DeleteResult` (Python's Phase 4 does too), and failures in the profiling-only retriever phase warn without a status field (documented at the call site, manual-profiling only).

## Verification

- `cargo clippy --features bench` and `--features bench,profiling`, `-D warnings`: clean.
- `cargo test -p cognee-cli --features bench`: 41 passed. The bench smoke test now asserts `dataset_delete_time_s` and `status.dataset_delete`, so it guards the schema.
- End-to-end through the **unchanged** Python orchestrator (`run_mock_bench.sh`, 2 runs, mock cassette): 2/2 success, `Dataset delete` renders in Python's exact row position, and the delete logs confirm real work (`deleted_graph_nodes=150 deleted_vector_points=150 deleted_data=50 deleted_datasets=1`).
- `scripts/check_all.sh`: green through every Rust lane and the C API check. The Python/TS/Java binding stages need a virtualenv the fresh worktree lacks and were not run — `crates/cli` is a leaf binary crate with no dependents, so those surfaces cannot reach this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGPxiXqmBDiX1fRscCxVD
