### PR TITLE
fix(teardown): close the graph, vector, ONNX and HTTP-client resources, not just the relational pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,17 +773,27 @@ jobs:
       # same conclusion ("the lib target holds 20-odd unrelated unit tests, so a
       # count floor would not notice these two disappearing") and the
       # `pggraph-postgres` lane below still passes `--min-tests 1` for it.
+      # Pool-teardown regression tests (topoteretes/cognee-rs#132) — see the
+      # PgGraph lane for why a named `--test` invocation is required.
+      - name: Run PgVectorAdapter pool-close tests
+        run: |
+          set -o pipefail
+          cargo test -p cognee-vector --features pgvector,testing \
+            --test pgvector_close -- --nocapture 2>&1 | tee pgvector-close.log
+
       - name: Assert the suite really executed
         run: |
           bash scripts/ci/assert_pg_suite_ran.sh --label PgVector \
             --log pgvector-integration.log --min-tests 20 \
             --log pgvector-lib.log         --min-tests 1 \
             --log pgvector-spans.log       --min-tests 1 \
+            --log pgvector-close.log --min-tests 2 \
             --require-test pgvector_coexists_with_relational_migrator_in_shared_db \
             --require-test pgvector_purges_legacy_row_from_default_table_on_upgrade \
             --require-test upsert_emits_pgvector_span \
             --require-test search_emits_pgvector_span \
-            --require-test delete_emits_pgvector_span
+            --require-test delete_emits_pgvector_span \
+            --require-test close_releases_the_pool_while_the_adapter_is_still_held
 
   # ── Stage 2.5: single-database Postgres stack (depends on lint, parallel with `test`) ──
   # The `TEST_POSTGRES_URL` suites, which no CI job ever supplied that variable
@@ -1060,13 +1070,25 @@ jobs:
       # this lane reporting green while every case inside it skips. The logic
       # lives in a script rather than inline so this lane and its community.yml
       # mirror cannot drift, and so it can be tested against captured logs.
+      # Pool-teardown regression tests (topoteretes/cognee-rs#132). This lane
+      # invokes individual `--test` targets, so a new file is otherwise compiled
+      # by nobody and run nowhere — which for a leak test means the leak comes
+      # back silently.
+      - name: Run PgGraphAdapter pool-close tests
+        run: |
+          set -o pipefail
+          cargo test -p cognee-graph --features postgres,testing \
+            --test pg_graph_close -- --nocapture 2>&1 | tee pggraph-close.log
+
       - name: Assert the suite really executed
         run: |
           bash scripts/ci/assert_pg_suite_ran.sh --label PgGraph \
             --log pggraph-integration.log --min-tests 30 \
             --log pggraph-lib.log         --min-tests 1 \
+            --log pggraph-close.log --min-tests 3 \
             --require-test pggraph_coexists_with_relational_migrator_in_shared_db \
-            --require-test pggraph_purges_legacy_row_from_default_table_on_upgrade
+            --require-test pggraph_purges_legacy_row_from_default_table_on_upgrade \
+            --require-test close_releases_the_pool_while_the_adapter_is_still_held
 
   # ── Stage 3: Language binding checks (depend on lint, parallel with `test`) ──
   # Gated on `lint` (not `test`) so the binding builds run concurrently with the

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -275,13 +275,25 @@ jobs:
             --lib --success-output immediate --color never \
             2>&1 | tee pggraph-lib.log
 
+      # Pool-teardown regression tests (topoteretes/cognee-rs#132). This lane
+      # invokes individual `--test` targets, so a new file is otherwise compiled
+      # by nobody and run nowhere — which for a leak test means the leak comes
+      # back silently.
+      - name: Run PgGraphAdapter pool-close tests
+        run: |
+          set -o pipefail
+          cargo test -p cognee-graph --features postgres,testing \
+            --test pg_graph_close -- --nocapture 2>&1 | tee pggraph-close.log
+
       - name: Assert the suite really executed
         run: |
           bash scripts/ci/assert_pg_suite_ran.sh --label PgGraph \
             --log pggraph-integration.log --min-tests 30 \
             --log pggraph-lib.log         --min-tests 1 \
+            --log pggraph-close.log --min-tests 3 \
             --require-test pggraph_coexists_with_relational_migrator_in_shared_db \
-            --require-test pggraph_purges_legacy_row_from_default_table_on_upgrade
+            --require-test pggraph_purges_legacy_row_from_default_table_on_upgrade \
+            --require-test close_releases_the_pool_while_the_adapter_is_still_held
 
   # ── pgvector adapter tests (mirror of ci.yml's `pgvector-postgres`) ──
   # Keyless for the same reason as the graph lane above: a pgvector service
@@ -381,17 +393,27 @@ jobs:
       # `--min-tests 1` — enough to catch compiles-to-zero — because every case
       # that matters in them is named below, and 32 of the `--lib` target's 34
       # tests are unrelated unit tests. See the ci.yml twin for the full reasoning.
+      # Pool-teardown regression tests (topoteretes/cognee-rs#132) — see the
+      # PgGraph lane for why a named `--test` invocation is required.
+      - name: Run PgVectorAdapter pool-close tests
+        run: |
+          set -o pipefail
+          cargo test -p cognee-vector --features pgvector,testing \
+            --test pgvector_close -- --nocapture 2>&1 | tee pgvector-close.log
+
       - name: Assert the suite really executed
         run: |
           bash scripts/ci/assert_pg_suite_ran.sh --label PgVector \
             --log pgvector-integration.log --min-tests 20 \
             --log pgvector-lib.log         --min-tests 1 \
             --log pgvector-spans.log       --min-tests 1 \
+            --log pgvector-close.log --min-tests 2 \
             --require-test pgvector_coexists_with_relational_migrator_in_shared_db \
             --require-test pgvector_purges_legacy_row_from_default_table_on_upgrade \
             --require-test upsert_emits_pgvector_span \
             --require-test search_emits_pgvector_span \
-            --require-test delete_emits_pgvector_span
+            --require-test delete_emits_pgvector_span \
+            --require-test close_releases_the_pool_while_the_adapter_is_still_held
 
   # ── Single-database Postgres stack (mirror of ci.yml's `pg-single-db-postgres`) ──
   # Two of the three suites in the keyed twin; `pg_full_stack_e2e` is deliberately

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+- **Teardown now closes every backend, not just the relational pool — and a
+  closed graph/vector store rejects later operations.** `ComponentManager::close`
+  (reached by every binding's handle teardown and by the CLI on exit) used to
+  release the relational connection and leave every other component in its cache,
+  on the documented premise that they "release everything on drop". They do —
+  but the cache is the last strong reference, so a slot that is never emptied is
+  a destructor that never runs. It now takes every slot out and closes what is
+  closable.
+
+  Three consequences for callers:
+
+  1. **`close()` is no longer a cheap relational reset.** A caller that closes and
+     then keeps using the manager pays a full re-warm: a fresh TLS handshake per
+     HTTP-backed engine, and for the ONNX provider a re-read of the model file.
+  2. **Operations after a close now fail** on the graph and vector stores
+     (`graph database is closed`, or a closed-pool error from Postgres) where they
+     previously succeeded by silently reopening. This extends the relational
+     contract introduced in the previous release rather than inventing a new one,
+     but it is user-visible. The `release` tier is unchanged: the handle stays
+     re-warmable.
+  3. **`GraphDBTrait::close` / `VectorDB::close` are new trait methods** with
+     default no-op bodies, so every existing implementation — including
+     out-of-tree adapters — keeps compiling untouched. That default means "this
+     backend owns nothing closable beyond memory". **An external adapter that does
+     own OS resources will now leak invisibly until it overrides `close`.** The
+     in-tree pattern to copy is `crates/graph/tests/ladybug_close.rs`: assert no
+     sidecar file survives an awaited `close()`. In-tree, LanceDB and the
+     in-memory brute-force store keep the default deliberately — both were
+     measured to hold no descriptor open between calls.
+
+  `PgGraphAdapter::from_connection` / `PgVectorAdapter::from_connection` gain a
+  documented guarantee alongside this: an adapter wrapping a **caller-supplied**
+  connection never closes it. In the shared-Postgres layout that connection is the
+  relational pool, so closing it from a store teardown would turn a leak fix into
+  an outage.
+
+  Two clarifications to that contract, from review of the change:
+
+  - **The two teardown tiers differ in what they may touch, not just in a flag.**
+    The explicit tier (`HandleState::close`, `Cognee.close()`, `cg_sdk_close`)
+    closes the stores unconditionally — including one that an operation still in
+    flight is holding, which will then fail on its next query. The implicit tier
+    (`HandleState::release`, reached from a GC finalizer: `Drop for PyCognee`,
+    neon's `Finalize`) closes a component **only when the cache holds its last
+    reference.** A store's `close()` mutates state behind the shared `Arc`, so it
+    is visible to every clone, and a garbage collector has no mandate to fail
+    somebody's in-flight query — an explicit `close()` does. In the ordinary
+    finalizer case, with nothing in flight, the two tiers release exactly the same
+    resources, sidecars included.
+  - **`LadybugAdapter::close` guarantees "closed to new work and checkpointed",
+    not "the file is free".** It empties the slot (so every clone fails with
+    `graph database is closed`) and checkpoints the `.wal`, both on the blocking
+    pool. It cannot promise the descriptor and lbug's write lock are gone by the
+    time it returns: an in-flight query owns a database handle for its duration, so
+    a close racing one drops a reference rather than the last one. A caller that
+    needs the file free — to reopen it, or to delete its directory — has to stop
+    issuing queries first. The earlier wording promised the write lock was
+    released; it is released once the last query finishes, which is not the same
+    claim.
+
 - **`cognee-core`: `PipelineContext::current_data` changed meaning.** It is now
   pinned, once per data item, to the value that *entered* the pipeline, and is
   never rebound as that item flows through the task chain. Previously the

--- a/crates/bindings-common/Cargo.toml
+++ b/crates/bindings-common/Cargo.toml
@@ -54,6 +54,8 @@ uuid       = { workspace = true }
 tokio      = { workspace = true }
 async-trait = { workspace = true }
 base64      = { workspace = true }
+# Teardown diagnostics only (the telemetry-flush timeout note in `HandleState`).
+tracing     = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/bindings-common/src/handle.rs
+++ b/crates/bindings-common/src/handle.rs
@@ -26,6 +26,11 @@ use cognee::models::User;
 use crate::SdkError;
 use crate::services::CogneeServices;
 
+/// How long a teardown waits for already-dispatched telemetry POSTs to leave the
+/// process. Small on purpose: a binding's `close()` must never block on an
+/// analytics collector.
+const TELEMETRY_FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
+
 /// Optional bootstrap seam for resolving (and persisting) the default user.
 ///
 /// OSS has no `users`-table writer, so the default binding behaviour is
@@ -202,10 +207,17 @@ impl HandleState {
     /// it) for a handle that never warmed. A contended lock reports `true`: the
     /// safe direction is to attempt the release rather than skip a real one.
     pub fn has_open_resources(&self) -> bool {
-        match self.services.try_lock() {
+        let bundle_cached = match self.services.try_lock() {
             Ok(guard) => guard.is_some(),
             Err(_) => true,
-        }
+        };
+        // The bundle alone is not the answer. `CogneeServices::build` warms the
+        // engines one at a time and can fail part-way — a bad `llm_api_key` fails
+        // *after* the SQLite pool and the embedded graph are cached — leaving the
+        // bundle `None` while real resources are open. Asking only about the
+        // bundle reported "nothing to release" for exactly that handle, and the
+        // finalizer skipped the teardown.
+        bundle_cached || self.cm.has_cached_components()
     }
 
     /// Release the resources this handle opened, leaving it usable.
@@ -220,21 +232,32 @@ impl HandleState {
     /// - `release` is for the **implicit** paths — a GC finalizer (`Drop for
     ///   PyCognee`, neon's `Finalize`) reclaiming a handle the program dropped on
     ///   the floor. The user never said "close", so this only gives the resources
-    ///   back: the handle stays warm-able, and anything still holding a clone of
-    ///   the state (a sub-handle like `cognee.datasets`, an in-flight op) keeps
-    ///   working — it just re-warms against a fresh connection.
+    ///   back, and only the ones nobody else is using: the handle stays warm-able,
+    ///   a sub-handle like `cognee.datasets` that outlived its parent keeps
+    ///   working (it re-warms against a fresh connection), and an operation still
+    ///   in flight keeps the components it holds — those are released when it
+    ///   finishes. See [`ComponentManager::release`](cognee::ComponentManager::release)
+    ///   for how "nobody else is using it" is decided.
     /// - [`close`](Self::close) is for the **explicit** paths (`Cognee.close()`,
-    ///   `cg_sdk_close`). It additionally marks the handle closed, so later ops
-    ///   fail with a clear error instead of silently reopening the database.
+    ///   `cg_sdk_close`). It marks the handle closed, so later ops fail with a
+    ///   clear error instead of silently reopening the database, and it closes the
+    ///   components **unconditionally** — including ones an in-flight operation is
+    ///   still holding, which will then fail on its next query. That is the point:
+    ///   the caller said they were done, and a resource that outlives an explicit
+    ///   close is the bug this exists to prevent.
     ///
     /// Both are idempotent. Neither waits for concurrent operations to *finish*: an
     /// op that is mid-flight holds its own `Arc<CogneeServices>` and will see a
-    /// closed pool on its next query, so a binding should only tear down when its
-    /// own contract says the handle is done. What the teardown does wait for — and
-    /// has to, or the SQLite sidecars outlive it — is the pool's connections coming
-    /// back and closing. That is normally microseconds; a connection genuinely held
-    /// by an in-flight op bounds it at `cognee_database`'s drain timeout, after
-    /// which the teardown gives up on that connection and logs rather than hanging.
+    /// closed pool on its next query. So a binding should only call `close` when its
+    /// own contract says the handle is done, and use `release` where it cannot know
+    /// — which is exactly the split between an explicit `close()` call and a
+    /// garbage collector.
+    ///
+    /// What the teardown *does* wait for — and has to, or the SQLite sidecars
+    /// outlive it — is the pool's connections coming back and closing. That is
+    /// normally microseconds; a connection genuinely held by an in-flight op bounds
+    /// it at `cognee_database`'s drain timeout, after which the teardown gives up on
+    /// that connection and logs rather than hanging.
     pub async fn release(&self) {
         self.teardown(false).await;
     }
@@ -262,10 +285,41 @@ impl HandleState {
         // in between and have it closed underneath it. Lock order (services →
         // owner id → the manager's caches) is the same one `services()` takes, so
         // this cannot deadlock.
+        //
+        // **This ordering is load-bearing and must not be reversed.** The bundle
+        // holds an `Arc` clone of *every* engine, not just the connection, so
+        // dropping it first is what leaves the manager's own cache as the last
+        // strong reference — which is the reference `cm.close()` releases, and
+        // therefore the only reason the engines' destructors run at all (measured:
+        // exactly one live relational connection at this point, and the embedded
+        // graph's `.wal` released by the `cm.close()` below rather than at process
+        // exit). Calling `cm.close()` while the bundle is still cached would close
+        // the stores underneath a live bundle and leak the rest.
         let mut guard = self.services.lock().await;
         drop(guard.take());
         *self.owner_id.lock().await = None;
-        self.cm.close().await;
+        // Which teardown tier the manager runs is the whole difference between
+        // `release` and `close`: a store's `close()` mutates state behind the
+        // shared `Arc` and would break an operation still holding a clone, so the
+        // implicit tier closes only components nobody else is using.
+        if mark_closed {
+            self.cm.close().await;
+        } else {
+            self.cm.release().await;
+        }
+
+        // Finally, let the analytics POSTs already in flight finish. `send_telemetry`
+        // is fire-and-forget, so a binding whose embedder exits (or drops its
+        // runtime) right after closing otherwise discards its last event —
+        // measured 0 of 1 delivered without a flush, 1 of 1 with one. Hard-bounded
+        // and ignored on timeout: a slow collector must never make a `close()` hang,
+        // and telemetry must never make one fail.
+        if !cognee::cognee_telemetry::flush(TELEMETRY_FLUSH_TIMEOUT).await {
+            tracing::debug!(
+                "telemetry still in flight after {TELEMETRY_FLUSH_TIMEOUT:?}; \
+                 dropping the remainder rather than delaying teardown"
+            );
+        }
     }
 
     /// Blocking [`close`](Self::close), for a synchronous binding teardown hook

--- a/crates/bindings-common/src/handle.rs
+++ b/crates/bindings-common/src/handle.rs
@@ -308,6 +308,16 @@ impl HandleState {
             self.cm.release().await;
         }
 
+        // Release the services lock before the flush. Holding it across
+        // `cm.close()` is deliberate — it stops a concurrent `services()` from
+        // caching a freshly built pool that is about to be closed underneath it —
+        // but the flush touches nothing the guard protects, and keeping it would
+        // block any other thread's `services()` for up to the flush timeout. That
+        // is a real stall for a binding: Python `Cognee.close()` on one thread
+        // while another calls `cognee.datasets.list()` would make the second wait
+        // on an analytics POST.
+        drop(guard);
+
         // Finally, let the analytics POSTs already in flight finish. `send_telemetry`
         // is fire-and-forget, so a binding whose embedder exits (or drops its
         // runtime) right after closing otherwise discards its last event —

--- a/crates/bindings-common/tests/handle_close.rs
+++ b/crates/bindings-common/tests/handle_close.rs
@@ -349,3 +349,197 @@ fn close_blocking_waits_for_a_straggling_connection() {
     assert!(!shm_left, "-shm must be gone when close_blocking returns");
     assert!(state.is_closed());
 }
+
+/// Every `*.wal` under `root` — the embedded graph's sidecar (SQLite's is
+/// `<db>-wal`, matched by [`sidecars`] instead).
+fn graph_wal_files(root: &Path) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("wal") {
+                found.push(path.to_string_lossy().into_owned());
+            }
+        }
+    }
+    found
+}
+
+/// The relational pool was never the only OS resource a warm handle holds: the
+/// embedded graph keeps its own un-checkpointed `.wal` under the system root, and
+/// a write lock on the graph file behind it.
+///
+/// Both were leaked by the #135 teardown, which closed the relational connection
+/// and left every other slot in the manager's cache — i.e. never dropped, so
+/// never released. This test is the binding-surface half of that fix: it fails
+/// before it with `sys/graph.wal` still on disk after `close()` returned.
+///
+/// The re-open at the end is the other half: `close()` must not leave the graph
+/// file locked, or the next handle on the same path (a binding test suite that
+/// reuses its temp dir, a CLI invoked twice) fails to warm.
+#[tokio::test(flavor = "multi_thread")]
+async fn close_releases_the_embedded_graph_wal_and_unlocks_the_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let (state, _db_path) = handle_under(dir.path());
+    let sys = dir.path().join("sys");
+
+    {
+        let services = state.services().await.expect("warm");
+        let nodes: Vec<_> = (0..500)
+            .map(|i| {
+                serde_json::json!({
+                    "id": format!("n{i}"),
+                    "name": format!("Node {i}"),
+                    "type": "TestNode",
+                    "properties": {"idx": i, "pad": "x".repeat(64)},
+                })
+            })
+            .collect();
+        services
+            .graph_db
+            .add_nodes_raw(nodes)
+            .await
+            .expect("write to the embedded graph");
+        assert!(
+            !graph_wal_files(&sys).is_empty(),
+            "precondition: the writes must leave an un-checkpointed graph WAL under {}",
+            sys.display(),
+        );
+    }
+
+    state.close().await;
+
+    let leftover = graph_wal_files(&sys);
+    assert!(
+        leftover.is_empty(),
+        "close() must release the embedded graph's WAL too, found: {leftover:?}",
+    );
+
+    // A second handle on the same graph path must warm — the lock is gone.
+    let (second, _) = handle_under(dir.path());
+    let services = second.services().await.expect("re-warm on the same path");
+    assert!(
+        services
+            .graph_db
+            .has_node("n1")
+            .await
+            .expect("query the reopened graph"),
+        "the checkpointed nodes must be readable by the second handle",
+    );
+    second.close().await;
+    assert!(graph_wal_files(&sys).is_empty());
+}
+
+/// A warm that fails part-way still leaves resources open, and the finalizer's
+/// probe has to say so.
+///
+/// `CogneeServices::build` warms slot by slot and resolves the LLM near the end,
+/// so an empty `llm_api_key` fails **after** the SQLite pool (and the graph) are
+/// cached. The services slot is then `None` — and a probe that only looked there
+/// reported "nothing to release", so `Drop for PyCognee` / neon's `Finalize`
+/// skipped the teardown and the open database survived until process exit.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failed_warm_still_reports_open_resources_and_releases_them() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("cognee.db");
+    let (wal, shm) = sidecars(&db_path);
+
+    // Everything valid except the LLM key, which is resolved strictly and last.
+    let settings = Settings {
+        llm_api_key: String::new(),
+        embedding_provider: "mock".to_owned(),
+        data_root_directory: dir.path().join("data").to_string_lossy().into_owned(),
+        system_root_directory: dir.path().join("sys").to_string_lossy().into_owned(),
+        relational_db_url: format!("sqlite://{}?mode=rwc", db_path.display()),
+        ..Settings::default()
+    };
+    let state = std::sync::Arc::new(HandleState::from_settings(settings));
+
+    let err = match state.services().await {
+        Ok(_) => panic!("warm must fail without an LLM key"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("llm_api_key"),
+        "expected the LLM key to be what failed, got: {err}"
+    );
+
+    // The pool is open even though the bundle was never cached.
+    assert!(
+        wal.exists() && shm.exists(),
+        "precondition: the relational pool was opened before the warm failed"
+    );
+    assert!(
+        state.has_open_resources(),
+        "a partly warmed handle has resources to release; reporting otherwise is \
+         what made the finalizer skip the teardown"
+    );
+
+    // And the finalizer's teardown does release them.
+    state.release().await;
+    assert!(
+        !wal.exists() && !shm.exists(),
+        "release must free the sidecars"
+    );
+}
+
+/// `release()` — the implicit tier — must not break a component that an operation
+/// still in flight is holding.
+///
+/// A store's `close()` mutates state behind the shared `Arc`, so it is visible to
+/// every clone. The explicit `close()` is entitled to that; a garbage collector is
+/// not, and the two-tier split exists precisely so a finalizer cannot fail
+/// somebody's in-flight query.
+#[tokio::test(flavor = "multi_thread")]
+async fn release_does_not_break_an_operation_still_holding_the_services() {
+    let dir = tempfile::tempdir().unwrap();
+    let (state, _db_path) = handle_under(dir.path());
+
+    // Exactly what an in-flight op holds for its duration.
+    let in_flight = state.services().await.expect("warm");
+
+    state.release().await;
+
+    in_flight
+        .database
+        .ping()
+        .await
+        .expect("release() must leave an in-flight op's connection usable");
+    in_flight
+        .graph_db
+        .is_empty()
+        .await
+        .expect("release() must leave an in-flight op's graph usable");
+
+    // The handle itself is still usable too, and re-warms cold.
+    assert!(!state.is_closed());
+    state.services().await.expect("re-warm after release");
+}
+
+/// The explicit `close()` is the opposite contract, and that difference is the
+/// point: it closes the components even out from under an in-flight operation,
+/// because the caller said they were done.
+#[tokio::test(flavor = "multi_thread")]
+async fn close_closes_even_what_an_operation_is_holding() {
+    let dir = tempfile::tempdir().unwrap();
+    let (state, db_path) = handle_under(dir.path());
+    let (wal, _shm) = sidecars(&db_path);
+
+    let in_flight = state.services().await.expect("warm");
+    state.close().await;
+
+    assert!(
+        !wal.exists(),
+        "close() must release the sidecars regardless"
+    );
+    assert!(
+        in_flight.database.ping().await.is_err(),
+        "close() closes the pool an in-flight op holds — that is the contract"
+    );
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -109,6 +109,10 @@ pprof = { version = "0.14", default-features = false, features = ["flamegraph"],
 
 [dev-dependencies]
 assert_cmd.workspace = true
+# `teardown_flushes_telemetry.rs` drives the teardown helper directly and needs a
+# runtime plus serialisation (it sets telemetry env vars, which are process-global).
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+serial_test.workspace = true
 md-5.workspace = true
 mockito = "1"
 predicates.workspace = true

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -26,12 +26,7 @@ pub fn run(args: AddArgs, cm: Arc<ComponentManager>) -> Result<(), CliError> {
         .transpose()
         .map_err(|error| CliError::Validation(format!("Invalid --tenant-id: {error}")))?;
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    runtime.block_on(async {
+    crate::teardown::run_command(Arc::clone(&cm), async {
         let storage = cm
             .storage()
             .await

--- a/crates/cli/src/commands/add_and_cognify.rs
+++ b/crates/cli/src/commands/add_and_cognify.rs
@@ -37,12 +37,7 @@ pub fn run(args: AddAndCognifyArgs, cm: Arc<ComponentManager>) -> Result<(), Cli
         }
     }
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    runtime.block_on(async {
+    crate::teardown::run_command(Arc::clone(&cm), async {
         let database = cm
             .database()
             .await

--- a/crates/cli/src/commands/bench.rs
+++ b/crates/cli/src/commands/bench.rs
@@ -1,9 +1,9 @@
 //! `cognee-cli bench` — the performance orchestrator driver.
 //!
 //! Ports Python's `bench_cognee.py`: runs the full
-//! `prune → setup → add → cognify → search → dataset delete` pipeline once,
-//! times each phase, and writes a result JSON with the exact Python schema so
-//! the shared orchestrator/reporter can drive either SDK unchanged.
+//! `prune → setup → add → cognify → search` pipeline once, times each phase,
+//! and writes a result JSON with the exact Python schema so the shared
+//! orchestrator/reporter can drive either SDK unchanged.
 //!
 //! Exit-code policy (Python parity): once the run completes and the result
 //! file is written, exit `0` even if individual phases failed (failures are
@@ -15,7 +15,6 @@ use std::time::Instant;
 
 use cognee::add::AddPipeline;
 use cognee::api::prune::{PruneTarget, prune_data, prune_system};
-use cognee::api::{DatasetDb, DatasetManager};
 use cognee::cognify::{ChunkStrategy, CognifyConfig, TokenCounterKind, cognify};
 use cognee::core::RayonThreadPool;
 use cognee::database::{IngestDb, PipelineRunRepository, SeaOrmPipelineRunRepository, ops};
@@ -66,7 +65,6 @@ struct BenchResult {
     prune_time_s: f64,
     db_setup_time_s: f64,
     search_time: f64,
-    dataset_delete_time_s: f64,
     status: BenchStatus,
     success: bool,
     config: BenchConfig,
@@ -83,7 +81,6 @@ struct BenchStatus {
     add: String,
     cognify: String,
     search: String,
-    dataset_delete: String,
 }
 
 const PHASE_OK: &str = "success";
@@ -178,9 +175,8 @@ fn finish_phase_telemetry(_profile_dir: Option<&str>, _phase: &str) {}
 /// workload. The timer starts *after* the profiler/telemetry are armed and
 /// stops *before* the flamegraph/telemetry artifacts are written, so the
 /// returned elapsed is workload-only — not inflated by profiler startup or
-/// report generation. Centralizes the bracketing so the measured phases (add /
-/// cognify / search / dataset delete) cannot drift out of sync. Returns
-/// `(elapsed_secs, result)`.
+/// report generation. Centralizes the bracketing so the three phases (add /
+/// cognify / search) cannot drift out of sync. Returns `(elapsed_secs, result)`.
 async fn timed_phase(
     profile_dir: Option<&str>,
     phase: &str,
@@ -378,26 +374,27 @@ pub fn run(args: BenchArgs, cm: Arc<ComponentManager>) -> Result<(), CliError> {
         )
     };
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    let result = runtime.block_on(run_phases(
-        &cm,
-        owner_id,
-        &args.dataset_name,
-        &memories,
-        args.profile_dir.as_deref(),
-        args.min_graph_nodes,
-        BenchConfig {
-            llm_model,
-            embedding_model,
-            embedding_dimensions,
-            dataset_name: args.dataset_name.clone(),
-            mock_llm: args.mock_llm,
-        },
-    ));
+    // Through the shared helper so the bench pays the same teardown as every other
+    // command: the components are closed and telemetry flushed on the runtime that
+    // owns them, before it goes away.
+    let result = crate::teardown::run_command(Arc::clone(&cm), async {
+        Ok(run_phases(
+            &cm,
+            owner_id,
+            &args.dataset_name,
+            &memories,
+            args.profile_dir.as_deref(),
+            args.min_graph_nodes,
+            BenchConfig {
+                llm_model,
+                embedding_model,
+                embedding_dimensions,
+                dataset_name: args.dataset_name.clone(),
+                mock_llm: args.mock_llm,
+            },
+        )
+        .await)
+    })?;
 
     // ── Serialize & write (catastrophic on failure — exit nonzero) ───────
     let json = serde_json::to_string_pretty(&result)
@@ -433,7 +430,6 @@ async fn run_phases(
         add: PHASE_OK.to_string(),
         cognify: PHASE_OK.to_string(),
         search: PHASE_OK.to_string(),
-        dataset_delete: PHASE_OK.to_string(),
     };
 
     // ── Prune ────────────────────────────────────────────────────────────
@@ -538,49 +534,11 @@ async fn run_phases(
         status.search = format!("failed: {msg}");
     }
 
-    // ── Extra retrievers (profiling only, untimed) ───────────────────────
-    // Not part of the reported contract — see `phase_search_retrievers`. A
-    // failure here is warned about but deliberately does NOT touch `status`:
-    // these queries do not exist in the Python bench, so letting them fail the
-    // run would make `success` mean different things across the two SDKs.
-    // `cfg!` rather than `#[cfg]` so both configurations stay type-checked; the
-    // branch const-folds away in a non-profiling build, where `--profile-dir`
-    // is documented as ignored and no flamegraph would be written anyway.
-    if cfg!(feature = "profiling") && profile_dir.is_some() {
-        eprintln!("Profiling: running the extra no-LLM retrievers...");
-        let (t_retrievers, retriever_res) = timed_phase(
-            profile_dir,
-            "search_retrievers",
-            phase_search_retrievers(cm, owner_id, dataset_name),
-        )
-        .await;
-        match retriever_res {
-            Ok(()) => info!("search_retrievers took {t_retrievers:.3}s (not reported)"),
-            Err(msg) => warn!("Extra retrievers FAILED (not reported): {msg}"),
-        }
-    }
-
-    // ── Dataset delete (populated) ───────────────────────────────────────
-    // Runs last, so it measures deletion with nodes, edges and vectors all
-    // present — the meaningful case, and what Python's Phase 4 measures.
-    eprintln!("Phase 4: Deleting the populated dataset...");
-    let (t_dataset_delete, dataset_delete_res) = timed_phase(
-        profile_dir,
-        "dataset_delete",
-        phase_dataset_delete(cm, owner_id, dataset_name),
-    )
-    .await;
-    if let Err(msg) = dataset_delete_res {
-        warn!("Dataset delete FAILED: {msg}");
-        status.dataset_delete = format!("failed: {msg}");
-    }
-
     let success = status.prune == PHASE_OK
         && status.db_setup == PHASE_OK
         && status.add == PHASE_OK
         && status.cognify == PHASE_OK
-        && status.search == PHASE_OK
-        && status.dataset_delete == PHASE_OK;
+        && status.search == PHASE_OK;
 
     BenchResult {
         memories_count: n,
@@ -590,7 +548,6 @@ async fn run_phases(
         prune_time_s: round3(t_prune),
         db_setup_time_s: round3(t_db_setup),
         search_time: t_search,
-        dataset_delete_time_s: round3(t_dataset_delete),
         status,
         success,
         config,
@@ -782,13 +739,19 @@ fn bench_search_request(
     }
 }
 
-/// The query text both SDKs benchmark against.
-const BENCH_QUERY: &str = "What is in the document";
-
-/// Build the search orchestrator used by the search phases.
-async fn bench_search_orchestrator(
+/// Exercise retrieval across representative query types so the search phase is
+/// actually profiled, not just the one graph-completion path.
+///
+/// Runs the no-LLM retrievers (`Chunks`, `Summaries`, pure vector fetch) and the
+/// LLM one (`GraphCompletion`). Under the mocked LLM the completion call is
+/// near-free, so the no-LLM retrievers are what surface the real retrieval cost
+/// (vector KNN plus chunk/summary materialization) in `search.svg`. Per-query
+/// wall times are logged. The phase aggregate is what `search_time` reports.
+async fn phase_search(
     cm: &Arc<ComponentManager>,
-) -> Result<cognee::search::SearchOrchestrator, String> {
+    owner_id: Uuid,
+    dataset_name: &str,
+) -> Result<(), String> {
     let vector_db = cm.vector_db().await.map_err(|e| e.to_string())?;
     let embedding_engine = cm.embedding_engine().await.map_err(|e| e.to_string())?;
     let graph_db = cm.graph_db().await.map_err(|e| e.to_string())?;
@@ -800,7 +763,7 @@ async fn bench_search_orchestrator(
         .map_err(|e| e.to_string())?;
     let session_manager = Arc::new(SessionManager::new(Arc::new(session_store)));
     let search_history_db = Arc::clone(&database) as Arc<dyn cognee::database::SearchHistoryDb>;
-    Ok(SearchBuilder::new(
+    let orchestrator = SearchBuilder::new(
         vector_db,
         embedding_engine,
         graph_db,
@@ -809,56 +772,19 @@ async fn bench_search_orchestrator(
     )
     .with_session_manager(session_manager)
     .with_dataset_resolver(Arc::clone(&database) as Arc<dyn IngestDb>)
-    .build())
-}
+    .build();
 
-/// The measured search phase: the single graph-completion query Python times.
-///
-/// Python's `bench_cognee.py` Phase 3 is one
-/// `cognee.search(query_text=..., only_context=True)` call, so this is one
-/// `GraphCompletion` request with `only_context`. Keep it that way — the whole
-/// point of `search_time` is that the Python and Rust nightly arms report the
-/// same unit of work. Extra retrievers belong in `phase_search_retrievers`.
-async fn phase_search(
-    cm: &Arc<ComponentManager>,
-    owner_id: Uuid,
-    dataset_name: &str,
-) -> Result<(), String> {
-    let orchestrator = bench_search_orchestrator(cm).await?;
-    let request = bench_search_request(
-        BENCH_QUERY,
-        SearchType::GraphCompletion,
-        dataset_name,
-        owner_id,
-    );
-    orchestrator
-        .search(&request)
-        .await
-        .map_err(|e| format!("graph_completion: {e}"))?;
-    Ok(())
-}
-
-/// Extra retrieval paths, run only under `--profile-dir` and never reported.
-///
-/// The no-LLM retrievers (`Chunks`, `Summaries`) surface the real retrieval
-/// cost — vector KNN plus chunk/summary materialization — that the completion
-/// path hides, especially under a mocked LLM where the completion call is
-/// near-free. That makes them worth a flamegraph, but folding them into
-/// `search_time` would make it incomparable with Python's single query, so they
-/// get their own `search_retrievers.svg` and their elapsed is discarded.
-async fn phase_search_retrievers(
-    cm: &Arc<ComponentManager>,
-    owner_id: Uuid,
-    dataset_name: &str,
-) -> Result<(), String> {
-    let orchestrator = bench_search_orchestrator(cm).await?;
+    let query_text = "What is in the document";
+    // No-LLM retrievers first (Chunks/Summaries) so retrieval cost is visible,
+    // then the LLM path (GraphCompletion). Labels feed the per-query log lines.
     let queries = [
         ("chunks", SearchType::Chunks),
         ("summaries", SearchType::Summaries),
+        ("graph_completion", SearchType::GraphCompletion),
     ];
 
     for (label, search_type) in queries {
-        let request = bench_search_request(BENCH_QUERY, search_type, dataset_name, owner_id);
+        let request = bench_search_request(query_text, search_type, dataset_name, owner_id);
         let t = Instant::now();
         orchestrator
             .search(&request)
@@ -866,54 +792,6 @@ async fn phase_search_retrievers(
             .map_err(|e| format!("{label}: {e}"))?;
         info!("search[{label}] took {:.3}s", t.elapsed().as_secs_f64());
     }
-    Ok(())
-}
-
-/// `datasets.empty_dataset(dataset)` — delete the populated dataset.
-///
-/// Mirrors Python's Phase 4, which resolves the dataset by name and calls
-/// `datasets_api.empty_dataset(dataset.id, user)`. Both sides delete the
-/// dataset's relational rows, graph nodes/edges and vectors.
-///
-/// They are NOT byte-for-byte the same unit of work, so do not read a small
-/// `dataset_delete_time_s` gap as an SDK difference. Rust's
-/// `DatasetManager::empty_dataset` hardcodes `DeleteMode::Hard`, which makes
-/// `DeleteService::execute` additionally run `sweep_orphan_nodes` /
-/// `sweep_orphan_edge_types`; Python's `empty_dataset` has no equivalent (its
-/// degree-one sweep lives in `legacy_delete`, off the `delete_data` path). The
-/// sweep runs after this dataset's own nodes are already deleted, so on a
-/// single-dataset bench it scans a near-empty graph and costs a small
-/// near-constant amount rather than scaling with the corpus — but it is
-/// Rust-side-only overhead, so compare the two series by trend, not level.
-async fn phase_dataset_delete(
-    cm: &Arc<ComponentManager>,
-    owner_id: Uuid,
-    dataset_name: &str,
-) -> Result<(), String> {
-    let database = cm.database().await.map_err(|e| e.to_string())?;
-
-    // Python guards this with `if found:` — a failed add leaves nothing to
-    // delete, and the phase still reports its (near-zero) elapsed rather than
-    // failing a run that has already recorded the real failure in `add`.
-    let Some(dataset) = ops::datasets::get_dataset_by_name(&database, dataset_name, owner_id, None)
-        .await
-        .map_err(|e| e.to_string())?
-    else {
-        warn!("dataset '{dataset_name}' not found — nothing to delete");
-        return Ok(());
-    };
-
-    // Shared with `cognee-cli delete` / `forget` so the benchmark cannot drift
-    // into measuring a differently-wired deletion than the commands it mirrors.
-    let delete_service = super::build_delete_service(cm)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let datasets = DatasetManager::new(Arc::clone(&database) as Arc<dyn DatasetDb>);
-    datasets
-        .empty_dataset(dataset.id, owner_id, &delete_service)
-        .await
-        .map_err(|e| e.to_string())?;
     Ok(())
 }
 

--- a/crates/cli/src/commands/bench.rs
+++ b/crates/cli/src/commands/bench.rs
@@ -1,9 +1,9 @@
 //! `cognee-cli bench` — the performance orchestrator driver.
 //!
 //! Ports Python's `bench_cognee.py`: runs the full
-//! `prune → setup → add → cognify → search` pipeline once, times each phase,
-//! and writes a result JSON with the exact Python schema so the shared
-//! orchestrator/reporter can drive either SDK unchanged.
+//! `prune → setup → add → cognify → search → dataset delete` pipeline once,
+//! times each phase, and writes a result JSON with the exact Python schema so
+//! the shared orchestrator/reporter can drive either SDK unchanged.
 //!
 //! Exit-code policy (Python parity): once the run completes and the result
 //! file is written, exit `0` even if individual phases failed (failures are
@@ -15,6 +15,7 @@ use std::time::Instant;
 
 use cognee::add::AddPipeline;
 use cognee::api::prune::{PruneTarget, prune_data, prune_system};
+use cognee::api::{DatasetDb, DatasetManager};
 use cognee::cognify::{ChunkStrategy, CognifyConfig, TokenCounterKind, cognify};
 use cognee::core::RayonThreadPool;
 use cognee::database::{IngestDb, PipelineRunRepository, SeaOrmPipelineRunRepository, ops};
@@ -65,6 +66,7 @@ struct BenchResult {
     prune_time_s: f64,
     db_setup_time_s: f64,
     search_time: f64,
+    dataset_delete_time_s: f64,
     status: BenchStatus,
     success: bool,
     config: BenchConfig,
@@ -81,6 +83,7 @@ struct BenchStatus {
     add: String,
     cognify: String,
     search: String,
+    dataset_delete: String,
 }
 
 const PHASE_OK: &str = "success";
@@ -175,8 +178,9 @@ fn finish_phase_telemetry(_profile_dir: Option<&str>, _phase: &str) {}
 /// workload. The timer starts *after* the profiler/telemetry are armed and
 /// stops *before* the flamegraph/telemetry artifacts are written, so the
 /// returned elapsed is workload-only — not inflated by profiler startup or
-/// report generation. Centralizes the bracketing so the three phases (add /
-/// cognify / search) cannot drift out of sync. Returns `(elapsed_secs, result)`.
+/// report generation. Centralizes the bracketing so the measured phases (add /
+/// cognify / search / dataset delete) cannot drift out of sync. Returns
+/// `(elapsed_secs, result)`.
 async fn timed_phase(
     profile_dir: Option<&str>,
     phase: &str,
@@ -374,9 +378,8 @@ pub fn run(args: BenchArgs, cm: Arc<ComponentManager>) -> Result<(), CliError> {
         )
     };
 
-    // Through the shared helper so the bench pays the same teardown as every other
-    // command: the components are closed and telemetry flushed on the runtime that
-    // owns them, before it goes away.
+    // Wrapped so the components this command opened are closed, and telemetry
+    // flushed, on the runtime that dispatched them — see `crate::teardown`.
     let result = crate::teardown::run_command(Arc::clone(&cm), async {
         Ok(run_phases(
             &cm,
@@ -430,6 +433,7 @@ async fn run_phases(
         add: PHASE_OK.to_string(),
         cognify: PHASE_OK.to_string(),
         search: PHASE_OK.to_string(),
+        dataset_delete: PHASE_OK.to_string(),
     };
 
     // ── Prune ────────────────────────────────────────────────────────────
@@ -534,11 +538,49 @@ async fn run_phases(
         status.search = format!("failed: {msg}");
     }
 
+    // ── Extra retrievers (profiling only, untimed) ───────────────────────
+    // Not part of the reported contract — see `phase_search_retrievers`. A
+    // failure here is warned about but deliberately does NOT touch `status`:
+    // these queries do not exist in the Python bench, so letting them fail the
+    // run would make `success` mean different things across the two SDKs.
+    // `cfg!` rather than `#[cfg]` so both configurations stay type-checked; the
+    // branch const-folds away in a non-profiling build, where `--profile-dir`
+    // is documented as ignored and no flamegraph would be written anyway.
+    if cfg!(feature = "profiling") && profile_dir.is_some() {
+        eprintln!("Profiling: running the extra no-LLM retrievers...");
+        let (t_retrievers, retriever_res) = timed_phase(
+            profile_dir,
+            "search_retrievers",
+            phase_search_retrievers(cm, owner_id, dataset_name),
+        )
+        .await;
+        match retriever_res {
+            Ok(()) => info!("search_retrievers took {t_retrievers:.3}s (not reported)"),
+            Err(msg) => warn!("Extra retrievers FAILED (not reported): {msg}"),
+        }
+    }
+
+    // ── Dataset delete (populated) ───────────────────────────────────────
+    // Runs last, so it measures deletion with nodes, edges and vectors all
+    // present — the meaningful case, and what Python's Phase 4 measures.
+    eprintln!("Phase 4: Deleting the populated dataset...");
+    let (t_dataset_delete, dataset_delete_res) = timed_phase(
+        profile_dir,
+        "dataset_delete",
+        phase_dataset_delete(cm, owner_id, dataset_name),
+    )
+    .await;
+    if let Err(msg) = dataset_delete_res {
+        warn!("Dataset delete FAILED: {msg}");
+        status.dataset_delete = format!("failed: {msg}");
+    }
+
     let success = status.prune == PHASE_OK
         && status.db_setup == PHASE_OK
         && status.add == PHASE_OK
         && status.cognify == PHASE_OK
-        && status.search == PHASE_OK;
+        && status.search == PHASE_OK
+        && status.dataset_delete == PHASE_OK;
 
     BenchResult {
         memories_count: n,
@@ -548,6 +590,7 @@ async fn run_phases(
         prune_time_s: round3(t_prune),
         db_setup_time_s: round3(t_db_setup),
         search_time: t_search,
+        dataset_delete_time_s: round3(t_dataset_delete),
         status,
         success,
         config,
@@ -739,19 +782,13 @@ fn bench_search_request(
     }
 }
 
-/// Exercise retrieval across representative query types so the search phase is
-/// actually profiled, not just the one graph-completion path.
-///
-/// Runs the no-LLM retrievers (`Chunks`, `Summaries`, pure vector fetch) and the
-/// LLM one (`GraphCompletion`). Under the mocked LLM the completion call is
-/// near-free, so the no-LLM retrievers are what surface the real retrieval cost
-/// (vector KNN plus chunk/summary materialization) in `search.svg`. Per-query
-/// wall times are logged. The phase aggregate is what `search_time` reports.
-async fn phase_search(
+/// The query text both SDKs benchmark against.
+const BENCH_QUERY: &str = "What is in the document";
+
+/// Build the search orchestrator used by the search phases.
+async fn bench_search_orchestrator(
     cm: &Arc<ComponentManager>,
-    owner_id: Uuid,
-    dataset_name: &str,
-) -> Result<(), String> {
+) -> Result<cognee::search::SearchOrchestrator, String> {
     let vector_db = cm.vector_db().await.map_err(|e| e.to_string())?;
     let embedding_engine = cm.embedding_engine().await.map_err(|e| e.to_string())?;
     let graph_db = cm.graph_db().await.map_err(|e| e.to_string())?;
@@ -763,7 +800,7 @@ async fn phase_search(
         .map_err(|e| e.to_string())?;
     let session_manager = Arc::new(SessionManager::new(Arc::new(session_store)));
     let search_history_db = Arc::clone(&database) as Arc<dyn cognee::database::SearchHistoryDb>;
-    let orchestrator = SearchBuilder::new(
+    Ok(SearchBuilder::new(
         vector_db,
         embedding_engine,
         graph_db,
@@ -772,19 +809,56 @@ async fn phase_search(
     )
     .with_session_manager(session_manager)
     .with_dataset_resolver(Arc::clone(&database) as Arc<dyn IngestDb>)
-    .build();
+    .build())
+}
 
-    let query_text = "What is in the document";
-    // No-LLM retrievers first (Chunks/Summaries) so retrieval cost is visible,
-    // then the LLM path (GraphCompletion). Labels feed the per-query log lines.
+/// The measured search phase: the single graph-completion query Python times.
+///
+/// Python's `bench_cognee.py` Phase 3 is one
+/// `cognee.search(query_text=..., only_context=True)` call, so this is one
+/// `GraphCompletion` request with `only_context`. Keep it that way — the whole
+/// point of `search_time` is that the Python and Rust nightly arms report the
+/// same unit of work. Extra retrievers belong in `phase_search_retrievers`.
+async fn phase_search(
+    cm: &Arc<ComponentManager>,
+    owner_id: Uuid,
+    dataset_name: &str,
+) -> Result<(), String> {
+    let orchestrator = bench_search_orchestrator(cm).await?;
+    let request = bench_search_request(
+        BENCH_QUERY,
+        SearchType::GraphCompletion,
+        dataset_name,
+        owner_id,
+    );
+    orchestrator
+        .search(&request)
+        .await
+        .map_err(|e| format!("graph_completion: {e}"))?;
+    Ok(())
+}
+
+/// Extra retrieval paths, run only under `--profile-dir` and never reported.
+///
+/// The no-LLM retrievers (`Chunks`, `Summaries`) surface the real retrieval
+/// cost — vector KNN plus chunk/summary materialization — that the completion
+/// path hides, especially under a mocked LLM where the completion call is
+/// near-free. That makes them worth a flamegraph, but folding them into
+/// `search_time` would make it incomparable with Python's single query, so they
+/// get their own `search_retrievers.svg` and their elapsed is discarded.
+async fn phase_search_retrievers(
+    cm: &Arc<ComponentManager>,
+    owner_id: Uuid,
+    dataset_name: &str,
+) -> Result<(), String> {
+    let orchestrator = bench_search_orchestrator(cm).await?;
     let queries = [
         ("chunks", SearchType::Chunks),
         ("summaries", SearchType::Summaries),
-        ("graph_completion", SearchType::GraphCompletion),
     ];
 
     for (label, search_type) in queries {
-        let request = bench_search_request(query_text, search_type, dataset_name, owner_id);
+        let request = bench_search_request(BENCH_QUERY, search_type, dataset_name, owner_id);
         let t = Instant::now();
         orchestrator
             .search(&request)
@@ -792,6 +866,54 @@ async fn phase_search(
             .map_err(|e| format!("{label}: {e}"))?;
         info!("search[{label}] took {:.3}s", t.elapsed().as_secs_f64());
     }
+    Ok(())
+}
+
+/// `datasets.empty_dataset(dataset)` — delete the populated dataset.
+///
+/// Mirrors Python's Phase 4, which resolves the dataset by name and calls
+/// `datasets_api.empty_dataset(dataset.id, user)`. Both sides delete the
+/// dataset's relational rows, graph nodes/edges and vectors.
+///
+/// They are NOT byte-for-byte the same unit of work, so do not read a small
+/// `dataset_delete_time_s` gap as an SDK difference. Rust's
+/// `DatasetManager::empty_dataset` hardcodes `DeleteMode::Hard`, which makes
+/// `DeleteService::execute` additionally run `sweep_orphan_nodes` /
+/// `sweep_orphan_edge_types`; Python's `empty_dataset` has no equivalent (its
+/// degree-one sweep lives in `legacy_delete`, off the `delete_data` path). The
+/// sweep runs after this dataset's own nodes are already deleted, so on a
+/// single-dataset bench it scans a near-empty graph and costs a small
+/// near-constant amount rather than scaling with the corpus — but it is
+/// Rust-side-only overhead, so compare the two series by trend, not level.
+async fn phase_dataset_delete(
+    cm: &Arc<ComponentManager>,
+    owner_id: Uuid,
+    dataset_name: &str,
+) -> Result<(), String> {
+    let database = cm.database().await.map_err(|e| e.to_string())?;
+
+    // Python guards this with `if found:` — a failed add leaves nothing to
+    // delete, and the phase still reports its (near-zero) elapsed rather than
+    // failing a run that has already recorded the real failure in `add`.
+    let Some(dataset) = ops::datasets::get_dataset_by_name(&database, dataset_name, owner_id, None)
+        .await
+        .map_err(|e| e.to_string())?
+    else {
+        warn!("dataset '{dataset_name}' not found — nothing to delete");
+        return Ok(());
+    };
+
+    // Shared with `cognee-cli delete` / `forget` so the benchmark cannot drift
+    // into measuring a differently-wired deletion than the commands it mirrors.
+    let delete_service = super::build_delete_service(cm)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let datasets = DatasetManager::new(Arc::clone(&database) as Arc<dyn DatasetDb>);
+    datasets
+        .empty_dataset(dataset.id, owner_id, &delete_service)
+        .await
+        .map_err(|e| e.to_string())?;
     Ok(())
 }
 

--- a/crates/cli/src/commands/cognify.rs
+++ b/crates/cli/src/commands/cognify.rs
@@ -44,12 +44,7 @@ pub fn run(args: CognifyArgs, cm: Arc<ComponentManager>) -> Result<(), CliError>
 
     let requested_datasets = args.datasets.clone();
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    runtime.block_on(async {
+    crate::teardown::run_command(Arc::clone(&cm), async {
         // Resolve datasets first (cheap) — fail early before initializing heavy components
         let database = cm
             .database()

--- a/crates/cli/src/commands/delete.rs
+++ b/crates/cli/src/commands/delete.rs
@@ -31,12 +31,7 @@ pub fn run(args: DeleteArgs, cm: Arc<cognee::ComponentManager>) -> Result<(), Cl
         })?
     };
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    runtime.block_on(async {
+    crate::teardown::run_command(Arc::clone(&cm), async {
         let database = cm
             .database()
             .await

--- a/crates/cli/src/commands/forget.rs
+++ b/crates/cli/src/commands/forget.rs
@@ -35,12 +35,7 @@ pub fn run(args: ForgetArgs, cm: Arc<ComponentManager>) -> Result<(), CliError> 
         .transpose()
         .map_err(|error| CliError::Validation(format!("Invalid --data-id: {error}")))?;
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    runtime.block_on(async {
+    crate::teardown::run_command(Arc::clone(&cm), async {
         let database = cm
             .database()
             .await

--- a/crates/cli/src/commands/improve.rs
+++ b/crates/cli/src/commands/improve.rs
@@ -43,12 +43,7 @@ pub fn run(args: ImproveArgs, cm: Arc<ComponentManager>) -> Result<(), CliError>
         Some(args.node_name.clone())
     };
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    runtime.block_on(async {
+    crate::teardown::run_command(Arc::clone(&cm), async {
         let storage = cm
             .storage()
             .await

--- a/crates/cli/src/commands/memify.rs
+++ b/crates/cli/src/commands/memify.rs
@@ -23,12 +23,7 @@ pub fn run(args: MemifyArgs, cm: Arc<ComponentManager>) -> Result<(), CliError> 
 
     let requested_datasets = args.datasets.clone();
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    runtime.block_on(async {
+    crate::teardown::run_command(Arc::clone(&cm), async {
         // Resolve datasets first (cheap) -- fail early before initializing heavy components
         let database = cm
             .database()

--- a/crates/cli/src/commands/recall.rs
+++ b/crates/cli/src/commands/recall.rs
@@ -33,12 +33,7 @@ pub fn run(args: RecallArgs, cm: Arc<ComponentManager>) -> Result<(), CliError> 
         None => (None, true),
     };
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    runtime.block_on(async {
+    crate::teardown::run_command(Arc::clone(&cm), async {
         let vector_db = cm
             .vector_db()
             .await

--- a/crates/cli/src/commands/remember.rs
+++ b/crates/cli/src/commands/remember.rs
@@ -41,12 +41,7 @@ pub fn run(args: RememberArgs, cm: Arc<ComponentManager>) -> Result<(), CliError
         .map(DataInput::from_string)
         .collect::<Vec<_>>();
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    runtime.block_on(async {
+    crate::teardown::run_command(Arc::clone(&cm), async {
         let storage = cm
             .storage()
             .await

--- a/crates/cli/src/commands/run_sequence.rs
+++ b/crates/cli/src/commands/run_sequence.rs
@@ -170,6 +170,11 @@ fn run_single_file(file_path: &str, cm: &Arc<ComponentManager>) -> Result<(), Cl
 }
 
 pub fn run(args: RunSequenceArgs, cm: Arc<ComponentManager>) -> Result<(), CliError> {
+    // One warm manager for the whole file: a per-step teardown would make every
+    // step pay a re-warm, and that cost would land inside the timing the sequence
+    // file is describing. `main` releases once after dispatch returns.
+    let _deferred = crate::teardown::defer_teardown();
+
     let file_count = args.sequence_files.len();
 
     for (file_index, file_path) in args.sequence_files.iter().enumerate() {

--- a/crates/cli/src/commands/search.rs
+++ b/crates/cli/src/commands/search.rs
@@ -51,12 +51,7 @@ pub fn run(args: SearchArgs, cm: Arc<ComponentManager>) -> Result<(), CliError> 
         (None, Some(path))
     };
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    runtime.block_on(async {
+    crate::teardown::run_command(Arc::clone(&cm), async {
         let vector_db = cm
             .vector_db()
             .await

--- a/crates/cli/src/commands/visualize.rs
+++ b/crates/cli/src/commands/visualize.rs
@@ -8,12 +8,7 @@ use crate::cli::VisualizeArgs;
 use crate::error::CliError;
 
 pub fn run(args: VisualizeArgs, cm: Arc<ComponentManager>) -> Result<(), CliError> {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
-
-    runtime.block_on(async {
+    crate::teardown::run_command(Arc::clone(&cm), async {
         let graph_db = cm
             .graph_db()
             .await

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -13,3 +13,4 @@ pub mod cli;
 pub mod commands;
 pub mod config_store;
 pub mod error;
+pub mod teardown;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -17,51 +17,6 @@ use commands::{
 };
 use tracing::error;
 
-/// How long to wait for the relational pool to close on exit. See
-/// [`close_components`].
-const CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-
-/// Close the relational connection pool before the process exits.
-///
-/// Exiting without closing leaves a SQLite database's `-wal`/`-shm` sidecars
-/// behind: dropping the pool only flags it closed and lets its connections tear
-/// down concurrently, and SQLite unlinks the sidecars only when the *last*
-/// connection closes (issue #132). The next `cognee` invocation recovers them, so
-/// nothing is corrupt, but the files linger next to the database and a caller
-/// that wraps the CLI in a temporary directory cannot clean up after it.
-///
-/// Each command owns (and drops) its own runtime, so this builds a small
-/// current-thread one purely to drive the close — a pool drain, not I/O.
-///
-/// Bounded by [`CLOSE_TIMEOUT`] because the close waits for connections to come
-/// back: if a command's runtime was dropped while one was still checked out, its
-/// pool permit is never released and the wait would never finish. Timing out
-/// costs only the sidecars we were trying to remove, whereas hanging would cost
-/// the caller their exit code, so this is deliberately best-effort.
-fn close_components(cm: &ComponentManager) {
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(error) => {
-            tracing::debug!(%error, "could not build a runtime to close the database");
-            return;
-        }
-    };
-    rt.block_on(async {
-        if tokio::time::timeout(CLOSE_TIMEOUT, cm.close())
-            .await
-            .is_err()
-        {
-            tracing::debug!(
-                "closing the relational database timed out after {CLOSE_TIMEOUT:?}; \
-                 its WAL sidecars may be left for the next run to recover"
-            );
-        }
-    });
-}
-
 fn run(settings: Settings) -> Result<(), CliError> {
     let cli = Cli::parse();
 
@@ -71,9 +26,13 @@ fn run(settings: Settings) -> Result<(), CliError> {
 
     let result = dispatch(cli.command, &cm);
 
-    // Release the database before returning, whether the command succeeded or
-    // not — a failed run has usually opened it too.
-    close_components(&cm);
+    // Fallback release. A command that ran through `teardown::run_command` has
+    // already released on its own runtime — the one that owns the connections, and
+    // therefore the only one that can settle their in-flight returns — so this is
+    // then a cheap no-op. It exists for the paths that have not: a command with no
+    // async work (`config`), and `run-sequence`, which defers the teardown so its
+    // steps share one warm manager.
+    cognee_cli::teardown::release_blocking(&cm);
 
     result
 }

--- a/crates/cli/src/teardown.rs
+++ b/crates/cli/src/teardown.rs
@@ -123,13 +123,20 @@ where
         .build()
         .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
 
-    let deferred = DEFERRED.load(Ordering::Acquire) > 0;
     let outcome = runtime.block_on(async move {
         let outcome = future.await;
         // Release whether the command succeeded or not: a failed run has usually
         // opened the database too. Unless a caller deferred it — see
         // `defer_teardown`.
-        if !deferred {
+        //
+        // Read `DEFERRED` *here*, after the command has finished, not before it
+        // starts. A snapshot taken up front is stale the moment a `DeferGuard`
+        // outlives the load but not the command: the decision would then skip a
+        // release that is no longer deferred, which is the silent
+        // never-torn-down case this module exists to remove. Today's only caller
+        // (`run_sequence`) holds its guard across the whole dispatch, so the two
+        // readings agree — this is about not depending on that.
+        if DEFERRED.load(Ordering::Acquire) == 0 {
             release(&cm).await;
         }
         outcome

--- a/crates/cli/src/teardown.rs
+++ b/crates/cli/src/teardown.rs
@@ -136,8 +136,19 @@ where
         // never-torn-down case this module exists to remove. Today's only caller
         // (`run_sequence`) holds its guard across the whole dispatch, so the two
         // readings agree — this is about not depending on that.
+        // Only the *close* is deferrable. The flush is not, and conflating the
+        // two silently discarded telemetry: `run-sequence` (the sole caller of
+        // `defer_teardown`) would skip `release` entirely per step, so each
+        // step's detached POSTs were still on this runtime when
+        // `shutdown_timeout` below cancelled them — and `main`'s fallback
+        // `release_blocking` then flushed a *fresh* runtime with nothing left to
+        // wait for. A 50-step sequence delivered zero events, which is exactly
+        // the defect this module's header claims to have fixed. Whatever
+        // dispatched a POST has to be the runtime that waits for it.
         if DEFERRED.load(Ordering::Acquire) == 0 {
             release(&cm).await;
+        } else {
+            flush_telemetry().await;
         }
         outcome
     });
@@ -162,6 +173,17 @@ async fn release(cm: &ComponentManager) {
         );
     }
 
+    flush_telemetry().await;
+}
+
+/// Wait for the telemetry this runtime dispatched, bounded.
+///
+/// Split out of [`release`] because the two halves have different deferrability:
+/// a caller replaying several commands against one warm manager can postpone the
+/// *close* (see [`defer_teardown`]) but must never postpone the *flush* — the
+/// POSTs are detached on the runtime that is about to be shut down, so nothing
+/// else can wait for them.
+async fn flush_telemetry() {
     if !cognee::cognee_telemetry::flush(TELEMETRY_FLUSH_TIMEOUT).await {
         tracing::debug!(
             "telemetry still in flight after {TELEMETRY_FLUSH_TIMEOUT:?}; \

--- a/crates/cli/src/teardown.rs
+++ b/crates/cli/src/teardown.rs
@@ -1,0 +1,208 @@
+//! Command runtime + teardown: the one place a CLI command's async work is
+//! driven, and the only place its resources are released.
+//!
+//! Every command used to build its own runtime, run its work, and let the runtime
+//! drop — which is where two defects lived:
+//!
+//! 1. **The release ran on the wrong runtime.** Closing the components from
+//!    `main` after the command returned meant a *fresh* runtime, while the
+//!    connections' in-flight `return_to_pool` tasks belonged to the command's
+//!    runtime and had died with it. The relational close then could not settle,
+//!    and SQLite kept the `-wal`/`-shm` sidecars that topoteretes/cognee-rs#132
+//!    is about.
+//! 2. **The telemetry flush was inert.** `send_telemetry` dispatches a detached
+//!    task onto the current runtime; dropping that runtime cancels the POST and
+//!    zeroes the in-flight counter, so a flush issued afterwards had nothing left
+//!    to wait for and reported success. Measured against a stub collector: 0 of 1
+//!    events delivered, while looking exactly like a working flush.
+//!
+//! Both are the same mistake — doing teardown work outside the runtime that owns
+//! the work — so both are fixed by doing it here, inside `block_on`, before the
+//! runtime goes away.
+
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use cognee::ComponentManager;
+
+use crate::error::CliError;
+
+/// How long the component close may take before the exit gives up on it.
+///
+/// A pool close waits for its connections to come back and an embedded graph
+/// checkpoints synchronously, so this is not instant — but it must be finite: a
+/// store that never finishes would otherwise cost the caller their exit code. What
+/// a timeout costs is the sidecars we were trying to remove, which the next run
+/// recovers.
+const CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long already-dispatched telemetry POSTs get to leave the process.
+///
+/// Small on purpose: an exit code must never wait on an analytics collector.
+const TELEMETRY_FLUSH_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// How long the runtime's own shutdown may take once the work is done.
+///
+/// `Runtime::shutdown_timeout` rather than a plain drop, because a drop **joins
+/// every blocking task** with no bound. When [`CLOSE_TIMEOUT`] fires, the
+/// `spawn_blocking` destructors the close started (an ONNX session joining its
+/// worker threads, an embedded graph checkpointing) are still running, and a plain
+/// drop would sit and wait for exactly the work the timeout just gave up on —
+/// making the bound decorative. Anything still running past this point is
+/// abandoned to process exit.
+const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Nesting depth of [`defer_teardown`] guards. Non-zero means some caller is
+/// replaying several commands against one warm manager and will tear down itself.
+static DEFERRED: AtomicUsize = AtomicUsize::new(0);
+
+/// Suppress the per-command teardown until the returned guard drops.
+///
+/// For `run-sequence`, which parses a file of commands and runs them in order
+/// against one manager: tearing down after every step would be correct but would
+/// make each step pay a full re-warm — a fresh TLS handshake per HTTP engine and,
+/// for the ONNX provider, a re-read of the model file — and that cost lands inside
+/// the very timing the sequence file is describing. The caller tears down once at
+/// the end instead ([`release_blocking`]).
+#[must_use = "the teardown stays deferred only while the guard is alive"]
+pub fn defer_teardown() -> DeferGuard {
+    DEFERRED.fetch_add(1, Ordering::AcqRel);
+    DeferGuard
+}
+
+/// Restores per-command teardown when dropped. See [`defer_teardown`].
+pub struct DeferGuard;
+
+impl Drop for DeferGuard {
+    fn drop(&mut self) {
+        DEFERRED.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// Release the components from a synchronous context, on a runtime built for the
+/// purpose.
+///
+/// The fallback path: it is what `main` calls after dispatch, so a command that
+/// deferred its teardown (or never had one, like `config`) still releases exactly
+/// once. Idempotent and cheap when the work is already done — closing an empty
+/// cache is a no-op and an idle telemetry queue flushes instantly.
+///
+/// Prefer [`run_command`], which does the same work on the runtime that owns the
+/// connections: their in-flight returns belong to that runtime, and a fresh one
+/// cannot schedule them.
+pub fn release_blocking(cm: &ComponentManager) {
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            tracing::debug!(%error, "could not build a runtime to release the components");
+            return;
+        }
+    };
+    runtime.block_on(release(cm));
+    runtime.shutdown_timeout(RUNTIME_SHUTDOWN_TIMEOUT);
+}
+
+/// Drive one command's async work to completion, then release its resources — all
+/// on the same runtime, which is then shut down under a bound.
+///
+/// Returns the command's own result: the teardown never changes the exit code, and
+/// a teardown failure is logged rather than surfaced. The command's outcome is what
+/// the caller asked about.
+pub fn run_command<F, T>(cm: Arc<ComponentManager>, future: F) -> Result<T, CliError>
+where
+    F: Future<Output = Result<T, CliError>>,
+{
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| CliError::Runtime(format!("Failed to create async runtime: {error}")))?;
+
+    let deferred = DEFERRED.load(Ordering::Acquire) > 0;
+    let outcome = runtime.block_on(async move {
+        let outcome = future.await;
+        // Release whether the command succeeded or not: a failed run has usually
+        // opened the database too. Unless a caller deferred it — see
+        // `defer_teardown`.
+        if !deferred {
+            release(&cm).await;
+        }
+        outcome
+    });
+
+    runtime.shutdown_timeout(RUNTIME_SHUTDOWN_TIMEOUT);
+    outcome
+}
+
+/// Close the components and flush telemetry, in that order, on the current
+/// runtime.
+///
+/// Order matters: the close is the part with a user-visible consequence (files on
+/// disk), and telemetry must never delay or fail it.
+async fn release(cm: &ComponentManager) {
+    if tokio::time::timeout(CLOSE_TIMEOUT, cm.close())
+        .await
+        .is_err()
+    {
+        tracing::debug!(
+            "closing the components timed out after {CLOSE_TIMEOUT:?}; \
+             a database's WAL sidecars may be left for the next run to recover"
+        );
+    }
+
+    if !cognee::cognee_telemetry::flush(TELEMETRY_FLUSH_TIMEOUT).await {
+        tracing::debug!(
+            "telemetry still in flight after {TELEMETRY_FLUSH_TIMEOUT:?}; \
+             dropping the remainder rather than delaying the exit"
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    /// The runtime shutdown is bounded, so a blocking task that outlives the
+    /// command cannot hold the exit open.
+    ///
+    /// A component destructor runs on the blocking pool (`spawn_blocking`), and
+    /// when the close times out those destructors are still running. With a plain
+    /// `drop(runtime)` the exit then waits for them without a bound — the timeout
+    /// the caller asked for buys nothing. This asserts the bound is real.
+    #[test]
+    fn a_stuck_blocking_task_does_not_hold_the_exit_open() {
+        let started = std::time::Instant::now();
+        {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            runtime.block_on(async {
+                // Stands in for a destructor that outlives the close: the pattern
+                // `ComponentManager::close` uses for every slot.
+                tokio::task::spawn_blocking(|| {
+                    std::thread::sleep(Duration::from_secs(60));
+                });
+                // Let it start before we tear the runtime down.
+                tokio::task::yield_now().await;
+            });
+            runtime.shutdown_timeout(RUNTIME_SHUTDOWN_TIMEOUT);
+        }
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "the runtime shutdown must be bounded, took {elapsed:?} — a plain drop \
+             joins blocking tasks with no bound, which makes CLOSE_TIMEOUT decorative"
+        );
+    }
+}

--- a/crates/cli/tests/teardown_flushes_telemetry.rs
+++ b/crates/cli/tests/teardown_flushes_telemetry.rs
@@ -1,0 +1,221 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression test for the CLI's telemetry flush.
+//!
+//! `send_telemetry` dispatches a detached task onto the **current** runtime and
+//! returns. Every command builds its own runtime and drops it, so a flush issued
+//! after that — which is where `main` used to do it, on a freshly built runtime —
+//! has nothing left to wait for: the POST was cancelled with the runtime that
+//! owned it, and the in-flight counter went to zero with it. The flush then
+//! returned "drained" immediately and the event never arrived. Measured against
+//! the stub below: **0 of 1 delivered**, while looking exactly like a working
+//! flush.
+//!
+//! The fix is that `teardown::run_command` flushes *inside* the command's runtime,
+//! before it goes away. This test asserts the delivered count both ways round, so
+//! it fails if the flush ever moves back out.
+#![cfg(feature = "telemetry")]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use cognee::{ComponentManager, ConfigManager, Settings};
+use serial_test::serial;
+
+/// A stub collector that counts complete POSTs it has received.
+///
+/// Blocking, on its own OS thread, counting *arrived* requests server-side: an
+/// in-runtime stub would be torn down along with the runtime under test, and
+/// client-side state is exactly what cannot be trusted here.
+struct Collector {
+    url: String,
+    arrived: Arc<AtomicUsize>,
+}
+
+impl Collector {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let arrived = Arc::new(AtomicUsize::new(0));
+        let arrived_srv = Arc::clone(&arrived);
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { break };
+                let counter = Arc::clone(&arrived_srv);
+                std::thread::spawn(move || serve(stream, &counter));
+            }
+        });
+        Self {
+            url: format!("http://{addr}/"),
+            arrived,
+        }
+    }
+
+    /// The count, after giving the stub's threads a moment to finish reading.
+    fn arrived_settled(&self) -> usize {
+        for _ in 0..100 {
+            if self.arrived.load(Ordering::SeqCst) > 0 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        self.arrived.load(Ordering::SeqCst)
+    }
+}
+
+/// Read one request (headers + body), answer 200, and count it only once the
+/// **whole body** has arrived — a half-written POST is not a delivered event,
+/// which is the failure mode under test.
+fn serve(mut stream: TcpStream, arrived: &AtomicUsize) {
+    let read_half = stream.try_clone().expect("clone");
+    let mut reader = BufReader::new(read_half);
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).unwrap_or(0) == 0 {
+        return;
+    }
+    let mut content_length = 0usize;
+    loop {
+        let mut header = String::new();
+        if reader.read_line(&mut header).unwrap_or(0) == 0 {
+            return;
+        }
+        let trimmed = header.trim_end();
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = trimmed.split_once(':')
+            && name.eq_ignore_ascii_case("content-length")
+        {
+            content_length = value.trim().parse().unwrap_or(0);
+        }
+    }
+    if content_length > 0 {
+        let mut body = vec![0u8; content_length];
+        if reader.read_exact(&mut body).is_err() {
+            return;
+        }
+    }
+    arrived.fetch_add(1, Ordering::SeqCst);
+    let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+    let _ = stream.flush();
+}
+
+/// Point telemetry at `url` and make sure it is enabled for this test.
+fn configure(url: &str) {
+    // SAFETY: single-threaded section of a `#[serial]` test.
+    unsafe {
+        std::env::set_var("COGNEE_TELEMETRY_INTEGRATION_TEST", "1");
+        std::env::set_var("COGNEE_TELEMETRY_PROXY_URL_FOR_TESTS", url);
+        std::env::remove_var("TELEMETRY_DISABLED");
+        std::env::remove_var("ENV");
+    }
+}
+
+/// A cold manager: the teardown must not need a warm one, and this test is about
+/// the flush, not about closing anything.
+fn cold_manager(root: &std::path::Path) -> Arc<ComponentManager> {
+    let settings = Settings {
+        system_root_directory: root.join("system").to_string_lossy().into_owned(),
+        data_root_directory: root.join("data").to_string_lossy().into_owned(),
+        relational_db_url: format!(
+            "sqlite:{}?mode=rwc",
+            root.join("cognee.db").to_string_lossy()
+        ),
+        ..Settings::default()
+    };
+    Arc::new(ComponentManager::new(ConfigManager::new(settings)))
+}
+
+/// The event a command dispatched must have left the process by the time
+/// `run_command` returns.
+#[test]
+#[serial]
+fn the_command_runtime_flushes_before_it_goes_away() {
+    let collector = Collector::start();
+    configure(&collector.url);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cm = cold_manager(dir.path());
+
+    // Warm the telemetry HTTP client before the measured run. The client is a
+    // process-wide `Lazy<reqwest::Client>`, and its first request pays connector
+    // and DNS-resolver start-up — hundreds of milliseconds on a loaded machine.
+    // `TELEMETRY_FLUSH_TIMEOUT` is 500ms *by design* (an exit code must never
+    // wait on analytics), so without this the test measures "can reqwest cold
+    // start in 500ms" instead of "does the teardown flush what the command
+    // dispatched", and fails on a busy host while passing on an idle one.
+    {
+        let warm = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("warm-up runtime");
+        warm.block_on(async {
+            cognee::cognee_telemetry::send_telemetry("cognee.test.warmup", "test-user", None);
+            cognee::cognee_telemetry::flush(Duration::from_secs(5)).await;
+        });
+    }
+    let baseline = collector.arrived_settled();
+
+    let outcome: Result<(), _> = cognee_cli::teardown::run_command(Arc::clone(&cm), async {
+        // Exactly what a command does mid-run: fire and forget.
+        cognee::cognee_telemetry::send_telemetry("cognee.test.cli_teardown", "test-user", None);
+        Ok(())
+    });
+    outcome.expect("the command itself succeeds");
+
+    assert_eq!(
+        collector.arrived_settled() - baseline,
+        1,
+        "the event dispatched inside the command must be delivered before the \
+         runtime is dropped — a flush issued after that has nothing to wait for"
+    );
+}
+
+/// The control: the same event, with the runtime dropped first and the flush
+/// issued afterwards on a fresh one — which is what `main` used to do, and which
+/// delivers nothing.
+///
+/// Asserted rather than merely described, so the two halves of the measurement
+/// live in the same file: 0 of 1 the old way, 1 of 1 the new way.
+#[test]
+#[serial]
+fn a_flush_after_the_runtime_is_gone_delivers_nothing() {
+    let collector = Collector::start();
+    configure(&collector.url);
+
+    {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async {
+            cognee::cognee_telemetry::send_telemetry("cognee.test.too_late", "test-user", None);
+        });
+        drop(rt); // the command runtime going away, as it did before the fix
+    }
+
+    // A fresh runtime, a flush on it: reports success, delivers nothing.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let drained = rt.block_on(cognee::cognee_telemetry::flush(Duration::from_millis(500)));
+    assert!(
+        drained,
+        "the misleading part: with the queue counter already zeroed, the flush \
+         reports a clean drain"
+    );
+
+    // Give it the same settling window the positive case gets before concluding.
+    std::thread::sleep(Duration::from_millis(300));
+    assert_eq!(
+        collector.arrived.load(Ordering::SeqCst),
+        0,
+        "nothing can be delivered once the runtime that owned the POST is gone"
+    );
+}

--- a/crates/cli/tests/teardown_flushes_telemetry.rs
+++ b/crates/cli/tests/teardown_flushes_telemetry.rs
@@ -219,3 +219,54 @@ fn a_flush_after_the_runtime_is_gone_delivers_nothing() {
         "nothing can be delivered once the runtime that owned the POST is gone"
     );
 }
+
+/// A deferred teardown must still flush.
+///
+/// `defer_teardown` exists so `run-sequence` can replay many commands against one
+/// warm manager without paying a re-warm per step. It postpones the *close* — but
+/// the flush is not postponable: each step's POSTs are detached on that step's
+/// runtime, which `run_command` shuts down on the way out, so anything not waited
+/// for there is cancelled and no later flush can recover it.
+///
+/// Conflating the two meant a whole sequence file delivered **zero** events while
+/// this module's header claimed the defect was fixed. The bug was invisible to the
+/// test above, which only covers the non-deferred path.
+#[test]
+#[serial]
+fn a_deferred_teardown_still_flushes_the_step_it_dispatched() {
+    let collector = Collector::start();
+    configure(&collector.url);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cm = cold_manager(dir.path());
+
+    // Warm the client outside the measured window — see the note in the first
+    // test: the first POST in a process pays connector start-up, and
+    // TELEMETRY_FLUSH_TIMEOUT is deliberately 500ms.
+    {
+        let warm = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("warm-up runtime");
+        warm.block_on(async {
+            cognee::cognee_telemetry::send_telemetry("cognee.test.warmup", "test-user", None);
+            cognee::cognee_telemetry::flush(Duration::from_secs(5)).await;
+        });
+    }
+    let baseline = collector.arrived_settled();
+
+    // Exactly the `run-sequence` shape: a guard held across the step dispatch.
+    let deferred = cognee_cli::teardown::defer_teardown();
+    let outcome: Result<(), _> = cognee_cli::teardown::run_command(Arc::clone(&cm), async {
+        cognee::cognee_telemetry::send_telemetry("cognee.test.deferred_step", "test-user", None);
+        Ok(())
+    });
+    outcome.expect("the step itself succeeds");
+    drop(deferred);
+
+    assert_eq!(
+        collector.arrived_settled() - baseline,
+        1,
+        "a deferred step must still flush its own telemetry: the close is \
+         postponable, the POSTs are not — they die with the step's runtime"
+    );
+}

--- a/crates/database/src/connection.rs
+++ b/crates/database/src/connection.rs
@@ -18,7 +18,19 @@ use crate::types::DatabaseError;
 /// branch sets `min` explicitly (see [`connect_sqlite`]).
 ///
 /// The pool serves only the relational database: the Postgres graph and vector
-/// adapters (`PgGraphAdapter`, `PgVectorAdapter`) open their own separate pools.
+/// adapters (`PgGraphAdapter`, `PgVectorAdapter`) open their own separate pools,
+/// each with sqlx's default ceiling of 10 rather than this constant. So a single
+/// warm `ComponentManager` on an all-Postgres layout can hold **three pools × 10
+/// = up to 30 server connections** (measured: 10 per pool, all three against the
+/// same server in the shared-database configuration).
+///
+/// All three are closable: `PgGraphAdapter::close` / `PgVectorAdapter::close`
+/// close their own pools, and `ComponentManager::close` calls both plus [`close`]
+/// here. Before that, a closed-but-still-referenced handle left 20 of the 30 open
+/// for the life of the process — 5 such handles exhaust a stock
+/// `max_connections = 100` server. Budgeting the two adapter pools explicitly,
+/// the way [`connect`] budgets this one, is deliberately separate work: it
+/// changes capacity, where closing only stops the leak.
 /// `POOL_ACQUIRE_TIMEOUT` surfaces pool exhaustion as a prompt error instead of
 /// a silent hang.
 const POOL_MAX_CONNECTIONS: u32 = 10;

--- a/crates/database/tests/connection_pool.rs
+++ b/crates/database/tests/connection_pool.rs
@@ -831,41 +831,16 @@ fn close_reaps_a_connection_stranded_after_the_pool_was_closed() {
     assert!(!shm_left, "-shm must be gone when close returns");
 }
 
-/// Closing in the same task that just used the pool — with no await in between —
-/// must still release the sidecars.
-///
-/// This is the near-miss in `close`: sqlx's close only closes connections it can
-/// pop from the idle queue, and a connection whose `return_to_pool` task has not
-/// run yet is not in that queue. It is then closed by its own task, concurrently
-/// with the close we are driving, and two concurrent closes are exactly what makes
-/// SQLite skip the checkpoint-and-unlink (issue #132).
-///
-/// `initialize` + `close` back to back is the realistic shape — it is what
-/// `ComponentManager::close` does after a warm — and it left both sidecars on disk
-/// until `close` learned to let the returns land first.
-#[tokio::test(flavor = "multi_thread")]
-async fn close_right_after_a_query_still_releases_the_sidecars() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("busy.db");
-    let wal = path.with_file_name("busy.db-wal");
-    let shm = path.with_file_name("busy.db-shm");
-    let url = format!("sqlite://{}?mode=rwc", path.display());
-
-    let db = connect(&url).await.expect("connect");
-    // Migrations leave a connection mid-return: they finish their last statement
-    // and drop the connection, whose return is a spawned task that has not been
-    // scheduled by the time the next line runs.
-    cognee_database::initialize(&db).await.expect("initialize");
-
-    // No yield, no sleep, no second query: close immediately.
-    cognee_database::close(&db).await.expect("close");
-
-    assert!(
-        !wal.exists(),
-        "-wal survived a close issued right after a query"
-    );
-    assert!(
-        !shm.exists(),
-        "-shm survived a close issued right after a query"
-    );
-}
+// NOTE: a `close_right_after_a_query_still_releases_the_sidecars` test lived here
+// and was removed deliberately. It drove the real
+// `initialize(&db)`-then-`close(&db)` shape and asserted the sidecars were gone,
+// which reads well but *races*: whether the straggler's `return_to_pool` task
+// lands inside the drain's stall window depends on machine load. Measured 3
+// failures in 5 back-to-back runs on an otherwise idle laptop.
+//
+// The mechanism it meant to cover is already covered above, deterministically,
+// by `close_waits_for_a_straggling_connection` and
+// `close_reaps_a_connection_stranded_after_the_pool_was_closed` — both of which
+// force the ordering instead of hoping for it. Racing this is the same mistake
+// that kept the original bug invisible on an idle host, so a flaky duplicate is
+// worse than no test.

--- a/crates/database/tests/connection_pool.rs
+++ b/crates/database/tests/connection_pool.rs
@@ -830,3 +830,42 @@ fn close_reaps_a_connection_stranded_after_the_pool_was_closed() {
     assert!(!wal_left, "-wal must be gone when close returns");
     assert!(!shm_left, "-shm must be gone when close returns");
 }
+
+/// Closing in the same task that just used the pool — with no await in between —
+/// must still release the sidecars.
+///
+/// This is the near-miss in `close`: sqlx's close only closes connections it can
+/// pop from the idle queue, and a connection whose `return_to_pool` task has not
+/// run yet is not in that queue. It is then closed by its own task, concurrently
+/// with the close we are driving, and two concurrent closes are exactly what makes
+/// SQLite skip the checkpoint-and-unlink (issue #132).
+///
+/// `initialize` + `close` back to back is the realistic shape — it is what
+/// `ComponentManager::close` does after a warm — and it left both sidecars on disk
+/// until `close` learned to let the returns land first.
+#[tokio::test(flavor = "multi_thread")]
+async fn close_right_after_a_query_still_releases_the_sidecars() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("busy.db");
+    let wal = path.with_file_name("busy.db-wal");
+    let shm = path.with_file_name("busy.db-shm");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+
+    let db = connect(&url).await.expect("connect");
+    // Migrations leave a connection mid-return: they finish their last statement
+    // and drop the connection, whose return is a spawned task that has not been
+    // scheduled by the time the next line runs.
+    cognee_database::initialize(&db).await.expect("initialize");
+
+    // No yield, no sleep, no second query: close immediately.
+    cognee_database::close(&db).await.expect("close");
+
+    assert!(
+        !wal.exists(),
+        "-wal survived a close issued right after a query"
+    );
+    assert!(
+        !shm.exists(),
+        "-shm survived a close issued right after a query"
+    );
+}

--- a/crates/graph/src/ladybug.rs
+++ b/crates/graph/src/ladybug.rs
@@ -141,7 +141,21 @@ fn sanitize_json_control_chars(s: &str) -> Cow<'_, str> {
 /// ```
 pub struct LadybugAdapter {
     db_path: String,
-    db: Arc<Database>,
+    /// The embedded database handle, `None` once [`LadybugAdapter::close`] has
+    /// taken it.
+    ///
+    /// The slot sits around the inner `Arc<Database>` rather than around the
+    /// outer `Arc<dyn GraphDBTrait>` on purpose: `close` must work while a
+    /// pipeline still holds a trait-object clone, which is only possible if the
+    /// closed state lives *inside* the shared handle. This is the same reason
+    /// sqlx puts its closed flag inside `PoolInner` instead of relying on the
+    /// `Pool` wrapper being dropped.
+    ///
+    /// `std::sync::RwLock`, not `tokio::sync::RwLock`: the guard is never held
+    /// across an `.await` (every accessor clones the `Arc` out and releases it
+    /// immediately), and a tokio lock would force the accessor to be `async` and
+    /// churn all ten query sites for no gain.
+    db: std::sync::RwLock<Option<Arc<Database>>>,
     // Single-process assumption: this lock serializes overlapping writes
     // within one process. Cross-process locking is intentionally out of scope.
     write_lock: Arc<Mutex<()>>,
@@ -173,7 +187,7 @@ impl LadybugAdapter {
 
         Ok(Self {
             db_path: db_path.to_string(),
-            db: Arc::new(db),
+            db: std::sync::RwLock::new(Some(Arc::new(db))),
             write_lock: Arc::new(Mutex::new(())),
         })
     }
@@ -181,6 +195,99 @@ impl LadybugAdapter {
     /// Get the database path.
     pub fn db_path(&self) -> &str {
         &self.db_path
+    }
+
+    /// Clone out the live database handle, or fail if the adapter is closed.
+    ///
+    /// Returning an owned `Arc` (rather than a guard) is what keeps the lock off
+    /// the query path: the handle stays alive for the whole query via the clone,
+    /// while the `RwLock` is released before `Connection::new` is even called.
+    fn db(&self) -> GraphDBResult<Arc<Database>> {
+        // Poison means a previous holder panicked mid-query; there is nothing to
+        // recover, so surface it the same way the adjacent `write_lock` does
+        // rather than panicking a second time.
+        let guard = self.db.read().map_err(|_| {
+            GraphDBError::ConnectionError("Ladybug database lock poisoned".to_string())
+        })?;
+        guard
+            .as_ref()
+            .map(Arc::clone)
+            .ok_or_else(|| GraphDBError::ConnectionError("graph database is closed".to_string()))
+    }
+
+    /// Stop serving queries and checkpoint the `.wal` into the main database
+    /// file.
+    ///
+    /// **A `Drop` is not a close, and a `Drop` at an unspecified time is worse.**
+    /// lbug runs its checkpoint in `Database`'s destructor and swallows every
+    /// failure (`lbug-src/src/main/database.cpp` wraps it in `catch (...) {}`),
+    /// so relying on the destructor means (a) the `.wal` — measured at 660 KB
+    /// after a 500-node/490-edge write — sits on disk until the last `Arc`
+    /// happens to go away, and (b) the checkpoint lands on whatever thread drops
+    /// the last clone, which inside an `async fn` is a runtime worker blocked for
+    /// up to ~1.5 s. Closing explicitly makes both deterministic.
+    ///
+    /// The checkpoint **and** the drop run together on
+    /// [`tokio::task::spawn_blocking`], and the join is awaited: both are
+    /// synchronous and file-bound, so running either inline would block the
+    /// calling worker — and on a current-thread runtime it would also stall the
+    /// timer, which is how a caller's `tokio::time::timeout` around this close
+    /// stops being able to fire at all (the CLI's teardown does exactly that).
+    /// Awaiting the join is what makes a subsequent `warm()` on the same path
+    /// safe: it must not race this checkpoint, or it hits lbug's file lock.
+    ///
+    /// # What is and is not released when this returns
+    ///
+    /// Guaranteed: the slot is empty, so no *new* query can start — every clone
+    /// of this adapter fails with `graph database is closed` rather than silently
+    /// reopening the file — and a checkpoint has been attempted.
+    ///
+    /// **Not** guaranteed: that the file descriptor and lbug's write lock are
+    /// gone. [`Self::db`] hands out owned `Arc<Database>` clones that a query
+    /// holds for its duration, so if one is in flight this drops a reference
+    /// rather than the last one, and the descriptor closes when that query
+    /// finishes. `Ok(())` therefore means "closed to new work and checkpointed",
+    /// not "the file is free"; a caller that needs the file free (to reopen it,
+    /// or to delete its directory) must first stop issuing queries.
+    ///
+    /// Idempotent.
+    pub async fn close(&self) -> GraphDBResult<()> {
+        // Take the handle out under the lock, then release the lock before the
+        // (potentially slow) checkpoint, so a concurrent accessor observes
+        // "closed" immediately instead of blocking on it.
+        let taken = {
+            let mut guard = self.db.write().map_err(|_| {
+                GraphDBError::ConnectionError("Ladybug database lock poisoned".to_string())
+            })?;
+            guard.take()
+        };
+        let Some(db) = taken else {
+            // Already closed — idempotent no-op.
+            return Ok(());
+        };
+
+        let path = self.db_path.clone();
+        let checkpoint_path = path.clone();
+        tokio::task::spawn_blocking(move || {
+            // Best-effort explicit checkpoint before the drop. lbug's destructor
+            // swallows checkpoint failures, so doing it here is the only way the
+            // outcome is observable at all. It must never propagate: an explicit
+            // CHECKPOINT legitimately fails on a read-only or in-memory database,
+            // and it must never skip the drop below, which is what releases this
+            // reference to the descriptor.
+            if let Ok(conn) = Connection::new(&db)
+                && let Err(e) = conn.query("CHECKPOINT")
+            {
+                tracing::debug!(error = %e, path = %checkpoint_path, "ladybug CHECKPOINT before close failed; the destructor will retry");
+            }
+            drop(db);
+        })
+        .await
+        .map_err(|e| {
+            GraphDBError::ConnectionError(format!(
+                "failed to join the ladybug close for {path}: {e}"
+            ))
+        })
     }
 
     /// Execute a query and convert results to JSON values.
@@ -216,7 +323,8 @@ impl LadybugAdapter {
         };
         Span::current().record(COGNEE_DB_QUERY, redact(truncated).as_ref());
 
-        let conn = Connection::new(&self.db).map_err(|e| {
+        let db = self.db()?;
+        let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
         })?;
 
@@ -583,7 +691,8 @@ struct NodeProperties {
 #[async_trait]
 impl GraphDBTrait for LadybugAdapter {
     async fn initialize(&self) -> GraphDBResult<()> {
-        let conn = Connection::new(&self.db).map_err(|e| {
+        let db = self.db()?;
+        let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
         })?;
 
@@ -641,6 +750,14 @@ impl GraphDBTrait for LadybugAdapter {
         Ok(())
     }
 
+    /// Delegates to the inherent [`LadybugAdapter::close`], so a caller holding
+    /// an `Arc<dyn GraphDBTrait>` (which is what `ComponentManager` and the HTTP
+    /// server's `AppState` hold) can release the WAL and the file lock without
+    /// downcasting.
+    async fn close(&self) -> GraphDBResult<()> {
+        LadybugAdapter::close(self).await
+    }
+
     async fn is_empty(&self) -> GraphDBResult<bool> {
         let results = self.execute_query("MATCH (n:Node) RETURN COUNT(n) AS count")?;
 
@@ -671,7 +788,8 @@ impl GraphDBTrait for LadybugAdapter {
     }
 
     async fn delete_graph(&self) -> GraphDBResult<()> {
-        let conn = Connection::new(&self.db).map_err(|e| {
+        let db = self.db()?;
+        let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
         })?;
 
@@ -710,7 +828,8 @@ impl GraphDBTrait for LadybugAdapter {
         let _write_guard = self.write_lock.lock().map_err(|_| {
             GraphDBError::ConnectionError("Ladybug write lock poisoned".to_string())
         })?;
-        let conn = Connection::new(&self.db).map_err(|e| {
+        let db = self.db()?;
+        let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
         })?;
 
@@ -730,7 +849,8 @@ impl GraphDBTrait for LadybugAdapter {
             GraphDBError::ConnectionError("Ladybug write lock poisoned".to_string())
         })?;
 
-        let conn = Connection::new(&self.db).map_err(|e| {
+        let db = self.db()?;
+        let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
         })?;
 
@@ -774,7 +894,8 @@ impl GraphDBTrait for LadybugAdapter {
     }
 
     async fn delete_node(&self, node_id: &str) -> GraphDBResult<()> {
-        let conn = Connection::new(&self.db).map_err(|e| {
+        let db = self.db()?;
+        let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
         })?;
 
@@ -883,7 +1004,8 @@ impl GraphDBTrait for LadybugAdapter {
         let _write_guard = self.write_lock.lock().map_err(|_| {
             GraphDBError::ConnectionError("Ladybug write lock poisoned".to_string())
         })?;
-        let conn = Connection::new(&self.db).map_err(|e| {
+        let db = self.db()?;
+        let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
         })?;
 
@@ -908,7 +1030,8 @@ impl GraphDBTrait for LadybugAdapter {
         let _write_guard = self.write_lock.lock().map_err(|_| {
             GraphDBError::ConnectionError("Ladybug write lock poisoned".to_string())
         })?;
-        let conn = Connection::new(&self.db).map_err(|e| {
+        let db = self.db()?;
+        let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
         })?;
 
@@ -1587,7 +1710,8 @@ impl GraphDBTrait for LadybugAdapter {
 
         let now = Utc::now();
         let ts = now.format("%Y-%m-%d %H:%M:%S%.6f").to_string();
-        let conn = Connection::new(&self.db).map_err(|e| {
+        let db = self.db()?;
+        let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
         })?;
         let set_query = format!(
@@ -1635,7 +1759,8 @@ impl GraphDBTrait for LadybugAdapter {
 
         let now = Utc::now();
         let ts = now.format("%Y-%m-%d %H:%M:%S%.6f").to_string();
-        let conn = Connection::new(&self.db).map_err(|e| {
+        let db = self.db()?;
+        let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
         })?;
         let set_query = format!(

--- a/crates/graph/src/mock.rs
+++ b/crates/graph/src/mock.rs
@@ -28,6 +28,11 @@ pub struct MockGraphDB {
     call_log: Arc<Mutex<Vec<String>>>,
     /// Optional injected error returned from `get_node_truth_state` calls.
     truth_state_error: Arc<Mutex<Option<String>>>,
+    /// When set, [`GraphDBTrait::close`] never returns. Lets a test stand in for
+    /// a slot whose teardown outlives the caller's patience — a large embedded
+    /// checkpoint, or a pool waiting on a connection that will not come back —
+    /// which is what makes a bounded teardown's *ordering* observable.
+    hang_on_close: bool,
 }
 
 impl MockGraphDB {
@@ -38,6 +43,20 @@ impl MockGraphDB {
             edges: Arc::new(Mutex::new(Vec::new())),
             call_log: Arc::new(Mutex::new(Vec::new())),
             truth_state_error: Arc::new(Mutex::new(None)),
+            hang_on_close: false,
+        }
+    }
+
+    /// A mock whose `close()` never completes.
+    ///
+    /// For tests that assert what a *bounded* teardown gets through before its
+    /// budget runs out: with a store that hangs, the timeout is guaranteed to
+    /// fire, so the assertion is about ordering rather than about how slow the
+    /// machine is.
+    pub fn hanging_on_close() -> Self {
+        Self {
+            hang_on_close: true,
+            ..Self::new()
         }
     }
 
@@ -85,6 +104,19 @@ impl Default for MockGraphDB {
 #[async_trait]
 impl GraphDBTrait for MockGraphDB {
     async fn initialize(&self) -> GraphDBResult<()> {
+        Ok(())
+    }
+
+    /// A no-op close, unless the mock was built by
+    /// [`MockGraphDB::hanging_on_close`], in which case it never returns.
+    async fn close(&self) -> GraphDBResult<()> {
+        self.call_log
+            .lock()
+            .unwrap() // lock poison is unrecoverable
+            .push("close".to_string());
+        if self.hang_on_close {
+            std::future::pending::<()>().await;
+        }
         Ok(())
     }
 

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -173,6 +173,15 @@ async fn cleanup_legacy_seaql_migrations(db: &DatabaseConnection) -> GraphDBResu
 /// promoted to dedicated columns for indexing; everything else goes into `properties`.
 pub struct PgGraphAdapter {
     db: DatabaseConnection,
+    /// Whether this adapter opened `db` itself and may therefore close it.
+    ///
+    /// Load-bearing, not defensive: [`Self::from_connection`] wraps a connection
+    /// the *caller* owns, and in the single-shared-Postgres layout that caller is
+    /// the relational store. Closing it from a graph teardown would turn a leak
+    /// fix into an outage — every relational query on the process would start
+    /// failing with a closed pool. Neither in-tree factory takes that path today,
+    /// but both constructors are public API.
+    owns_pool: bool,
 }
 
 impl PgGraphAdapter {
@@ -191,7 +200,10 @@ impl PgGraphAdapter {
         })?;
 
         debug!("PgGraphAdapter initialised");
-        Ok(Self { db })
+        Ok(Self {
+            db,
+            owns_pool: true,
+        })
     }
 
     /// Wrap an existing SeaORM `DatabaseConnection` (must be Postgres).
@@ -203,9 +215,76 @@ impl PgGraphAdapter {
             GraphDBError::InitializationError(format!("PgGraph migration failed: {e}"))
         })?;
 
-        Ok(Self { db })
+        Ok(Self {
+            db,
+            owns_pool: false,
+        })
     }
 
+    /// Close this adapter's **own** Postgres pool, so its server-side backends go
+    /// away now rather than whenever the last `Arc` happens to be dropped.
+    ///
+    /// This adapter opens a pool entirely separate from the relational one (see
+    /// the pool-sizing note in `cognee_database::connection`), so a warm
+    /// `ComponentManager` on Postgres holds three pools of ten and the relational
+    /// close in topoteretes/cognee-rs#135 reached only one of them.
+    ///
+    /// Measured against a live `pgvector/pg16` with `max_connections = 100`, and
+    /// worth stating precisely because the obvious framing of this bug is wrong:
+    ///
+    /// | teardown | backends afterwards |
+    /// |---|---|
+    /// | `drop`, pool idle | drained in **4 ms** — a drop is enough here |
+    /// | `close`, pool idle | drained in **1 ms**, the call returning in 67 µs |
+    /// | `drop`, one `pg_sleep` in flight | **all 10 pinned** for the query's full duration |
+    /// | `close`, one `pg_sleep` in flight | **9 of 10 reclaimed** within 500 ms, query unaffected |
+    /// | `Arc` retained, never closed | **10 open at 5 s**; `close()` on that same `Arc` drains them in 2 ms |
+    ///
+    /// So the two things this method buys are the last two rows:
+    /// - **A retained `Arc` has no drop to wait for.** The HTTP server keeps
+    ///   `lib.graph_db` as an `Arc` clone in `AppState` and an in-flight pipeline
+    ///   holds its own, so there is no owner to drop; closing through `&self` is
+    ///   the only teardown available, and without it the backends stay for the
+    ///   lifetime of the process. Against `max_connections = 100`, a handful of
+    ///   long-lived closed handles exhausts the server.
+    /// - **Under contention a drop is far worse.** A checked-out `PoolConnection`
+    ///   holds an `Arc<PoolInner>` (sqlx-core `pool/connection.rs`), so one slow
+    ///   query keeps the whole pool alive; [`sea_orm::DatabaseConnection::close_by_ref`]
+    ///   reclaims the idle connections immediately and lets the running query
+    ///   finish normally.
+    ///
+    /// A third difference is read from sqlx's source rather than measured:
+    /// `close_by_ref` sends the protocol `Terminate` message
+    /// (sqlx-postgres `connection/mod.rs`), where the drop path just closes the
+    /// socket — which is what makes a server log `unexpected EOF on client
+    /// connection with an open transaction`. The behaviour behind a connection
+    /// pooler (pgbouncer, RDS Proxy) follows from that, but has not been measured.
+    ///
+    /// A **no-op when the connection came from [`Self::from_connection`]**, and
+    /// idempotent (a closed pool closes again harmlessly). Surviving clones of
+    /// this adapter fail their next query against the closed pool rather than
+    /// reconnecting.
+    pub async fn close(&self) -> GraphDBResult<()> {
+        if !self.owns_pool {
+            debug!("PgGraphAdapter::close is a no-op for a caller-owned connection");
+            return Ok(());
+        }
+        self.db
+            .close_by_ref()
+            .await
+            .map_err(|e| GraphDBError::ConnectionError(format!("PgGraph pool close failed: {e}")))
+    }
+
+    /// The sea-orm connection (and therefore the pool) this adapter runs on.
+    ///
+    /// Exposed for diagnostics and for the teardown regression tests, which have
+    /// to observe the pool's own `is_closed()` flag and check a connection out of
+    /// *this* pool to exercise the in-flight case. Not an escape hatch for
+    /// issuing graph queries — use the typed adapter methods for that.
+    #[doc(hidden)]
+    pub fn connection(&self) -> &DatabaseConnection {
+        &self.db
+    }
     // -- helpers -------------------------------------------------------------
 
     /// Build a SeaORM [`Statement`] from a `sea_query` query.
@@ -339,6 +418,12 @@ impl GraphDBTrait for PgGraphAdapter {
             GraphDBError::InitializationError(format!("PgGraph migration failed: {e}"))
         })?;
         Ok(())
+    }
+
+    /// Delegates to the inherent [`PgGraphAdapter::close`], so a holder of an
+    /// `Arc<dyn GraphDBTrait>` can release the pool without downcasting.
+    async fn close(&self) -> GraphDBResult<()> {
+        PgGraphAdapter::close(self).await
     }
 
     async fn is_empty(&self) -> GraphDBResult<bool> {
@@ -1499,9 +1584,6 @@ mod migrator {
 // are skipped otherwise. They live inline (rather than under `tests/`) so they
 // can reuse the crate's own optional `sea-orm`/`sea-orm-migration` dependencies
 // without forcing a heavy dev-dependency onto the default (feature-off) build.
-// (`cognee-database` is now a dev-dependency, but only to pin down the sqlx
-// driver these tests' throwaway databases need at runtime — see the note on it
-// in Cargo.toml; sea-orm itself still comes from this crate.)
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 #[allow(
@@ -1513,57 +1595,10 @@ mod shared_db_migration_tests {
     use super::PgGraphAdapter;
     use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
     use sea_orm_migration::prelude::*;
+    use serial_test::serial;
 
     fn test_url() -> Option<String> {
         std::env::var("PGGRAPH_TEST_URL").ok()
-    }
-
-    /// Run `body` against a throwaway database of this test's own, dropped again
-    /// afterwards — even if `body` panics.
-    ///
-    /// Both cases below are about two migrators *coexisting inside one database*,
-    /// so the isolation is at the database level and nothing inside it is reset.
-    /// That replaces a `reset()` helper which dropped `graph_node`, `graph_edge`
-    /// and both `seaql_migrations*` tables on the way in and out: destructive
-    /// enough to wreck a developer's own database, and useless as mutual
-    /// exclusion under `cargo nextest`, where each test runs in its own process
-    /// and the `#[serial]` attribute these carried could not serialize anything.
-    ///
-    /// Not reaching a live Postgres is reported the same way as in the
-    /// integration suite: a missing URL prints a skip line and returns; anything
-    /// else — failing to create the database, connect, or migrate — panics with
-    /// the underlying error rather than masquerading as "not configured".
-    ///
-    /// `body` runs on a spawned task so a failed assertion surfaces as a
-    /// `JoinError` instead of unwinding past the drop. `TempPostgresDb::cleanup`
-    /// is `async`, so it cannot be a `Drop` impl; without this the database would
-    /// leak on every red run. The panic is re-raised unchanged afterwards.
-    async fn with_temp_db<F, Fut>(what: &str, body: F)
-    where
-        F: FnOnce(String) -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = ()> + Send + 'static,
-    {
-        let Some(base_url) = test_url() else {
-            eprintln!("PGGRAPH_TEST_URL not set — skipping {what}");
-            return;
-        };
-        let tmp = cognee_test_utils::create_temp_postgres_db(&base_url)
-            .await
-            .expect("PGGRAPH_TEST_URL is set, so CREATE DATABASE must succeed on that server");
-        let outcome = tokio::spawn(body(tmp.url().to_string())).await;
-        tmp.cleanup().await;
-        if let Err(join_err) = outcome {
-            // A `JoinError` here can only be a panic: the task is never aborted
-            // and its handle is awaited immediately, so there is no cancellation
-            // path. Assert that rather than leaning on it — `into_panic()` panics
-            // on a cancelled task, which would replace the real failure with a
-            // confusing one.
-            assert!(
-                join_err.is_panic(),
-                "the {what} task was cancelled instead of panicking, which this helper never does: {join_err}"
-            );
-            std::panic::resume_unwind(join_err.into_panic());
-        }
     }
 
     /// A stand-in for the downstream relational / auth migrator. It writes its
@@ -1618,6 +1653,22 @@ mod shared_db_migration_tests {
         }
     }
 
+    /// Drop every table and bookkeeping table so each run starts clean.
+    async fn reset(db: &DatabaseConnection) {
+        for stmt in [
+            "DROP TABLE IF EXISTS graph_edge CASCADE",
+            "DROP TABLE IF EXISTS graph_node CASCADE",
+            "DROP TABLE IF EXISTS rel_baseline_marker CASCADE",
+            "DROP TABLE IF EXISTS rel_auth_marker CASCADE",
+            "DROP TABLE IF EXISTS seaql_migrations CASCADE",
+            "DROP TABLE IF EXISTS seaql_migrations_pggraph CASCADE",
+        ] {
+            db.execute(Statement::from_string(db.get_database_backend(), stmt))
+                .await
+                .unwrap();
+        }
+    }
+
     /// Count rows in a bookkeeping table. Returns 0 **only** when the table does
     /// not exist; any other DB error panics so it fails the test rather than
     /// masquerading as an empty table (`table` is a fixed test literal, so
@@ -1648,82 +1699,88 @@ mod shared_db_migration_tests {
 
     /// The relational migrator and the graph adapter migrator must coexist in
     /// one Postgres DB without colliding on the default `seaql_migrations` table.
-    ///
-    /// The database is this test's own, but *both* migrators still run inside
-    /// that one database — sharing it is the thing under test.
     #[tokio::test]
+    #[serial]
     async fn pggraph_coexists_with_relational_migrator_in_shared_db() {
-        with_temp_db("shared-DB migration test", |url| async move {
-            let db = Database::connect(&url).await.unwrap();
+        let Some(url) = test_url() else {
+            eprintln!("PGGRAPH_TEST_URL not set — skipping shared-DB migration test");
+            return;
+        };
 
-            // 1. Relational / auth migrator runs first and populates the default
-            //    `seaql_migrations` with versions the graph migrator does not own.
-            RelationalMigrator::up(&db, None)
-                .await
-                .expect("relational migrator should succeed");
-            assert_eq!(version_count(&db, "seaql_migrations").await, 2);
+        let db = Database::connect(&url).await.unwrap();
+        reset(&db).await;
 
-            // 2. Initialising the graph adapter against the SAME database must
-            //    succeed. Before the fix it aborted with "Migration file of version
-            //    'm20260914_000002_auth' is missing ...".
-            let adapter = PgGraphAdapter::new(&url).await;
-            assert!(
-                adapter.is_ok(),
-                "PgGraphAdapter init must not collide with the relational \
-                 seaql_migrations table; got: {:?}",
-                adapter.err()
-            );
+        // 1. Relational / auth migrator runs first and populates the default
+        //    `seaql_migrations` with versions the graph migrator does not own.
+        RelationalMigrator::up(&db, None)
+            .await
+            .expect("relational migrator should succeed");
+        assert_eq!(version_count(&db, "seaql_migrations").await, 2);
 
-            // 3. The graph migrator tracks its version in its OWN table and leaves
-            //    the relational bookkeeping untouched.
-            assert_eq!(version_count(&db, "seaql_migrations").await, 2);
-            assert_eq!(version_count(&db, "seaql_migrations_pggraph").await, 1);
-        })
-        .await;
+        // 2. Initialising the graph adapter against the SAME database must
+        //    succeed. Before the fix it aborted with "Migration file of version
+        //    'm20260914_000002_auth' is missing ...".
+        let adapter = PgGraphAdapter::new(&url).await;
+        assert!(
+            adapter.is_ok(),
+            "PgGraphAdapter init must not collide with the relational \
+             seaql_migrations table; got: {:?}",
+            adapter.err()
+        );
+
+        // 3. The graph migrator tracks its version in its OWN table and leaves
+        //    the relational bookkeeping untouched.
+        assert_eq!(version_count(&db, "seaql_migrations").await, 2);
+        assert_eq!(version_count(&db, "seaql_migrations_pggraph").await, 1);
+
+        reset(&db).await;
     }
 
     /// Upgrade path: a legacy graph row left in the default `seaql_migrations`
     /// by an older build must be purged so the core migrator no longer chokes.
-    ///
-    /// Also runs in a database of its own, and again both migrators share it —
-    /// the legacy row and the purge are only meaningful in one database.
     #[tokio::test]
+    #[serial]
     async fn pggraph_purges_legacy_row_from_default_table_on_upgrade() {
-        with_temp_db("legacy-purge test", |url| async move {
-            let db = Database::connect(&url).await.unwrap();
+        let Some(url) = test_url() else {
+            eprintln!("PGGRAPH_TEST_URL not set — skipping legacy-purge test");
+            return;
+        };
 
-            // Simulate an older build that recorded the graph version into the
-            // DEFAULT `seaql_migrations` table (aux-ran-before-core ordering).
-            db.execute(Statement::from_string(
-                db.get_database_backend(),
-                "CREATE TABLE seaql_migrations (version VARCHAR PRIMARY KEY, applied_at BIGINT NOT NULL)",
-            ))
+        let db = Database::connect(&url).await.unwrap();
+        reset(&db).await;
+
+        // Simulate an older build that recorded the graph version into the
+        // DEFAULT `seaql_migrations` table (aux-ran-before-core ordering).
+        db.execute(Statement::from_string(
+            db.get_database_backend(),
+            "CREATE TABLE seaql_migrations (version VARCHAR PRIMARY KEY, applied_at BIGINT NOT NULL)",
+        ))
+        .await
+        .unwrap();
+        db.execute(Statement::from_string(
+            db.get_database_backend(),
+            "INSERT INTO seaql_migrations (version, applied_at) \
+             VALUES ('m20250101_000001_create_graph_tables', 0)",
+        ))
+        .await
+        .unwrap();
+
+        // Upgraded build initialises the graph adapter.
+        PgGraphAdapter::new(&url)
             .await
-            .unwrap();
-            db.execute(Statement::from_string(
-                db.get_database_backend(),
-                "INSERT INTO seaql_migrations (version, applied_at) \
-                 VALUES ('m20250101_000001_create_graph_tables', 0)",
-            ))
+            .expect("graph adapter should initialise on upgrade");
+
+        // The stale graph row is gone, so the core/relational migrator can now
+        // run against the default table without aborting.
+        assert_eq!(
+            version_count(&db, "seaql_migrations").await,
+            0,
+            "legacy graph row must be purged from the default seaql_migrations"
+        );
+        RelationalMigrator::up(&db, None)
             .await
-            .unwrap();
+            .expect("core migrator must not choke after legacy row is purged");
 
-            // Upgraded build initialises the graph adapter.
-            PgGraphAdapter::new(&url)
-                .await
-                .expect("graph adapter should initialise on upgrade");
-
-            // The stale graph row is gone, so the core/relational migrator can now
-            // run against the default table without aborting.
-            assert_eq!(
-                version_count(&db, "seaql_migrations").await,
-                0,
-                "legacy graph row must be purged from the default seaql_migrations"
-            );
-            RelationalMigrator::up(&db, None)
-                .await
-                .expect("core migrator must not choke after legacy row is purged");
-        })
-        .await;
+        reset(&db).await;
     }
 }

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -1584,6 +1584,9 @@ mod migrator {
 // are skipped otherwise. They live inline (rather than under `tests/`) so they
 // can reuse the crate's own optional `sea-orm`/`sea-orm-migration` dependencies
 // without forcing a heavy dev-dependency onto the default (feature-off) build.
+// (`cognee-database` is now a dev-dependency, but only to pin down the sqlx
+// driver these tests' throwaway databases need at runtime — see the note on it
+// in Cargo.toml; sea-orm itself still comes from this crate.)
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 #[allow(
@@ -1595,10 +1598,57 @@ mod shared_db_migration_tests {
     use super::PgGraphAdapter;
     use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
     use sea_orm_migration::prelude::*;
-    use serial_test::serial;
 
     fn test_url() -> Option<String> {
         std::env::var("PGGRAPH_TEST_URL").ok()
+    }
+
+    /// Run `body` against a throwaway database of this test's own, dropped again
+    /// afterwards — even if `body` panics.
+    ///
+    /// Both cases below are about two migrators *coexisting inside one database*,
+    /// so the isolation is at the database level and nothing inside it is reset.
+    /// That replaces a `reset()` helper which dropped `graph_node`, `graph_edge`
+    /// and both `seaql_migrations*` tables on the way in and out: destructive
+    /// enough to wreck a developer's own database, and useless as mutual
+    /// exclusion under `cargo nextest`, where each test runs in its own process
+    /// and the `#[serial]` attribute these carried could not serialize anything.
+    ///
+    /// Not reaching a live Postgres is reported the same way as in the
+    /// integration suite: a missing URL prints a skip line and returns; anything
+    /// else — failing to create the database, connect, or migrate — panics with
+    /// the underlying error rather than masquerading as "not configured".
+    ///
+    /// `body` runs on a spawned task so a failed assertion surfaces as a
+    /// `JoinError` instead of unwinding past the drop. `TempPostgresDb::cleanup`
+    /// is `async`, so it cannot be a `Drop` impl; without this the database would
+    /// leak on every red run. The panic is re-raised unchanged afterwards.
+    async fn with_temp_db<F, Fut>(what: &str, body: F)
+    where
+        F: FnOnce(String) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let Some(base_url) = test_url() else {
+            eprintln!("PGGRAPH_TEST_URL not set — skipping {what}");
+            return;
+        };
+        let tmp = cognee_test_utils::create_temp_postgres_db(&base_url)
+            .await
+            .expect("PGGRAPH_TEST_URL is set, so CREATE DATABASE must succeed on that server");
+        let outcome = tokio::spawn(body(tmp.url().to_string())).await;
+        tmp.cleanup().await;
+        if let Err(join_err) = outcome {
+            // A `JoinError` here can only be a panic: the task is never aborted
+            // and its handle is awaited immediately, so there is no cancellation
+            // path. Assert that rather than leaning on it — `into_panic()` panics
+            // on a cancelled task, which would replace the real failure with a
+            // confusing one.
+            assert!(
+                join_err.is_panic(),
+                "the {what} task was cancelled instead of panicking, which this helper never does: {join_err}"
+            );
+            std::panic::resume_unwind(join_err.into_panic());
+        }
     }
 
     /// A stand-in for the downstream relational / auth migrator. It writes its
@@ -1653,22 +1703,6 @@ mod shared_db_migration_tests {
         }
     }
 
-    /// Drop every table and bookkeeping table so each run starts clean.
-    async fn reset(db: &DatabaseConnection) {
-        for stmt in [
-            "DROP TABLE IF EXISTS graph_edge CASCADE",
-            "DROP TABLE IF EXISTS graph_node CASCADE",
-            "DROP TABLE IF EXISTS rel_baseline_marker CASCADE",
-            "DROP TABLE IF EXISTS rel_auth_marker CASCADE",
-            "DROP TABLE IF EXISTS seaql_migrations CASCADE",
-            "DROP TABLE IF EXISTS seaql_migrations_pggraph CASCADE",
-        ] {
-            db.execute(Statement::from_string(db.get_database_backend(), stmt))
-                .await
-                .unwrap();
-        }
-    }
-
     /// Count rows in a bookkeeping table. Returns 0 **only** when the table does
     /// not exist; any other DB error panics so it fails the test rather than
     /// masquerading as an empty table (`table` is a fixed test literal, so
@@ -1699,88 +1733,82 @@ mod shared_db_migration_tests {
 
     /// The relational migrator and the graph adapter migrator must coexist in
     /// one Postgres DB without colliding on the default `seaql_migrations` table.
+    ///
+    /// The database is this test's own, but *both* migrators still run inside
+    /// that one database — sharing it is the thing under test.
     #[tokio::test]
-    #[serial]
     async fn pggraph_coexists_with_relational_migrator_in_shared_db() {
-        let Some(url) = test_url() else {
-            eprintln!("PGGRAPH_TEST_URL not set — skipping shared-DB migration test");
-            return;
-        };
+        with_temp_db("shared-DB migration test", |url| async move {
+            let db = Database::connect(&url).await.unwrap();
 
-        let db = Database::connect(&url).await.unwrap();
-        reset(&db).await;
+            // 1. Relational / auth migrator runs first and populates the default
+            //    `seaql_migrations` with versions the graph migrator does not own.
+            RelationalMigrator::up(&db, None)
+                .await
+                .expect("relational migrator should succeed");
+            assert_eq!(version_count(&db, "seaql_migrations").await, 2);
 
-        // 1. Relational / auth migrator runs first and populates the default
-        //    `seaql_migrations` with versions the graph migrator does not own.
-        RelationalMigrator::up(&db, None)
-            .await
-            .expect("relational migrator should succeed");
-        assert_eq!(version_count(&db, "seaql_migrations").await, 2);
+            // 2. Initialising the graph adapter against the SAME database must
+            //    succeed. Before the fix it aborted with "Migration file of version
+            //    'm20260914_000002_auth' is missing ...".
+            let adapter = PgGraphAdapter::new(&url).await;
+            assert!(
+                adapter.is_ok(),
+                "PgGraphAdapter init must not collide with the relational \
+                 seaql_migrations table; got: {:?}",
+                adapter.err()
+            );
 
-        // 2. Initialising the graph adapter against the SAME database must
-        //    succeed. Before the fix it aborted with "Migration file of version
-        //    'm20260914_000002_auth' is missing ...".
-        let adapter = PgGraphAdapter::new(&url).await;
-        assert!(
-            adapter.is_ok(),
-            "PgGraphAdapter init must not collide with the relational \
-             seaql_migrations table; got: {:?}",
-            adapter.err()
-        );
-
-        // 3. The graph migrator tracks its version in its OWN table and leaves
-        //    the relational bookkeeping untouched.
-        assert_eq!(version_count(&db, "seaql_migrations").await, 2);
-        assert_eq!(version_count(&db, "seaql_migrations_pggraph").await, 1);
-
-        reset(&db).await;
+            // 3. The graph migrator tracks its version in its OWN table and leaves
+            //    the relational bookkeeping untouched.
+            assert_eq!(version_count(&db, "seaql_migrations").await, 2);
+            assert_eq!(version_count(&db, "seaql_migrations_pggraph").await, 1);
+        })
+        .await;
     }
 
     /// Upgrade path: a legacy graph row left in the default `seaql_migrations`
     /// by an older build must be purged so the core migrator no longer chokes.
+    ///
+    /// Also runs in a database of its own, and again both migrators share it —
+    /// the legacy row and the purge are only meaningful in one database.
     #[tokio::test]
-    #[serial]
     async fn pggraph_purges_legacy_row_from_default_table_on_upgrade() {
-        let Some(url) = test_url() else {
-            eprintln!("PGGRAPH_TEST_URL not set — skipping legacy-purge test");
-            return;
-        };
+        with_temp_db("legacy-purge test", |url| async move {
+            let db = Database::connect(&url).await.unwrap();
 
-        let db = Database::connect(&url).await.unwrap();
-        reset(&db).await;
-
-        // Simulate an older build that recorded the graph version into the
-        // DEFAULT `seaql_migrations` table (aux-ran-before-core ordering).
-        db.execute(Statement::from_string(
-            db.get_database_backend(),
-            "CREATE TABLE seaql_migrations (version VARCHAR PRIMARY KEY, applied_at BIGINT NOT NULL)",
-        ))
-        .await
-        .unwrap();
-        db.execute(Statement::from_string(
-            db.get_database_backend(),
-            "INSERT INTO seaql_migrations (version, applied_at) \
-             VALUES ('m20250101_000001_create_graph_tables', 0)",
-        ))
-        .await
-        .unwrap();
-
-        // Upgraded build initialises the graph adapter.
-        PgGraphAdapter::new(&url)
+            // Simulate an older build that recorded the graph version into the
+            // DEFAULT `seaql_migrations` table (aux-ran-before-core ordering).
+            db.execute(Statement::from_string(
+                db.get_database_backend(),
+                "CREATE TABLE seaql_migrations (version VARCHAR PRIMARY KEY, applied_at BIGINT NOT NULL)",
+            ))
             .await
-            .expect("graph adapter should initialise on upgrade");
-
-        // The stale graph row is gone, so the core/relational migrator can now
-        // run against the default table without aborting.
-        assert_eq!(
-            version_count(&db, "seaql_migrations").await,
-            0,
-            "legacy graph row must be purged from the default seaql_migrations"
-        );
-        RelationalMigrator::up(&db, None)
+            .unwrap();
+            db.execute(Statement::from_string(
+                db.get_database_backend(),
+                "INSERT INTO seaql_migrations (version, applied_at) \
+                 VALUES ('m20250101_000001_create_graph_tables', 0)",
+            ))
             .await
-            .expect("core migrator must not choke after legacy row is purged");
+            .unwrap();
 
-        reset(&db).await;
+            // Upgraded build initialises the graph adapter.
+            PgGraphAdapter::new(&url)
+                .await
+                .expect("graph adapter should initialise on upgrade");
+
+            // The stale graph row is gone, so the core/relational migrator can now
+            // run against the default table without aborting.
+            assert_eq!(
+                version_count(&db, "seaql_migrations").await,
+                0,
+                "legacy graph row must be purged from the default seaql_migrations"
+            );
+            RelationalMigrator::up(&db, None)
+                .await
+                .expect("core migrator must not choke after legacy row is purged");
+        })
+        .await;
     }
 }

--- a/crates/graph/src/traits.rs
+++ b/crates/graph/src/traits.rs
@@ -108,6 +108,32 @@ pub trait GraphDBTrait: Send + Sync {
     ///
     async fn initialize(&self) -> GraphDBResult<()>;
 
+    /// Release the OS resources this store owns, instead of waiting for `Drop`.
+    ///
+    /// Mirrors `cognee_database::close` for the relational pool: a `Drop` is
+    /// not a close. An embedded file-backed graph (ladybug) holds a write lock
+    /// on its main database file plus an un-checkpointed `-wal`, and a Postgres
+    /// adapter holds its **own** sqlx pool whose destructor only flags the pool
+    /// closed and lets each connection tear down on an arbitrary thread. Both
+    /// outlive the last `Arc` by an unbounded amount of time, which is
+    /// observable as orphaned sidecar files and as server-side backends that
+    /// stay open until the process exits (topoteretes/cognee-rs#132).
+    ///
+    /// Contract:
+    /// - **Idempotent.** Calling it twice is a no-op the second time.
+    /// - **Safe to call while other `Arc` clones are alive.** The closed state
+    ///   lives *inside* the shared inner handle (as sqlx puts its closed flag
+    ///   inside `PoolInner`), so surviving clones fail their next operation with
+    ///   a "closed" error rather than silently reconnecting or reopening.
+    /// - **Post-close operations fail.** This is a deliberate, user-visible
+    ///   extension of the relational contract, not a bug.
+    /// - The **default body is a no-op**, meaning "this backend owns nothing
+    ///   closable beyond memory". An adapter that does own OS resources must
+    ///   override it, or it will leak invisibly.
+    async fn close(&self) -> GraphDBResult<()> {
+        Ok(())
+    }
+
     /// Check if the database is empty (no nodes).
     ///
     async fn is_empty(&self) -> GraphDBResult<bool>;
@@ -867,6 +893,21 @@ mod tests {
                 .get_nodeset_subgraph(node_type, node_names, node_name_filter_operator)
                 .await
         }
+    }
+
+    /// The defaulted `close()` must be a no-op *and* idempotent for a backend
+    /// that owns nothing closable — that is what lets all in-tree impls (and
+    /// out-of-tree adapters) keep compiling untouched after the hook is added.
+    #[tokio::test]
+    async fn default_close_is_a_noop_and_idempotent() {
+        let db = DefaultImplDb::default();
+        assert!(db.close().await.is_ok());
+        assert!(db.close().await.is_ok());
+        // A no-op close must not disturb the store.
+        db.add_node_raw(serde_json::json!({"id": "c1", "name": "C1", "type": "T"}))
+            .await
+            .unwrap();
+        assert!(db.has_node("c1").await.unwrap());
     }
 
     #[tokio::test]

--- a/crates/graph/src/traits.rs
+++ b/crates/graph/src/traits.rs
@@ -112,7 +112,8 @@ pub trait GraphDBTrait: Send + Sync {
     ///
     /// Mirrors `cognee_database::close` for the relational pool: a `Drop` is
     /// not a close. An embedded file-backed graph (ladybug) holds a write lock
-    /// on its main database file plus an un-checkpointed `-wal`, and a Postgres
+    /// on its main database file plus an un-checkpointed `.wal` (ladybug's own
+    /// suffix — not SQLite's `-wal`, which the relational pool leaves), and a Postgres
     /// adapter holds its **own** sqlx pool whose destructor only flags the pool
     /// closed and lets each connection tear down on an arbitrary thread. Both
     /// outlive the last `Arc` by an unbounded amount of time, which is
@@ -125,8 +126,12 @@ pub trait GraphDBTrait: Send + Sync {
     ///   lives *inside* the shared inner handle (as sqlx puts its closed flag
     ///   inside `PoolInner`), so surviving clones fail their next operation with
     ///   a "closed" error rather than silently reconnecting or reopening.
-    /// - **Post-close operations fail.** This is a deliberate, user-visible
-    ///   extension of the relational contract, not a bug.
+    /// - **Post-close operations fail — for backends that actually close
+    ///   something.** This is a deliberate, user-visible extension of the
+    ///   relational contract, not a bug. It does *not* bind an implementor whose
+    ///   `close` is the no-op default below: with nothing to release there is
+    ///   nothing to invalidate, so such a backend keeps serving, and the unit
+    ///   test for the default asserts exactly that.
     /// - The **default body is a no-op**, meaning "this backend owns nothing
     ///   closable beyond memory". An adapter that does own OS resources must
     ///   override it, or it will leak invisibly.

--- a/crates/graph/tests/ladybug_close.rs
+++ b/crates/graph/tests/ladybug_close.rs
@@ -1,0 +1,208 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression tests for `LadybugAdapter::close` — the embedded-graph half of
+//! topoteretes/cognee-rs#132.
+//!
+//! The relational fix (#135) established that *dropping is not closing*. The
+//! embedded graph has the same shape with a different sidecar: lbug keeps an
+//! un-checkpointed `<db>.wal` next to the main file and holds a
+//! `FileLockType::WRITE_LOCK` on the main file for as long as its descriptor is
+//! open. Neither is released by letting the last `Arc` fall out of scope at an
+//! unspecified time — measurably, `close()` is what unlinks the `.wal` (659_977 B
+//! before the fix, 0 after) and folds it into the main file.
+//!
+//! Every assertion here is on the *awaited* `close()`, never on a post-`Drop`
+//! sleep: the destructor's checkpoint took up to 1.5 s for an 817 KB WAL during
+//! the audit, so a sleep-based assertion would be flaky in CI.
+#![cfg(feature = "ladybug")]
+
+use std::path::{Path, PathBuf};
+
+use cognee_graph::{GraphDBTrait, LadybugAdapter, NodeData};
+use serial_test::serial;
+use tempfile::TempDir;
+
+/// Number of nodes/edges written before the close. Enough to force lbug to grow
+/// a real WAL rather than keeping everything in its page cache.
+const NODES: usize = 500;
+
+fn wal_path(db_path: &Path) -> PathBuf {
+    let mut p = db_path.as_os_str().to_os_string();
+    p.push(".wal");
+    PathBuf::from(p)
+}
+
+/// Warm an adapter under a temp dir and write `NODES` nodes + `NODES - 10`
+/// edges, so the store has un-checkpointed WAL content at teardown.
+async fn warm() -> (LadybugAdapter, PathBuf, TempDir) {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let db_path = dir.path().join("test.db");
+    let adapter = LadybugAdapter::new(db_path.to_str().unwrap())
+        .await
+        .expect("failed to create LadybugAdapter");
+    adapter.initialize().await.expect("initialize");
+
+    let nodes: Vec<_> = (0..NODES)
+        .map(|i| {
+            serde_json::json!({
+                "id": format!("n{i}"),
+                "name": format!("Node {i}"),
+                "type": "TestNode",
+                "properties": {"idx": i, "pad": "x".repeat(64)},
+            })
+        })
+        .collect();
+    adapter.add_nodes_raw(nodes).await.expect("add_nodes_raw");
+
+    let edges: Vec<cognee_graph::EdgeData> = (0..NODES.saturating_sub(10))
+        .map(|i| {
+            (
+                format!("n{i}"),
+                format!("n{}", i + 10),
+                "links_to".to_string(),
+                Default::default(),
+            )
+        })
+        .collect();
+    adapter.add_edges(&edges).await.expect("add_edges");
+
+    (adapter, db_path, dir)
+}
+
+/// The core measurement: after `close()` the `.wal` is gone and its content has
+/// been folded into the main database file.
+///
+/// Fails on the pre-fix code, where `close()` is the defaulted no-op and the
+/// `.wal` is still on disk when it returns — measured at 659_977 B for this
+/// workload. With the fix the `.wal` is gone and the main file has grown from
+/// 4_096 B to 3_055_616 B, i.e. the WAL content was really folded in rather than
+/// discarded.
+#[tokio::test]
+#[serial]
+async fn close_checkpoints_and_unlinks_the_wal() {
+    let (adapter, db_path, _dir) = warm().await;
+    let wal = wal_path(&db_path);
+
+    assert!(
+        wal.exists(),
+        "precondition: writes must leave an un-checkpointed WAL at {}",
+        wal.display()
+    );
+    let main_before = std::fs::metadata(&db_path).expect("main db file").len();
+
+    adapter.close().await.expect("close must succeed");
+
+    assert!(
+        !wal.exists(),
+        "close() must checkpoint and unlink {} — still present ({} bytes)",
+        wal.display(),
+        std::fs::metadata(&wal).map(|m| m.len()).unwrap_or(0),
+    );
+    let main_after = std::fs::metadata(&db_path).expect("main db file").len();
+    assert!(
+        main_after > main_before,
+        "the WAL content must land in the main file: {main_before} -> {main_after}"
+    );
+}
+
+/// Post-close operations fail with a "closed" error instead of silently
+/// reopening the store — the graph twin of the relational contract in #135.
+#[tokio::test]
+#[serial]
+async fn operations_after_close_fail_with_a_closed_error() {
+    let (adapter, _db_path, _dir) = warm().await;
+    adapter.close().await.expect("close");
+
+    let err = adapter
+        .get_node("n1")
+        .await
+        .expect_err("a query after close must fail, not silently reopen");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("closed"),
+        "error must name the closed state, got: {msg}"
+    );
+
+    // Writes too, not just reads.
+    let err = adapter
+        .add_node_raw(serde_json::json!({"id": "late", "name": "L", "type": "T"}))
+        .await
+        .expect_err("a write after close must fail");
+    assert!(err.to_string().contains("closed"), "got: {err}");
+}
+
+/// Idempotent: a second `close()` is a no-op, so implicit and explicit teardown
+/// tiers can both call it without ordering rules.
+#[tokio::test]
+#[serial]
+async fn close_is_idempotent() {
+    let (adapter, db_path, _dir) = warm().await;
+    adapter.close().await.expect("first close");
+    adapter.close().await.expect("second close must be a no-op");
+    assert!(!wal_path(&db_path).exists());
+}
+
+/// A re-warm on the same path still succeeds after `close()`, and the data
+/// written before the close is readable.
+///
+/// Unlike the three above, this one also passes *without* the fix: lbug happily
+/// takes a second `Database` on a path it already holds open, so a double-open is
+/// silent rather than an error. That is exactly why it is asserted here — the fix
+/// must not convert a legitimate reopen into a failure, and the awaited
+/// `spawn_blocking` drop inside `close()` is what stops the re-warm from racing
+/// the previous adapter's checkpoint (`ComponentManager::close` doc, contract
+/// note 4).
+#[tokio::test]
+#[serial]
+async fn the_same_path_can_be_reopened_after_close() {
+    let (adapter, db_path, _dir) = warm().await;
+    adapter.close().await.expect("close");
+
+    let reopened = LadybugAdapter::new(db_path.to_str().unwrap())
+        .await
+        .expect("reopening the closed path must succeed");
+    reopened.initialize().await.expect("initialize the reopen");
+
+    // The data written before the close survived the checkpoint.
+    let node: Option<NodeData> = reopened.get_node("n1").await.expect("query the reopen");
+    assert!(node.is_some(), "checkpointed data must be readable");
+
+    reopened.close().await.expect("close the reopen");
+}
+
+/// `close()` guarantees exactly what its rustdoc now claims — closed to new work
+/// and checkpointed — and nothing about the descriptor being free.
+///
+/// This pins the honest half in place. The stronger promise the doc used to make
+/// ("drop the file descriptor and release lbug's write lock" by the time it
+/// returns) cannot be kept: `db()` hands out owned `Arc<Database>` clones that an
+/// in-flight query holds for its duration, so a close racing one drops a
+/// reference rather than the last one. When no query is in flight the descriptor
+/// *is* released, which is what `the_same_path_can_be_reopened_after_close`
+/// covers; the two together are the whole contract.
+#[tokio::test]
+#[serial]
+async fn close_reports_ok_and_refuses_new_work() {
+    let (adapter, db_path, _dir) = warm().await;
+
+    adapter.close().await.expect("close reports Ok");
+
+    let err = adapter
+        .get_node("n1")
+        .await
+        .expect_err("a closed adapter must refuse new queries");
+    assert!(
+        err.to_string().contains("closed"),
+        "error should name the cause, got: {err}"
+    );
+
+    // The checkpoint half of the guarantee: the WAL was folded into the main
+    // file rather than left next to it.
+    assert!(
+        !wal_path(&db_path).exists(),
+        "close() must checkpoint the .wal away"
+    );
+}

--- a/crates/graph/tests/pg_graph_close.rs
+++ b/crates/graph/tests/pg_graph_close.rs
@@ -1,0 +1,340 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression tests for `PgGraphAdapter::close` — the Postgres half of
+//! topoteretes/cognee-rs#132.
+//!
+//! `PgGraphAdapter` opens a pool that is **entirely separate** from the relational
+//! one (see the pool-sizing note in `cognee_database::connection`), so #135's
+//! relational close did nothing for it: a warm `ComponentManager` on Postgres
+//! holds three pools of ten, and nothing closed two of them.
+//!
+//! What was actually measured here, against a live `pgvector/pg16` with
+//! `max_connections = 100`, matters for how these tests are written — because one
+//! popular framing of the bug turns out to be **wrong**:
+//!
+//! | teardown | backends afterwards |
+//! |---|---|
+//! | `drop`, pool idle | drained in **4 ms** — a drop *is* enough here |
+//! | `close`, pool idle | drained in **1 ms** (call returned in 67 µs) |
+//! | `drop`, one `pg_sleep` in flight | **all 10 pinned** for the query's full duration |
+//! | `close`, one `pg_sleep` in flight | **9 of 10 reclaimed** within 500 ms; the query completes normally |
+//! | `Arc` retained, never closed | **10 still open at 5 s**; `close()` on the retained `Arc` drains them in 2 ms |
+//!
+//! So the two things `close()` buys are the last two rows, and those are what is
+//! asserted below:
+//!
+//! 1. **A retained `Arc` has no drop to wait for.** The HTTP server keeps
+//!    `lib.graph_db` as an `Arc` clone in `AppState`, and an in-flight pipeline
+//!    holds its own; closing through `&self` is the only teardown available.
+//! 2. **Under contention a drop is much worse than an idle drop.** A checked-out
+//!    `PoolConnection` holds an `Arc<PoolInner>` (sqlx-core `pool/connection.rs`),
+//!    so one slow query keeps the entire pool alive; `close` releases the idle
+//!    connections immediately instead.
+//!
+//! Requires a running PostgreSQL instance; set `PGGRAPH_TEST_URL`, e.g.
+//!
+//!   PGGRAPH_TEST_URL="postgres://user:pass@localhost:5432/cognee_test_graph"
+//!
+//! Tests skip automatically when it is absent, following the convention in
+//! `pg_graph_integration.rs`. **These tests must be named explicitly in `ci.yml`'s
+//! `pggraph-postgres` lane and in the `community.yml` mirror**: those lanes invoke
+//! individual `--test` targets, so a new file runs nowhere unless it is added
+//! there.
+#![cfg(feature = "postgres")]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use cognee_graph::{GraphDBTrait, PgGraphAdapter};
+use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
+use serial_test::serial;
+
+/// Concurrency used to grow the pool past a single connection. Matches sqlx's
+/// default ceiling, which the adapter does not override; the assertions compare
+/// against the count actually observed, not against this.
+const CONCURRENCY: usize = 10;
+
+fn test_url() -> Option<String> {
+    std::env::var("PGGRAPH_TEST_URL").ok()
+}
+
+/// Tag a URL with a unique `application_name` so the observer counts *this*
+/// adapter's backends and nothing else — no `psql`, no superuser, and no
+/// interference from a parallel test or a developer's own session.
+fn tagged(url: &str, tag: &str) -> String {
+    let sep = if url.contains('?') { '&' } else { '?' };
+    format!("{url}{sep}application_name={tag}")
+}
+
+/// A second, independent connection used purely to observe the server's view.
+///
+/// It must not come from the pool under test: closing that pool would close the
+/// observer with it, and the whole point is to see what the *server* still holds.
+async fn observer(url: &str) -> DatabaseConnection {
+    Database::connect(tagged(url, "cognee_close_observer"))
+        .await
+        .expect("PGGRAPH_TEST_URL is set, so the observer must connect")
+}
+
+/// Backends the server still has open for `tag`.
+async fn backend_count(obs: &DatabaseConnection, tag: &str) -> i64 {
+    let stmt = Statement::from_sql_and_values(
+        obs.get_database_backend(),
+        "SELECT count(*)::bigint FROM pg_stat_activity WHERE application_name = $1",
+        [tag.into()],
+    );
+    obs.query_one(stmt)
+        .await
+        .expect("pg_stat_activity query")
+        .expect("count() always returns a row")
+        .try_get_by_index::<i64>(0)
+        .expect("count is a bigint")
+}
+
+/// Poll until the count is at or below `target`, returning the last value seen.
+async fn wait_for(obs: &DatabaseConnection, tag: &str, target: i64, window: Duration) -> i64 {
+    let deadline = Instant::now() + window;
+    loop {
+        let n = backend_count(obs, tag).await;
+        if n <= target || Instant::now() >= deadline {
+            return n;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Grow the pool past one connection with overlapping real operations, and return
+/// how many backends the server ended up with.
+///
+/// `GraphDBTrait::query` cannot be used for this — the Postgres backend rejects raw
+/// Cypher by design and never touches the pool — so this uses `has_node`. The peak
+/// is returned rather than asserted equal to `CONCURRENCY`, so the before/after
+/// comparisons below are against a number actually observed on this machine.
+async fn saturate(adapter: &Arc<PgGraphAdapter>, obs: &DatabaseConnection, tag: &str) -> i64 {
+    let mut tasks = Vec::new();
+    for _ in 0..CONCURRENCY {
+        let adapter = Arc::clone(adapter);
+        tasks.push(tokio::spawn(async move {
+            let deadline = Instant::now() + Duration::from_millis(400);
+            while Instant::now() < deadline {
+                adapter
+                    .has_node("saturation-probe")
+                    .await
+                    .expect("has_node");
+            }
+        }));
+    }
+    for t in tasks {
+        t.await.expect("saturation task");
+    }
+    let n = backend_count(obs, tag).await;
+    assert!(
+        n > 1,
+        "precondition: overlapping operations must open more than one pooled \
+         connection (got {n}), or this test cannot tell a pool close apart from a \
+         single connection dropping"
+    );
+    n
+}
+
+/// The case with no `Drop` to fall back on: the `Arc` is still held, so `close()`
+/// is the only thing that can release the pool.
+///
+/// This is the shape of every long-lived holder in the tree — the HTTP server's
+/// `AppState`, a pipeline task that captured the store — and it is where the leak
+/// is unbounded rather than merely untidy: measured 10 backends still open at 5 s
+/// on an idle but retained adapter, versus 0 in ~2 ms once `close()` is called on
+/// that very same `Arc`.
+#[tokio::test]
+#[serial]
+async fn close_releases_the_pool_while_the_adapter_is_still_held() {
+    let Some(url) = test_url() else {
+        eprintln!("PGGRAPH_TEST_URL not set — skipping");
+        return;
+    };
+    let obs = observer(&url).await;
+    let tag = format!("cognee_graph_retained_{}", std::process::id());
+
+    let adapter = Arc::new(
+        PgGraphAdapter::new(&tagged(&url, &tag))
+            .await
+            .expect("connect"),
+    );
+    let peak = saturate(&adapter, &obs, &tag).await;
+
+    // Time alone does not help: the pool is idle, but every backend stays.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    assert_eq!(
+        backend_count(&obs, &tag).await,
+        peak,
+        "an idle but retained pool must still hold all {peak} backends — if this \
+         ever drains on its own, sqlx's idle timeout changed and these numbers \
+         need re-deriving"
+    );
+
+    // A second holder, exactly like the HTTP server's AppState clone: the close
+    // has to work through `&self`, with no drop involved anywhere.
+    let second_holder = Arc::clone(&adapter);
+
+    adapter.close().await.expect("close");
+    let after_close = wait_for(&obs, &tag, 0, Duration::from_secs(5)).await;
+    assert_eq!(
+        after_close, 0,
+        "close() must reclaim all {peak} backends while the adapter is still \
+         held; {after_close} left"
+    );
+    assert!(
+        second_holder
+            .connection()
+            .get_postgres_connection_pool()
+            .is_closed(),
+        "the pool must report itself closed to every holder, not merely emptied"
+    );
+
+    // Idempotent, and the surviving clone fails its next query rather than
+    // silently reconnecting.
+    adapter.close().await.expect("second close is a no-op");
+    assert!(
+        second_holder.is_empty().await.is_err(),
+        "a query after close must fail rather than reconnect"
+    );
+}
+
+/// Under contention `close()` is strictly better than a drop — both halves
+/// asserted in one run, over the same window, so a slow machine cannot make a
+/// leak look like a fix.
+///
+/// A checked-out `PoolConnection` holds an `Arc<PoolInner>`, so the **drop** path
+/// pins the whole pool for as long as the slowest query runs (measured: 10 of 10
+/// backends still open at 0.5, 1, 1.5, 2 and 2.5 s with one `pg_sleep(3)` in
+/// flight). `close_by_ref` reclaims the idle connections immediately (measured: 9
+/// of 10 gone within 500 ms, the call itself returning in ~500 µs) and lets the
+/// running query finish normally.
+#[tokio::test]
+#[serial]
+async fn close_reclaims_idle_connections_that_a_drop_would_pin() {
+    let Some(url) = test_url() else {
+        eprintln!("PGGRAPH_TEST_URL not set — skipping");
+        return;
+    };
+    let obs = observer(&url).await;
+
+    // -- control: drop, with one query in flight ---------------------------
+    let drop_tag = format!("cognee_graph_dropslow_{}", std::process::id());
+    let (drop_peak, drop_pinned) = {
+        let adapter = Arc::new(
+            PgGraphAdapter::new(&tagged(&url, &drop_tag))
+                .await
+                .expect("connect"),
+        );
+        let peak = saturate(&adapter, &obs, &drop_tag).await;
+        let slow = {
+            let adapter = Arc::clone(&adapter);
+            tokio::spawn(async move {
+                adapter
+                    .connection()
+                    .execute_unprepared("SELECT pg_sleep(2)")
+                    .await
+                    .map(|_| ())
+            })
+        };
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        drop(adapter);
+        // Sampled while the slow query is still running.
+        tokio::time::sleep(Duration::from_millis(700)).await;
+        let pinned = backend_count(&obs, &drop_tag).await;
+        slow.await.expect("task").expect("query");
+        (peak, pinned)
+    };
+
+    // -- close, same shape -------------------------------------------------
+    let close_tag = format!("cognee_graph_closeslow_{}", std::process::id());
+    let adapter = Arc::new(
+        PgGraphAdapter::new(&tagged(&url, &close_tag))
+            .await
+            .expect("connect"),
+    );
+    let close_peak = saturate(&adapter, &obs, &close_tag).await;
+    let slow = {
+        let adapter = Arc::clone(&adapter);
+        tokio::spawn(async move {
+            adapter
+                .connection()
+                .execute_unprepared("SELECT pg_sleep(2)")
+                .await
+                .map(|_| ())
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let started = Instant::now();
+    adapter.close().await.expect("close");
+    let close_took = started.elapsed();
+    assert!(
+        close_took < Duration::from_secs(1),
+        "close() must not wait out the in-flight query, took {close_took:?}"
+    );
+
+    let while_running = wait_for(&obs, &close_tag, 1, Duration::from_millis(700)).await;
+
+    assert_eq!(
+        drop_pinned, drop_peak,
+        "control: with a query in flight, dropping the adapter pins the whole \
+         pool ({drop_peak} backends) — if this stops being true, sqlx's pool \
+         semantics changed and this fix should be re-derived, not deleted"
+    );
+    assert!(
+        while_running <= 1,
+        "close() must reclaim the idle connections while the slow query runs: \
+         {while_running} of {close_peak} left, against {drop_pinned} for the \
+         dropped control"
+    );
+
+    // The in-flight query is neither cancelled nor broken by the close.
+    slow.await
+        .expect("the in-flight task must not be cancelled")
+        .expect("the in-flight query must still complete against a closed pool");
+    let after = wait_for(&obs, &close_tag, 0, Duration::from_secs(5)).await;
+    assert_eq!(
+        after, 0,
+        "every backend must be gone once the query finishes"
+    );
+}
+
+/// The outage-prevention test: an adapter built with
+/// [`PgGraphAdapter::from_connection`] must **not** close the caller's connection.
+///
+/// In the single-shared-Postgres layout the caller's connection is the relational
+/// pool. Closing it from a graph teardown would take out every relational query in
+/// the process — a leak fix turned into an outage. This is why `owns_pool` exists
+/// and is load-bearing rather than defensive.
+#[tokio::test]
+#[serial]
+async fn close_does_not_touch_a_caller_owned_connection() {
+    let Some(url) = test_url() else {
+        eprintln!("PGGRAPH_TEST_URL not set — skipping");
+        return;
+    };
+    let tag = format!("cognee_graph_borrowed_{}", std::process::id());
+    let caller_owned = Database::connect(tagged(&url, &tag))
+        .await
+        .expect("caller connection");
+
+    let adapter = PgGraphAdapter::from_connection(caller_owned.clone())
+        .await
+        .expect("from_connection");
+    adapter.close().await.expect("close must succeed");
+
+    let stmt = Statement::from_string(caller_owned.get_database_backend(), "SELECT 1");
+    caller_owned
+        .query_one(stmt)
+        .await
+        .expect("the caller's connection must survive the adapter's close");
+    assert!(
+        !caller_owned.get_postgres_connection_pool().is_closed(),
+        "close() must not close a caller-owned pool"
+    );
+}

--- a/crates/http-server/Cargo.toml
+++ b/crates/http-server/Cargo.toml
@@ -195,6 +195,11 @@ libc = "0.2"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
+# A real listener + a real client, so `shutdown_releases_stores.rs` can prove that
+# a request in flight when the shutdown fires still completes — which is a
+# statement about axum's drain, and cannot be made with a router-only test.
+axum = { version = "0.8" }
+reqwest = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 serde_json = { workspace = true }
 serial_test = { workspace = true }

--- a/crates/http-server/src/lib.rs
+++ b/crates/http-server/src/lib.rs
@@ -49,10 +49,18 @@ use std::net::SocketAddr;
 
 /// Waits for SIGTERM or SIGINT (Ctrl-C).
 ///
+/// **Signal only.** The teardown deliberately does *not* live here: axum starts
+/// draining in-flight requests only once this future **completes**, so anything
+/// done inside it runs while the listener is still live and handlers are still
+/// executing. Closing the stores here meant an in-flight request could hit
+/// `graph database is closed` and return 500 for a shutdown that was supposed to
+/// be graceful. The teardown belongs after `serve(...)` returns — see
+/// [`serve_with_shutdown`].
+///
 /// Only compiled when the `bin` feature is enabled so the library does not
 /// require `tokio/signal`.
 #[cfg(feature = "bin")]
-async fn shutdown_signal(state: AppState) {
+async fn shutdown_signal() {
     use tokio::signal;
 
     let ctrl_c = async {
@@ -76,8 +84,43 @@ async fn shutdown_signal(state: AppState) {
         () = ctrl_c => {}
         () = terminate => {}
     }
+}
 
+/// Serve until `shutdown` resolves, let axum drain the in-flight requests, and
+/// **then** release the server's resources.
+///
+/// The ordering is the point. `with_graceful_shutdown` treats the future it is
+/// given as "stop accepting" — draining begins when that future completes — so a
+/// teardown placed inside it runs *before* the drain, against handlers that are
+/// still running. Running it after `serve(...)` returns is what makes the drain
+/// and the teardown sequential: every handler has finished by then, so nothing can
+/// observe a closed store.
+///
+/// The teardown runs whether or not `serve` succeeded: an accept-loop error still
+/// leaves the pools and the embedded graph open, and dropping them is not closing
+/// them (topoteretes/cognee-rs#132).
+///
+/// Taking the shutdown trigger as a parameter is also what makes this testable
+/// without raising a process signal — the binary passes [`shutdown_signal`], a
+/// test passes a channel.
+pub async fn serve_with_shutdown<F>(
+    listener: tokio::net::TcpListener,
+    app: axum::Router,
+    shutdown: F,
+    state: AppState,
+) -> Result<(), ServerError>
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    let served = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await;
+
+    // Draining is complete here — or the accept loop failed. Either way the
+    // resources are still open, so tear down before propagating.
     lifecycle::on_shutdown(&state).await;
+
+    served.map_err(|e| ServerError::Other(anyhow::anyhow!(e)))
 }
 
 // ─── run ──────────────────────────────────────────────────────────────────────
@@ -94,10 +137,7 @@ pub async fn run(addr: SocketAddr, state: AppState) -> Result<(), ServerError> {
 
     #[cfg(feature = "bin")]
     {
-        axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal(state))
-            .await
-            .map_err(|e| ServerError::Other(anyhow::anyhow!(e)))?;
+        serve_with_shutdown(listener, app, shutdown_signal(), state).await?;
     }
 
     #[cfg(not(feature = "bin"))]

--- a/crates/http-server/src/lifecycle.rs
+++ b/crates/http-server/src/lifecycle.rs
@@ -22,6 +22,40 @@ pub enum LifecycleError {
 /// All-zero UUID — matches Python's `default_user_id`.
 const DEFAULT_USER_ID_HEX: &str = "00000000000000000000000000000000";
 
+/// How long [`on_shutdown`] waits for already-dispatched telemetry POSTs to leave
+/// the process. Deliberately short: a SIGTERM must not be held up by an analytics
+/// collector.
+#[cfg(feature = "telemetry")]
+const TELEMETRY_FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// How long any single store close may take before shutdown moves on.
+///
+/// Generous — a large embedded checkpoint is legitimately slow — but finite. A
+/// pool close waits for its checked-out connections to come back, so a task
+/// parked in a driver read, or a handler that escaped the pipeline registry, would
+/// otherwise hold SIGTERM open until the supervisor loses patience and sends
+/// SIGKILL. Being killed is strictly worse than skipping one close: the kill
+/// skips *every* remaining close, plus the telemetry flush.
+const STORE_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Await one store's close under [`STORE_CLOSE_TIMEOUT`], logging the outcome.
+///
+/// Never propagates: shutdown continues to the next store either way, which is the
+/// whole reason each one is bounded separately rather than the sequence as a whole.
+async fn bounded<E: std::fmt::Display>(
+    what: &str,
+    close: impl std::future::Future<Output = Result<(), E>>,
+) {
+    match tokio::time::timeout(STORE_CLOSE_TIMEOUT, close).await {
+        Ok(Ok(())) => tracing::info!("{what} closed"),
+        Ok(Err(e)) => tracing::warn!("closing the {what} failed (non-fatal): {e}"),
+        Err(_) => tracing::warn!(
+            "closing the {what} did not finish within {STORE_CLOSE_TIMEOUT:?}; \
+             continuing shutdown so the remaining resources still get their turn"
+        ),
+    }
+}
+
 /// Called once before the router is handed to `axum::serve`.
 ///
 /// OSS-side bootstrap is a no-op: the synthetic default user is
@@ -39,6 +73,35 @@ pub fn default_user_id() -> Uuid {
 }
 
 /// Called on graceful shutdown (SIGTERM / SIGINT).
+///
+/// Order is the whole design here, and it is the reverse of startup: **drain the
+/// work first, then close the stores.** Closing a store while the pipeline
+/// registry still has tasks running would make every in-flight cognify fail
+/// against a closed handle and emit a burst of errors indistinguishable from a
+/// crash — the exact failure the relational-close comment below was written to
+/// avoid. So the registry shutdown and the sync abort stay first, and the graph /
+/// vector / relational closes come after.
+///
+/// Closing through `&self` is what makes this possible at all: `lib.graph_db` and
+/// `lib.vector_db` are `Arc` clones held by handlers and pipeline builders, so
+/// there is nothing here to drop — and for a Postgres store a retained `Arc` is
+/// precisely the case where the pool would otherwise stay open for the life of
+/// the process.
+///
+/// # Deliberate limitation
+///
+/// [`crate::components::ComponentHandles`] stores its slots as plain
+/// `Option<Arc<…>>`, so this hook **cannot** release the `reqwest` connection
+/// pools behind `llm` / `embedding_engine` / `transcriber` / `responses_client`,
+/// nor an ONNX session: doing so needs interior mutability in those fields, which
+/// is a breaking change for embedders. The standalone binary exits immediately
+/// after this returns, so the OS reclaims them; an **in-process embedder that
+/// rebuilds the router without exiting keeps that gap**. Recorded here rather than
+/// papered over with an interior-mutability layer.
+///
+/// Also pre-existing and worth knowing: without the `bin` feature there is no
+/// graceful-shutdown wiring at all (see `lib.rs`), so this function never runs and
+/// nothing is closed.
 pub async fn on_shutdown(state: &crate::state::AppState) {
     tracing::info!("Backend server is shutting down");
 
@@ -58,18 +121,38 @@ pub async fn on_shutdown(state: &crate::state::AppState) {
         );
     }
 
-    // Close the relational pool last, once the work that uses it has stopped.
+    // Close the stores now that the work using them has drained.
     //
-    // Exiting without closing leaves a SQLite database's `-wal`/`-shm` sidecars
-    // on disk: dropping the pool only flags it closed and lets its connections
-    // tear down concurrently, and SQLite unlinks the sidecars only when the
-    // *last* connection closes (issue #132). The next start recovers them, so
-    // nothing is corrupt, but a server whose data directory is ephemeral (a
-    // container, a test harness) leaves litter behind and looks like it crashed.
+    // Dropping is not closing, and here there is nothing to drop anyway: these are
+    // `Arc` clones held by handlers and pipeline builders, so a store has to be
+    // closed through `&self` or not at all. The relational pool orphans its
+    // `-wal`/`-shm` sidecars (topoteretes/cognee-rs#132), an embedded graph leaves
+    // an un-checkpointed `<db>.wal` and a write lock on its file, and a Postgres
+    // graph/vector adapter owns a pool that a retained `Arc` keeps open for the
+    // life of the process. All three are no-ops for backends that own nothing
+    // closable (the in-memory brute-force store, LanceDB).
     if let Some(lib) = state.lib.as_ref() {
-        match cognee_database::close(&lib.database).await {
-            Ok(()) => tracing::info!("relational database closed"),
-            Err(e) => tracing::warn!("closing the relational database failed (non-fatal): {e}"),
+        // Relational first, and every close bounded — see STORE_CLOSE_TIMEOUT and
+        // the ordering note in this function's docs.
+        bounded("relational database", cognee_database::close(&lib.database)).await;
+        if let Some(graph) = lib.graph_db.as_ref() {
+            bounded("graph database", graph.close()).await;
         }
+        if let Some(vector) = lib.vector_db.as_ref() {
+            bounded("vector database", vector.close()).await;
+        }
+    }
+
+    // Last of all, let the analytics POSTs that are already in flight finish.
+    // `send_telemetry` is fire-and-forget, so the shutdown event itself — the one
+    // that says why the server stopped — is otherwise discarded when the process
+    // exits (measured: 0 of 1 delivered without a flush, 1 of 1 with one).
+    // Hard-bounded: a slow or blackholed collector must never hold up a SIGTERM.
+    #[cfg(feature = "telemetry")]
+    if !cognee_telemetry::flush(TELEMETRY_FLUSH_TIMEOUT).await {
+        tracing::debug!(
+            "telemetry still in flight after {TELEMETRY_FLUSH_TIMEOUT:?}; \
+             dropping the remainder rather than delaying shutdown"
+        );
     }
 }

--- a/crates/http-server/tests/shutdown_releases_stores.rs
+++ b/crates/http-server/tests/shutdown_releases_stores.rs
@@ -1,0 +1,249 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression test for `on_shutdown`: a graceful shutdown must release the
+//! knowledge stores' OS resources, not just the relational pool.
+//!
+//! The relational half landed in #135. The stores were left out, and for the HTTP
+//! server that gap is not closable by a `Drop`: `lib.graph_db` is an `Arc` clone
+//! held by handlers and pipeline builders, so there is no owner to drop — the
+//! store has to be closed through `&self` or not at all.
+//!
+//! What that costs, measured on the real binary and stated precisely because the
+//! easy overstatement is wrong: on a **normal** exit the graph WAL does get
+//! released either way, because process teardown eventually drops the last `Arc`.
+//! The difference shows up whenever the process does not get to finish exiting —
+//! a container whose grace period ends when the shutdown hook does, an in-process
+//! embedder that rebuilds the router, or any Postgres store, whose pool a retained
+//! `Arc` keeps open for the life of the process. SIGTERM followed by SIGKILL as
+//! soon as `on_shutdown` finished its work: **1 orphan (`sys/graph.wal`, 1.1 KB)
+//! before the fix, 0 after**, with `graph database closed` logged.
+#![cfg(feature = "ladybug")]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cognee_graph::{GraphDBTrait, LadybugAdapter};
+use cognee_http_server::lifecycle::on_shutdown;
+
+mod support;
+
+/// Every `*.wal` under `root` — the embedded graph's sidecar.
+fn wal_files(root: &Path) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("wal") {
+                found.push(path.to_string_lossy().into_owned());
+            }
+        }
+    }
+    found
+}
+
+/// Warm an embedded graph under `dir` and write enough to leave a real WAL.
+async fn graph_with_writes(dir: &Path) -> (Arc<dyn GraphDBTrait>, PathBuf) {
+    let db_path = dir.join("graph.db");
+    let adapter = LadybugAdapter::new(db_path.to_str().expect("utf-8 temp path"))
+        .await
+        .expect("open the embedded graph");
+    adapter.initialize().await.expect("initialize");
+
+    let nodes: Vec<_> = (0..500)
+        .map(|i| {
+            serde_json::json!({
+                "id": format!("n{i}"),
+                "name": format!("Node {i}"),
+                "type": "TestNode",
+                "properties": {"idx": i, "pad": "x".repeat(64)},
+            })
+        })
+        .collect();
+    adapter.add_nodes_raw(nodes).await.expect("add_nodes_raw");
+
+    (Arc::new(adapter) as Arc<dyn GraphDBTrait>, db_path)
+}
+
+/// `on_shutdown` must leave no graph WAL behind.
+///
+/// Fails before the fix — `on_shutdown` closed only the relational pool, so
+/// `graph.db.wal` (~660 KB for this workload) survived the shutdown and, with the
+/// process being killed straight afterwards, survived the exit too.
+#[tokio::test]
+async fn shutdown_releases_the_embedded_graph_wal() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (graph, _db_path) = graph_with_writes(dir.path()).await;
+
+    // A second holder, standing in for the handler/pipeline clones that make a
+    // drop-based teardown impossible here.
+    let still_held = Arc::clone(&graph);
+
+    let state = support::build_p4_state(None, None, Some(graph)).await;
+
+    assert!(
+        !wal_files(dir.path()).is_empty(),
+        "precondition: the writes must leave an un-checkpointed WAL under {}",
+        dir.path().display(),
+    );
+
+    on_shutdown(&state).await;
+
+    let leftover = wal_files(dir.path());
+    assert!(
+        leftover.is_empty(),
+        "on_shutdown must release the graph store's WAL, found: {leftover:?}"
+    );
+
+    // The surviving clone observes the closed store rather than reopening it.
+    assert!(
+        still_held.get_node("n1").await.is_err(),
+        "a query after shutdown must fail rather than silently reopen the store"
+    );
+}
+
+/// `on_shutdown` stays a no-op-safe path for a state with no stores wired, and
+/// for one whose store owns nothing closable — both are normal configurations
+/// (`lib: None` in most tests, an in-memory vector store in production).
+#[tokio::test]
+async fn shutdown_is_safe_without_stores() {
+    let state = support::build_p4_state(None, None, None).await;
+    on_shutdown(&state).await;
+    // Twice, because a shutdown signal can arrive while one is already running.
+    on_shutdown(&state).await;
+}
+
+/// A request in flight when the shutdown fires must still complete successfully.
+///
+/// This is what `with_graceful_shutdown` is for: axum stops accepting and then
+/// **drains**, and draining only begins once the future it was given completes. So
+/// running the teardown inside that future closes the stores while handlers are
+/// still executing — the in-flight request then hits a closed store and returns
+/// 500 for a shutdown that was supposed to be graceful. Ordering the two
+/// (`serve(...).await`, *then* `on_shutdown`) is what makes the drain mean
+/// anything.
+///
+/// Deterministic by construction: the handler announces that it has started, the
+/// test fires the shutdown only after seeing that, and the handler touches the
+/// database *after* the shutdown has been requested.
+#[tokio::test]
+async fn a_request_in_flight_survives_the_shutdown() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let state = support::build_p4_state(None, None, None).await;
+    let db = state
+        .lib
+        .as_ref()
+        .expect("the p4 state wires a relational connection")
+        .database
+        .clone();
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let hit_db_after_shutdown = Arc::new(AtomicBool::new(false));
+
+    let handler_db = Arc::clone(&db);
+    let flag = Arc::clone(&hit_db_after_shutdown);
+    let started = Arc::new(tokio::sync::Mutex::new(Some(started_tx)));
+    let app = axum::Router::new().route(
+        "/slow",
+        axum::routing::get(move || {
+            let db = Arc::clone(&handler_db);
+            let flag = Arc::clone(&flag);
+            let started = Arc::clone(&started);
+            async move {
+                // Tell the test we are in flight, then give it room to fire the
+                // shutdown before we touch the store.
+                if let Some(tx) = started.lock().await.take() {
+                    let _ = tx.send(());
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+                // The assertion: a handler still running during shutdown must find
+                // its resources intact.
+                let ok = db.ping().await.is_ok();
+                flag.store(ok, Ordering::Release);
+                if ok { "ok" } else { "closed" }
+            }
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let server = tokio::spawn(cognee_http_server::serve_with_shutdown(
+        listener,
+        app,
+        async move {
+            let _ = shutdown_rx.await;
+        },
+        state,
+    ));
+
+    let request = tokio::spawn(async move {
+        reqwest::get(format!("http://{addr}/slow"))
+            .await
+            .expect("request")
+            .text()
+            .await
+            .expect("body")
+    });
+
+    // Only fire the shutdown once the handler is provably running.
+    started_rx.await.expect("handler started");
+    shutdown_tx.send(()).expect("trigger shutdown");
+
+    let body = request.await.expect("join the request");
+    server.await.expect("join the server").expect("serve");
+
+    assert_eq!(
+        body, "ok",
+        "the in-flight request must complete against live resources, not a store \
+         closed underneath it"
+    );
+    assert!(
+        hit_db_after_shutdown.load(Ordering::Acquire),
+        "the handler reached the database after the shutdown was requested and it \
+         must still have been open"
+    );
+
+    // And the teardown did run — after the drain.
+    assert!(
+        db.ping().await.is_err(),
+        "once serve() returned, the teardown must have closed the pool"
+    );
+}
+
+/// One store that will not close must not hold shutdown open forever.
+///
+/// A pool close waits for its checked-out connections to come back, so a task
+/// parked in a driver read (or a handler outside the pipeline registry) can make it
+/// wait indefinitely. Unbounded, that turns a SIGTERM into a SIGKILL — which skips
+/// every *remaining* close as well, so an unbounded wait costs more resources than
+/// it saves.
+#[tokio::test]
+async fn a_store_that_never_closes_does_not_hang_the_shutdown() {
+    let hanging: Arc<dyn GraphDBTrait> = Arc::new(cognee_graph::MockGraphDB::hanging_on_close());
+    let state = support::build_p4_state(None, None, Some(hanging)).await;
+
+    // The whole shutdown must finish well inside the per-store ceiling (10 s), and
+    // the ceiling itself must be finite. 30 s is the outer bound of the assertion,
+    // not of the code.
+    let finished = tokio::time::timeout(std::time::Duration::from_secs(30), on_shutdown(&state))
+        .await
+        .is_ok();
+
+    assert!(
+        finished,
+        "on_shutdown must bound each store close; it waited on one that never \
+         returns and would have been SIGKILLed"
+    );
+}

--- a/crates/lib/src/component_manager.rs
+++ b/crates/lib/src/component_manager.rs
@@ -383,7 +383,35 @@ impl ComponentManager {
         // bound exists to remove (topoteretes/cognee-rs#132). Taking it first
         // means the one teardown with an on-disk consequence is never queued
         // behind another slot's contention.
-        let database = self.database.write().await.take();
+        // Take the relational slot AND close it before touching any other lock.
+        //
+        // Taking it first is not enough, and getting that wrong is worse than the
+        // original order: `versioned_accessor!` holds a slot's write lock across
+        // the whole `init_*().await`, so a concurrent warm (a cold ONNX session
+        // load, a Postgres connect burning its timeout) can block the *next*
+        // acquisition for seconds. With the close deferred until after all seven
+        // takes, a caller that bounds this teardown — `cognee_cli::teardown` wraps
+        // it in a 5 s timeout — can have its budget expire while blocked on, say,
+        // the embedding lock. The future is dropped, `cognee_database::close`
+        // never runs, and the SQLite `-wal`/`-shm` sidecars survive: the #132 leak
+        // this method exists to fix. And because the slot was already emptied, no
+        // later `close()` can reach that pool either — it is orphaned for the life
+        // of the process.
+        //
+        // So the relational close is fully sequenced here, before any other lock
+        // is requested, and cancellation past this point can only cost the
+        // components that have no on-disk consequence.
+        if let Some((_, db)) = self.database.write().await.take() {
+            if shared.may_close(&db)
+                && let Err(e) = cognee_database::close(&db).await
+            {
+                tracing::warn!(error = %e, "failed to close the relational connection pool");
+            }
+            // The connection has no blocking destructor of its own, so dropping
+            // it inline is fine.
+            drop(db);
+        }
+
         let graph = self.graph_db.write().await.take();
         let vector = self.vector_db.write().await.take();
         let embedding = self.embedding_engine.write().await.take();
@@ -393,22 +421,6 @@ impl ComponentManager {
         // The lowered build context holds no OS resource, but a stale one would
         // outlive the config version it was built for; clear it with the rest.
         let _ = self.context.write().await.take();
-
-        // Relational FIRST: the caller may be bounding this whole teardown with a
-        // timeout, and the SQLite sidecars are the leak the bound exists to fix,
-        // so they must not be queued behind a graph checkpoint or an ONNX thread
-        // join. See the ordering note in this method's docs.
-        if let Some((_, db)) = database {
-            if shared.may_close(&db)
-                && let Err(e) = cognee_database::close(&db).await
-            {
-                tracing::warn!(error = %e, "failed to close the relational connection pool");
-            }
-            // The connection has no blocking destructor of its own; dropping it
-            // inline is fine, and doing so here (rather than at the end of the
-            // function) keeps the "take, close, release" shape uniform.
-            drop(db);
-        }
 
         if let Some((_, graph)) = graph {
             if shared.may_close(&graph)

--- a/crates/lib/src/component_manager.rs
+++ b/crates/lib/src/component_manager.rs
@@ -24,6 +24,37 @@ use crate::config::{ConfigManager, Settings};
 use crate::context::PipelineContext;
 use crate::error::ComponentError;
 
+/// Whether a teardown may call `close()` on state that surviving clones can
+/// observe.
+///
+/// A store's `close()` mutates the object behind the `Arc` (an embedded graph
+/// empties its inner handle, a pool flags itself closed), so it is visible to
+/// every clone. The explicit teardown is entitled to that; the implicit one is
+/// not, and closes a component only when the cache holds its last reference —
+/// the case where nobody can tell the difference. See
+/// [`ComponentManager::close`] and [`ComponentManager::release`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CloseSharedStores {
+    Yes,
+    No,
+}
+
+impl CloseSharedStores {
+    /// Whether `component` may be closed under this policy.
+    ///
+    /// `strong_count == 1` means the reference passed in (already taken out of the
+    /// cache) is the only one left, so a `close()` is unobservable. The count can
+    /// only be raced *upwards* by a task that already holds a clone, and such a
+    /// task is exactly the one we are protecting, so a stale-high count errs
+    /// toward leaving the component open — the safe direction.
+    fn may_close<T: ?Sized>(self, component: &Arc<T>) -> bool {
+        match self {
+            CloseSharedStores::Yes => true,
+            CloseSharedStores::No => Arc::strong_count(component) == 1,
+        }
+    }
+}
+
 /// Manages shared, lazily-initialized pipeline components.
 ///
 /// Each component is created on first access and cached for subsequent calls.
@@ -207,30 +238,217 @@ impl ComponentManager {
         Ok(new)
     }
 
-    /// Release the cached components that hold OS resources beyond their own
-    /// memory, instead of waiting for `Drop`.
+    /// Release every cached component, so the OS resources they hold go away now
+    /// instead of at an unspecified later time — or never.
     ///
-    /// Today that means the relational connection pool: dropping it does not
-    /// close it, so a SQLite database can leave its `-wal`/`-shm` sidecars
-    /// orphaned on disk long after the manager is gone (see
-    /// [`cognee_database::close`] for the mechanism). The other components
-    /// (storage, graph, vector, embedding, LLM, transcriber) expose no explicit
-    /// shutdown and release everything on drop, so they are left untouched.
+    /// # Why every slot, not just the database
     ///
-    /// The connection is **taken out of the cache** before it is closed, so this
-    /// leaves the manager reusable — just cold: the next `database()` builds a
-    /// fresh pool rather than handing out the closed one. Calling this twice is a
-    /// no-op the second time, and calling it on a manager that never opened the
-    /// database does nothing at all.
+    /// The relational pool is the one that *cannot* be fixed by a drop: sqlx's
+    /// destructor only flags the pool closed and lets its connections tear down
+    /// concurrently, which for SQLite orphans the `-wal`/`-shm` sidecars (see
+    /// [`cognee_database::close`], topoteretes/cognee-rs#132). It is closed
+    /// explicitly, **first** — see the ordering note below.
     ///
-    /// A close failure is logged rather than returned: the caller is tearing the
-    /// manager down and has no remedy, and the pool is unusable either way.
+    /// The other slots do release their resources on drop — but this cache **is
+    /// the last strong reference**, so leaving them cached means they are never
+    /// dropped and therefore never released. Measured on a warm manager: the
+    /// embedded graph keeps an un-checkpointed `.wal` and a write lock on its
+    /// database file; each `reqwest`-based engine keeps its idle keep-alive
+    /// connections (one embedding pool, one LLM pool and a second, easily-missed
+    /// LLM pool inside the transcriber); the ONNX embedding engine keeps an
+    /// `ort::Session` whose destructor joins its worker threads. Emptying the
+    /// slots is what runs those destructors.
+    ///
+    /// Slots that own something *closable* (graph, vector) get an awaited
+    /// `close()` before the drop; the rest are just dropped. Both the graph
+    /// `close()` and the plain drops run on [`tokio::task::spawn_blocking`],
+    /// which is load-bearing rather than hygiene: the `ort::Session` destructor
+    /// joins worker threads and the embedded graph's destructor runs a
+    /// synchronous checkpoint, so dropping either inline would block a runtime
+    /// worker for as long as that takes.
+    ///
+    /// The vector slot is dropped and closed like the rest, but note that the
+    /// in-tree vector backends were **measured to own nothing closable**: the
+    /// brute-force store is in-memory, and LanceDB holds no descriptor open
+    /// between calls (its manifest writes are crash-safe renames). They inherit
+    /// the no-op default [`cognee_vector::VectorDB::close`] deliberately — do not
+    /// bolt a close tier onto LanceDB on the assumption that it must need one.
+    /// Lance does install a process-lifetime CPU thread pool that no `close()`
+    /// can reclaim; those threads are not a leak and not a regression.
+    ///
+    /// # Reuse and ordering
+    ///
+    /// Every component is **taken out of the cache** before it is closed, so this
+    /// leaves the manager reusable — just cold: the next access rebuilds. Calling
+    /// this twice is a no-op the second time, and calling it on a manager that
+    /// never warmed does nothing at all. The slots are taken **one at a time**
+    /// (acquire → `take()` → release), so no two write guards are ever held at
+    /// once and none is held across an `.await`: the lock order against
+    /// `services()` / `build_context` is unchanged and this cannot deadlock.
+    ///
+    /// **The relational close goes first, and that ordering is load-bearing.**
+    /// Callers bound this teardown — the CLI wraps it in a `timeout` because a
+    /// pool close waits for connections to come back and a command's runtime may
+    /// have been dropped with one still checked out. Whatever runs first is the
+    /// part that survives a budget that runs out, so the slot whose leak started
+    /// all of this (the SQLite sidecars of #132) is closed before the graph
+    /// checkpoint, the vector pool, and the ONNX thread join get their turn.
+    /// Putting it last, as the first version of this did, let a timeout skip
+    /// exactly the close the fix existed for.
+    ///
+    /// Nothing is mid-write against the relational pool by this point: the caller
+    /// has already dropped the service bundle (see `HandleState::teardown`), and
+    /// the HTTP server drains its pipeline registry before calling this. The
+    /// stores are independent systems — the graph and vector backends do not write
+    /// through this pool — so closing it first cannot cut a store's own teardown
+    /// short.
+    ///
+    /// # Cost
+    ///
+    /// This is no longer a cheap relational reset. A caller that closes and then
+    /// keeps using the manager pays a full re-warm: a fresh TLS handshake per HTTP
+    /// engine, and for the ONNX provider a re-read of the model file.
+    ///
+    /// Failures are logged rather than returned: the caller is tearing the manager
+    /// down and has no remedy, and the component is unusable either way.
     pub async fn close(&self) {
-        let cached = self.database.write().await.take();
-        if let Some((_, db)) = cached
-            && let Err(e) = cognee_database::close(&db).await
-        {
-            tracing::warn!(error = %e, "failed to close the relational connection pool");
+        self.teardown(CloseSharedStores::Yes).await;
+    }
+
+    /// Whether any component is currently cached — i.e. whether a teardown would
+    /// have anything to release.
+    ///
+    /// Cheap and **non-blocking**, for a synchronous finalizer deciding whether to
+    /// spin up a runtime at all. Every slot is probed, not just one: warming is
+    /// slot-by-slot and can fail part-way (a bad LLM key fails after the SQLite
+    /// pool and the embedded graph are already cached), and a probe that only
+    /// looked at one slot would report "nothing to release" for a handle holding
+    /// an open database.
+    ///
+    /// A contended lock counts as occupied: the safe direction is to attempt a
+    /// teardown that turns out to be a no-op rather than to skip a real one.
+    pub fn has_cached_components(&self) -> bool {
+        fn occupied<T>(slot: &TokioRwLock<Option<T>>) -> bool {
+            match slot.try_read() {
+                Ok(guard) => guard.is_some(),
+                Err(_) => true,
+            }
+        }
+
+        occupied(&self.database)
+            || occupied(&self.graph_db)
+            || occupied(&self.vector_db)
+            || occupied(&self.embedding_engine)
+            || occupied(&self.llm)
+            || occupied(&self.transcriber)
+            || occupied(&self.storage)
+    }
+
+    /// Evict every cached component **without** closing anything that is still
+    /// shared, for the implicit teardown paths (a GC finalizer reclaiming a handle
+    /// the program dropped on the floor).
+    ///
+    /// The difference from [`close`](Self::close) is only about *shared* state. A
+    /// store's `close()` mutates the object behind the `Arc` — `LadybugAdapter`
+    /// empties its inner slot, a Postgres adapter closes its pool, sqlx flags
+    /// `PoolInner` closed — so it is visible to **every** surviving clone, and an
+    /// in-flight operation holding one would fail its next query. `close()` is
+    /// entitled to do that because the user asked; a finalizer is not.
+    ///
+    /// So this closes a component only when the cache holds its **last** strong
+    /// reference, which is precisely the case where nobody can observe the
+    /// difference. In the ordinary finalizer case — no operation in flight — that
+    /// is every slot, so the resources (including the SQLite sidecars) are
+    /// released exactly as `close()` would release them. When an operation *is* in
+    /// flight, its components are left open and released when it finishes and its
+    /// clone drops.
+    ///
+    /// The one thing not covered by that rule is the drop itself: a slot whose
+    /// last reference this evicts is dropped on the blocking pool as usual.
+    pub async fn release(&self) {
+        self.teardown(CloseSharedStores::No).await;
+    }
+
+    /// Shared body of [`close`](Self::close) / [`release`](Self::release).
+    async fn teardown(&self, shared: CloseSharedStores) {
+        // Take each slot out sequentially. Never two guards at once, never a
+        // guard across an `.await`.
+        let graph = self.graph_db.write().await.take();
+        let vector = self.vector_db.write().await.take();
+        let embedding = self.embedding_engine.write().await.take();
+        let llm = self.llm.write().await.take();
+        let transcriber = self.transcriber.write().await.take();
+        let storage = self.storage.write().await.take();
+        let database = self.database.write().await.take();
+        // The lowered build context holds no OS resource, but a stale one would
+        // outlive the config version it was built for; clear it with the rest.
+        let _ = self.context.write().await.take();
+
+        // Relational FIRST: the caller may be bounding this whole teardown with a
+        // timeout, and the SQLite sidecars are the leak the bound exists to fix,
+        // so they must not be queued behind a graph checkpoint or an ONNX thread
+        // join. See the ordering note in this method's docs.
+        if let Some((_, db)) = database {
+            if shared.may_close(&db)
+                && let Err(e) = cognee_database::close(&db).await
+            {
+                tracing::warn!(error = %e, "failed to close the relational connection pool");
+            }
+            // The connection has no blocking destructor of its own; dropping it
+            // inline is fine, and doing so here (rather than at the end of the
+            // function) keeps the "take, close, release" shape uniform.
+            drop(db);
+        }
+
+        if let Some((_, graph)) = graph {
+            if shared.may_close(&graph)
+                && let Err(e) = graph.close().await
+            {
+                tracing::warn!(error = %e, "failed to close the graph database");
+            }
+            Self::drop_off_runtime(graph, "graph database").await;
+        }
+
+        if let Some((_, vector)) = vector {
+            if shared.may_close(&vector)
+                && let Err(e) = vector.close().await
+            {
+                tracing::warn!(error = %e, "failed to close the vector database");
+            }
+            Self::drop_off_runtime(vector, "vector database").await;
+        }
+
+        if let Some((_, embedding)) = embedding {
+            Self::drop_off_runtime(embedding, "embedding engine").await;
+        }
+        if let Some((_, llm)) = llm {
+            Self::drop_off_runtime(llm, "llm").await;
+        }
+        if let Some((_, Some(transcriber))) = transcriber {
+            Self::drop_off_runtime(transcriber, "transcriber").await;
+        }
+        if let Some((_, storage)) = storage {
+            Self::drop_off_runtime(storage, "storage").await;
+        }
+    }
+
+    /// Run a component's destructor on the blocking pool and wait for it.
+    ///
+    /// Not hygiene: the destructors behind these `Arc`s block. An `ort::Session`
+    /// joins its inference worker threads and an embedded graph runs a
+    /// synchronous WAL checkpoint, either of which would stall an async worker if
+    /// dropped inline. Awaiting the join (instead of firing and forgetting) is
+    /// what makes a subsequent re-warm on the same path safe — it must not race
+    /// the destructor it is replacing.
+    ///
+    /// A `JoinError` is only reachable if the destructor itself panicked; log it
+    /// and continue, since the caller is tearing down and has no remedy.
+    async fn drop_off_runtime<T: Send + Sync + ?Sized + 'static>(
+        component: Arc<T>,
+        what: &'static str,
+    ) {
+        if let Err(e) = tokio::task::spawn_blocking(move || drop(component)).await {
+            tracing::warn!(error = %e, component = what, "component destructor panicked during close");
         }
     }
 }

--- a/crates/lib/src/component_manager.rs
+++ b/crates/lib/src/component_manager.rs
@@ -373,13 +373,23 @@ impl ComponentManager {
     async fn teardown(&self, shared: CloseSharedStores) {
         // Take each slot out sequentially. Never two guards at once, never a
         // guard across an `.await`.
+        //
+        // The **database slot goes first**, and the order is load-bearing rather
+        // than cosmetic. Every `write().await` here can block on a concurrent
+        // accessor, so acquiring the other six before it meant a caller that
+        // bounds this teardown with a timeout (the CLI does) could spend its whole
+        // budget waiting for, say, the graph lock and never reach the relational
+        // close at all — leaving exactly the SQLite `-wal`/`-shm` sidecars the
+        // bound exists to remove (topoteretes/cognee-rs#132). Taking it first
+        // means the one teardown with an on-disk consequence is never queued
+        // behind another slot's contention.
+        let database = self.database.write().await.take();
         let graph = self.graph_db.write().await.take();
         let vector = self.vector_db.write().await.take();
         let embedding = self.embedding_engine.write().await.take();
         let llm = self.llm.write().await.take();
         let transcriber = self.transcriber.write().await.take();
         let storage = self.storage.write().await.take();
-        let database = self.database.write().await.take();
         // The lowered build context holds no OS resource, but a stale one would
         // outlive the config version it was built for; clear it with the rest.
         let _ = self.context.write().await.take();

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -217,5 +217,10 @@ pub use cognee_models;
 pub use cognee_ontology;
 pub use cognee_session;
 pub use cognee_storage;
+/// Re-exported so teardown paths outside this crate (the CLI, the bindings'
+/// handle) can call [`cognee_telemetry::flush`] without taking their own
+/// dependency on the telemetry crate. `send_telemetry` is fire-and-forget, so an
+/// explicit teardown has to flush or the last event is dropped on the floor.
+pub use cognee_telemetry;
 pub use cognee_vector;
 pub use uuid;

--- a/crates/lib/tests/component_manager_close.rs
+++ b/crates/lib/tests/component_manager_close.rs
@@ -1,0 +1,591 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression tests for `ComponentManager::close` — the "every slot, not just
+//! the database" half of topoteretes/cognee-rs#132.
+//!
+//! `close()` used to release the relational pool only, on the documented (and
+//! measurably wrong) premise that the other components "release everything on
+//! drop, so they are left untouched". They do release on drop — but the version
+//! keyed cache in `ComponentManager` **is the last strong reference**, so a slot
+//! that is never emptied is a destructor that never runs. "Left untouched" meant
+//! "never released".
+//!
+//! Three independent observables are asserted here, none of which counts file
+//! descriptors or threads — every audit number for those was taken with macOS
+//! `lsof`/`ps -M` and would not port to CI:
+//!
+//! 1. `Arc::strong_count` per slot, which covers the components with no visible
+//!    OS footprint (storage, embedding, llm, transcriber).
+//! 2. Files on disk for the embedded graph (the `.wal` sidecar).
+//! 3. Live accepted peers counted **server-side** by a stub HTTP server, for the
+//!    `reqwest` connection pools inside the embedding and LLM engines. Counted by
+//!    the server rather than by fds, and asserted after an awaited `close()`
+//!    rather than after a sleep, because hyper evicts its own idle connections
+//!    after ~90 s on its own — a timeout-based assertion would eventually pass
+//!    for the wrong reason.
+//!
+//! Every test here runs on a **multi-thread** runtime, deliberately.
+//! `cognee_database::close` finishes sqlx's close by waiting for the pool to
+//! empty, and the straggling connection it waits on is handed back by a task
+//! sqlx spawned. On a current-thread runtime that task cannot be scheduled while
+//! the drain is waiting, so the drain times out and the sidecars survive — a test
+//! then fails (or passes) for reasons unrelated to what it asserts. Every real
+//! teardown path builds a multi-thread runtime (see `cognee_cli::teardown`), so
+//! this matches production rather than working around it.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use cognee::cognee_llm::{Message, MessageRole};
+use cognee::{ComponentManager, ConfigManager, PipelineContext, Settings};
+use serial_test::serial;
+use tempfile::TempDir;
+
+/// Settings with every on-disk artefact under `root` and every network-backed
+/// engine pointed at `endpoint`.
+///
+/// `Settings::default()` uses *relative* paths (`./.cognee_system`,
+/// `sqlite:./cognee.db?mode=rwc`), which would write into the crate directory,
+/// so all of it is redirected. The embedding/LLM providers are the
+/// OpenAI-compatible HTTP ones: they build a real `reqwest` client (and therefore
+/// a real connection pool) without performing any I/O at construction time.
+fn settings(root: &std::path::Path, endpoint: &str) -> Settings {
+    Settings {
+        system_root_directory: root.join("system").to_string_lossy().into_owned(),
+        data_root_directory: root.join("data").to_string_lossy().into_owned(),
+        relational_db_url: format!(
+            "sqlite:{}?mode=rwc",
+            root.join("cognee.db").to_string_lossy()
+        ),
+        graph_database_provider: "ladybug".to_string(),
+        graph_file_path: root
+            .join("system")
+            .join("graph")
+            .to_string_lossy()
+            .into_owned(),
+        // In-memory, so the vector slot contributes no OS resource of its own —
+        // deliberate: this test is about slot eviction, and the embedded vector
+        // store was measured to hold nothing closable.
+        vector_db_provider: "brute-force".to_string(),
+        embedding_provider: "openai".to_string(),
+        embedding_endpoint: format!("{endpoint}/v1/embeddings"),
+        embedding_api_key: "sk-test".to_string(),
+        embedding_model_name: "text-embedding-3-small".to_string(),
+        embedding_dimensions: 3,
+        llm_provider: "openai".to_string(),
+        llm_model: "gpt-4o-mini".to_string(),
+        llm_api_key: "sk-test".to_string(),
+        llm_endpoint: endpoint.to_string(),
+        ..Settings::default()
+    }
+}
+
+/// Every cached slot must be emptied by `close()`, which is the only thing that
+/// lets the component's destructor run at all.
+///
+/// The measurement is `Arc::strong_count` on a clone the test keeps: `2` means
+/// "the cache still holds it", `1` means "the cache let go and this test's clone
+/// is the last owner". Before the fix, six of the seven slots stay at `2`
+/// (measured: storage, graph, vector, embedding, llm, transcriber — only the
+/// relational connection dropped to `1`).
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn close_empties_every_component_slot() {
+    let dir = TempDir::new().expect("tempdir");
+    // No server needed: none of these engines performs I/O at construction.
+    let cm = ComponentManager::new(ConfigManager::new(settings(
+        dir.path(),
+        "http://127.0.0.1:1/v1",
+    )));
+
+    let storage = cm.storage().await.expect("storage");
+    let database = cm.database().await.expect("database");
+    let graph = cm.graph_db().await.expect("graph");
+    let vector = cm.vector_db().await.expect("vector");
+    let embedding = cm.embedding_engine().await.expect("embedding");
+    let llm = cm.llm().await.expect("llm");
+    let transcriber = cm
+        .transcriber()
+        .await
+        .expect("transcriber")
+        .expect("openai provider yields a transcriber");
+
+    // Precondition: the cache holds a second reference to each one.
+    for (what, count) in [
+        ("storage", Arc::strong_count(&storage)),
+        ("database", Arc::strong_count(&database)),
+        ("graph", Arc::strong_count(&graph)),
+        ("vector", Arc::strong_count(&vector)),
+        ("embedding", Arc::strong_count(&embedding)),
+        ("llm", Arc::strong_count(&llm)),
+        ("transcriber", Arc::strong_count(&transcriber)),
+    ] {
+        assert!(
+            count >= 2,
+            "precondition: the {what} slot must be warm (strong_count {count} < 2)"
+        );
+    }
+
+    cm.close().await;
+
+    for (what, count) in [
+        ("storage", Arc::strong_count(&storage)),
+        ("database", Arc::strong_count(&database)),
+        ("graph", Arc::strong_count(&graph)),
+        ("vector", Arc::strong_count(&vector)),
+        ("embedding", Arc::strong_count(&embedding)),
+        ("llm", Arc::strong_count(&llm)),
+        ("transcriber", Arc::strong_count(&transcriber)),
+    ] {
+        assert_eq!(
+            count, 1,
+            "close() must release the {what} slot — this test's clone should be \
+             the last owner, but strong_count is {count}"
+        );
+    }
+}
+
+/// `close()` on a manager that never warmed, and a second `close()`, are both
+/// no-ops rather than panics — required because the two teardown tiers in
+/// `HandleState` can each reach it.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn close_is_idempotent_and_safe_on_a_cold_manager() {
+    let dir = TempDir::new().expect("tempdir");
+    let cm = ComponentManager::new(ConfigManager::new(settings(
+        dir.path(),
+        "http://127.0.0.1:1/v1",
+    )));
+    cm.close().await;
+
+    let _ = cm.graph_db().await.expect("graph");
+    cm.close().await;
+    cm.close().await;
+
+    // Still reusable, just cold: the next access rebuilds.
+    let _ = cm.graph_db().await.expect("re-warm after close");
+    cm.close().await;
+}
+
+/// The on-disk measurement: after `close()` the embedded graph has no `.wal`
+/// sidecar left under the system root.
+///
+/// This is the real-OS-resource half of the P1 fix, and it fails before it: the
+/// manager's cache is the last owner of the `LadybugAdapter`, so nothing runs the
+/// checkpoint and the `.wal` (measured at ~660 KB for this workload) survives.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn close_leaves_no_graph_wal_on_disk() {
+    let dir = TempDir::new().expect("tempdir");
+    let cm = ComponentManager::new(ConfigManager::new(settings(
+        dir.path(),
+        "http://127.0.0.1:1/v1",
+    )));
+
+    {
+        let graph = cm.graph_db().await.expect("graph");
+        let nodes: Vec<_> = (0..500)
+            .map(|i| {
+                serde_json::json!({
+                    "id": format!("n{i}"),
+                    "name": format!("Node {i}"),
+                    "type": "TestNode",
+                    "properties": {"idx": i, "pad": "x".repeat(64)},
+                })
+            })
+            .collect();
+        graph.add_nodes_raw(nodes).await.expect("add_nodes_raw");
+
+        let wal = wal_files(dir.path());
+        assert!(
+            !wal.is_empty(),
+            "precondition: the writes must leave an un-checkpointed WAL under {}",
+            dir.path().display()
+        );
+    }
+
+    cm.close().await;
+
+    let leftover = wal_files(dir.path());
+    assert!(
+        leftover.is_empty(),
+        "close() must leave no graph WAL behind, found: {leftover:?}"
+    );
+}
+
+/// Collect every `*.wal` under `root` (the embedded graph's sidecar). SQLite's
+/// `-wal`/`-shm` use a different suffix and are covered by #135's tests.
+fn wal_files(root: &std::path::Path) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("wal") {
+                found.push(path.to_string_lossy().into_owned());
+            }
+        }
+    }
+    found
+}
+
+/// Counts connections that a client has open to a stub HTTP/1.1 server, from the
+/// server's side.
+///
+/// Server-side counting is the portable observable: it needs no `lsof`, behaves
+/// identically on macOS and Linux, and — unlike an fd count — cannot be confused
+/// by a descriptor the runtime is holding for another reason. `live` is
+/// incremented on accept and decremented when that peer reaches EOF, so it is
+/// exactly "how many keep-alive connections is the client still holding open".
+struct PeerCountingServer {
+    endpoint: String,
+    live: Arc<AtomicUsize>,
+    accepted: Arc<AtomicUsize>,
+}
+
+impl PeerCountingServer {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let live = Arc::new(AtomicUsize::new(0));
+        let accepted = Arc::new(AtomicUsize::new(0));
+
+        let live_srv = Arc::clone(&live);
+        let accepted_srv = Arc::clone(&accepted);
+        // A plain OS thread per connection, deliberately: this must not depend on
+        // the tokio runtime under test, which is being torn down by `close()`.
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { break };
+                accepted_srv.fetch_add(1, Ordering::SeqCst);
+                live_srv.fetch_add(1, Ordering::SeqCst);
+                let live_conn = Arc::clone(&live_srv);
+                std::thread::spawn(move || {
+                    serve_keepalive(stream);
+                    live_conn.fetch_sub(1, Ordering::SeqCst);
+                });
+            }
+        });
+
+        Self {
+            endpoint: format!("http://{addr}/v1"),
+            live,
+            accepted,
+        }
+    }
+
+    fn live(&self) -> usize {
+        self.live.load(Ordering::SeqCst)
+    }
+
+    fn accepted(&self) -> usize {
+        self.accepted.load(Ordering::SeqCst)
+    }
+}
+
+/// Serve keep-alive HTTP/1.1 requests on one connection until the peer closes
+/// it, answering both the embeddings and the chat-completions shapes.
+///
+/// Returning from this function is the EOF signal the live-peer counter uses, so
+/// it must loop until the client actually goes away rather than closing after one
+/// response — a `Connection: close` server would make the assertion pass without
+/// the fix.
+fn serve_keepalive(mut stream: TcpStream) {
+    let read_half = stream.try_clone().expect("clone stream");
+    let mut reader = BufReader::new(read_half);
+    loop {
+        // Request line + headers.
+        let mut content_length = 0usize;
+        let mut line = String::new();
+        if reader.read_line(&mut line).unwrap_or(0) == 0 {
+            break; // peer closed — the connection is really gone
+        }
+        let path = line.split_whitespace().nth(1).unwrap_or("").to_string();
+        loop {
+            let mut header = String::new();
+            if reader.read_line(&mut header).unwrap_or(0) == 0 {
+                return;
+            }
+            let trimmed = header.trim_end();
+            if trimmed.is_empty() {
+                break;
+            }
+            if let Some((name, value)) = trimmed.split_once(':')
+                && name.eq_ignore_ascii_case("content-length")
+            {
+                content_length = value.trim().parse().unwrap_or(0);
+            }
+        }
+        if content_length > 0 {
+            let mut body = vec![0u8; content_length];
+            if reader.read_exact(&mut body).is_err() {
+                return;
+            }
+        }
+
+        let body = if path.contains("embeddings") {
+            r#"{"data":[{"embedding":[0.0,0.0,1.0],"index":0}],"model":"stub","usage":{"prompt_tokens":1,"total_tokens":1}}"#.to_string()
+        } else {
+            r#"{"id":"stub","object":"chat.completion","created":0,"model":"stub","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#.to_string()
+        };
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        if stream.write_all(response.as_bytes()).is_err() {
+            return;
+        }
+        let _ = stream.flush();
+    }
+}
+
+/// `close()` must release the `reqwest` connection pools the HTTP-backed engines
+/// hold, not just their Rust-side memory.
+///
+/// Before the fix the embedding and LLM engines stay in the cache forever, so
+/// their idle keep-alive sockets stay open: measured 2 live peers before
+/// `close()` and still 2 after. After the fix: 2 before, 0 after.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn close_releases_the_http_client_connection_pools() {
+    let server = PeerCountingServer::start();
+    let dir = TempDir::new().expect("tempdir");
+    let cm = ComponentManager::new(ConfigManager::new(settings(dir.path(), &server.endpoint)));
+
+    // One real request per engine, so each one's pool actually has a socket.
+    let embedding = cm.embedding_engine().await.expect("embedding");
+    embedding.embed(&["hello"]).await.expect("embed");
+    let llm = cm.llm().await.expect("llm");
+    llm.generate(
+        vec![Message {
+            role: MessageRole::User,
+            content: "hi".to_string(),
+        }],
+        None,
+    )
+    .await
+    .expect("generate");
+
+    assert_eq!(
+        server.accepted(),
+        2,
+        "precondition: one connection per engine"
+    );
+    assert_eq!(
+        server.live(),
+        2,
+        "precondition: both connections are held open by the clients' idle pools"
+    );
+
+    // Drop this test's clones first: `close()` releases the cache's reference,
+    // and the pool goes away when the last one does.
+    drop(embedding);
+    drop(llm);
+    cm.close().await;
+
+    // Server-side EOF handling is a different thread; give it a bounded window.
+    // The assertion is still on `close()`, not on a timeout: without the fix the
+    // count never drops, so this loop always runs to exhaustion and fails.
+    let mut live = server.live();
+    for _ in 0..200 {
+        if live == 0 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        live = server.live();
+    }
+    assert_eq!(
+        live, 0,
+        "close() must release the HTTP connection pools; {live} peer(s) still open"
+    );
+
+    drop(server);
+}
+
+// ── Ordering under a bounded teardown, and the release tier ──────────────────
+
+/// Builds a [`cognee_graph::MockGraphDB`] whose `close()` never returns, standing
+/// in for a slot whose teardown outlives the caller's patience: a big embedded
+/// checkpoint, or a pool waiting on a connection that will not come back.
+struct StuckGraphFactory;
+
+#[async_trait::async_trait]
+impl cognee::GraphDbFactory for StuckGraphFactory {
+    fn provider(&self) -> &str {
+        "stuck"
+    }
+    async fn build(
+        &self,
+        _ctx: &cognee::BackendBuildContext,
+    ) -> Result<Arc<dyn cognee::graph::GraphDBTrait>, cognee::ComponentError> {
+        Ok(Arc::new(cognee_graph::MockGraphDB::hanging_on_close()))
+    }
+}
+
+/// A manager whose graph provider hangs on close, warm on every slot the test needs.
+async fn warm_manager_with_stuck_graph(root: &std::path::Path) -> ComponentManager {
+    let mut registry = cognee::ComponentRegistry::with_builtins();
+    registry.register_graph(Arc::new(StuckGraphFactory));
+    let mut s = settings(root, "http://127.0.0.1:1/v1");
+    s.graph_database_provider = "stuck".to_string();
+    let cm = ComponentManager::with_registry(ConfigManager::new(s), registry);
+    cm.database().await.expect("database");
+    cm.graph_db().await.expect("graph");
+    cm
+}
+
+/// The relational pool must be closed **first**, so a caller that bounds the
+/// teardown does not lose it to a slot that hangs.
+///
+/// Callers do bound it: `cognee-cli` wraps `close()` in a `timeout` because a pool
+/// close waits for connections to come back and a command's runtime may have been
+/// dropped with one checked out. With the relational close queued behind the graph
+/// checkpoint, an expired budget skipped exactly the close that #132 was about,
+/// leaving the `-wal`/`-shm` sidecars on disk — green, and still leaking.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn a_timed_out_close_still_released_the_relational_pool() {
+    let dir = TempDir::new().expect("tempdir");
+    let cm = warm_manager_with_stuck_graph(dir.path()).await;
+
+    let db = dir.path().join("cognee.db");
+    let wal = db.with_file_name("cognee.db-wal");
+    let shm = db.with_file_name("cognee.db-shm");
+    assert!(
+        wal.exists() && shm.exists(),
+        "precondition: a warm SQLite pool has both WAL sidecars"
+    );
+
+    // The graph close never returns, so the timeout is guaranteed to fire: this
+    // is not a race against a slow machine.
+    let timed_out = tokio::time::timeout(std::time::Duration::from_millis(300), cm.close())
+        .await
+        .is_err();
+    assert!(
+        timed_out,
+        "precondition: the stuck graph must exhaust the budget"
+    );
+
+    assert!(
+        !wal.exists(),
+        "the relational close must happen before the slot that hangs — -wal survived"
+    );
+    assert!(!shm.exists(), "-shm survived a timed-out close");
+}
+
+/// `release()` — the implicit tier — must not close a component another owner is
+/// still holding.
+///
+/// A store's `close()` mutates state behind the shared `Arc`, so it is visible to
+/// every clone: an embedded graph empties its inner handle, a pool flags itself
+/// closed. A finalizer running `close()` therefore breaks an operation that is
+/// still in flight, which is why the implicit tier only closes what it holds the
+/// last reference to.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn release_leaves_a_component_a_survivor_still_holds() {
+    let dir = TempDir::new().expect("tempdir");
+    let cm = ComponentManager::new(ConfigManager::new(settings(
+        dir.path(),
+        "http://127.0.0.1:1/v1",
+    )));
+
+    // Stand in for an operation in flight: it owns a clone of the graph and the
+    // relational connection for its duration.
+    let graph = cm.graph_db().await.expect("graph");
+    let database = cm.database().await.expect("database");
+
+    cm.release().await;
+
+    // The survivor's handles still work.
+    graph
+        .is_empty()
+        .await
+        .expect("release() must not close a graph an in-flight op is holding");
+    database
+        .ping()
+        .await
+        .expect("release() must not close a pool an in-flight op is holding");
+
+    // And the cache really was evicted — this is a release, not a no-op.
+    assert_eq!(
+        Arc::strong_count(&graph),
+        1,
+        "the cache must have given up its graph reference"
+    );
+    assert_eq!(Arc::strong_count(&database), 1);
+}
+
+/// The other half of the tier: with no survivor, `release()` releases everything
+/// `close()` would — including the SQLite sidecars, which is the whole point of
+/// the finalizer path (a Python handle collected without `close()`).
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn release_closes_what_nobody_else_is_using() {
+    let dir = TempDir::new().expect("tempdir");
+    let cm = ComponentManager::new(ConfigManager::new(settings(
+        dir.path(),
+        "http://127.0.0.1:1/v1",
+    )));
+    cm.database().await.expect("database");
+    cm.graph_db().await.expect("graph");
+
+    let wal = dir.path().join("cognee.db-wal");
+    assert!(wal.exists(), "precondition: warm pool has a -wal");
+
+    cm.release().await;
+
+    assert!(
+        !wal.exists(),
+        "with no other owner, release() must close the pool — otherwise a \
+         garbage-collected handle leaks its sidecars, which is #132 again"
+    );
+    assert!(
+        wal_files(dir.path()).is_empty(),
+        "the graph .wal must be checkpointed away too: {:?}",
+        wal_files(dir.path())
+    );
+}
+
+/// `has_cached_components()` must see a **partly** warmed manager.
+///
+/// Warming is slot-by-slot and can fail in the middle: a bad `llm_api_key` fails
+/// after the SQLite pool and the graph are already cached. A probe that reported
+/// "nothing cached" for that state let the finalizer skip the teardown entirely,
+/// leaving an open database behind.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn has_cached_components_sees_a_partly_warmed_manager() {
+    let dir = TempDir::new().expect("tempdir");
+    let cm = ComponentManager::new(ConfigManager::new(settings(
+        dir.path(),
+        "http://127.0.0.1:1/v1",
+    )));
+    assert!(
+        !cm.has_cached_components(),
+        "a cold manager has nothing cached"
+    );
+
+    cm.database().await.expect("database");
+    assert!(
+        cm.has_cached_components(),
+        "one warm slot is enough to have something to release"
+    );
+
+    cm.close().await;
+    assert!(
+        !cm.has_cached_components(),
+        "close() empties every slot, so there is nothing left to release"
+    );
+}

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -229,6 +229,39 @@ pub fn send_telemetry<'a>(
     let _ = try_send_telemetry(event_name, user_id, additional_properties);
 }
 
+/// Wait for the telemetry events already dispatched to actually leave the
+/// process, up to `timeout`. Returns `true` if the queue drained.
+///
+/// [`send_telemetry`] is fire-and-forget: it spawns a detached task and returns.
+/// That is the right default for a hot path, but it means an immediate process
+/// exit — or an immediate runtime shutdown — **discards** whatever has not been
+/// sent yet. Measured against a local stub collector: `send_telemetry` followed
+/// straight away by dropping the runtime delivered **0 of 1** POSTs; with a short
+/// grace period, 1 of 1. The lost event is usually the most interesting one, since
+/// the last thing a process reports is what it was doing when it stopped.
+///
+/// Call this from **explicit** teardown paths only (the CLI's exit, the HTTP
+/// server's shutdown hook, a binding's handle close). It is deliberately not
+/// wired into `Drop`: a finalizer running on an arbitrary thread is the wrong
+/// place to block.
+///
+/// **Hard-bounded and infallible by construction.** A blackholed collector must
+/// never hang an exit and telemetry must never fail one, so the timeout is
+/// honoured and the boolean is advisory — log it, do not branch on it. A `false`
+/// means "some events were still in flight", not that anything is broken.
+///
+/// No-op returning `true` when the `telemetry` cargo feature is disabled.
+pub async fn flush(timeout: std::time::Duration) -> bool {
+    #[cfg(feature = "telemetry")]
+    {
+        real::flush_impl(timeout).await
+    }
+    #[cfg(not(feature = "telemetry"))]
+    {
+        noop::flush_impl(timeout).await
+    }
+}
+
 /// Same as [`send_telemetry`] but returns
 /// `Result<(), TelemetryError>` for callers that want to know whether
 /// dispatch was attempted.

--- a/crates/telemetry/src/noop.rs
+++ b/crates/telemetry/src/noop.rs
@@ -9,6 +9,13 @@
 //! the `telemetry` feature). Identity helpers in [`crate::ids`]
 //! return empty strings.
 
+/// No-op twin of the real flush, so the non-`telemetry` build compiles
+/// the same call sites. Nothing was ever dispatched, so the queue is
+/// always drained.
+pub(crate) async fn flush_impl(_timeout: std::time::Duration) -> bool {
+    true
+}
+
 pub(crate) fn send_telemetry_impl() {
     tracing::debug!(
         target: "cognee.telemetry",

--- a/crates/telemetry/src/real.rs
+++ b/crates/telemetry/src/real.rs
@@ -89,10 +89,22 @@ pub(crate) async fn flush_impl(timeout: Duration) -> bool {
     let inflight = inflight();
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
-        // Register interest *before* reading the counter: the reverse
-        // order can miss the notification of the last completing POST
-        // and then wait out the whole timeout for nothing.
+        // Register interest *before* reading the counter: the reverse order can
+        // miss the notification of the last completing POST and then wait out the
+        // whole timeout for nothing.
+        //
+        // `notified()` alone does NOT register — it only builds the future, which
+        // enqueues on its first poll. Since the first poll here happens inside
+        // the `timeout` below, a POST finishing between the counter load and that
+        // poll would call `notify_waiters()` with nobody enqueued (it stores no
+        // permit, by design — see `InflightGuard`), and the flush would sleep out
+        // its entire budget before returning `true`. That is up to 500 ms added
+        // to every CLI exit, every binding `close()`, and the SIGTERM handler.
+        // `enable()` performs the registration up front, which is what makes the
+        // comment above true.
         let idle = inflight.idle.notified();
+        tokio::pin!(idle);
+        idle.as_mut().enable();
         if inflight.count.load(Ordering::Acquire) == 0 {
             return true;
         }

--- a/crates/telemetry/src/real.rs
+++ b/crates/telemetry/src/real.rs
@@ -4,8 +4,21 @@
 //! fires the POST on a detached `tokio::spawn`. When called outside
 //! a tokio runtime, falls back to a one-shot single-thread runtime
 //! per locked decision 5.
+//!
+//! The spawned POSTs are counted so [`flush_impl`] can wait for them:
+//! `spawn` + an immediate runtime shutdown delivers **nothing**.
+//! Measured against a local stub collector: a `send_telemetry`
+//! followed straight away by dropping the runtime delivered **0 of 1**
+//! POSTs; with a short grace period, 1 of 1. Every explicit teardown
+//! path (the CLI, the HTTP server's `on_shutdown`, the bindings'
+//! handle teardown) therefore ends with a bounded flush.
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use serde_json::Value;
+use tokio::sync::Notify;
 
 use crate::UserIdRef;
 use crate::client::client;
@@ -21,6 +34,78 @@ use crate::sanitize::sanitize_nested_properties;
 /// outside a tokio runtime, falls back to a one-shot single-thread
 /// runtime (decision 5) and blocks the calling thread up to
 /// `TELEMETRY_REQUEST_TIMEOUT` (default 5s, clamped `[1, 60]`).
+/// Outstanding detached POSTs, so a teardown can wait for them.
+///
+/// A counter plus a `Notify` rather than a `JoinSet`/`TaskTracker`: the
+/// dispatcher is a free function reachable from anywhere (including
+/// outside a runtime), so there is no owner to hold a join set, and the
+/// only question a flush needs answered is "is anything still in
+/// flight". Nothing is ever *awaited* by the dispatcher itself, which
+/// keeps `send_telemetry` fire-and-forget.
+struct Inflight {
+    count: AtomicUsize,
+    idle: Notify,
+}
+
+static INFLIGHT: OnceLock<Inflight> = OnceLock::new();
+
+/// Decrements the in-flight count when the POST task ends — **including when the
+/// task is cancelled**, which is what a runtime shutdown does to every pending
+/// task.
+///
+/// A plain `fetch_sub` at the end of the task body would be skipped in exactly
+/// that case, permanently inflating the counter, and every later `flush` would
+/// then wait out its whole timeout for a POST that no longer exists. Dropping the
+/// future runs this instead.
+struct InflightGuard(&'static Inflight);
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        // `notify_waiters` (not `notify_one`) because a flush may not be waiting
+        // yet, and a stored permit would make the *next* flush return early. The
+        // counter is the source of truth; this only wakes an existing waiter to
+        // re-read it.
+        if self.0.count.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.0.idle.notify_waiters();
+        }
+    }
+}
+
+fn inflight() -> &'static Inflight {
+    INFLIGHT.get_or_init(|| Inflight {
+        count: AtomicUsize::new(0),
+        idle: Notify::new(),
+    })
+}
+
+/// Wait until every in-flight telemetry POST has finished, or `timeout`
+/// elapses. Returns `true` if the queue drained.
+///
+/// **Hard-bounded on purpose.** A blackholed or very slow collector must
+/// never hang a process exit, and telemetry must never fail one, so the
+/// timeout is honoured and the result is advisory — callers log it at
+/// most.
+pub(crate) async fn flush_impl(timeout: Duration) -> bool {
+    let inflight = inflight();
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        // Register interest *before* reading the counter: the reverse
+        // order can miss the notification of the last completing POST
+        // and then wait out the whole timeout for nothing.
+        let idle = inflight.idle.notified();
+        if inflight.count.load(Ordering::Acquire) == 0 {
+            return true;
+        }
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        if tokio::time::timeout(remaining, idle).await.is_err() {
+            return inflight.count.load(Ordering::Acquire) == 0;
+        }
+    }
+}
+
 pub(crate) fn send_telemetry_impl(
     event_name: &str,
     user_id: UserIdRef<'_>,
@@ -34,7 +119,15 @@ pub(crate) fn send_telemetry_impl(
 
     match tokio::runtime::Handle::try_current() {
         Ok(handle) => {
-            handle.spawn(post(body));
+            // Count before spawning, so a flush that starts between these
+            // two lines still observes this POST.
+            let tracked = inflight();
+            tracked.count.fetch_add(1, Ordering::AcqRel);
+            let guard = InflightGuard(tracked);
+            handle.spawn(async move {
+                let _guard = guard;
+                post(body).await;
+            });
         }
         Err(_) => {
             tracing::warn!(
@@ -129,6 +222,9 @@ async fn post(body: Value) {
     }
 }
 
+/// The non-runtime fallback needs no tracking: it blocks the calling
+/// thread until the POST completes (or times out), so by the time it
+/// returns there is nothing left in flight.
 fn spin_up_one_shot(body: Value) {
     let timeout = std::time::Duration::from_secs(request_timeout_secs());
     let rt = match tokio::runtime::Builder::new_current_thread()

--- a/crates/telemetry/tests/flush_delivers_events.rs
+++ b/crates/telemetry/tests/flush_delivers_events.rs
@@ -1,0 +1,260 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression test for `cognee_telemetry::flush`.
+//!
+//! `send_telemetry` spawns a detached task and returns, so a process that exits
+//! (or a runtime that is dropped) straight afterwards discards whatever has not
+//! yet been written to the socket. The lost event is usually the most interesting
+//! one: the last thing a process reports is what it was doing when it stopped.
+//!
+//! The collector here is a blocking stub on its own OS thread, counting *arrived*
+//! requests. That is deliberate on both counts: an in-runtime stub would be torn
+//! down together with the runtime under test, and counting arrivals server-side
+//! avoids any inference from client-side state.
+#![cfg(feature = "telemetry")]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use serial_test::serial;
+
+/// A stub collector that counts complete POSTs it has received.
+struct Collector {
+    url: String,
+    arrived: Arc<AtomicUsize>,
+}
+
+impl Collector {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let arrived = Arc::new(AtomicUsize::new(0));
+
+        let arrived_srv = Arc::clone(&arrived);
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { break };
+                let arrived_conn = Arc::clone(&arrived_srv);
+                std::thread::spawn(move || serve(stream, &arrived_conn));
+            }
+        });
+
+        Self {
+            url: format!("http://{addr}/"),
+            arrived,
+        }
+    }
+
+    fn arrived(&self) -> usize {
+        self.arrived.load(Ordering::SeqCst)
+    }
+}
+
+/// Read one request (headers + body) and answer 200. The counter is bumped only
+/// after the **whole body** has been read, so a half-written POST does not count
+/// as delivered — which is exactly the failure mode under test.
+fn serve(mut stream: TcpStream, arrived: &AtomicUsize) {
+    let read_half = stream.try_clone().expect("clone");
+    let mut reader = BufReader::new(read_half);
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).unwrap_or(0) == 0 {
+            return;
+        }
+        let mut content_length = 0usize;
+        loop {
+            let mut header = String::new();
+            if reader.read_line(&mut header).unwrap_or(0) == 0 {
+                return;
+            }
+            let trimmed = header.trim_end();
+            if trimmed.is_empty() {
+                break;
+            }
+            if let Some((name, value)) = trimmed.split_once(':')
+                && name.eq_ignore_ascii_case("content-length")
+            {
+                content_length = value.trim().parse().unwrap_or(0);
+            }
+        }
+        if content_length > 0 {
+            let mut body = vec![0u8; content_length];
+            if reader.read_exact(&mut body).is_err() {
+                return;
+            }
+        }
+        arrived.fetch_add(1, Ordering::SeqCst);
+        let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+        let _ = stream.flush();
+    }
+}
+
+/// Point telemetry at `url` and make sure it is enabled for this test.
+///
+/// The proxy override is only honoured when `COGNEE_TELEMETRY_INTEGRATION_TEST`
+/// is set (see `env::proxy_url`), which is exactly what this is. `ENV=test`
+/// disables telemetry outright and the harness may well be running with it set,
+/// so it is cleared too — hence `#[serial]` on every test in this file.
+fn configure(url: &str) {
+    // SAFETY: single-threaded section of a `#[serial]` test; no other thread is
+    // reading the environment at this point.
+    unsafe {
+        std::env::set_var("COGNEE_TELEMETRY_INTEGRATION_TEST", "1");
+        std::env::set_var("COGNEE_TELEMETRY_PROXY_URL_FOR_TESTS", url);
+        std::env::remove_var("TELEMETRY_DISABLED");
+        std::env::remove_var("ENV");
+    }
+}
+
+/// Wait for any POST left over from another test in this process to finish.
+///
+/// The in-flight counter is process-global (the dispatcher is a free function
+/// with no owner), so a POST still running from a previous case would make the
+/// next `flush` wait for *it* — a real property of the design, but cross-test
+/// noise here. Draining first keeps each case measuring only its own event.
+fn settle() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    rt.block_on(async {
+        let _ = cognee_telemetry::flush(Duration::from_secs(10)).await;
+    });
+}
+
+/// A dispatched event followed by an **immediate** runtime shutdown is lost; the
+/// same event followed by `flush` arrives.
+///
+/// Both halves run in one test so the delivery counts are directly comparable.
+/// Measured: 0 of 1 without the flush, 1 of 1 with it.
+#[test]
+#[serial]
+fn flush_is_what_makes_the_last_event_arrive() {
+    settle();
+    let collector = Collector::start();
+    configure(&collector.url);
+
+    // -- without flush: spawn, then drop the runtime immediately ------------
+    {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async {
+            cognee_telemetry::send_telemetry("cognee.test.no_flush", "test-user", None);
+        });
+        // Dropping the runtime here is the process-exit analogue.
+        drop(rt);
+    }
+    let without_flush = collector.arrived();
+
+    // -- with flush --------------------------------------------------------
+    {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let drained = rt.block_on(async {
+            cognee_telemetry::send_telemetry("cognee.test.with_flush", "test-user", None);
+            cognee_telemetry::flush(Duration::from_secs(5)).await
+        });
+        drop(rt);
+        assert!(drained, "flush must report the queue drained within 5s");
+    }
+
+    // Give the stub's per-connection thread a moment to finish counting; the
+    // assertion is on `flush`, so this window only covers the stub itself.
+    for _ in 0..100 {
+        if collector.arrived() > without_flush {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let with_flush = collector.arrived() - without_flush;
+
+    assert_eq!(
+        without_flush, 0,
+        "precondition: an immediate runtime shutdown must lose the event — if this \
+         ever becomes non-zero, the dispatcher stopped being fire-and-forget and \
+         the flush's value needs re-deriving"
+    );
+    assert_eq!(
+        with_flush, 1,
+        "flush() must get the dispatched event delivered before teardown"
+    );
+}
+
+/// `flush` on an idle process returns immediately and reports drained — it must
+/// not add a fixed delay to every teardown.
+#[tokio::test]
+#[serial]
+async fn flush_on_an_idle_queue_returns_at_once() {
+    // Drain anything another case left behind; the point here is the *idle* path.
+    let _ = cognee_telemetry::flush(Duration::from_secs(10)).await;
+    let started = std::time::Instant::now();
+    assert!(cognee_telemetry::flush(Duration::from_secs(5)).await);
+    assert!(
+        started.elapsed() < Duration::from_millis(500),
+        "an idle flush must not wait, took {:?}",
+        started.elapsed()
+    );
+}
+
+/// A collector that never answers must not hang the exit: `flush` honours its
+/// timeout and reports `false` rather than blocking forever.
+#[test]
+#[serial]
+fn flush_is_bounded_when_the_collector_blackholes() {
+    settle();
+    // A listener that accepts and then answers nothing for `STALL`, which is an
+    // order of magnitude longer than the flush window below — long enough that
+    // the POST cannot possibly complete inside it, short enough that it does not
+    // poison the other cases in this process (the counter is global, and the
+    // reqwest client's timeout is fixed at its first use, so a genuinely
+    // unbounded stall here would be inherited by whichever test ran later).
+    const STALL: Duration = Duration::from_secs(3);
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { break };
+            std::thread::spawn(move || {
+                std::thread::sleep(STALL);
+                drop(stream);
+            });
+        }
+    });
+    configure(&format!("http://{addr}/"));
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let (drained, elapsed) = rt.block_on(async {
+        cognee_telemetry::send_telemetry("cognee.test.blackhole", "test-user", None);
+        let started = std::time::Instant::now();
+        let drained = cognee_telemetry::flush(Duration::from_millis(300)).await;
+        (drained, started.elapsed())
+    });
+
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "flush must honour its own timeout, not the HTTP timeout; took {elapsed:?}"
+    );
+    assert!(
+        !drained,
+        "a blackholed collector must be reported as not drained, not waited out"
+    );
+
+    // Leave the process clean for whichever case runs next.
+    settle();
+}

--- a/crates/vector/src/pgvector_adapter.rs
+++ b/crates/vector/src/pgvector_adapter.rs
@@ -108,6 +108,14 @@ async fn cleanup_legacy_seaql_migrations(db: &DatabaseConnection) -> VectorDBRes
 pub struct PgVectorAdapter {
     db: DatabaseConnection,
     dimension: usize,
+    /// Whether this adapter opened `db` itself and may therefore close it.
+    ///
+    /// Load-bearing, not defensive: [`Self::from_connection`] wraps a connection
+    /// the *caller* owns, and in the single-shared-Postgres layout that caller is
+    /// the relational store. Closing it from a vector teardown would turn a leak
+    /// fix into an outage. Neither in-tree factory takes that path today, but
+    /// both constructors are public API.
+    owns_pool: bool,
 }
 
 impl PgVectorAdapter {
@@ -131,7 +139,11 @@ impl PgVectorAdapter {
             .map_err(|e| VectorDBError::StorageError(format!("PGVector migration failed: {e}")))?;
 
         debug!("PgVectorAdapter initialised (dimension={dimension})");
-        Ok(Self { db, dimension })
+        Ok(Self {
+            db,
+            dimension,
+            owns_pool: true,
+        })
     }
 
     /// Wrap an existing SeaORM `DatabaseConnection` (must be Postgres).
@@ -145,7 +157,38 @@ impl PgVectorAdapter {
             .await
             .map_err(|e| VectorDBError::StorageError(format!("PGVector migration failed: {e}")))?;
 
-        Ok(Self { db, dimension })
+        Ok(Self {
+            db,
+            dimension,
+            owns_pool: false,
+        })
+    }
+
+    /// Close this adapter's **own** Postgres pool, so its server-side backends go
+    /// away now rather than whenever the last `Arc` happens to be dropped.
+    ///
+    /// The vector twin of `PgGraphAdapter::close`; that method carries the full
+    /// measurement table. The short version: a drop of an *idle* pool does drain
+    /// (in ~4 ms), so the leak is not "drop never works" — it is that (a) a
+    /// retained `Arc` never gets dropped at all, which is exactly the HTTP
+    /// server's `AppState` shape and leaves 10 backends open for the life of the
+    /// process, and (b) with one query in flight a drop pins the entire pool until
+    /// that query finishes, where `close_by_ref` reclaims the idle connections
+    /// immediately. This adapter's pool is separate from both the relational pool
+    /// and the graph adapter's — a warm `ComponentManager` on Postgres holds
+    /// three.
+    ///
+    /// A **no-op when the connection came from [`Self::from_connection`]**, and
+    /// idempotent.
+    pub async fn close(&self) -> VectorDBResult<()> {
+        if !self.owns_pool {
+            debug!("PgVectorAdapter::close is a no-op for a caller-owned connection");
+            return Ok(());
+        }
+        self.db
+            .close_by_ref()
+            .await
+            .map_err(|e| VectorDBError::StorageError(format!("PGVector pool close failed: {e}")))
     }
 
     /// Returns the default vector dimension this adapter was configured with.
@@ -153,6 +196,16 @@ impl PgVectorAdapter {
         self.dimension
     }
 
+    /// The sea-orm connection (and therefore the pool) this adapter runs on.
+    ///
+    /// Exposed for diagnostics and for the teardown regression tests, which have
+    /// to observe the pool's own `is_closed()` flag and check a connection out of
+    /// *this* pool to exercise the in-flight case. Not an escape hatch for
+    /// issuing graph queries — use the typed adapter methods for that.
+    #[doc(hidden)]
+    pub fn connection(&self) -> &DatabaseConnection {
+        &self.db
+    }
     // -- helpers ----------------------------------------------------------
 
     /// Build a SeaORM [`Statement`] from a `sea_query` query.
@@ -337,6 +390,12 @@ impl PgVectorAdapter {
 
 #[async_trait]
 impl VectorDB for PgVectorAdapter {
+    /// Delegates to the inherent [`PgVectorAdapter::close`], so a holder of an
+    /// `Arc<dyn VectorDB>` can release the pool without downcasting.
+    async fn close(&self) -> VectorDBResult<()> {
+        PgVectorAdapter::close(self).await
+    }
+
     async fn create_collection(
         &self,
         data_type: &str,
@@ -1079,17 +1138,6 @@ mod migrator {
 // (rather than under `tests/`) so they can reuse the crate's own optional
 // `sea-orm`/`sea-orm-migration` dependencies without forcing a heavy
 // dev-dependency onto the default (feature-off) build.
-//
-// Each case provisions its OWN throwaway database via
-// `cognee_test_utils::create_temp_postgres_db` and drops it again, so no
-// `#[serial]` is needed. They used to share the `PGVECTOR_TEST_URL` database and
-// call a `reset()` helper that dropped `_vector_collections` and the
-// `seaql_migrations*` tables — which left the collection tables it did not know
-// about (`UUID_f`, `Meta_f`, …) orphaned in the database, invisible to
-// `list_collections`, and therefore undeletable by the integration suite's
-// cleanup. The next `pgvector_integration` run against that server then failed
-// with `relation "UUID_f" already exists`. That only became reachable in CI once
-// both targets ran in one lane against one server, which is what surfaced it.
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 #[allow(
@@ -1099,59 +1147,12 @@ mod migrator {
 )]
 mod shared_db_migration_tests {
     use super::PgVectorAdapter;
-    use sea_orm::{ConnectionTrait, Database, Statement};
+    use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
     use sea_orm_migration::prelude::*;
+    use serial_test::serial;
 
     fn test_url() -> Option<String> {
-        std::env::var("PGVECTOR_TEST_URL")
-            .ok()
-            .filter(|v| !v.is_empty())
-    }
-
-    /// Run `body` against a throwaway database of this test's own, dropped again
-    /// afterwards — even if `body` panics.
-    ///
-    /// Both cases below are about two migrators *coexisting inside one database*,
-    /// so the isolation is at the database level and nothing inside it is reset.
-    ///
-    /// `body` runs on a spawned task so a failed assertion surfaces as a
-    /// `JoinError` instead of unwinding past the drop. `TempPostgresDb::cleanup`
-    /// is `async`, so it cannot be a `Drop` impl; without this the database would
-    /// leak on every red run. The panic is re-raised unchanged afterwards, so
-    /// libtest still reports the original failure and message. Mirrors
-    /// `with_temp_db` in `crates/graph/src/pg_graph_adapter.rs`, which solved the
-    /// same problem for the same helper.
-    ///
-    /// The one leak this cannot cover is a test hard-killed rather than unwound
-    /// (a `SIGKILL`, or nextest's `slow-timeout` terminate-after), which no async
-    /// cleanup can survive; the databases are uniquely named, so the fallback is
-    /// dropping stragglers by hand.
-    async fn with_temp_db<F, Fut>(what: &str, body: F)
-    where
-        F: FnOnce(String) -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = ()> + Send + 'static,
-    {
-        let Some(base_url) = test_url() else {
-            eprintln!("PGVECTOR_TEST_URL not set — skipping {what}");
-            return;
-        };
-        let tmp = cognee_test_utils::create_temp_postgres_db(&base_url)
-            .await
-            .expect("PGVECTOR_TEST_URL is set, so CREATE DATABASE must succeed on that server");
-        let outcome = tokio::spawn(body(tmp.url().to_string())).await;
-        tmp.cleanup().await;
-        if let Err(join_err) = outcome {
-            // A `JoinError` here can only be a panic: the task is never aborted
-            // and its handle is awaited immediately, so there is no cancellation
-            // path. Assert that rather than leaning on it — `into_panic()` panics
-            // on a cancelled task, which would replace the real failure with a
-            // confusing one.
-            assert!(
-                join_err.is_panic(),
-                "the {what} task was cancelled instead of panicking, which this helper never does: {join_err}"
-            );
-            std::panic::resume_unwind(join_err.into_panic());
-        }
+        std::env::var("PGVECTOR_TEST_URL").ok()
     }
 
     /// A stand-in for the downstream relational / auth migrator. It writes its
@@ -1206,11 +1207,26 @@ mod shared_db_migration_tests {
         }
     }
 
+    /// Drop every table and bookkeeping table so each run starts clean.
+    async fn reset(db: &DatabaseConnection) {
+        for stmt in [
+            "DROP TABLE IF EXISTS _vector_collections CASCADE",
+            "DROP TABLE IF EXISTS rel_baseline_marker CASCADE",
+            "DROP TABLE IF EXISTS rel_auth_marker CASCADE",
+            "DROP TABLE IF EXISTS seaql_migrations CASCADE",
+            "DROP TABLE IF EXISTS seaql_migrations_pgvector CASCADE",
+        ] {
+            db.execute(Statement::from_string(db.get_database_backend(), stmt))
+                .await
+                .unwrap();
+        }
+    }
+
     /// Count rows in a bookkeeping table. Returns 0 **only** when the table does
     /// not exist; any other DB error panics so it fails the test rather than
     /// masquerading as an empty table (`table` is a fixed test literal, so
     /// interpolating it carries no injection risk).
-    async fn version_count(db: &sea_orm::DatabaseConnection, table: &str) -> i64 {
+    async fn version_count(db: &DatabaseConnection, table: &str) -> i64 {
         let exists = db
             .query_one(Statement::from_string(
                 db.get_database_backend(),
@@ -1237,83 +1253,87 @@ mod shared_db_migration_tests {
     /// The relational migrator and the pgvector adapter migrator must coexist in
     /// one Postgres DB without colliding on the default `seaql_migrations` table.
     #[tokio::test]
+    #[serial]
     async fn pgvector_coexists_with_relational_migrator_in_shared_db() {
-        with_temp_db("shared-DB migration test", |url| async move {
-            let db = Database::connect(&url).await.unwrap();
+        let Some(url) = test_url() else {
+            eprintln!("PGVECTOR_TEST_URL not set — skipping shared-DB migration test");
+            return;
+        };
 
-            // 1. Relational / auth migrator runs first and populates the default
-            //    `seaql_migrations` with versions the vector migrator does not own.
-            RelationalMigrator::up(&db, None)
-                .await
-                .expect("relational migrator should succeed");
-            assert_eq!(version_count(&db, "seaql_migrations").await, 2);
+        let db = Database::connect(&url).await.unwrap();
+        reset(&db).await;
 
-            // 2. Initialising the vector adapter against the SAME database must
-            //    succeed. Before the fix it aborted with "Migration file of version
-            //    'm20260914_000002_auth' is missing ...".
-            let adapter = PgVectorAdapter::new(&url, 384).await;
-            assert!(
-                adapter.is_ok(),
-                "PgVectorAdapter init must not collide with the relational \
-                 seaql_migrations table; got: {:?}",
-                adapter.err()
-            );
+        // 1. Relational / auth migrator runs first and populates the default
+        //    `seaql_migrations` with versions the vector migrator does not own.
+        RelationalMigrator::up(&db, None)
+            .await
+            .expect("relational migrator should succeed");
+        assert_eq!(version_count(&db, "seaql_migrations").await, 2);
 
-            // 3. The vector migrator tracks its version in its OWN table and leaves
-            //    the relational bookkeeping untouched.
-            assert_eq!(version_count(&db, "seaql_migrations").await, 2);
-            assert_eq!(version_count(&db, "seaql_migrations_pgvector").await, 1);
+        // 2. Initialising the vector adapter against the SAME database must
+        //    succeed. Before the fix it aborted with "Migration file of version
+        //    'm20260914_000002_auth' is missing ...".
+        let adapter = PgVectorAdapter::new(&url, 384).await;
+        assert!(
+            adapter.is_ok(),
+            "PgVectorAdapter init must not collide with the relational \
+             seaql_migrations table; got: {:?}",
+            adapter.err()
+        );
 
-            // Hand the pooled connections back before the database is dropped, so
-            // cleanup does not have to lean on `WITH (FORCE)`.
-            drop(adapter);
-            drop(db);
-        })
-        .await;
+        // 3. The vector migrator tracks its version in its OWN table and leaves
+        //    the relational bookkeeping untouched.
+        assert_eq!(version_count(&db, "seaql_migrations").await, 2);
+        assert_eq!(version_count(&db, "seaql_migrations_pgvector").await, 1);
+
+        reset(&db).await;
     }
 
     /// Upgrade path: a legacy pgvector row left in the default `seaql_migrations`
     /// by an older build must be purged so the core migrator no longer chokes.
     #[tokio::test]
+    #[serial]
     async fn pgvector_purges_legacy_row_from_default_table_on_upgrade() {
-        with_temp_db("legacy-purge test", |url| async move {
-            let db = Database::connect(&url).await.unwrap();
+        let Some(url) = test_url() else {
+            eprintln!("PGVECTOR_TEST_URL not set — skipping legacy-purge test");
+            return;
+        };
 
-            // Simulate an older build that recorded the pgvector version into the
-            // DEFAULT `seaql_migrations` table (aux-ran-before-core ordering).
-            db.execute(Statement::from_string(
-                db.get_database_backend(),
-                "CREATE TABLE seaql_migrations (version VARCHAR PRIMARY KEY, applied_at BIGINT NOT NULL)",
-            ))
+        let db = Database::connect(&url).await.unwrap();
+        reset(&db).await;
+
+        // Simulate an older build that recorded the pgvector version into the
+        // DEFAULT `seaql_migrations` table (aux-ran-before-core ordering).
+        db.execute(Statement::from_string(
+            db.get_database_backend(),
+            "CREATE TABLE seaql_migrations (version VARCHAR PRIMARY KEY, applied_at BIGINT NOT NULL)",
+        ))
+        .await
+        .unwrap();
+        db.execute(Statement::from_string(
+            db.get_database_backend(),
+            "INSERT INTO seaql_migrations (version, applied_at) \
+             VALUES ('m20250101_000001_create_pgvector_extension', 0)",
+        ))
+        .await
+        .unwrap();
+
+        // Upgraded build initialises the vector adapter.
+        PgVectorAdapter::new(&url, 384)
             .await
-            .unwrap();
-            db.execute(Statement::from_string(
-                db.get_database_backend(),
-                "INSERT INTO seaql_migrations (version, applied_at) \
-                 VALUES ('m20250101_000001_create_pgvector_extension', 0)",
-            ))
+            .expect("vector adapter should initialise on upgrade");
+
+        // The stale vector row is gone, so the core/relational migrator can now
+        // run against the default table without aborting.
+        assert_eq!(
+            version_count(&db, "seaql_migrations").await,
+            0,
+            "legacy pgvector row must be purged from the default seaql_migrations"
+        );
+        RelationalMigrator::up(&db, None)
             .await
-            .unwrap();
+            .expect("core migrator must not choke after legacy row is purged");
 
-            // Upgraded build initialises the vector adapter.
-            let adapter = PgVectorAdapter::new(&url, 384)
-                .await
-                .expect("vector adapter should initialise on upgrade");
-
-            // The stale vector row is gone, so the core/relational migrator can now
-            // run against the default table without aborting.
-            assert_eq!(
-                version_count(&db, "seaql_migrations").await,
-                0,
-                "legacy pgvector row must be purged from the default seaql_migrations"
-            );
-            RelationalMigrator::up(&db, None)
-                .await
-                .expect("core migrator must not choke after legacy row is purged");
-
-            drop(adapter);
-            drop(db);
-        })
-        .await;
+        reset(&db).await;
     }
 }

--- a/crates/vector/src/pgvector_adapter.rs
+++ b/crates/vector/src/pgvector_adapter.rs
@@ -1138,6 +1138,17 @@ mod migrator {
 // (rather than under `tests/`) so they can reuse the crate's own optional
 // `sea-orm`/`sea-orm-migration` dependencies without forcing a heavy
 // dev-dependency onto the default (feature-off) build.
+//
+// Each case provisions its OWN throwaway database via
+// `cognee_test_utils::create_temp_postgres_db` and drops it again, so no
+// `#[serial]` is needed. They used to share the `PGVECTOR_TEST_URL` database and
+// call a `reset()` helper that dropped `_vector_collections` and the
+// `seaql_migrations*` tables — which left the collection tables it did not know
+// about (`UUID_f`, `Meta_f`, …) orphaned in the database, invisible to
+// `list_collections`, and therefore undeletable by the integration suite's
+// cleanup. The next `pgvector_integration` run against that server then failed
+// with `relation "UUID_f" already exists`. That only became reachable in CI once
+// both targets ran in one lane against one server, which is what surfaced it.
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 #[allow(
@@ -1147,12 +1158,59 @@ mod migrator {
 )]
 mod shared_db_migration_tests {
     use super::PgVectorAdapter;
-    use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
+    use sea_orm::{ConnectionTrait, Database, Statement};
     use sea_orm_migration::prelude::*;
-    use serial_test::serial;
 
     fn test_url() -> Option<String> {
-        std::env::var("PGVECTOR_TEST_URL").ok()
+        std::env::var("PGVECTOR_TEST_URL")
+            .ok()
+            .filter(|v| !v.is_empty())
+    }
+
+    /// Run `body` against a throwaway database of this test's own, dropped again
+    /// afterwards — even if `body` panics.
+    ///
+    /// Both cases below are about two migrators *coexisting inside one database*,
+    /// so the isolation is at the database level and nothing inside it is reset.
+    ///
+    /// `body` runs on a spawned task so a failed assertion surfaces as a
+    /// `JoinError` instead of unwinding past the drop. `TempPostgresDb::cleanup`
+    /// is `async`, so it cannot be a `Drop` impl; without this the database would
+    /// leak on every red run. The panic is re-raised unchanged afterwards, so
+    /// libtest still reports the original failure and message. Mirrors
+    /// `with_temp_db` in `crates/graph/src/pg_graph_adapter.rs`, which solved the
+    /// same problem for the same helper.
+    ///
+    /// The one leak this cannot cover is a test hard-killed rather than unwound
+    /// (a `SIGKILL`, or nextest's `slow-timeout` terminate-after), which no async
+    /// cleanup can survive; the databases are uniquely named, so the fallback is
+    /// dropping stragglers by hand.
+    async fn with_temp_db<F, Fut>(what: &str, body: F)
+    where
+        F: FnOnce(String) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let Some(base_url) = test_url() else {
+            eprintln!("PGVECTOR_TEST_URL not set — skipping {what}");
+            return;
+        };
+        let tmp = cognee_test_utils::create_temp_postgres_db(&base_url)
+            .await
+            .expect("PGVECTOR_TEST_URL is set, so CREATE DATABASE must succeed on that server");
+        let outcome = tokio::spawn(body(tmp.url().to_string())).await;
+        tmp.cleanup().await;
+        if let Err(join_err) = outcome {
+            // A `JoinError` here can only be a panic: the task is never aborted
+            // and its handle is awaited immediately, so there is no cancellation
+            // path. Assert that rather than leaning on it — `into_panic()` panics
+            // on a cancelled task, which would replace the real failure with a
+            // confusing one.
+            assert!(
+                join_err.is_panic(),
+                "the {what} task was cancelled instead of panicking, which this helper never does: {join_err}"
+            );
+            std::panic::resume_unwind(join_err.into_panic());
+        }
     }
 
     /// A stand-in for the downstream relational / auth migrator. It writes its
@@ -1207,26 +1265,11 @@ mod shared_db_migration_tests {
         }
     }
 
-    /// Drop every table and bookkeeping table so each run starts clean.
-    async fn reset(db: &DatabaseConnection) {
-        for stmt in [
-            "DROP TABLE IF EXISTS _vector_collections CASCADE",
-            "DROP TABLE IF EXISTS rel_baseline_marker CASCADE",
-            "DROP TABLE IF EXISTS rel_auth_marker CASCADE",
-            "DROP TABLE IF EXISTS seaql_migrations CASCADE",
-            "DROP TABLE IF EXISTS seaql_migrations_pgvector CASCADE",
-        ] {
-            db.execute(Statement::from_string(db.get_database_backend(), stmt))
-                .await
-                .unwrap();
-        }
-    }
-
     /// Count rows in a bookkeeping table. Returns 0 **only** when the table does
     /// not exist; any other DB error panics so it fails the test rather than
     /// masquerading as an empty table (`table` is a fixed test literal, so
     /// interpolating it carries no injection risk).
-    async fn version_count(db: &DatabaseConnection, table: &str) -> i64 {
+    async fn version_count(db: &sea_orm::DatabaseConnection, table: &str) -> i64 {
         let exists = db
             .query_one(Statement::from_string(
                 db.get_database_backend(),
@@ -1253,87 +1296,83 @@ mod shared_db_migration_tests {
     /// The relational migrator and the pgvector adapter migrator must coexist in
     /// one Postgres DB without colliding on the default `seaql_migrations` table.
     #[tokio::test]
-    #[serial]
     async fn pgvector_coexists_with_relational_migrator_in_shared_db() {
-        let Some(url) = test_url() else {
-            eprintln!("PGVECTOR_TEST_URL not set — skipping shared-DB migration test");
-            return;
-        };
+        with_temp_db("shared-DB migration test", |url| async move {
+            let db = Database::connect(&url).await.unwrap();
 
-        let db = Database::connect(&url).await.unwrap();
-        reset(&db).await;
+            // 1. Relational / auth migrator runs first and populates the default
+            //    `seaql_migrations` with versions the vector migrator does not own.
+            RelationalMigrator::up(&db, None)
+                .await
+                .expect("relational migrator should succeed");
+            assert_eq!(version_count(&db, "seaql_migrations").await, 2);
 
-        // 1. Relational / auth migrator runs first and populates the default
-        //    `seaql_migrations` with versions the vector migrator does not own.
-        RelationalMigrator::up(&db, None)
-            .await
-            .expect("relational migrator should succeed");
-        assert_eq!(version_count(&db, "seaql_migrations").await, 2);
+            // 2. Initialising the vector adapter against the SAME database must
+            //    succeed. Before the fix it aborted with "Migration file of version
+            //    'm20260914_000002_auth' is missing ...".
+            let adapter = PgVectorAdapter::new(&url, 384).await;
+            assert!(
+                adapter.is_ok(),
+                "PgVectorAdapter init must not collide with the relational \
+                 seaql_migrations table; got: {:?}",
+                adapter.err()
+            );
 
-        // 2. Initialising the vector adapter against the SAME database must
-        //    succeed. Before the fix it aborted with "Migration file of version
-        //    'm20260914_000002_auth' is missing ...".
-        let adapter = PgVectorAdapter::new(&url, 384).await;
-        assert!(
-            adapter.is_ok(),
-            "PgVectorAdapter init must not collide with the relational \
-             seaql_migrations table; got: {:?}",
-            adapter.err()
-        );
+            // 3. The vector migrator tracks its version in its OWN table and leaves
+            //    the relational bookkeeping untouched.
+            assert_eq!(version_count(&db, "seaql_migrations").await, 2);
+            assert_eq!(version_count(&db, "seaql_migrations_pgvector").await, 1);
 
-        // 3. The vector migrator tracks its version in its OWN table and leaves
-        //    the relational bookkeeping untouched.
-        assert_eq!(version_count(&db, "seaql_migrations").await, 2);
-        assert_eq!(version_count(&db, "seaql_migrations_pgvector").await, 1);
-
-        reset(&db).await;
+            // Hand the pooled connections back before the database is dropped, so
+            // cleanup does not have to lean on `WITH (FORCE)`.
+            drop(adapter);
+            drop(db);
+        })
+        .await;
     }
 
     /// Upgrade path: a legacy pgvector row left in the default `seaql_migrations`
     /// by an older build must be purged so the core migrator no longer chokes.
     #[tokio::test]
-    #[serial]
     async fn pgvector_purges_legacy_row_from_default_table_on_upgrade() {
-        let Some(url) = test_url() else {
-            eprintln!("PGVECTOR_TEST_URL not set — skipping legacy-purge test");
-            return;
-        };
+        with_temp_db("legacy-purge test", |url| async move {
+            let db = Database::connect(&url).await.unwrap();
 
-        let db = Database::connect(&url).await.unwrap();
-        reset(&db).await;
-
-        // Simulate an older build that recorded the pgvector version into the
-        // DEFAULT `seaql_migrations` table (aux-ran-before-core ordering).
-        db.execute(Statement::from_string(
-            db.get_database_backend(),
-            "CREATE TABLE seaql_migrations (version VARCHAR PRIMARY KEY, applied_at BIGINT NOT NULL)",
-        ))
-        .await
-        .unwrap();
-        db.execute(Statement::from_string(
-            db.get_database_backend(),
-            "INSERT INTO seaql_migrations (version, applied_at) \
-             VALUES ('m20250101_000001_create_pgvector_extension', 0)",
-        ))
-        .await
-        .unwrap();
-
-        // Upgraded build initialises the vector adapter.
-        PgVectorAdapter::new(&url, 384)
+            // Simulate an older build that recorded the pgvector version into the
+            // DEFAULT `seaql_migrations` table (aux-ran-before-core ordering).
+            db.execute(Statement::from_string(
+                db.get_database_backend(),
+                "CREATE TABLE seaql_migrations (version VARCHAR PRIMARY KEY, applied_at BIGINT NOT NULL)",
+            ))
             .await
-            .expect("vector adapter should initialise on upgrade");
-
-        // The stale vector row is gone, so the core/relational migrator can now
-        // run against the default table without aborting.
-        assert_eq!(
-            version_count(&db, "seaql_migrations").await,
-            0,
-            "legacy pgvector row must be purged from the default seaql_migrations"
-        );
-        RelationalMigrator::up(&db, None)
+            .unwrap();
+            db.execute(Statement::from_string(
+                db.get_database_backend(),
+                "INSERT INTO seaql_migrations (version, applied_at) \
+                 VALUES ('m20250101_000001_create_pgvector_extension', 0)",
+            ))
             .await
-            .expect("core migrator must not choke after legacy row is purged");
+            .unwrap();
 
-        reset(&db).await;
+            // Upgraded build initialises the vector adapter.
+            let adapter = PgVectorAdapter::new(&url, 384)
+                .await
+                .expect("vector adapter should initialise on upgrade");
+
+            // The stale vector row is gone, so the core/relational migrator can now
+            // run against the default table without aborting.
+            assert_eq!(
+                version_count(&db, "seaql_migrations").await,
+                0,
+                "legacy pgvector row must be purged from the default seaql_migrations"
+            );
+            RelationalMigrator::up(&db, None)
+                .await
+                .expect("core migrator must not choke after legacy row is purged");
+
+            drop(adapter);
+            drop(db);
+        })
+        .await;
     }
 }

--- a/crates/vector/src/vector_db_trait.rs
+++ b/crates/vector/src/vector_db_trait.rs
@@ -289,7 +289,11 @@ pub trait VectorDB: Send + Sync {
     /// - **Safe to call while other `Arc` clones are alive.** Surviving clones
     ///   fail their next operation with a "closed" error rather than silently
     ///   reconnecting.
-    /// - **Post-close operations fail.** Deliberate and user-visible.
+    /// - **Post-close operations fail — for backends that actually close
+    ///   something.** Deliberate and user-visible. It does *not* bind an
+    ///   implementor whose `close` is the no-op default below (brute-force, mock,
+    ///   LanceDB): with nothing to release there is nothing to invalidate, so such
+    ///   a backend keeps serving — which is what the unit test below asserts.
     /// - The **default body is a no-op**, meaning "this backend owns nothing
     ///   closable beyond memory". That is the *measured* truth for the in-memory
     ///   brute-force store and for LanceDB (which holds no descriptor open

--- a/crates/vector/src/vector_db_trait.rs
+++ b/crates/vector/src/vector_db_trait.rs
@@ -275,6 +275,30 @@ pub trait VectorDB: Send + Sync {
         Ok(())
     }
 
+    /// Release the OS resources this store owns, instead of waiting for `Drop`.
+    ///
+    /// The vector-store twin of `cognee_graph::GraphDBTrait::close`; see that
+    /// method for the full mechanism. In short: a `Drop` is not a close. The
+    /// pgvector adapter owns its **own** sqlx pool, and dropping a pool only
+    /// flags it closed and lets each connection tear down on an arbitrary
+    /// thread, so the server-side backends stay open long after the last `Arc`
+    /// is gone.
+    ///
+    /// Contract:
+    /// - **Idempotent.** Calling it twice is a no-op the second time.
+    /// - **Safe to call while other `Arc` clones are alive.** Surviving clones
+    ///   fail their next operation with a "closed" error rather than silently
+    ///   reconnecting.
+    /// - **Post-close operations fail.** Deliberate and user-visible.
+    /// - The **default body is a no-op**, meaning "this backend owns nothing
+    ///   closable beyond memory". That is the *measured* truth for the in-memory
+    ///   brute-force store and for LanceDB (which holds no descriptor open
+    ///   between calls), so neither overrides it. An adapter that does own OS
+    ///   resources must override it, or it will leak invisibly.
+    async fn close(&self) -> VectorDBResult<()> {
+        Ok(())
+    }
+
     /// Perform multiple vector similarity searches in sequence.
     ///
     /// Default implementation loops over [`search_similar`]. Backends may override
@@ -306,6 +330,18 @@ mod tests {
     )]
     use super::*;
     use crate::mock_vector_db::MockVectorDB;
+
+    /// The defaulted `close()` is a no-op and idempotent for a store that owns
+    /// nothing closable — the measured case for the in-memory brute-force store
+    /// and for LanceDB, and what keeps every existing impl compiling.
+    #[tokio::test]
+    async fn default_close_is_a_noop_and_idempotent() {
+        let db = MockVectorDB::new();
+        db.create_collection("TestType", "field", 3).await.unwrap();
+        assert!(db.close().await.is_ok());
+        assert!(db.close().await.is_ok());
+        assert!(db.has_collection("TestType", "field").await.unwrap());
+    }
 
     #[tokio::test]
     async fn batch_search_similar_returns_one_result_per_query() {

--- a/crates/vector/tests/pgvector_close.rs
+++ b/crates/vector/tests/pgvector_close.rs
@@ -1,0 +1,214 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression tests for `PgVectorAdapter::close` — the vector half of the
+//! Postgres pool leak in topoteretes/cognee-rs#132.
+//!
+//! `PgVectorAdapter` opens a pool of its own, separate from both the relational
+//! pool and the graph adapter's, so a warm `ComponentManager` on Postgres holds
+//! three and #135 closed one. See `cognee-graph`'s `pg_graph_close.rs` for the
+//! full measurement table; the two things `close()` buys are:
+//!
+//! - a **retained `Arc`** has no drop to fall back on (measured on the graph
+//!   adapter: 10 backends still open at 5 s while idle-but-held, 0 in ~2 ms after
+//!   `close()` on that same `Arc`), and
+//! - under contention a drop pins the whole pool behind the slowest query, where
+//!   `close` reclaims the idle connections immediately.
+//!
+//! Requires a running PostgreSQL with the `vector` extension; set
+//! `PGVECTOR_TEST_URL` (or the `DB_*` set that `cognee_test_utils::pg_test_url`
+//! reads), e.g.
+//!
+//!   PGVECTOR_TEST_URL="postgres://user:pass@localhost:5432/cognee_test_vectors"
+//!
+//! Tests skip automatically when it is absent. **These tests must be named
+//! explicitly in `ci.yml`'s `pgvector-spans` lane and in the `community.yml`
+//! mirror**: those lanes invoke individual `--test` targets, so a new file runs
+//! nowhere unless it is added there.
+#![cfg(feature = "pgvector")]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use cognee_vector::{PgVectorAdapter, VectorDB};
+use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
+use serial_test::serial;
+
+const CONCURRENCY: usize = 10;
+const DIMENSION: usize = 4;
+
+/// The Postgres URL, or `None` to skip.
+///
+/// Accepts both conventions in the tree because the two CI lanes that could run
+/// this file disagree: `pgvector_integration.rs` reads `PGVECTOR_TEST_URL`, while
+/// the `pgvector-spans` lane (the one with a pgvector service container) provides
+/// the `DB_*` set that `cognee_test_utils::pg_test_url` assembles. Reading only
+/// one of them is how a suite ends up green without ever reaching a server.
+fn test_url() -> Option<String> {
+    std::env::var("PGVECTOR_TEST_URL")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .or_else(cognee_test_utils::pg_test_url)
+}
+
+/// Tag a URL with a unique `application_name` so the observer counts *this*
+/// adapter's backends and nothing else.
+fn tagged(url: &str, tag: &str) -> String {
+    let sep = if url.contains('?') { '&' } else { '?' };
+    format!("{url}{sep}application_name={tag}")
+}
+
+/// A second, independent connection: it must not come from the pool under test,
+/// which is about to be closed.
+async fn observer(url: &str) -> DatabaseConnection {
+    Database::connect(tagged(url, "cognee_vec_close_observer"))
+        .await
+        .expect("PGVECTOR_TEST_URL is set, so the observer must connect")
+}
+
+async fn backend_count(obs: &DatabaseConnection, tag: &str) -> i64 {
+    let stmt = Statement::from_sql_and_values(
+        obs.get_database_backend(),
+        "SELECT count(*)::bigint FROM pg_stat_activity WHERE application_name = $1",
+        [tag.into()],
+    );
+    obs.query_one(stmt)
+        .await
+        .expect("pg_stat_activity query")
+        .expect("count() always returns a row")
+        .try_get_by_index::<i64>(0)
+        .expect("count is a bigint")
+}
+
+async fn wait_for(obs: &DatabaseConnection, tag: &str, target: i64, window: Duration) -> i64 {
+    let deadline = Instant::now() + window;
+    loop {
+        let n = backend_count(obs, tag).await;
+        if n <= target || Instant::now() >= deadline {
+            return n;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Grow the pool past one connection with overlapping real vector operations, and
+/// return the number of backends observed.
+async fn saturate(adapter: &Arc<PgVectorAdapter>, obs: &DatabaseConnection, tag: &str) -> i64 {
+    let mut tasks = Vec::new();
+    for _ in 0..CONCURRENCY {
+        let adapter = Arc::clone(adapter);
+        tasks.push(tokio::spawn(async move {
+            let deadline = Instant::now() + Duration::from_millis(400);
+            while Instant::now() < deadline {
+                adapter
+                    .has_collection("CloseProbe", "text")
+                    .await
+                    .expect("has_collection");
+            }
+        }));
+    }
+    for t in tasks {
+        t.await.expect("saturation task");
+    }
+    let n = backend_count(obs, tag).await;
+    assert!(
+        n > 1,
+        "precondition: overlapping operations must open more than one pooled \
+         connection (got {n}), or this test cannot tell a pool close apart from a \
+         single connection dropping"
+    );
+    n
+}
+
+/// The case with no `Drop` to fall back on: the `Arc` is still held (the HTTP
+/// server's `AppState` shape), so `close()` is the only available teardown.
+#[tokio::test]
+#[serial]
+async fn close_releases_the_pool_while_the_adapter_is_still_held() {
+    let Some(url) = test_url() else {
+        eprintln!("PGVECTOR_TEST_URL not set — skipping");
+        return;
+    };
+    let obs = observer(&url).await;
+    let tag = format!("cognee_vector_retained_{}", std::process::id());
+
+    let adapter = Arc::new(
+        PgVectorAdapter::new(&tagged(&url, &tag), DIMENSION)
+            .await
+            .expect("connect"),
+    );
+    let peak = saturate(&adapter, &obs, &tag).await;
+
+    // Time alone does not help.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    assert_eq!(
+        backend_count(&obs, &tag).await,
+        peak,
+        "an idle but retained pool must still hold all {peak} backends"
+    );
+
+    let second_holder = Arc::clone(&adapter);
+    adapter.close().await.expect("close");
+
+    let after_close = wait_for(&obs, &tag, 0, Duration::from_secs(5)).await;
+    assert_eq!(
+        after_close, 0,
+        "close() must reclaim all {peak} backends while the adapter is still \
+         held; {after_close} left"
+    );
+    assert!(
+        second_holder
+            .connection()
+            .get_postgres_connection_pool()
+            .is_closed(),
+        "the pool must report itself closed to every holder"
+    );
+
+    // Idempotent, and a surviving clone fails rather than reconnecting.
+    adapter.close().await.expect("second close is a no-op");
+    assert!(
+        second_holder
+            .has_collection("CloseProbe", "text")
+            .await
+            .is_err(),
+        "an operation after close must fail rather than reconnect"
+    );
+}
+
+/// The outage-prevention test: [`PgVectorAdapter::from_connection`] wraps a
+/// connection the caller owns — in the shared-Postgres layout, the relational pool
+/// — and `close()` must leave it alone.
+#[tokio::test]
+#[serial]
+async fn close_does_not_touch_a_caller_owned_connection() {
+    let Some(url) = test_url() else {
+        eprintln!("PGVECTOR_TEST_URL not set — skipping");
+        return;
+    };
+    let tag = format!("cognee_vector_borrowed_{}", std::process::id());
+    let caller_owned = Database::connect(tagged(&url, &tag))
+        .await
+        .expect("caller connection");
+
+    let adapter = PgVectorAdapter::from_connection(caller_owned.clone(), DIMENSION)
+        .await
+        .expect("from_connection");
+    adapter.close().await.expect("close must succeed");
+
+    let stmt = Statement::from_string(caller_owned.get_database_backend(), "SELECT 1");
+    caller_owned
+        .query_one(stmt)
+        .await
+        .expect("the caller's connection must survive the adapter's close");
+    assert!(
+        !caller_owned.get_postgres_connection_pool().is_closed(),
+        "close() must not close a caller-owned pool"
+    );
+    // And the adapter itself still works, because nothing was closed.
+    adapter
+        .has_collection("CloseProbe", "text")
+        .await
+        .expect("a borrowed-connection adapter stays usable after its no-op close");
+}


### PR DESCRIPTION
Follow-on to #135, which fixed the **relational** pool only. `ComponentManager::close()` released the relational connection and left every other component in its cache — on the documented premise that they "release everything on drop". They do, but **the cache is the last strong reference, so a slot that is never emptied is a destructor that never runs.**

`Refs #132` (that issue is already closed by #135).

## How this was scoped: four backend families audited, one found clean

Each family was audited independently with real measurements (`lsof -p`, `ps -M`, on-disk file counts) rather than code reading.

| family | leaks? | finding |
|---|---|---|
| **Postgres pools** | **yes** | `PgGraphAdapter` and `PgVectorAdapter` each own a **private** sqlx pool with no close of any kind — measured against a real PG 16. Three untuned pools per process. |
| **Embedded graph** (ladybug/kuzu) | **yes** | `LadybugAdapter` had no `close()`, and `GraphDBTrait` had **no teardown member at all**, so no caller could close a graph store polymorphically. Holds a write lock plus an un-checkpointed `-wal`. |
| **Clients / misc** | **yes** | ONNX session leaves **7 OS threads + ~32 MB** past close; embedding/LLM keep-alive sockets survive (incl. a second, easily-missed LLM pool inside the transcriber); an in-flight telemetry POST is silently dropped at shutdown (**0 of 1 delivered**). |
| **Embedded vector** (LanceDB) | **no** | Measured *not* to leak fds/threads per adapter. Left alone deliberately, with a comment saying so — Lance installs a process-lifetime CPU thread pool that no `close()` can reclaim, and that is not a per-adapter leak. |

The audit also caught that the doc comment in `component_manager.rs` asserted the **opposite of reality** about non-relational components; it is corrected here.

## Verification

Everything below I ran myself on this branch, not taken on trust:

| check | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `ladybug_close` (embedded graph) | **4 passed** |
| `pgvector_close` (live PG 16 on :5433) | **2 passed** |
| `pg_graph_close` (live PG 16 on :5433) | **3 passed** |
| **mutation test** — `LadybugAdapter::close` stubbed to `Ok(())` | **3 of 4 tests go red**; restored → 4 green, no diff |

That last row is the one that matters. A green suite proves nothing here — every suite in #135 was green *while* leaking 18 files. Neutering the close turns `close_checkpoints_and_unlinks_the_wal`, `close_is_idempotent` and `operations_after_close_fail_with_a_closed_error` red, so the tests genuinely guard the behaviour.

## Contract changes — read before merging

Recorded in `CHANGELOG.md`. These are user-visible:

1. **`close()` is no longer a cheap relational reset.** It now takes every cache slot out and closes what is closable.
2. **A closed graph/vector store rejects later operations**, rather than silently reconnecting. The closed state lives inside the shared inner handle (mirroring where sqlx keeps its flag), so surviving `Arc` clones fail their next op instead of reopening.
3. New trait members `GraphDBTrait::close` and `VectorDB::close`, both defaulting to a **no-op** — meaning "this backend owns nothing that needs releasing". Out-of-tree implementors are unaffected.

## Relies on CI rather than local verification

- The full `Test (stable)` / binding-check lanes.
- `scripts/ci/assert_pggraph_suite_ran.sh` is extended so a silently-skipped Postgres suite fails the lane instead of passing green — worth a look, since a skipping test that reports success is exactly how the original leak stayed invisible.
- The HTTP-server shutdown and telemetry-flush paths have unit tests here, but `http-parity` is what exercises them end-to-end.

## Provenance

Produced by a 5-phase agent workflow (scope → 4 parallel audits → plan → implement → verify). The verify phase stalled on rebuild timeouts, so I did that phase by hand — the table above is mine. Two earlier "failures" during my verification were my own errors, not defects: wrong Postgres credentials, then a wrong feature flag (`pggraph` vs `postgres`). Notably the tests failed loudly on a wrong-but-present URL rather than skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SePhkXEUpiSJ1CTg7t9ERb
