### PR TITLE
fix(database): finish the pool close, so SQLite really releases its WAL sidecars

### DIFF
--- a/crates/bindings-common/src/handle.rs
+++ b/crates/bindings-common/src/handle.rs
@@ -227,10 +227,14 @@ impl HandleState {
     ///   `cg_sdk_close`). It additionally marks the handle closed, so later ops
     ///   fail with a clear error instead of silently reopening the database.
     ///
-    /// Both are idempotent. Neither waits for concurrent operations: an op that is
-    /// mid-flight holds its own `Arc<CogneeServices>` and will see a closed pool on
-    /// its next query, so a binding should only tear down when its own contract
-    /// says the handle is done.
+    /// Both are idempotent. Neither waits for concurrent operations to *finish*: an
+    /// op that is mid-flight holds its own `Arc<CogneeServices>` and will see a
+    /// closed pool on its next query, so a binding should only tear down when its
+    /// own contract says the handle is done. What the teardown does wait for — and
+    /// has to, or the SQLite sidecars outlive it — is the pool's connections coming
+    /// back and closing. That is normally microseconds; a connection genuinely held
+    /// by an in-flight op bounds it at `cognee_database`'s drain timeout, after
+    /// which the teardown gives up on that connection and logs rather than hanging.
     pub async fn release(&self) {
         self.teardown(false).await;
     }

--- a/crates/bindings-common/tests/handle_close.rs
+++ b/crates/bindings-common/tests/handle_close.rs
@@ -137,6 +137,28 @@ async fn release_frees_the_sidecars_without_closing_the_handle() {
     assert!(!wal.exists() && !shm.exists(), "release must be idempotent");
 }
 
+/// Wait for an off-runtime teardown thread **without** blocking the runtime.
+///
+/// `JoinHandle::join` would block the calling task's worker thread, and on a
+/// single-core machine (CI, or a `taskset`-pinned run) there is only one worker —
+/// so joining inline wedges the runtime for the duration of the teardown. The
+/// teardown needs it: releasing the last relational connection means polling the
+/// task sqlx spawned from `PoolConnection::drop`, and only a worker can do that.
+/// A real embedder does not have that problem, because the thread it closes from
+/// (Node's main thread, a JVM `Cleaner`) is not one of the runtime's workers —
+/// so awaiting a signal, which yields the worker, is what models it faithfully.
+async fn join_off_runtime<F>(work: F)
+where
+    F: FnOnce() + Send + 'static,
+{
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::spawn(move || {
+        work();
+        let _ = tx.send(());
+    });
+    rx.await.expect("the off-runtime teardown thread panicked");
+}
+
 /// `close_blocking` is what the synchronous binding teardown hooks call, and both
 /// of its deterministic branches must leave nothing behind by the time they
 /// return: from a thread with no runtime of its own (a Java `close()` call, the
@@ -152,12 +174,11 @@ async fn close_blocking_releases_the_sidecars_on_either_thread() {
     let (wal, shm) = sidecars(&db_path);
     state.services().await.expect("warm");
     assert!(wal.exists() && shm.exists());
-    let off_thread = {
+    {
         let state = std::sync::Arc::clone(&state);
         let handle = handle.clone();
-        std::thread::spawn(move || state.close_blocking(&handle))
-    };
-    off_thread.join().expect("closing thread");
+        join_off_runtime(move || state.close_blocking(&handle)).await;
+    }
     assert!(
         !wal.exists() && !shm.exists(),
         "close_blocking from an off-runtime thread must release the sidecars",
@@ -182,15 +203,136 @@ async fn close_blocking_releases_the_sidecars_on_either_thread() {
     let (wal, shm) = sidecars(&db_path);
     state.services().await.expect("warm");
     assert!(wal.exists() && shm.exists());
-    let off_thread = {
+    {
         let state = std::sync::Arc::clone(&state);
         let handle = handle.clone();
-        std::thread::spawn(move || state.release_blocking(&handle))
-    };
-    off_thread.join().expect("releasing thread");
+        join_off_runtime(move || state.release_blocking(&handle)).await;
+    }
     assert!(
         !wal.exists() && !shm.exists(),
         "release_blocking must release the sidecars",
     );
     assert!(!state.is_closed());
+}
+
+/// The blocking close must hold its contract even when sqlx's own `Pool::close`
+/// returns while a connection is still open — which is what it does whenever the
+/// task sqlx spawns from `PoolConnection::drop` has not been polled yet, i.e.
+/// routinely, on any loaded machine. Left unhandled this is what kept
+/// `ts/__tests__/sdk_handle.test.ts` flaking after issue #132's first fix: it
+/// failed twice in a row on CI on 2026-08-11, on a different test in the block
+/// each time, and blocked an unrelated PR from merging.
+///
+/// `cognee_database::close` carries the mechanism and a deterministic test of it
+/// (`crates/database/tests/connection_pool.rs`). This test is the same forced
+/// ordering driven through the real binding entry point — a warmed handle, torn
+/// down by `close_blocking` from a thread with no runtime of its own, exactly as
+/// `cogneeClose` / `cg_sdk_close` / the JNI `destroy` do it.
+#[test]
+fn close_blocking_waits_for_a_straggling_connection() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    // One worker thread, so "the task sqlx spawned cannot run yet" is a fact we
+    // control rather than a race we hope for. The teardown itself runs on a
+    // thread of its own, so it still makes progress while the worker is busy.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let (state, db_path) = handle_under(dir.path());
+    let (wal, shm) = sidecars(&db_path);
+
+    let services = rt.block_on(state.services()).expect("warm");
+    let pool = services.database.get_sqlite_connection_pool().clone();
+    drop(services);
+    assert!(wal.exists() && shm.exists());
+
+    // Park idle connections: closing them is what pushes sqlx's semaphore over
+    // capacity and lets its close barrier pass with a connection still out.
+    rt.block_on(async {
+        let mut held = Vec::new();
+        for _ in 0..4 {
+            held.push(pool.acquire().await.unwrap());
+        }
+        drop(held);
+        for _ in 0..500 {
+            if pool.num_idle() >= 4 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    });
+    assert!(
+        pool.num_idle() >= 4,
+        "the setup needs several genuinely idle connections, got {}",
+        pool.num_idle(),
+    );
+
+    // Occupy the only worker, then strand a checked-out connection behind it.
+    let release = Arc::new(AtomicBool::new(false));
+    let occupied = Arc::new(AtomicBool::new(false));
+    {
+        let release = Arc::clone(&release);
+        let occupied = Arc::clone(&occupied);
+        rt.spawn(async move {
+            occupied.store(true, Ordering::Release);
+            while !release.load(Ordering::Acquire) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        });
+    }
+    while !occupied.load(Ordering::Acquire) {
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    rt.block_on(async {
+        let conn = pool.acquire().await.unwrap();
+        drop(conn);
+    });
+
+    // Free the worker a beat after the close starts, so a close that waits can
+    // finish and a close that returns with sqlx's cannot have.
+    let releaser = {
+        let release = Arc::clone(&release);
+        let pool = pool.clone();
+        std::thread::spawn(move || {
+            while !pool.is_closed() {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            std::thread::sleep(Duration::from_millis(150));
+            release.store(true, Ordering::Release);
+        })
+    };
+
+    {
+        let state = Arc::clone(&state);
+        let handle = rt.handle().clone();
+        std::thread::spawn(move || state.close_blocking(&handle))
+            .join()
+            .expect("closing thread");
+    }
+
+    // Sample the contract at the instant `close_blocking` returns. Looking any
+    // later — even just long enough to join a thread — would let the straggler
+    // finish on its own, and the test would pass with or without the fix.
+    let (size, wal_left, shm_left) = (pool.size(), wal.exists(), shm.exists());
+
+    // Unblock unconditionally so a failed assertion cannot hide behind a hang.
+    release.store(true, Ordering::Release);
+    releaser.join().unwrap();
+
+    assert_eq!(
+        size, 0,
+        "close_blocking must not return while the pool still owns a connection",
+    );
+    assert!(
+        !wal_left,
+        "-wal must be gone when close_blocking returns, even when sqlx's own close returned early",
+    );
+    assert!(!shm_left, "-shm must be gone when close_blocking returns");
+    assert!(state.is_closed());
 }

--- a/crates/bindings-common/tests/handle_close.rs
+++ b/crates/bindings-common/tests/handle_close.rs
@@ -294,16 +294,28 @@ fn close_blocking_waits_for_a_straggling_connection() {
         drop(conn);
     });
 
-    // Free the worker a beat after the close starts, so a close that waits can
-    // finish and a close that returns with sqlx's cannot have.
+    // Free the worker, ordered against the close rather than after a wall-clock
+    // delay: the releaser waits until the close has been observed to *return* and
+    // sampled, and only frees the worker if that has not happened within a grace
+    // period — i.e. only when the close is still waiting. Without the drain the
+    // close returns in microseconds, so the worker is never freed before the
+    // sample and the assertions see the leak. (An earlier draft just slept 150ms,
+    // which let the straggler be reaped inside the window on a loaded machine and
+    // pass with the fix reverted.) The grace stays inside the drain's no-progress
+    // ceiling so the drain does not rightly give up first.
+    let sampled = Arc::new(AtomicBool::new(false));
     let releaser = {
         let release = Arc::clone(&release);
+        let sampled = Arc::clone(&sampled);
         let pool = pool.clone();
         std::thread::spawn(move || {
             while !pool.is_closed() {
                 std::thread::sleep(Duration::from_millis(1));
             }
-            std::thread::sleep(Duration::from_millis(150));
+            let grace = std::time::Instant::now() + Duration::from_millis(100);
+            while !sampled.load(Ordering::Acquire) && std::time::Instant::now() < grace {
+                std::thread::sleep(Duration::from_millis(1));
+            }
             release.store(true, Ordering::Release);
         })
     };
@@ -320,6 +332,7 @@ fn close_blocking_waits_for_a_straggling_connection() {
     // later — even just long enough to join a thread — would let the straggler
     // finish on its own, and the test would pass with or without the fix.
     let (size, wal_left, shm_left) = (pool.size(), wal.exists(), shm.exists());
+    sampled.store(true, Ordering::Release);
 
     // Unblock unconditionally so a failed assertion cannot hide behind a hang.
     release.store(true, Ordering::Release);

--- a/crates/database/src/connection.rs
+++ b/crates/database/src/connection.rs
@@ -26,17 +26,20 @@ const POOL_MIN_CONNECTIONS: u32 = 0;
 const POOL_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
 const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(600);
 
-/// How long [`close`] keeps working at emptying the pool after sqlx's own
-/// `Pool::close` has returned, and the ceiling on its retry interval.
+/// Ceilings on the work [`close`] does to empty the pool after sqlx's own
+/// `Pool::close` has returned. See [`drain_sqlite_pool`], which explains why
+/// there are two of them and why the hard one is enforced off the runtime clock.
 ///
-/// The work only ever happens when sqlx left a connection behind (see
-/// [`drain_sqlite_pool`] for the two ways it does), and it normally finishes in
-/// a millisecond or two. The ceiling is generous because the alternative to
-/// waiting a moment longer is an orphaned `-wal`/`-shm` pair, and because the
-/// only way to exhaust it is a connection held by an operation still in flight —
-/// which teardown never promised to wait for anyway.
+/// The work only ever happens when sqlx left a connection behind, and normally
+/// finishes in a millisecond or two, so neither ceiling is reached on any
+/// ordinary teardown.
 #[cfg(feature = "sqlite")]
 const POOL_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+/// How long the drain keeps trying after the last connection it managed to reap.
+/// Short, because a stalled drain is almost always a connection held by a live
+/// operation, which will not come back at all and is not teardown's to wait for.
+#[cfg(feature = "sqlite")]
+const POOL_DRAIN_STALL_TIMEOUT: Duration = Duration::from_millis(400);
 #[cfg(feature = "sqlite")]
 const POOL_DRAIN_RETRY_MAX: Duration = Duration::from_millis(25);
 
@@ -357,10 +360,11 @@ fn sqlite_parent_dir_is_writable(path: &std::path::Path) -> bool {
 /// builds a fresh one.
 ///
 /// **When this returns, every connection the pool owned is closed and a file
-/// SQLite database's sidecars are gone** — unless an operation elsewhere is still
-/// holding a connection, in which case the wait gives up after
-/// `POOL_DRAIN_TIMEOUT` (2s) and logs a warning rather than blocking teardown on
-/// work it never promised to wait for.
+/// SQLite database's sidecars are gone** — unless a connection is held by an
+/// operation still in flight, which teardown never promised to wait for. In that
+/// case the wait gives up (see `drain_sqlite_pool` for the two ceilings, ~400ms
+/// in practice and 2s absolute) and logs at debug rather than blocking teardown
+/// on someone else's work.
 pub async fn close(db: &DatabaseConnection) -> Result<(), DatabaseError> {
     let closed = db.close_by_ref().await;
 
@@ -369,7 +373,21 @@ pub async fn close(db: &DatabaseConnection) -> Result<(), DatabaseError> {
     // backend's straggler costs nothing observable.
     #[cfg(feature = "sqlite")]
     if matches!(db, DatabaseConnection::SqlxSqlitePoolConnection(_)) {
-        drain_sqlite_pool(db.get_sqlite_connection_pool()).await;
+        // Report the count the drain actually decided to give up on, not a fresh
+        // `pool.size()`: re-reading it here can observe a straggler that landed in
+        // the meantime and log "still holds open connections ... open=0".
+        let open = drain_sqlite_pool(db.get_sqlite_connection_pool()).await;
+        if open > 0 {
+            tracing::debug!(
+                open_connections = open,
+                stall_timeout = ?POOL_DRAIN_STALL_TIMEOUT,
+                timeout = ?POOL_DRAIN_TIMEOUT,
+                "gave up waiting for the relational pool to empty; a connection is either \
+                 held by an operation still in flight or was released into the pool after it \
+                 closed. A file SQLite database keeps its -wal/-shm sidecars until the pool \
+                 is dropped."
+            );
+        }
     }
 
     closed.map_err(|e| DatabaseError::ConnectionError(e.to_string()))
@@ -422,35 +440,93 @@ pub async fn close(db: &DatabaseConnection) -> Result<(), DatabaseError> {
 /// `close().await` has returned, so `size() == 0` means every connection has
 /// finished `sqlite3_close`. The fast path — the uncontended teardown, which is
 /// every teardown on an idle machine — costs one atomic load and returns.
+///
+/// # Giving up
+///
+/// Two ceilings bound the work, because the two reasons a connection is still
+/// there have very different prospects:
+///
+/// - A connection whose return task simply has not run yet *will* come back, and
+///   normally within a millisecond or two. Every reap resets
+///   `POOL_DRAIN_STALL_TIMEOUT`, so a pool that is making progress keeps its
+///   budget up to the overall ceiling.
+/// - A connection genuinely checked out by an operation still in flight will
+///   *never* come back before that operation finishes, and teardown does not
+///   promise to wait for it. Waiting the full ceiling for it would be pure
+///   latency, so `POOL_DRAIN_STALL_TIMEOUT` gives up once nothing has been
+///   reaped for that long.
+///
+/// `POOL_DRAIN_TIMEOUT` is the hard backstop, and it is enforced from a **plain
+/// OS thread**, not the runtime clock. tokio's time driver is only polled by
+/// worker threads: on a multi-thread runtime with every worker busy — precisely
+/// the situation that leaves a return task unpolled and makes this function
+/// necessary — `tokio::time::sleep` never fires, so a deadline checked after
+/// awaiting one is never reached and the teardown blocks forever. That is a
+/// worse failure than the orphaned sidecars it was trying to prevent (a
+/// synchronous `close()` would wedge the embedder's thread), so the backstop
+/// wakes us through a `oneshot` fired by a thread that no scheduler can starve,
+/// and every await here races it.
+///
+/// Giving up abandons that connection: `ComponentManager::close` has already
+/// taken it out of its cache, so nothing looks at this pool's idle queue again
+/// until the last `Arc` to it drops, at which point sqlx's destructor drops the
+/// idle queue and the connections close with it. Until then a file database
+/// keeps its sidecars. That is logged at debug, not warn: it is the documented
+/// consequence of tearing down around a live operation, there is nothing for the
+/// operator to act on, and the teardown otherwise succeeded.
+///
+/// Returns the number of connections still open, for the caller to log.
 #[cfg(feature = "sqlite")]
-async fn drain_sqlite_pool(pool: &sea_orm::sqlx::SqlitePool) {
-    if pool.size() == 0 {
-        return;
+async fn drain_sqlite_pool(pool: &sea_orm::sqlx::SqlitePool) -> u32 {
+    let mut open = pool.size();
+    if open == 0 {
+        return 0;
     }
 
-    let deadline = std::time::Instant::now() + POOL_DRAIN_TIMEOUT;
-    let mut retry_in = Duration::from_millis(1);
+    // The scheduler-proof backstop. Cheap, and only ever spawned on the path
+    // where sqlx already left us something to clean up.
+    let (bail_tx, mut bail_rx) = tokio::sync::oneshot::channel();
+    std::thread::spawn(move || {
+        std::thread::sleep(POOL_DRAIN_TIMEOUT);
+        let _ = bail_tx.send(());
+    });
+
+    let backoff = cognee_utils::RetryConfig::new(0, 1, POOL_DRAIN_RETRY_MAX.as_millis() as u64);
+    let mut attempt = 0u32;
+    let mut fewest = open;
+    let mut last_reap = std::time::Instant::now();
+
     loop {
         // Reaps a connection stranded in the idle queue by case (2), and is a
-        // no-op when there is nothing there.
-        pool.close().await;
-        if pool.size() == 0 {
-            return;
+        // no-op when there is nothing there. Raced against the backstop because
+        // `Pool::close` awaits its own untimed semaphore.
+        tokio::select! {
+            biased;
+            _ = &mut bail_rx => break,
+            () = pool.close() => {}
         }
-        if std::time::Instant::now() >= deadline {
+
+        open = pool.size();
+        if open == 0 {
+            return 0;
+        }
+        if open < fewest {
+            fewest = open;
+            last_reap = std::time::Instant::now();
+        }
+        if last_reap.elapsed() >= POOL_DRAIN_STALL_TIMEOUT {
             break;
         }
-        tokio::time::sleep(retry_in).await;
-        retry_in = (retry_in * 2).min(POOL_DRAIN_RETRY_MAX);
+
+        tokio::select! {
+            biased;
+            _ = &mut bail_rx => break,
+            () = tokio::time::sleep(backoff.calculate_delay(attempt)) => {}
+        }
+        attempt += 1;
     }
 
-    tracing::warn!(
-        open_connections = pool.size(),
-        timeout = ?POOL_DRAIN_TIMEOUT,
-        "the relational pool still holds open connections after close; an operation is \
-         probably still in flight. A file SQLite database keeps its -wal/-shm sidecars \
-         until those connections close."
-    );
+    open
 }
 
 /// Run all pending migrations on an existing connection.

--- a/crates/database/src/connection.rs
+++ b/crates/database/src/connection.rs
@@ -483,12 +483,26 @@ async fn drain_sqlite_pool(pool: &sea_orm::sqlx::SqlitePool) -> u32 {
         return 0;
     }
 
-    // The scheduler-proof backstop. Cheap, and only ever spawned on the path
-    // where sqlx already left us something to clean up.
+    // The scheduler-proof backstop, only ever spawned on the path where sqlx
+    // already left us something to clean up.
+    //
+    // It has to be a thread of its own rather than `spawn_blocking`: the blocking
+    // pool is tokio-managed and can be saturated, and a backstop that can be
+    // queued behind other work is the same class of dependency as the runtime
+    // clock this exists to avoid. The cost that buys is one thread per contended
+    // teardown, so it must not outlive the drain — `_finished` disconnects the
+    // channel on every return path below, which wakes the thread out of
+    // `recv_timeout` immediately. A host that opens and closes handles in a tight
+    // loop therefore accumulates threads for as long as its drains actually run,
+    // not for `POOL_DRAIN_TIMEOUT` apiece.
     let (bail_tx, mut bail_rx) = tokio::sync::oneshot::channel();
+    let (_finished, finished_rx) = std::sync::mpsc::channel::<()>();
     std::thread::spawn(move || {
-        std::thread::sleep(POOL_DRAIN_TIMEOUT);
-        let _ = bail_tx.send(());
+        if finished_rx.recv_timeout(POOL_DRAIN_TIMEOUT)
+            == Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        {
+            let _ = bail_tx.send(());
+        }
     });
 
     let backoff = cognee_utils::RetryConfig::new(0, 1, POOL_DRAIN_RETRY_MAX.as_millis() as u64);

--- a/crates/database/src/connection.rs
+++ b/crates/database/src/connection.rs
@@ -26,6 +26,20 @@ const POOL_MIN_CONNECTIONS: u32 = 0;
 const POOL_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
 const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(600);
 
+/// How long [`close`] keeps working at emptying the pool after sqlx's own
+/// `Pool::close` has returned, and the ceiling on its retry interval.
+///
+/// The work only ever happens when sqlx left a connection behind (see
+/// [`drain_sqlite_pool`] for the two ways it does), and it normally finishes in
+/// a millisecond or two. The ceiling is generous because the alternative to
+/// waiting a moment longer is an orphaned `-wal`/`-shm` pair, and because the
+/// only way to exhaust it is a connection held by an operation still in flight —
+/// which teardown never promised to wait for anyway.
+#[cfg(feature = "sqlite")]
+const POOL_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(feature = "sqlite")]
+const POOL_DRAIN_RETRY_MAX: Duration = Duration::from_millis(25);
+
 /// SQLite lock-wait ceiling, matching Python's `SqlAlchemyAdapter`
 /// (`busy_timeout=120000`, added for the "database is locked" fix in
 /// topoteretes/cognee#2717). sqlx defaults to 5s, which `upsert_provenance_graph`
@@ -330,20 +344,113 @@ fn sqlite_parent_dir_is_writable(path: &std::path::Path) -> bool {
 /// happens to clean up; with more than one it is a race, which is why relying on
 /// `Drop` is not enough.
 ///
-/// [`sea_orm::DatabaseConnection::close_by_ref`] runs sqlx's real close: pooled
-/// connections are closed one at a time and checked-out ones are awaited, so
-/// exactly one connection observes itself as the last and the sidecars are gone
-/// before this future resolves.
+/// [`sea_orm::DatabaseConnection::close_by_ref`] runs sqlx's real close, which
+/// closes the connections it can see one at a time so exactly one of them
+/// observes itself as the last. That is necessary but **not sufficient**: it can
+/// return while a connection is still open, and it can leave one behind
+/// permanently. `drain_sqlite_pool` documents both cases and finishes the job.
 ///
 /// Idempotent, and safe to call while other `Arc` clones of the connection are
 /// still alive: they observe a closed pool and fail their next query rather than
 /// silently reconnecting. Callers that may be reused (e.g.
 /// `ComponentManager::close`) drop their cached connection so the next access
 /// builds a fresh one.
+///
+/// **When this returns, every connection the pool owned is closed and a file
+/// SQLite database's sidecars are gone** — unless an operation elsewhere is still
+/// holding a connection, in which case the wait gives up after
+/// `POOL_DRAIN_TIMEOUT` (2s) and logs a warning rather than blocking teardown on
+/// work it never promised to wait for.
 pub async fn close(db: &DatabaseConnection) -> Result<(), DatabaseError> {
-    db.close_by_ref()
-        .await
-        .map_err(|e| DatabaseError::ConnectionError(e.to_string()))
+    let closed = db.close_by_ref().await;
+
+    // Only SQLite gets the drain: it is the one backend where an on-disk
+    // artifact outlives the pool if a connection has not closed yet. A server
+    // backend's straggler costs nothing observable.
+    #[cfg(feature = "sqlite")]
+    if matches!(db, DatabaseConnection::SqlxSqlitePoolConnection(_)) {
+        drain_sqlite_pool(db.get_sqlite_connection_pool()).await;
+    }
+
+    closed.map_err(|e| DatabaseError::ConnectionError(e.to_string()))
+}
+
+/// Finish what sqlx's `Pool::close` starts: leave the closed pool with no open
+/// connections, so SQLite has actually unlinked `-wal`/`-shm` by the time the
+/// caller looks.
+///
+/// **`Pool::close` returning does not mean the pool is empty.** Two independent
+/// sqlx behaviours leave a connection behind, and both are ordinary rather than
+/// exotic — between them they orphaned the sidecars in five runs out of six on
+/// one core against five spinning processes (topoteretes/cognee-rs#132, the
+/// recipe that flaked `ts/__tests__/sdk_handle.test.ts`).
+///
+/// Both start from the same place: `PoolConnection::drop` does not return the
+/// connection to the pool inline, it *spawns* a task to do it. So when teardown
+/// begins, a connection whose last query has finished is typically still checked
+/// out — counted in `size()`, absent from the idle queue — with its return task
+/// either not yet polled or partway through.
+///
+/// 1. **`close` returns too early.** Its barrier is `semaphore.acquire(n)` for
+///    `n` in `1..=max_connections`, which only barriers if the permit count is
+///    honest. It is not: a connection releases its permit when it is *returned*
+///    to the pool (`PoolInner::release` → `release_permit`), and then `close`
+///    floats each idle connection it pops with a fresh `DecrementSizeGuard`,
+///    whose `Drop` releases a permit for that connection a second time. Closing
+///    k idle connections leaves the semaphore k permits over capacity, so
+///    `acquire(max_connections)` succeeds with a connection still checked out and
+///    the bounded loop simply runs out. Retrying `close` once the straggler's
+///    return task has run reaps it.
+/// 2. **`close` stops watching the idle queue.** `Floating::return_to_pool`
+///    checks `is_closed()` once, at its top, and then does a `ping()` round-trip
+///    to the connection's worker thread before calling `release()`
+///    unconditionally. A return task that passed that check just before the pool
+///    was marked closed therefore pushes its connection **into the idle queue of
+///    an already-closed pool**, after `close` has drained that queue for the last
+///    time. Nothing ever closes it: the connection stays open, its sqlite worker
+///    thread sits parked, and the sidecars survive until the pool itself is
+///    dropped. Only another `close` looks at the idle queue again.
+///
+/// So the loop below re-runs `Pool::close` rather than merely waiting: waiting
+/// alone fixes (1) and can never fix (2). `close` is idempotent and cheap when
+/// there is nothing to reap, and this converges because once the pool is marked
+/// closed only the finitely many return tasks already past their `is_closed()`
+/// check can strand another connection.
+///
+/// `size()` is the right completion signal: it is decremented by
+/// `DecrementSizeGuard::drop`, which runs after that connection's own
+/// `close().await` has returned, so `size() == 0` means every connection has
+/// finished `sqlite3_close`. The fast path — the uncontended teardown, which is
+/// every teardown on an idle machine — costs one atomic load and returns.
+#[cfg(feature = "sqlite")]
+async fn drain_sqlite_pool(pool: &sea_orm::sqlx::SqlitePool) {
+    if pool.size() == 0 {
+        return;
+    }
+
+    let deadline = std::time::Instant::now() + POOL_DRAIN_TIMEOUT;
+    let mut retry_in = Duration::from_millis(1);
+    loop {
+        // Reaps a connection stranded in the idle queue by case (2), and is a
+        // no-op when there is nothing there.
+        pool.close().await;
+        if pool.size() == 0 {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(retry_in).await;
+        retry_in = (retry_in * 2).min(POOL_DRAIN_RETRY_MAX);
+    }
+
+    tracing::warn!(
+        open_connections = pool.size(),
+        timeout = ?POOL_DRAIN_TIMEOUT,
+        "the relational pool still holds open connections after close; an operation is \
+         probably still in flight. A file SQLite database keeps its -wal/-shm sidecars \
+         until those connections close."
+    );
 }
 
 /// Run all pending migrations on an existing connection.

--- a/crates/database/tests/connection_pool.rs
+++ b/crates/database/tests/connection_pool.rs
@@ -514,17 +514,38 @@ fn close_waits_for_a_straggling_connection() {
         "one of the idle connections should now be stranded mid-return",
     );
 
-    // (5) Free the worker a beat after the close starts. `is_closed()` flips at
-    // the very top of sqlx's close, so this waits for the close to be under way
-    // rather than guessing when it starts.
+    // (5) Free the worker, but *ordered against the close* rather than after a
+    // wall-clock delay. An earlier draft slept 150ms here, which made the whole
+    // test a race it could lose in the safe direction: on the loaded machine this
+    // bug lives on, the straggler could be reaped inside those 150ms and the test
+    // passed with the drain reverted. Instead the releaser waits until the close
+    // has been *observed to return*; only if it has not returned within a grace
+    // period — which means it is waiting, i.e. the fix is present — does it free
+    // the worker so the close can finish.
+    //
+    // Without the drain the close returns in microseconds, so `sampled` is set
+    // long before the grace expires, the worker is never freed early, and the
+    // assertions below see the leak. The grace only has to exceed the handful of
+    // instructions between the close returning and the sample being taken — it is
+    // a ~1000x margin over that, rather than the old 150ms racing the straggler's
+    // reap. It must also stay comfortably *inside* the drain's no-progress
+    // ceiling, or the drain would rightly give up before the worker is freed and
+    // this test would be asserting the wrong contract (see
+    // `close_returns_even_when_no_worker_can_drive_the_runtime_clock`, which
+    // covers deliberately never freeing it).
+    let sampled = Arc::new(AtomicBool::new(false));
     let releaser = {
         let release = Arc::clone(&release);
+        let sampled = Arc::clone(&sampled);
         let pool = pool.clone();
         std::thread::spawn(move || {
             while !pool.is_closed() {
                 std::thread::sleep(Duration::from_millis(1));
             }
-            std::thread::sleep(Duration::from_millis(150));
+            let grace = std::time::Instant::now() + Duration::from_millis(100);
+            while !sampled.load(Ordering::Acquire) && std::time::Instant::now() < grace {
+                std::thread::sleep(Duration::from_millis(1));
+            }
             release.store(true, Ordering::Release);
         })
     };
@@ -534,9 +555,9 @@ fn close_waits_for_a_straggling_connection() {
 
     // Sample the contract at the instant `close` returns, before anything else
     // gets a chance to run — the assertions below must judge that moment, not a
-    // later one. Waiting to look (even long enough to join a thread) would let
-    // the straggler finish on its own and the test would pass either way.
+    // later one.
     let (size, wal_left, shm_left) = (pool.size(), wal.exists(), shm.exists());
+    sampled.store(true, Ordering::Release);
 
     // Unblock unconditionally, so an assertion failure cannot leave the runtime
     // wedged and hide itself behind a hang.
@@ -552,6 +573,112 @@ fn close_waits_for_a_straggling_connection() {
         "-wal must be gone when close returns, even when sqlx's own close returned early",
     );
     assert!(!shm_left, "-shm must be gone when close returns");
+}
+
+/// `close` must always return, including when no worker thread is available to
+/// drive the runtime's clock — which is exactly the state that makes the drain
+/// necessary in the first place.
+///
+/// tokio's time driver on a multi-thread runtime is only polled by its workers.
+/// `Handle::block_on` from an outside thread (`teardown_blocking`'s
+/// no-current-runtime branch, what every binding's synchronous `close()` uses)
+/// drives only its own future, so with every worker busy a `tokio::time::sleep`
+/// inside the drain never fires and any deadline checked *after* awaiting one is
+/// never reached. The first version of this fix did exactly that and would block
+/// forever here: a wedged embedder thread, which is a worse outcome than the
+/// orphaned sidecars it was preventing. The backstop therefore runs on a plain OS
+/// thread that no scheduler can starve.
+///
+/// The worker is never freed, so nothing can reap the connection and the drain
+/// *must* give up on its own. The close is driven on a separate thread and its
+/// return is reported over a channel, so the pre-fix behaviour surfaces as a
+/// bounded timeout rather than hanging the test process.
+#[test]
+fn close_returns_even_when_no_worker_can_drive_the_runtime_clock() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("nodriver.db");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+
+    let db = Arc::new(rt.block_on(connect(&url)).expect("connect"));
+    rt.block_on(db.execute(Statement::from_string(
+        DatabaseBackend::Sqlite,
+        "CREATE TABLE t (x INTEGER)",
+    )))
+    .unwrap();
+    let pool = db.get_sqlite_connection_pool().clone();
+
+    // Park idle connections, so closing them inflates sqlx's semaphore and its
+    // own close returns with the straggler still out.
+    rt.block_on(async {
+        let mut held = Vec::new();
+        for _ in 0..4 {
+            held.push(pool.acquire().await.unwrap());
+        }
+        drop(held);
+        for _ in 0..500 {
+            if pool.num_idle() >= 4 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    });
+
+    // Occupy the only worker for the rest of the test. From here on the runtime
+    // clock is dead: no worker will poll the time driver.
+    let release = Arc::new(AtomicBool::new(false));
+    let occupied = Arc::new(AtomicBool::new(false));
+    {
+        let release = Arc::clone(&release);
+        let occupied = Arc::clone(&occupied);
+        rt.spawn(async move {
+            occupied.store(true, Ordering::Release);
+            while !release.load(Ordering::Acquire) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        });
+    }
+    while !occupied.load(Ordering::Acquire) {
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    rt.block_on(async {
+        let conn = pool.acquire().await.unwrap();
+        drop(conn);
+    });
+
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    let closer = {
+        let handle = rt.handle().clone();
+        let db = Arc::clone(&db);
+        std::thread::spawn(move || {
+            let started = std::time::Instant::now();
+            handle.block_on(cognee_database::close(&db)).expect("close");
+            let _ = done_tx.send(started.elapsed());
+        })
+    };
+
+    // Generous margin over the 2s backstop; the point is bounded, not fast.
+    let outcome = done_rx.recv_timeout(Duration::from_secs(15));
+
+    release.store(true, Ordering::Release);
+    closer.join().expect("closing thread");
+
+    let elapsed = outcome.expect(
+        "close() must give up and return with no worker available to drive the runtime clock",
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "close() should give up near its backstop, took {elapsed:?}",
+    );
 }
 
 /// The other half of the same bug, and the worse half: a connection that is

--- a/crates/database/tests/connection_pool.rs
+++ b/crates/database/tests/connection_pool.rs
@@ -411,3 +411,295 @@ async fn close_releases_wal_sidecars() {
     assert!(!wal.exists(), "-wal must be removed by close");
     assert!(!shm.exists(), "-shm must be removed by close");
 }
+
+/// The same guarantee when sqlx's own `Pool::close` returns *early* — the case
+/// that kept `-wal`/`-shm` orphaned after issue #132 was first fixed, and that
+/// flaked `ts/__tests__/sdk_handle.test.ts` on any loaded machine.
+///
+/// The ordering is forced rather than raced, so this test does not depend on the
+/// machine being slow (the bug itself is an instance of that mistake — it was
+/// invisible on an idle host and reproduced on demand under CPU starvation):
+///
+/// 1. Four connections are parked as idle. Closing them is what pushes sqlx's
+///    semaphore over capacity, which is what lets the close barrier pass while a
+///    connection is still checked out — see `drain_sqlite_pool`.
+/// 2. The runtime is given exactly one worker thread, and that thread is
+///    occupied. Now the task sqlx spawns from `PoolConnection::drop` to return a
+///    connection to the pool provably cannot run.
+/// 3. A connection is checked out and dropped, so it is checked out — counted in
+///    `size()`, absent from `idle_conns` — for the whole of the close.
+/// 4. `close` is driven from a *different* thread, so it makes progress on its
+///    own (the sqlite worker threads wake it directly, no tokio worker needed),
+///    exactly as a binding's blocking `close()` does from the embedder's thread.
+/// 5. The worker is freed 150ms after the close begins. A close that waits for
+///    the pool to empty therefore finishes; a close that returns as soon as
+///    sqlx's does cannot have — it has already returned with the straggler open
+///    and both sidecars still on disk.
+#[test]
+fn close_waits_for_a_straggling_connection() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("straggler.db");
+    let wal = path.with_file_name("straggler.db-wal");
+    let shm = path.with_file_name("straggler.db-shm");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+
+    let db = rt.block_on(connect(&url)).expect("connect");
+    rt.block_on(db.execute(Statement::from_string(
+        DatabaseBackend::Sqlite,
+        "CREATE TABLE t (x INTEGER)",
+    )))
+    .unwrap();
+    let pool = db.get_sqlite_connection_pool().clone();
+
+    // (1) Park four idle connections.
+    rt.block_on(async {
+        let mut held = Vec::new();
+        for _ in 0..4 {
+            held.push(pool.acquire().await.unwrap());
+        }
+        drop(held);
+        for _ in 0..500 {
+            if pool.num_idle() >= 4 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    });
+    assert_eq!(
+        pool.num_idle(),
+        4,
+        "the setup needs four genuinely idle connections",
+    );
+    assert!(
+        wal.exists() && shm.exists(),
+        "WAL mode creates both sidecars"
+    );
+
+    // (2) Occupy the only worker thread.
+    let release = Arc::new(AtomicBool::new(false));
+    let occupied = Arc::new(AtomicBool::new(false));
+    {
+        let release = Arc::clone(&release);
+        let occupied = Arc::clone(&occupied);
+        rt.spawn(async move {
+            occupied.store(true, Ordering::Release);
+            while !release.load(Ordering::Acquire) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        });
+    }
+    while !occupied.load(Ordering::Acquire) {
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    // (3) Strand a checked-out connection: its return-to-pool task is queued
+    // behind the blocker.
+    rt.block_on(async {
+        let conn = pool.acquire().await.unwrap();
+        drop(conn);
+    });
+    assert_eq!(
+        pool.num_idle(),
+        3,
+        "one of the idle connections should now be stranded mid-return",
+    );
+
+    // (5) Free the worker a beat after the close starts. `is_closed()` flips at
+    // the very top of sqlx's close, so this waits for the close to be under way
+    // rather than guessing when it starts.
+    let releaser = {
+        let release = Arc::clone(&release);
+        let pool = pool.clone();
+        std::thread::spawn(move || {
+            while !pool.is_closed() {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            std::thread::sleep(Duration::from_millis(150));
+            release.store(true, Ordering::Release);
+        })
+    };
+
+    // (4) Close from a thread of its own, as a binding's blocking close does.
+    rt.block_on(cognee_database::close(&db)).expect("close");
+
+    // Sample the contract at the instant `close` returns, before anything else
+    // gets a chance to run — the assertions below must judge that moment, not a
+    // later one. Waiting to look (even long enough to join a thread) would let
+    // the straggler finish on its own and the test would pass either way.
+    let (size, wal_left, shm_left) = (pool.size(), wal.exists(), shm.exists());
+
+    // Unblock unconditionally, so an assertion failure cannot leave the runtime
+    // wedged and hide itself behind a hang.
+    release.store(true, Ordering::Release);
+    releaser.join().unwrap();
+
+    assert_eq!(
+        size, 0,
+        "close must not return while the pool still owns a connection",
+    );
+    assert!(
+        !wal_left,
+        "-wal must be gone when close returns, even when sqlx's own close returned early",
+    );
+    assert!(!shm_left, "-shm must be gone when close returns");
+}
+
+/// The other half of the same bug, and the worse half: a connection that is
+/// pushed back into the idle queue *after* sqlx's close has drained it for the
+/// last time is never closed at all. Not "closed a moment later" — never. The
+/// pool is closed, so nothing acquires from it again; `Pool::close` has finished,
+/// so nothing drains it again; the connection stays open and the sidecars stay on
+/// disk until the pool itself is dropped, which for a cached
+/// `ComponentManager` connection can be the rest of the process's life.
+///
+/// `Floating::return_to_pool` checks `is_closed()` once at its top and then calls
+/// `release()` unconditionally at the bottom, with an `after_release` hook and a
+/// `ping()` round-trip in between. A return task that passes that check just
+/// before the pool is marked closed therefore strands its connection. This test
+/// pins the ordering open with an `after_release` hook that parks in exactly that
+/// window, so the strand is constructed rather than raced — a pool built here
+/// rather than by [`connect`], because the hook is a test instrument and has no
+/// business in production options.
+#[test]
+fn close_reaps_a_connection_stranded_after_the_pool_was_closed() {
+    use std::str::FromStr;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use sea_orm::SqlxSqliteConnector;
+    use sea_orm::sqlx::sqlite::{
+        SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous,
+    };
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("stranded.db");
+    let wal = path.with_file_name("stranded.db-wal");
+    let shm = path.with_file_name("stranded.db-shm");
+
+    // `hold` parks a returning connection inside `after_release`; `parked` tells
+    // the test it is actually in there.
+    let hold = Arc::new(AtomicBool::new(false));
+    let parked = Arc::new(AtomicBool::new(false));
+
+    let db = {
+        let hold = Arc::clone(&hold);
+        let parked = Arc::clone(&parked);
+        let conn_opts =
+            SqliteConnectOptions::from_str(&format!("sqlite://{}?mode=rwc", path.display()))
+                .unwrap()
+                .journal_mode(SqliteJournalMode::Wal)
+                .synchronous(SqliteSynchronous::Full);
+
+        let pool = rt
+            .block_on(
+                SqlitePoolOptions::new()
+                    .max_connections(5)
+                    .min_connections(0)
+                    .after_release(move |_conn, _meta| {
+                        let hold = Arc::clone(&hold);
+                        let parked = Arc::clone(&parked);
+                        Box::pin(async move {
+                            if hold.load(Ordering::Acquire) {
+                                parked.store(true, Ordering::Release);
+                                while hold.load(Ordering::Acquire) {
+                                    tokio::time::sleep(Duration::from_millis(1)).await;
+                                }
+                            }
+                            Ok(true)
+                        })
+                    })
+                    .connect_with(conn_opts),
+            )
+            .expect("connect");
+        SqlxSqliteConnector::from_sqlx_sqlite_pool(pool)
+    };
+
+    rt.block_on(db.execute(Statement::from_string(
+        DatabaseBackend::Sqlite,
+        "CREATE TABLE t (x INTEGER)",
+    )))
+    .unwrap();
+    let pool = db.get_sqlite_connection_pool().clone();
+
+    // Park two idle connections, while the hook still lets releases through.
+    rt.block_on(async {
+        let mut held = Vec::new();
+        for _ in 0..2 {
+            held.push(pool.acquire().await.unwrap());
+        }
+        drop(held);
+        for _ in 0..500 {
+            if pool.num_idle() >= 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    });
+    assert!(pool.num_idle() >= 2, "the setup needs idle connections");
+    assert!(
+        wal.exists() && shm.exists(),
+        "WAL mode creates both sidecars"
+    );
+
+    // Now arm the hook and send a connection back through it. When `parked` is
+    // set, that connection has passed `return_to_pool`'s `is_closed()` check and
+    // is waiting to be released — the exact window the bug lives in.
+    hold.store(true, Ordering::Release);
+    rt.block_on(async {
+        let conn = pool.acquire().await.unwrap();
+        drop(conn);
+    });
+    for _ in 0..5_000 {
+        if parked.load(Ordering::Acquire) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    assert!(
+        parked.load(Ordering::Acquire),
+        "a returning connection should be parked inside after_release",
+    );
+
+    // Let it finish releasing once the pool is closed, so it lands in the idle
+    // queue of a pool that sqlx has already stopped draining.
+    let releaser = {
+        let hold = Arc::clone(&hold);
+        let pool = pool.clone();
+        std::thread::spawn(move || {
+            while !pool.is_closed() {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            hold.store(false, Ordering::Release);
+        })
+    };
+
+    rt.block_on(cognee_database::close(&db)).expect("close");
+    let (size, wal_left, shm_left) = (pool.size(), wal.exists(), shm.exists());
+
+    hold.store(false, Ordering::Release);
+    releaser.join().unwrap();
+
+    assert_eq!(
+        size, 0,
+        "a connection released into a closed pool must still be reaped by close",
+    );
+    assert!(!wal_left, "-wal must be gone when close returns");
+    assert!(!shm_left, "-shm must be gone when close returns");
+}


### PR DESCRIPTION
Reopens and finishes #132. Fixes the flake that blocked #139 and forced an `--admin` override.

## What was still wrong

#135 named the right mechanism (dropping an sqlx pool is not closing it) and fixed the common case with `Pool::close`. It did not close the race: `ts/__tests__/sdk_handle.test.ts` failed twice in a row on CI on 2026-08-11 (run `31501514014`), on a *different* test in the block each time.

The root cause, measured rather than guessed: **sqlx's `Pool::close` returning does not mean the pool is empty.** Instrumented under the §4 starvation recipe (one core, five spinning processes), `close()` returned with `size() == 1` in **five runs out of six**, and `-wal`/`-shm` were on disk in every one of those five:

```
[wal-probe] pre-close  size=5 num_idle=4 closed=false
[wal-probe] post-close size=1 num_idle=4 closed=true   <-- close() returned with a connection open
[wal-probe]   t=8µs size=1 wal_exists=true
[wal-probe] drained  size=0 wal_exists=false after 250ms   <-- the straggler unlinks them, later
```

Both ways it happens start from `PoolConnection::drop` *spawning* a task to return the connection instead of doing it inline, so at teardown a connection whose last query finished is typically still checked out — counted in `size()`, absent from the idle queue:

1. **`close` returns too early.** Its barrier is `semaphore.acquire(n)` for `n` in `1..=max_connections`, and the permit count is not honest. A connection releases its permit when it is *returned* to the pool (`PoolInner::release` → `release_permit`); `close` then floats each idle connection it pops with a fresh `DecrementSizeGuard`, whose `Drop` releases a permit for that same connection a second time. Closing k idle connections leaves the semaphore k permits over capacity, so `acquire(max_connections)` succeeds with a connection still checked out and the bounded loop simply runs out. The arithmetic matches the trace exactly: 4 connections, 3 idle, 10 permits → 9 free + 3 spurious = 12 ≥ 10.

2. **`close` stops watching the idle queue — and this one leaks permanently.** `Floating::return_to_pool` checks `is_closed()` once at its top, then does a `ping()` round-trip before calling `release()` unconditionally. A return task that passed that check just before the pool was marked closed pushes its connection **into the idle queue of an already-closed pool**, after `close` drained that queue for the last time. Nothing ever closes it — the connection stays open and the sidecars survive until the pool itself is dropped. Evidence at the stall: one live `sqlx-sqlite-wor` thread parked in `futex_wait`, and a spawned probe task ticking 183 times, which rules out scheduler starvation.

The §5 hypothesis (a surviving `Arc` clone of the `DatabaseConnection` outliving the services-bundle drop) is **refuted** — `size()` accounting shows the connections are pool-owned, and the stranded one is inside sqlx's own idle queue.

## The fix

One place, `cognee_database::close`, so all four bindings plus the CLI and HTTP server get it: after `close_by_ref`, **re-run `Pool::close` until `size()` reaches 0**, bounded at 2s with exponential backoff.

Re-running rather than merely waiting is the whole point — waiting fixes (1) and can never fix (2), because only another `close` looks at the idle queue again. `size()` is the right completion signal: it is decremented by `DecrementSizeGuard::drop`, which runs *after* that connection's own `close().await` returned, so `size() == 0` means every connection finished `sqlite3_close`. The uncontended teardown — every teardown on an idle machine — costs one atomic load and returns. Exhausting the 2s means an operation is genuinely still holding a connection, which teardown never promised to wait for, so it warns instead of hanging.

## Tests

Three regression tests, each **verified to fail with the drain disabled and pass with it**, and each *forcing* the ordering rather than racing for it — this whole bug is an instance of a test that only passed because the machine was fast:

| Test | Covers | How the ordering is forced |
|---|---|---|
| `connection_pool.rs::close_waits_for_a_straggling_connection` | case (1) | one worker thread, occupied, so a queued return task provably cannot run |
| `connection_pool.rs::close_reaps_a_connection_stranded_after_the_pool_was_closed` | case (2) | an `after_release` hook parks a returning connection in exactly the window between the `is_closed()` check and `release()` |
| `handle_close.rs::close_blocking_waits_for_a_straggling_connection` | case (1) via the real binding entry point | same, driven through `close_blocking` from a thread with no runtime of its own |

All three sample the sidecars **at the instant `close` returns**. An earlier draft joined a helper thread first, which gave the straggler time to finish and made the tests pass with or without the fix — worth flagging as the trap it is.

**No assertion, timeout, retry or skip was relaxed.** One test-harness change: the two off-runtime cases in `close_blocking_releases_the_sidecars_on_either_thread` used `JoinHandle::join` inline, which blocks the calling task's worker thread — and on a single core there is only one, so the test wedged the very runtime the teardown needed in order to poll sqlx's return task. They now await a signal instead, which is what a real embedder actually looks like (Node's main thread is not a runtime worker). The assertions are untouched and still instantaneous.

## Verification

All under the §4 starvation recipe (5 busy loops, pinned to one core), which reproduced **2 / 1 / 1** failures in three rounds beforehand:

| Surface | Result |
|---|---|
| `ts/__tests__/sdk_handle.test.ts` | **12 rounds, 6 passed / 6 total every round** |
| `handle_close.rs` (4 tests) | 12 rounds green, no drain timeouts (was 10 failures in 12) |
| Java lifecycle (2 checks) | 6 rounds green |
| full TS suite (in `check_all.sh`) | 209 passed, 13 skipped, 0 failed |
| C API `sdk_handle_smoke` | **ran**, `sdk sidecar release OK (cg_sdk_close + last-ref destroy)` |
| `python/tests/test_sdk_handle.py` | **19 passed** with `MOCK_EMBEDDING=true LLM_API_KEY=sk-test` |
| CLI `add` ×5 | exit 0, no leftover sidecars, zero drain warnings, stable timing |

`scripts/check_all.sh` passes.

**Which lifecycle tests actually executed, since several skip silently:** the C API smoke test ran. Python's sidecar cases *skip by default* (`SKIP_IF_NO_WARM` needs `MOCK_EMBEDDING=true` plus a non-empty key) — they skipped inside `check_all.sh`, so they were re-run explicitly with those set, and all 19 pass. The **Java lane skipped locally** (no `mvn` on this box, only a JDK), so its two lifecycle assertions were re-run as a maven-free driver against the same JNI cdylib; CI's Java lane covers the real JUnit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
