### PR TITLE
feat(llm): native AWS Bedrock provider for LLM and embeddings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ on:
   #
   #   1. Toolchain churn. The jobs here install `dtolnay/rust-toolchain@stable`,
   #      which sets RUSTUP_TOOLCHAIN and so overrides rust-toolchain.toml's
-  #      `channel = "1.91"` pin (CI really runs current stable; the MSRV job is
-  #      what covers 1.91). Every stable release therefore rotates the rustc
+  #      `channel = "1.91.1"` pin (CI really runs current stable; the MSRV job is
+  #      what covers 1.91.1). Every stable release therefore rotates the rustc
   #      component of every rust-cache key at once — observed going
   #      adf1a63c -> b33fdd40 while the dependency hash held at c4307474.
   #   2. The 7-day idle eviction. GitHub deletes any cache not *read* for a
@@ -256,7 +256,7 @@ jobs:
   # ── MSRV floor: build against the declared rust-version (T2.3) ─────────
   # rust-toolchain.toml pins the toolchain repo-wide (it takes precedence over
   # @stable), so every lane already builds on the floor; this lane additionally
-  # installs 1.91.0 explicitly so a newer-than-MSRV API is caught before release
+  # installs 1.91.1 explicitly so a newer-than-MSRV API is caught before release
   # even if the pin moves.
   # Note: 1.89 is the real floor on x86_64 — the embedded qdrant `quantization`
   # crate uses AVX-512 target features/intrinsics (avx512vl, avx512vpopcntdq,
@@ -265,7 +265,7 @@ jobs:
   # would allow 1.85 in principle. The aarch64 build never compiles the AVX-512
   # path, so this only manifests on x86_64.
   msrv:
-    name: MSRV (1.91)
+    name: MSRV (1.91.1)
     runs-on: ubuntu-latest
     # In-repo only (no `needs`, so it carries its own gate). See `lint`.
     if: >-
@@ -275,8 +275,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
-        uses: dtolnay/rust-toolchain@1.91.0
+      - name: Install Rust 1.91.1
+        uses: dtolnay/rust-toolchain@1.91.1
 
       - name: Install mold linker
         uses: rui314/setup-mold@v1
@@ -319,7 +319,7 @@ jobs:
           key: ort-v2.0.0-rc.12-cpu-linux-x86_64
 
       - name: Check (MSRV)
-        run: cargo +1.91.0 check --all-targets
+        run: cargo +1.91.1 check --all-targets
 
   # ── wasm32 Config-1 lane: logic crates compile + run on wasm32 ────────
   # The wasm smoke-test files are #![cfg(target_arch = "wasm32")], so the native
@@ -345,9 +345,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      # rust-toolchain.toml pins the repo to 1.91, and that pin takes precedence
+      # rust-toolchain.toml pins the repo to 1.91.1, and that pin takes precedence
       # over @stable — so `cargo build --target wasm32-unknown-unknown` runs under
-      # 1.91, not stable. The wasm32 std component must be on the *pinned*
+      # 1.91.1, not stable. The wasm32 std component must be on the *pinned*
       # toolchain. `rustup target add` honors the rust-toolchain.toml override
       # (exactly as scripts/check_all.sh does locally); the action's `targets:`
       # input adds it to @stable instead, which is why CI hit

--- a/.github/workflows/http-parity.yml
+++ b/.github/workflows/http-parity.yml
@@ -239,13 +239,43 @@ jobs:
       # the forget/search tests that seed via add) need a key — they run in
       # Phase-1b. Running datasets without add in the same session also keeps
       # the dataset-list assertions free of add-created pollution.
-      - name: Phase-1a — health, auth, datasets, openapi, errors, settings (no LLM)
+      - name: Phase-1a — health, auth, datasets, openapi, errors (no LLM)
         run: >-
           docker compose
           -f cognee-rust/e2e-cross-sdk/docker-compose.yml
           run --rm e2e-http-tests
           pytest -vs /harness/
-          -k "test_http_health or test_http_auth or test_http_datasets or test_http_openapi or test_http_errors or test_http_self or test_http_settings"
+          -k "test_http_health or test_http_auth or test_http_datasets or test_http_openapi or test_http_errors or test_http_self"
+          --tb=short
+
+      # ── Phase-1a-settings: /settings parity, needs a NON-EMPTY key ─────────
+      # Still unconditional (no secrets), so it keeps gating fork PRs — but it
+      # cannot share the step above, because Python's GET /api/v1/settings 500s
+      # outright when no LLM key is configured. At the pinned SHA,
+      # `LLMConfig.api_key` is a required `str` while the masking expression
+      # yields `None` for a falsy key, so `SettingsDict.model_validate` raises:
+      #
+      #   pydantic_core.ValidationError: 1 validation error for SettingsDict
+      #   llm.api_key  Input should be a valid string [input_value=None]
+      #
+      # (Fixed upstream after the pin — `api_key` is `Optional[str]` on `dev` —
+      # so this step can fold back into Phase-1a when the SHA is next bumped.)
+      #
+      # The key only has to be non-empty: these tests read server-rendered
+      # provider/model lists and never call an LLM. A deliberately fake value is
+      # used so nothing can mistake it for a live credential; both SDKs mask it
+      # in the response, and `apiKey` is in the test's ignore set regardless.
+      # Servers start fresh per `docker compose run`, so this cannot perturb the
+      # keyless assertions in the step above.
+      - name: Phase-1a — settings parity (fake key, no LLM calls)
+        env:
+          LLM_API_KEY: sk-parity-fake-key-never-used-for-calls
+        run: >-
+          docker compose
+          -f cognee-rust/e2e-cross-sdk/docker-compose.yml
+          run --rm e2e-http-tests
+          pytest -vs /harness/
+          -k "test_http_settings"
           --tb=short
 
       # ── Phase-1b: add + forget + search (needs a key — Python /add does) ───

--- a/.github/workflows/http-parity.yml
+++ b/.github/workflows/http-parity.yml
@@ -239,13 +239,13 @@ jobs:
       # the forget/search tests that seed via add) need a key — they run in
       # Phase-1b. Running datasets without add in the same session also keeps
       # the dataset-list assertions free of add-created pollution.
-      - name: Phase-1a — health, auth, datasets, openapi, errors (no LLM)
+      - name: Phase-1a — health, auth, datasets, openapi, errors, settings (no LLM)
         run: >-
           docker compose
           -f cognee-rust/e2e-cross-sdk/docker-compose.yml
           run --rm e2e-http-tests
           pytest -vs /harness/
-          -k "test_http_health or test_http_auth or test_http_datasets or test_http_openapi or test_http_errors or test_http_self"
+          -k "test_http_health or test_http_auth or test_http_datasets or test_http_openapi or test_http_errors or test_http_self or test_http_settings"
           --tb=short
 
       # ── Phase-1b: add + forget + search (needs a key — Python /add does) ───

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain (1.91 + iOS targets)
+      - name: Install Rust toolchain (1.91.1 + iOS targets)
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.91"
+          toolchain: "1.91.1"
           targets: aarch64-apple-ios,aarch64-apple-ios-sim
           components: rustfmt,clippy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ Plain unit tests that don't touch the LLM run with `cargo test`.
 
 ### MSRV & lockfiles
 
-The MSRV is **1.91**, declared via `rust-version` and pinned for local builds by
+The MSRV is **1.91.1**, declared via `rust-version` and pinned for local builds by
 `rust-toolchain.toml`. It must be stated in **every** workspace, because the three of
 them resolve independently: `[workspace.package]` in `Cargo.toml` and `capi/Cargo.toml`,
 and the `[package]` sections of `ts/cognee-ts-neon/Cargo.toml` and
@@ -92,7 +92,7 @@ below.
 (The hard floor from dependencies is lower: on x86_64 the embedded qdrant `quantization`
 crate uses AVX-512 intrinsics stabilized in Rust 1.89, and edition 2024 + resolver 3 would
 allow 1.85 in principle. The aarch64 build never compiles the AVX-512 path, so a Mac may
-build on an older toolchain while CI on x86_64 will not. 1.91 is the declared floor
+build on an older toolchain while CI on x86_64 will not. 1.91.1 is the declared floor
 regardless, and the `msrv` CI lane builds against it.)
 
 `Cargo.lock` is intentionally **not committed** (see `.gitignore`); the edition-2024
@@ -110,11 +110,11 @@ second full build of the bundled Ladybug C++ tree
 If `scripts/check_all.sh` fails with an error like
 `roaring@x.y.z requires rustc 1.92.0` (or any other "requires rustc > 1.91"), you have a
 **stale local lockfile** that pinned a version published with a higher MSRV — it is not a
-real breakage (a fresh resolve under the pinned toolchain selects a 1.91-compatible version).
+real breakage (a fresh resolve under the pinned toolchain selects a 1.91.1-compatible version).
 Recover by regenerating the lock or pinning the offending crate down, e.g.:
 
 ```bash
-# Regenerate fresh (uses the 1.91-aware resolver), or pin the specific crate:
+# Regenerate fresh (uses the 1.91.1-aware resolver), or pin the specific crate:
 cargo update                                            # whole workspace
 cargo update -p roaring@0.11.4 --precise 0.11.3         # one transitive dep
 # capi/ and bindings/ are their own workspaces — run the same from inside

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 version = "0.2.0"
-rust-version = "1.91"
+rust-version = "1.91.1"
 license = "MIT OR Apache-2.0"
 authors = ["Topoteretes <support@cognee.ai>"]
 description = "Rust port of cognee — an AI memory pipeline that turns raw data into queryable knowledge graphs."
@@ -69,7 +69,7 @@ assert_cmd = "2.0"
 async-trait = "0.1.89"
 # AWS Bedrock provider stack (cognee-llm `bedrock` feature, non-default).
 #
-# EXACT pins on purpose: the workspace pins rustc 1.91 (`rust-toolchain.toml`,
+# EXACT pins on purpose: the workspace pins rustc 1.91.1 (`rust-toolchain.toml`,
 # `rust-version` above) and every newer AWS release line requires 1.94.1. These
 # are the newest lines whose MSRV is <= 1.91.1. Do not assume `resolver = "3"`
 # handles this on its own — measured on this graph it does not (see the note on

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,34 @@ anyhow = "1"
 base64 = "0.22"
 assert_cmd = "2.0"
 async-trait = "0.1.89"
+# AWS Bedrock provider stack (cognee-llm `bedrock` feature, non-default).
+#
+# EXACT pins on purpose: the workspace pins rustc 1.91 (`rust-toolchain.toml`,
+# `rust-version` above) and every newer AWS release line requires 1.94.1. These
+# are the newest lines whose MSRV is <= 1.91.1. Do not assume `resolver = "3"`
+# handles this on its own — measured on this graph it does not (see the note on
+# the smithy pins below) — and the explicit pins also turn a future
+# `cargo update` from a confusing MSRV failure into a visible manifest change.
+# Revisit on the next toolchain bump — see
+# docs/roadmap/bedrock-provider-plan.md §3 (MSRV ceiling) and §6.9.
+#
+# aws-config keeps its DEFAULT features on purpose: the default set
+# (`default-https-client`, `rt-tokio`, `credentials-process`, `sso`) is what
+# carries the SSO leg of the boto3-equivalent credential chain (plan §1.2).
+# Do not add `default-features = false` to trim dep weight.
+aws-config = "=1.8.18"
+aws-credential-types = "=1.2.14"
+aws-sigv4 = "=1.4.5"
+aws-smithy-runtime-api = "=1.12.3"
+# Transitive smithy crates, pinned for the same reason. They are not imported
+# directly; they are declared so the pin exists at all. Cargo.lock is
+# .gitignore'd in this repo, so every clone and every CI run resolves from
+# scratch, and `resolver = "3"`'s MSRV-aware selection does NOT rescue these:
+# verified by deleting Cargo.lock and re-resolving, which picks
+# aws-smithy-async 1.3.0 / aws-smithy-types 1.6.2 and fails with
+# "rustc 1.91.1 is not supported".
+aws-smithy-async = "=1.2.14"
+aws-smithy-types = "=1.5.0"
 calamine = "0.34"
 csv = "1.3"
 clap = "4.5"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ feedback, **`forget`** what's stale.
 ### Prerequisites
 
 - **Rust toolchain** — install [rustup](https://rustup.rs); the repo's pinned
-  toolchain (Rust 1.91, declared in `rust-toolchain.toml`) is selected
-  automatically. The workspace is edition 2024 / resolver 3; MSRV is 1.91.
+  toolchain (Rust 1.91.1, declared in `rust-toolchain.toml`) is selected
+  automatically. The workspace is edition 2024 / resolver 3; MSRV is 1.91.1.
 - An **LLM API key** (OpenAI-compatible). 
 
 Build the CLI from source with Cargo. 

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 version = "0.2.0"
-rust-version = "1.91"
+rust-version = "1.91.1"
 license = "MIT OR Apache-2.0"
 authors = ["Topoteretes <support@cognee.ai>"]
 description = "C API bindings for the cognee Rust SDK — AI memory pipeline (add → cognify → search)."

--- a/capi/cognee-capi/Cargo.toml
+++ b/capi/cognee-capi/Cargo.toml
@@ -32,6 +32,7 @@ default = [
     "ladybug",
     "lancedb",
     "onnx",
+    "bedrock",
     "hf-tokenizer",
     "tiktoken",
     "sqlite",
@@ -51,6 +52,7 @@ visualization = ["cognee/visualization",         "cognee-bindings-common/visuali
 ladybug       = ["cognee/ladybug",               "cognee-bindings-common/ladybug"]
 lancedb       = ["cognee/lancedb",               "cognee-bindings-common/lancedb"]
 onnx          = ["cognee/onnx",                  "cognee-bindings-common/onnx"]
+bedrock       = ["cognee/bedrock",               "cognee-bindings-common/bedrock"]
 hf-tokenizer  = ["cognee/hf-tokenizer",          "cognee-bindings-common/hf-tokenizer"]
 tiktoken      = ["cognee/tiktoken",               "cognee-bindings-common/tiktoken"]
 sqlite        = ["cognee/sqlite",                "cognee-bindings-common/sqlite"]

--- a/crates/bindings-common/Cargo.toml
+++ b/crates/bindings-common/Cargo.toml
@@ -31,6 +31,7 @@ default = [
     "ladybug",
     "lancedb",
     "onnx",
+    "bedrock",
     "hf-tokenizer",
     "tiktoken",
     "sqlite",
@@ -40,6 +41,7 @@ visualization = ["cognee/visualization"]
 ladybug       = ["cognee/ladybug"]
 lancedb       = ["cognee/lancedb"]
 onnx          = ["cognee/onnx"]
+bedrock       = ["cognee/bedrock"]
 hf-tokenizer  = ["cognee/hf-tokenizer"]
 tiktoken      = ["cognee/tiktoken"]
 sqlite        = ["cognee/sqlite"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -39,6 +39,7 @@ default = [
     "unstructured",
     "visualization",
     "mock-llm",
+    "bedrock",
     "bench",
     # decision 1: telemetry is ON by default in cognee-cli. Disable with
     # --no-default-features for compile-time opt-out.
@@ -69,6 +70,10 @@ hf-tokenizer  = ["cognee/hf-tokenizer"]
 tiktoken      = ["cognee/tiktoken"]
 telemetry     = ["cognee/telemetry"]
 visualization = ["cognee/visualization"]
+# AWS Bedrock LLM adapter + embedding engine (plan §2.3, §6.2). Default-on. This
+# crate declares its own `default` list and reaches every backend through the
+# `cognee` facade, so a single forward is enough.
+bedrock       = ["cognee/bedrock"]
 
 # Document format loaders (forwarded through cognee)
 pdf-pdfium        = ["cognee/pdf-pdfium"]

--- a/crates/components/Cargo.toml
+++ b/crates/components/Cargo.toml
@@ -35,6 +35,12 @@ pgvector     = ["cognee-vector/pgvector", "dep:url"]
 pggraph      = ["cognee-graph/postgres", "dep:url"]
 # Record/replay cassette-based mock LLM (MOCK_LLM / COGNEE_RECORD_LLM).
 mock-llm     = ["cognee-llm/mock"]
+# AWS Bedrock provider. Non-default for now: R5 adds the LLM factory, its
+# registration and the default-on wiring (plan §2.3, §6.8). Turning it on here
+# only makes the embedding side reachable — the `aws` carry-across in
+# `builtins::embedding::build_embedding_config` and `cognee-embedding`'s
+# Bedrock engine.
+bedrock      = ["cognee-embedding/bedrock", "cognee-llm/bedrock"]
 # Enables the in-memory `mock` vector and graph providers in `with_builtins()`.
 testing      = ["cognee-vector/testing", "cognee-graph/testing"]
 

--- a/crates/components/Cargo.toml
+++ b/crates/components/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 # (cognee, cognee-http-server) depend with `default-features = false` and
 # forward exactly the features they want, so `--no-default-features` builds
 # stay precise.
-default = ["onnx", "ladybug", "lancedb", "pgvector", "pggraph", "mock-llm"]
+default = ["onnx", "ladybug", "lancedb", "pgvector", "pggraph", "mock-llm", "bedrock"]
 
 onnx         = ["cognee-embedding/onnx"]
 onnx-dynamic = ["onnx", "cognee-embedding/onnx-dynamic"]
@@ -35,11 +35,12 @@ pgvector     = ["cognee-vector/pgvector", "dep:url"]
 pggraph      = ["cognee-graph/postgres", "dep:url"]
 # Record/replay cassette-based mock LLM (MOCK_LLM / COGNEE_RECORD_LLM).
 mock-llm     = ["cognee-llm/mock"]
-# AWS Bedrock provider. Non-default for now: R5 adds the LLM factory, its
-# registration and the default-on wiring (plan §2.3, §6.8). Turning it on here
-# only makes the embedding side reachable — the `aws` carry-across in
-# `builtins::embedding::build_embedding_config` and `cognee-embedding`'s
-# Bedrock engine.
+# AWS Bedrock provider. Default-on (plan §2.3, §6.2): it registers the
+# `bedrock` LLM factory in `with_builtins()` (`builtins::llm::BedrockLlmFactory`,
+# the Converse adapter) *and* the embedding side — the `aws` carry-across in
+# `builtins::embedding::build_embedding_config` plus `cognee-embedding`'s
+# Bedrock engine. Drop it with `--no-default-features` the same way `lancedb` is
+# dropped; `LLM_PROVIDER=bedrock` then reports an unsupported provider.
 bedrock      = ["cognee-embedding/bedrock", "cognee-llm/bedrock"]
 # Enables the in-memory `mock` vector and graph providers in `with_builtins()`.
 testing      = ["cognee-vector/testing", "cognee-graph/testing"]

--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -129,6 +129,7 @@ mod tests {
                 onnx_dimensions: 384,
                 onnx_max_sequence_length: 512,
                 onnx_batch_size: 32,
+                aws: crate::context::AwsInputs::default(),
             },
             llm: crate::context::LlmInputs {
                 provider: "openai".to_string(),
@@ -144,6 +145,7 @@ mod tests {
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),
+                aws: crate::context::AwsInputs::default(),
             },
         }
     }

--- a/crates/components/src/builtins/embedding.rs
+++ b/crates/components/src/builtins/embedding.rs
@@ -66,6 +66,11 @@ fn parse_embedding_provider(provider: &str) -> Option<EmbeddingProvider> {
         "openai" => Some(EmbeddingProvider::OpenAi),
         "openai_compatible" => Some(EmbeddingProvider::OpenAiCompatible),
         "ollama" => Some(EmbeddingProvider::Ollama),
+        // Ungated on purpose: the id is a recognised backend regardless of the
+        // build's features, so `EMBEDDING_PROVIDER=bedrock` is never rejected
+        // here as a typo. A build without `cognee-embedding/bedrock` gives the
+        // honest error later, from `create_engine`'s `NotImplemented` arm.
+        "bedrock" => Some(EmbeddingProvider::Bedrock),
         "mock" => Some(EmbeddingProvider::Mock),
         _ => None,
     }
@@ -116,6 +121,16 @@ pub fn build_embedding_config(inputs: &EmbeddingInputs) -> EmbeddingConfig {
     config.mock = inputs.mock;
     config.mock_mode = mock_mode;
     config.huggingface_tokenizer = inputs.huggingface_tokenizer.clone();
+    // Same feature-unification caveat as `onnx` above, with a benign
+    // degradation: when `cognee-embedding/bedrock` is unified on while *this*
+    // crate's `bedrock` feature is off, the field exists but stays `Default` —
+    // which resolves region, credentials and endpoint entirely from the ambient
+    // environment. That is exactly Python's embedding-path behaviour (plan
+    // §1.5), so the only thing lost is an explicitly caller-supplied override.
+    #[cfg(feature = "bedrock")]
+    {
+        config.aws = (&inputs.aws).into();
+    }
     #[cfg(feature = "onnx")]
     {
         config.onnx = cognee_embedding::OnnxEmbeddingConfig {
@@ -151,7 +166,7 @@ impl EmbeddingFactory for DefaultEmbeddingFactory {
         {
             return Err(ComponentError::EmbeddingEngine(format!(
                 "unknown embedding provider '{provider}'. Supported: onnx, fastembed, \
-                 openai, openai_compatible, ollama, mock."
+                 openai, openai_compatible, ollama, bedrock, mock."
             )));
         }
         let config = build_embedding_config(&ctx.embedding);
@@ -173,10 +188,16 @@ mod tests {
             "openai",
             "openai_compatible",
             "ollama",
+            "bedrock",
             "mock",
         ] {
             assert!(parse_embedding_provider(id).is_some(), "'{id}' must parse");
         }
+        assert_eq!(
+            parse_embedding_provider("  BEDROCK "),
+            Some(EmbeddingProvider::Bedrock),
+            "trimmed and case-insensitive, like every other id",
+        );
         assert!(
             parse_embedding_provider("OpenAI").is_some(),
             "case-insensitive"
@@ -230,5 +251,40 @@ mod tests {
             build_embedding_config(&inputs("ollama", false)).provider,
             EmbeddingProvider::Ollama
         );
+        assert_eq!(
+            build_embedding_config(&inputs("bedrock", false)).provider,
+            EmbeddingProvider::Bedrock
+        );
+    }
+
+    /// The carry-across in `build_embedding_config`: without it the Bedrock
+    /// engine silently resolves everything from the ambient environment and an
+    /// explicitly supplied credential is dropped.
+    #[test]
+    #[cfg(feature = "bedrock")]
+    fn aws_inputs_are_carried_into_the_embedding_config() {
+        let mut inputs = inputs("bedrock", false);
+        inputs.aws = crate::context::AwsInputs {
+            region: Some("eu-central-1".to_string()),
+            access_key_id: Some("AKIDEXAMPLE".to_string()),
+            secret_access_key: Some("secret".to_string()),
+            profile_name: Some("cognee".to_string()),
+            bedrock_runtime_endpoint: Some("https://vpce.example".to_string()),
+            bearer_token: Some("bedrock-api-key".to_string()),
+            ..Default::default()
+        };
+
+        let config = build_embedding_config(&inputs);
+
+        let expected: cognee_llm::adapters::bedrock::aws::env::AwsInputs = (&inputs.aws).into();
+        assert_eq!(config.aws, expected);
+        assert_eq!(config.aws.region.as_deref(), Some("eu-central-1"));
+        assert_eq!(config.aws.access_key_id.as_deref(), Some("AKIDEXAMPLE"));
+        assert_eq!(config.aws.profile_name.as_deref(), Some("cognee"));
+        assert_eq!(
+            config.aws.bedrock_runtime_endpoint.as_deref(),
+            Some("https://vpce.example")
+        );
+        assert_eq!(config.aws.bearer_token.as_deref(), Some("bedrock-api-key"));
     }
 }

--- a/crates/components/src/builtins/embedding.rs
+++ b/crates/components/src/builtins/embedding.rs
@@ -210,6 +210,7 @@ mod tests {
             onnx_dimensions: 384,
             onnx_max_sequence_length: 512,
             onnx_batch_size: 32,
+            aws: crate::context::AwsInputs::default(),
         }
     }
 

--- a/crates/components/src/builtins/llm.rs
+++ b/crates/components/src/builtins/llm.rs
@@ -196,6 +196,69 @@ impl LlmFactory for AzureLlmFactory {
     }
 }
 
+/// Provider id served by [`BedrockLlmFactory`].
+#[cfg(feature = "bedrock")]
+pub const BEDROCK_PROVIDER: &str = "bedrock";
+
+/// Built-in factory for the native AWS Bedrock **Converse** adapter (plan §4 R5).
+///
+/// Bedrock is neither OpenAI-compatible nor Anthropic-Messages-compatible: it
+/// carries its own request shape, its own auth (SigV4 or a Bedrock API key) and
+/// its own region/endpoint resolution, all of which live in
+/// [`cognee_llm::adapters::BedrockAdapter`] behind the `bedrock` feature.
+#[cfg(feature = "bedrock")]
+pub struct BedrockLlmFactory;
+
+#[cfg(feature = "bedrock")]
+#[async_trait]
+impl LlmFactory for BedrockLlmFactory {
+    fn provider(&self) -> &str {
+        BEDROCK_PROVIDER
+    }
+
+    async fn build(&self, ctx: &BackendBuildContext) -> Result<Arc<dyn Llm>, ComponentError> {
+        // Deliberately NO API-key requirement, unlike the Anthropic factory
+        // above. Bedrock is absent from Python's `_API_KEY_REQUIRED_PROVIDERS`
+        // (`get_llm_client.py:98`) and listed in `_NO_API_KEY_PROVIDERS`
+        // (`get_native_client.py:20`) — the exemption holds on both framework
+        // paths (plan §1.1). An empty `LLM_API_KEY` is the *normal* IAM
+        // configuration: it must fall through to the SigV4 credential ladder
+        // rather than error.
+        let api_key = Some(ctx.llm.api_key.trim()).filter(|key| !key.is_empty());
+
+        // The single crossing point to the adapter-side struct; see
+        // `crate::context::AwsInputs`.
+        let aws: cognee_llm::adapters::bedrock::aws::env::AwsInputs = (&ctx.llm.aws).into();
+
+        // `api_base = None` on purpose: never pass `ctx.llm.endpoint`, which
+        // aliases OPENAI_URL (the same trap `anthropic_base_url` exists to
+        // avoid — see the Anthropic factory above). The Bedrock runtime
+        // endpoint travels via `AWS_BEDROCK_RUNTIME_ENDPOINT` on
+        // `ctx.llm.aws.bedrock_runtime_endpoint` and the plan's §1.3 chain
+        // inside the adapter.
+        let adapter =
+            cognee_llm::adapters::BedrockAdapter::new(ctx.llm.model.clone(), api_key, None, &aws)
+                .await
+                .map_err(|e| ComponentError::Llm(e.to_string()))?
+                .with_structured_output_retries(ctx.llm.max_retries)
+                .with_network_retries(ctx.llm.max_retries)
+                .with_max_completion_tokens(ctx.llm.max_completion_tokens)
+                .with_extra_args(ctx.llm.llm_args.clone());
+        Ok(Arc::new(adapter))
+    }
+
+    async fn build_transcriber(
+        &self,
+        _ctx: &BackendBuildContext,
+    ) -> Result<Option<Arc<dyn Transcriber>>, ComponentError> {
+        // Bedrock has no Whisper equivalent (plan §6.4): Python's
+        // `BedrockAdapter.create_transcript` raises NotImplementedError, so
+        // audio degrades gracefully to None here, matching the
+        // anthropic/ollama/gemini/mistral factories.
+        Ok(None)
+    }
+}
+
 // ── Cross-cutting mock / record helpers ───────────────────────────────────
 //
 // These are applied uniformly by `ComponentRegistry::build_llm` regardless of

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -229,6 +229,49 @@ impl fmt::Debug for AwsInputs {
     }
 }
 
+/// The field-for-field conversion to the adapter-side struct.
+///
+/// The two declarations are a deliberately mirrored pair (see [`AwsInputs`]):
+/// this module stays feature-free so every consumer can carry the inputs, while
+/// `cognee_llm::adapters::bedrock::aws::env::AwsInputs` — the one the
+/// credential/region/endpoint chains actually resolve — lives behind the
+/// `bedrock` feature. This impl is the single crossing point between them, and
+/// it is exhaustive on purpose: adding a field on either side without the other
+/// breaks the build here rather than silently dropping a credential.
+#[cfg(feature = "bedrock")]
+impl From<&AwsInputs> for cognee_llm::adapters::bedrock::aws::env::AwsInputs {
+    fn from(inputs: &AwsInputs) -> Self {
+        let AwsInputs {
+            region,
+            access_key_id,
+            secret_access_key,
+            session_token,
+            profile_name,
+            role_name,
+            session_name,
+            web_identity_token,
+            sts_endpoint,
+            external_id,
+            bedrock_runtime_endpoint,
+            bearer_token,
+        } = inputs;
+        Self {
+            region: region.clone(),
+            access_key_id: access_key_id.clone(),
+            secret_access_key: secret_access_key.clone(),
+            session_token: session_token.clone(),
+            profile_name: profile_name.clone(),
+            role_name: role_name.clone(),
+            session_name: session_name.clone(),
+            web_identity_token: web_identity_token.clone(),
+            sts_endpoint: sts_endpoint.clone(),
+            external_id: external_id.clone(),
+            bedrock_runtime_endpoint: bedrock_runtime_endpoint.clone(),
+            bearer_token: bearer_token.clone(),
+        }
+    }
+}
+
 /// `"set"` / `"unset"`, so a secret's presence can be debugged without the
 /// secret itself reaching a log line.
 fn shown(value: &Option<String>) -> &'static str {

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -9,6 +9,7 @@
 //! provider-specific URL assembly where the field differences live and lets
 //! each caller opt into mock / recording behavior explicitly.
 
+use std::fmt;
 use std::path::PathBuf;
 
 /// Resolved inputs consumed by [`crate::ComponentRegistry`] and the free
@@ -60,7 +61,7 @@ pub struct BackendBuildContext {
 
 /// Resolved embedding-engine inputs. Mapped to a `cognee_embedding::EmbeddingConfig`
 /// by [`crate::build_embedding_config`].
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct EmbeddingInputs {
     /// Lowercase provider string. An empty value defaults to `onnx`; a
     /// non-empty *unrecognized* value is rejected as a misconfiguration by the
@@ -90,10 +91,15 @@ pub struct EmbeddingInputs {
     pub onnx_dimensions: usize,
     pub onnx_max_sequence_length: usize,
     pub onnx_batch_size: usize,
+
+    /// Resolved AWS inputs for the Bedrock embedding engine. Env-only, filled
+    /// by [`aws_inputs_from_env`] at both lowering sites; ignored by every
+    /// other provider.
+    pub aws: AwsInputs,
 }
 
 /// Resolved LLM / transcriber inputs.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct LlmInputs {
     /// Lowercase provider string (`openai` | `ollama` | `mistral` | `gemini` |
     /// `custom` | `openai_compatible` | `mock` | closed providers).
@@ -137,6 +143,143 @@ pub struct LlmInputs {
     pub cassette: String,
     /// When non-empty, wraps the real adapter in a recorder (`mock-llm`).
     pub record_path: String,
+
+    /// Resolved AWS inputs for the Bedrock adapter. Env-only, filled by
+    /// [`aws_inputs_from_env`] at both lowering sites; ignored by every other
+    /// provider.
+    pub aws: AwsInputs,
+}
+
+/// Caller-supplied AWS parameters for the Bedrock LLM adapter and embedding
+/// engine, resolved from the environment when a config is lowered into a
+/// [`BackendBuildContext`].
+///
+/// Deliberately mirrors `cognee_llm::adapters::bedrock::aws::env::AwsInputs`
+/// field-for-field: that struct lives behind the `bedrock` feature (see
+/// `crates/llm/src/adapters/mod.rs`) while this module stays feature-free, so
+/// the two are a mirrored pair rather than a re-export, and the field-for-field
+/// conversion between them lives on the consumer side. **The two declarations
+/// must move together** — adding, renaming or reordering a field here without
+/// doing the same there breaks that conversion.
+///
+/// Follows the [`anthropic_base_url_from_env`] precedent: env-only, carried on
+/// [`LlmInputs`] / [`EmbeddingInputs`], and **not** a `Settings` field — Python
+/// resolves these from the environment and never threads them through its LLM
+/// config.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct AwsInputs {
+    /// An explicitly caller-supplied region **only** — deliberately never
+    /// backfilled from `AWS_REGION_NAME` / `AWS_REGION` by
+    /// [`aws_inputs_from_env`].
+    ///
+    /// The plan's §1.3 chain is: this parameter → the region embedded in a
+    /// model ARN → `AWS_REGION_NAME` → `AWS_REGION` → the ambient profile chain
+    /// → the hard default `us-west-2`, and it is implemented by
+    /// `cognee_llm::adapters::bedrock::aws::region::resolve_region_without_ambient`.
+    /// Filling this field from the environment here would make the first rung
+    /// always populated and silently push the model-ARN region below the env
+    /// vars, inverting Python's precedence for every ARN model id. Nothing sets
+    /// it today; it is kept for shape parity with the adapter-side struct and
+    /// for a future explicit override.
+    pub region: Option<String>,
+    /// `aws_access_key_id` ← `AWS_ACCESS_KEY_ID`.
+    pub access_key_id: Option<String>,
+    /// `aws_secret_access_key` ← `AWS_SECRET_ACCESS_KEY`.
+    pub secret_access_key: Option<String>,
+    /// `aws_session_token` ← `AWS_SESSION_TOKEN`.
+    pub session_token: Option<String>,
+    /// `aws_profile_name` ← `AWS_PROFILE_NAME` (**not** `AWS_PROFILE`).
+    pub profile_name: Option<String>,
+    /// `aws_role_name` ← `AWS_ROLE_NAME` — an IAM role ARN to assume.
+    pub role_name: Option<String>,
+    /// `aws_session_name` ← `AWS_SESSION_NAME` — STS session name.
+    pub session_name: Option<String>,
+    /// `aws_web_identity_token` ← `AWS_WEB_IDENTITY_TOKEN`.
+    pub web_identity_token: Option<String>,
+    /// `aws_sts_endpoint` ← `AWS_STS_ENDPOINT`.
+    pub sts_endpoint: Option<String>,
+    /// `aws_external_id` ← `AWS_EXTERNAL_ID`.
+    pub external_id: Option<String>,
+    /// `aws_bedrock_runtime_endpoint` ← `AWS_BEDROCK_RUNTIME_ENDPOINT`.
+    pub bedrock_runtime_endpoint: Option<String>,
+    /// Bedrock API-key bearer token ← `AWS_BEARER_TOKEN_BEDROCK`.
+    pub bearer_token: Option<String>,
+}
+
+/// Hand-written (never derived) so credentials cannot reach a log line: the
+/// sibling input structs on [`BackendBuildContext`] are routinely rendered with
+/// `{:?}` in build-failure diagnostics. Mirrors the redaction of
+/// `cognee_llm::adapters::bedrock::aws::env::AwsInputs`.
+impl fmt::Debug for AwsInputs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AwsInputs")
+            .field("region", &self.region)
+            .field("access_key_id", &shown(&self.access_key_id))
+            .field("secret_access_key", &shown(&self.secret_access_key))
+            .field("session_token", &shown(&self.session_token))
+            .field("profile_name", &self.profile_name)
+            .field("role_name", &self.role_name)
+            .field("session_name", &self.session_name)
+            .field("web_identity_token", &shown(&self.web_identity_token))
+            .field("sts_endpoint", &self.sts_endpoint)
+            .field("external_id", &self.external_id)
+            .field("bedrock_runtime_endpoint", &self.bedrock_runtime_endpoint)
+            .field("bearer_token", &shown(&self.bearer_token))
+            .finish()
+    }
+}
+
+/// `"set"` / `"unset"`, so a secret's presence can be debugged without the
+/// secret itself reaching a log line.
+fn shown(value: &Option<String>) -> &'static str {
+    if value.is_some() { "set" } else { "unset" }
+}
+
+/// Read the Bedrock/AWS knobs from the environment.
+///
+/// The names are litellm's `params_to_check` uppercase set
+/// (`base_aws_llm.py::get_credentials`) plus the endpoint and bearer-token
+/// variables — several are not the ones a reader guesses, notably
+/// `AWS_PROFILE_NAME` (**not** the boto3-standard `AWS_PROFILE`). Every value
+/// is trimmed and an empty (or all-whitespace) value is treated as unset, so an
+/// exported-but-empty variable cannot select a code path with an unusable
+/// value.
+///
+/// [`AwsInputs::region`] is deliberately left `None` — see that field's docs.
+///
+/// Lives here — the env-read boundary for [`LlmInputs`] / [`EmbeddingInputs`] —
+/// so both the SDK `Settings` and the standalone HTTP server resolve these
+/// knobs identically when lowering their config into a
+/// [`BackendBuildContext`].
+pub fn aws_inputs_from_env() -> AwsInputs {
+    aws_inputs_from(|key| std::env::var(key).ok())
+}
+
+/// [`aws_inputs_from_env`] over an injectable lookup, so the name mapping is
+/// testable without mutating shared process state (the workspace test runner is
+/// parallel, and `std::env::set_var` is `unsafe` in edition 2024).
+fn aws_inputs_from(lookup: impl Fn(&str) -> Option<String>) -> AwsInputs {
+    let read = |key: &str| {
+        lookup(key)
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    };
+
+    AwsInputs {
+        // No env leg on purpose — see the field docs (plan §1.3 / `region.rs`).
+        region: None,
+        access_key_id: read("AWS_ACCESS_KEY_ID"),
+        secret_access_key: read("AWS_SECRET_ACCESS_KEY"),
+        session_token: read("AWS_SESSION_TOKEN"),
+        profile_name: read("AWS_PROFILE_NAME"),
+        role_name: read("AWS_ROLE_NAME"),
+        session_name: read("AWS_SESSION_NAME"),
+        web_identity_token: read("AWS_WEB_IDENTITY_TOKEN"),
+        sts_endpoint: read("AWS_STS_ENDPOINT"),
+        external_id: read("AWS_EXTERNAL_ID"),
+        bedrock_runtime_endpoint: read("AWS_BEDROCK_RUNTIME_ENDPOINT"),
+        bearer_token: read("AWS_BEARER_TOKEN_BEDROCK"),
+    }
 }
 
 /// Read the optional Anthropic base-URL override from the environment
@@ -172,7 +315,7 @@ pub fn parse_reasoning_override(value: &str) -> Option<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_reasoning_override;
+    use super::{AwsInputs, aws_inputs_from, parse_reasoning_override};
 
     #[test]
     fn parse_reasoning_override_maps_known_tokens() {
@@ -186,5 +329,196 @@ mod tests {
         for auto in ["auto", "", "   ", "maybe", "yes"] {
             assert_eq!(parse_reasoning_override(auto), None, "{auto:?}");
         }
+    }
+
+    /// A fake environment: every key not listed is unset.
+    fn env_of(pairs: &[(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> + use<> {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |key: &str| {
+            owned
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.to_string())
+        }
+    }
+
+    /// One row of [`FIELDS`]: an env-var name and the accessor for the field it
+    /// must land in.
+    type FieldRow = (&'static str, fn(&AwsInputs) -> Option<&str>);
+
+    /// Every field paired with the **exact** variable it must be read from.
+    /// `AWS_PROFILE_NAME` (not `AWS_PROFILE`) and the other non-obvious litellm
+    /// names are the whole point of this table.
+    const FIELDS: &[FieldRow] = &[
+        ("AWS_ACCESS_KEY_ID", |i| i.access_key_id.as_deref()),
+        ("AWS_SECRET_ACCESS_KEY", |i| i.secret_access_key.as_deref()),
+        ("AWS_SESSION_TOKEN", |i| i.session_token.as_deref()),
+        ("AWS_PROFILE_NAME", |i| i.profile_name.as_deref()),
+        ("AWS_ROLE_NAME", |i| i.role_name.as_deref()),
+        ("AWS_SESSION_NAME", |i| i.session_name.as_deref()),
+        ("AWS_WEB_IDENTITY_TOKEN", |i| {
+            i.web_identity_token.as_deref()
+        }),
+        ("AWS_STS_ENDPOINT", |i| i.sts_endpoint.as_deref()),
+        ("AWS_EXTERNAL_ID", |i| i.external_id.as_deref()),
+        ("AWS_BEDROCK_RUNTIME_ENDPOINT", |i| {
+            i.bedrock_runtime_endpoint.as_deref()
+        }),
+        ("AWS_BEARER_TOKEN_BEDROCK", |i| i.bearer_token.as_deref()),
+    ];
+
+    #[test]
+    fn each_field_reads_exactly_its_own_env_var() {
+        for (var, get) in FIELDS {
+            // Only this one variable is set, so a field reading the wrong name
+            // (e.g. `AWS_PROFILE` for `profile_name`) stays `None` and fails.
+            let inputs = aws_inputs_from(env_of(&[(var, "value-for-this-var")]));
+
+            assert_eq!(
+                get(&inputs),
+                Some("value-for-this-var"),
+                "{var} must populate its field"
+            );
+            for (other, other_get) in FIELDS {
+                if other != var {
+                    assert_eq!(
+                        other_get(&inputs),
+                        None,
+                        "{var} must not also populate the {other} field"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Guards [`FIELDS`] against drifting behind the struct: the exhaustive
+    /// destructuring is `E0027` the moment a field is added to [`AwsInputs`],
+    /// and a field with no row in the table stays `None` and fails here — so a
+    /// newly mirrored field cannot slip in untested.
+    #[test]
+    fn every_field_except_region_has_a_row_in_the_table() {
+        let pairs: Vec<(&'static str, &'static str)> =
+            FIELDS.iter().map(|(var, _)| (*var, "covered")).collect();
+        let AwsInputs {
+            region,
+            access_key_id,
+            secret_access_key,
+            session_token,
+            profile_name,
+            role_name,
+            session_name,
+            web_identity_token,
+            sts_endpoint,
+            external_id,
+            bedrock_runtime_endpoint,
+            bearer_token,
+        } = aws_inputs_from(env_of(&pairs));
+
+        assert_eq!(
+            region, None,
+            "region has no env leg — see `region_is_never_read_from_the_environment`"
+        );
+        for (name, value) in [
+            ("access_key_id", access_key_id),
+            ("secret_access_key", secret_access_key),
+            ("session_token", session_token),
+            ("profile_name", profile_name),
+            ("role_name", role_name),
+            ("session_name", session_name),
+            ("web_identity_token", web_identity_token),
+            ("sts_endpoint", sts_endpoint),
+            ("external_id", external_id),
+            ("bedrock_runtime_endpoint", bedrock_runtime_endpoint),
+            ("bearer_token", bearer_token),
+        ] {
+            assert_eq!(
+                value.as_deref(),
+                Some("covered"),
+                "{name} is not covered by FIELDS"
+            );
+        }
+    }
+
+    #[test]
+    fn values_are_trimmed() {
+        let pairs: Vec<(&'static str, &'static str)> = FIELDS
+            .iter()
+            .map(|(var, _)| (*var, "  us-east-1  "))
+            .collect();
+        let inputs = aws_inputs_from(env_of(&pairs));
+
+        for (var, get) in FIELDS {
+            assert_eq!(get(&inputs), Some("us-east-1"), "{var} must be trimmed");
+        }
+    }
+
+    #[test]
+    fn exported_but_empty_values_are_unset() {
+        for blank in ["", "   ", "\t\n"] {
+            let pairs: Vec<(&'static str, &'static str)> =
+                FIELDS.iter().map(|(var, _)| (*var, blank)).collect();
+            let inputs = aws_inputs_from(env_of(&pairs));
+
+            assert_eq!(
+                inputs,
+                AwsInputs::default(),
+                "{blank:?} must read as unset, not Some(\"\")"
+            );
+        }
+    }
+
+    #[test]
+    fn an_empty_environment_yields_the_default() {
+        assert_eq!(aws_inputs_from(|_: &str| None), AwsInputs::default());
+    }
+
+    /// Plan §1.3: the region chain is caller parameter → model-ARN region →
+    /// `AWS_REGION_NAME` → `AWS_REGION` → ambient profile → `us-west-2`, and it
+    /// is owned by `cognee_llm::adapters::bedrock::aws::region`. Backfilling
+    /// `region` here would occupy the first rung and silently push the model-ARN
+    /// region below the env vars, so this must stay `None`.
+    #[test]
+    fn region_is_never_read_from_the_environment() {
+        let inputs = aws_inputs_from(env_of(&[
+            ("AWS_REGION_NAME", "eu-central-1"),
+            ("AWS_REGION", "ap-south-1"),
+            ("AWS_DEFAULT_REGION", "sa-east-1"),
+        ]));
+
+        assert_eq!(inputs.region, None);
+        assert_eq!(inputs, AwsInputs::default());
+    }
+
+    #[test]
+    fn debug_redacts_secret_material() {
+        let inputs = AwsInputs {
+            access_key_id: Some("AKIA_VISIBLE".to_string()),
+            secret_access_key: Some("super-secret".to_string()),
+            session_token: Some("session-secret".to_string()),
+            web_identity_token: Some("jwt-secret".to_string()),
+            bearer_token: Some("bearer-secret".to_string()),
+            profile_name: Some("dev".to_string()),
+            ..AwsInputs::default()
+        };
+
+        let rendered = format!("{inputs:?}");
+
+        for secret in [
+            "AKIA_VISIBLE",
+            "super-secret",
+            "session-secret",
+            "jwt-secret",
+            "bearer-secret",
+        ] {
+            assert!(!rendered.contains(secret), "{secret} leaked: {rendered}");
+        }
+        assert!(rendered.contains("secret_access_key: \"set\""));
+        assert!(
+            rendered.contains("profile_name: Some(\"dev\")"),
+            "non-secret fields stay readable: {rendered}"
+        );
     }
 }

--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -36,8 +36,8 @@ mod traits;
 pub use builtins::embedding::{OnnxAssetDefaults, onnx_asset_defaults};
 pub use builtins::{build_database, build_embedding_config, build_storage};
 pub use context::{
-    BackendBuildContext, EmbeddingInputs, LlmInputs, anthropic_base_url_from_env,
-    parse_reasoning_override,
+    AwsInputs, BackendBuildContext, EmbeddingInputs, LlmInputs, anthropic_base_url_from_env,
+    aws_inputs_from_env, parse_reasoning_override,
 };
 pub use error::ComponentError;
 pub use registry::ComponentRegistry;

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -423,6 +423,7 @@ mod tests {
                 onnx_dimensions: 384,
                 onnx_max_sequence_length: 512,
                 onnx_batch_size: 32,
+                aws: crate::context::AwsInputs::default(),
             },
             llm: crate::context::LlmInputs {
                 provider: "openai".to_string(),
@@ -438,6 +439,7 @@ mod tests {
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),
+                aws: crate::context::AwsInputs::default(),
             },
         }
     }

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -99,6 +99,11 @@ impl ComponentRegistry {
         reg.register_llm(Arc::new(llm::AnthropicLlmFactory));
         // Azure OpenAI: OpenAI-compatible wire, but api-key auth + api-version.
         reg.register_llm(Arc::new(llm::AzureLlmFactory));
+        // AWS Bedrock Converse. Feature-gated because the AWS stack (aws-config
+        // + aws-sigv4) is not free; this registration is the point at which
+        // `LLM_PROVIDER=bedrock` works end to end.
+        #[cfg(feature = "bedrock")]
+        reg.register_llm(Arc::new(llm::BedrockLlmFactory));
 
         reg
     }
@@ -273,6 +278,14 @@ fn unsupported_msg(field: &str, provider: &str, supported: &[String]) -> String 
             "mock" => " Rebuild with the `testing` crate feature to enable it.",
             _ => "",
         },
+        "llm_provider" => match p.as_str() {
+            // The only feature-gated built-in LLM provider: without `bedrock`
+            // the factory is not registered at all, so LLM_PROVIDER=bedrock
+            // lands here and must read as a build-configuration problem rather
+            // than an unknown provider.
+            "bedrock" => " Rebuild with the `bedrock` crate feature to enable it.",
+            _ => "",
+        },
         _ => "",
     };
     format!(
@@ -304,10 +317,17 @@ mod tests {
         // is the hint an operator of a build without it actually sees.
         assert!(v("lancedb").contains("`lancedb` crate feature"));
         assert!(v("mock").contains("`testing` crate feature"));
+        // `bedrock` is the only feature-gated built-in LLM provider, so a build
+        // without the feature must point at it rather than read as an unknown
+        // provider.
+        let l = |p: &str| unsupported_msg("llm_provider", p, &[]);
+        assert!(l("bedrock").contains("`bedrock` crate feature"));
+        assert!(!l("openai").contains("crate feature"));
         // No cross-kind hint: a graph provider in a vector error (and vice-versa)
         // gets no feature hint at all.
         assert!(!v("postgres").contains("crate feature"));
         assert!(!g("pgvector").contains("crate feature"));
+        assert!(!v("bedrock").contains("crate feature"));
     }
 
     // Drift-guard: `with_builtins()` must register the documented provider set
@@ -372,6 +392,152 @@ mod tests {
                 reg.llm_providers()
             );
         }
+        // Bedrock follows its feature, like lancedb above: on means the factory
+        // is registered and `LLM_PROVIDER=bedrock` resolves; off means the
+        // provider must be absent so the operator gets the unsupported-provider
+        // message instead of a build without the AWS stack.
+        #[cfg(feature = "bedrock")]
+        assert!(
+            reg.llm_providers().iter().any(|p| p == "bedrock"),
+            "the `bedrock` feature must register the `bedrock` llm provider; have {:?}",
+            reg.llm_providers()
+        );
+        #[cfg(not(feature = "bedrock"))]
+        assert!(
+            !reg.llm_providers().iter().any(|p| p == "bedrock"),
+            "without the `bedrock` feature the provider must NOT be registered; have {:?}",
+            reg.llm_providers()
+        );
+    }
+
+    // `LLM_PROVIDER=bedrock` must resolve through the *registry lookup*, not
+    // just exist as a type: `build_llm` keys on the lowercased provider id, so
+    // this is the assertion that ties the factory's `provider()` string to the
+    // env value operators actually set.
+    #[cfg(feature = "bedrock")]
+    #[test]
+    fn with_builtins_registers_bedrock_llm_provider() {
+        let reg = ComponentRegistry::with_builtins();
+        assert!(
+            reg.llm_providers().iter().any(|p| p == "bedrock"),
+            "with_builtins() must register the `bedrock` llm provider; have {:?}",
+            reg.llm_providers()
+        );
+        assert_eq!(crate::builtins::llm::BEDROCK_PROVIDER, "bedrock");
+    }
+
+    // Parity guard (plan §1.1 / §4 R5): Bedrock is absent from Python's
+    // `_API_KEY_REQUIRED_PROVIDERS` and listed in `_NO_API_KEY_PROVIDERS`, so an
+    // empty `LLM_API_KEY` is the normal IAM configuration and must NOT be
+    // rejected the way the Anthropic factory rejects it.
+    //
+    // Kept strictly offline: the bearer token short-circuits `resolve_auth`
+    // before any credential lookup (`aws/credentials.rs` — that early return is
+    // documented as behaviour, not an optimisation), and the explicit region
+    // short-circuits the ambient region chain, so nothing here touches IMDS,
+    // SSO or the profile files.
+    #[cfg(feature = "bedrock")]
+    #[tokio::test]
+    async fn bedrock_builds_without_an_api_key() {
+        let reg = ComponentRegistry::with_builtins();
+        let mut ctx = test_ctx();
+        ctx.llm.provider = "bedrock".to_string();
+        // A converse-routed id cognee ships; an invoke-routed id fails by design.
+        ctx.llm.model = "eu.anthropic.claude-haiku-4-5-20251001-v1:0".to_string();
+        ctx.llm.api_key = String::new();
+        ctx.llm.aws.bearer_token = Some("test-token".to_string());
+        ctx.llm.aws.region = Some("us-east-1".to_string());
+
+        let built = reg.build_llm(&ctx).await;
+        let adapter = match built {
+            Ok(adapter) => adapter,
+            Err(e) => panic!(
+                "an empty LLM_API_KEY must fall through to the credential ladder, not error: {e:?}"
+            ),
+        };
+        // `is_ok()` alone would also pass if the factory built some other
+        // adapter entirely; the model id is the cheapest proof that the
+        // configured Bedrock model is what came back.
+        assert_eq!(
+            adapter.model(),
+            "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+        );
+
+        // §6.4: Bedrock has no Whisper equivalent, so audio degrades to None
+        // rather than erroring or wiring an adapter that 404s at runtime.
+        match reg.build_transcriber(&ctx).await {
+            Ok(None) => {}
+            Ok(Some(_)) => panic!("bedrock must not advertise a transcriber (plan §6.4)"),
+            Err(e) => {
+                panic!("build_transcriber must return Ok(None) for bedrock, not error: {e:?}")
+            }
+        }
+    }
+
+    // The LLM-side twin of `aws_inputs_are_carried_into_the_embedding_config`
+    // (`builtins::embedding`): without the `(&ctx.llm.aws).into()` carry-across
+    // the factory would hand `BedrockAdapter::new` a defaulted `AwsInputs` and
+    // every explicitly supplied credential/region/endpoint would be silently
+    // replaced by the ambient environment.
+    //
+    // A syntactically invalid region is the discriminator: it is rejected at the
+    // *first* rung of the §1.3 chain (`aws::region::validate`), before any
+    // ambient lookup and before the credential ladder, so the error naming it
+    // can only come from `ctx.llm.aws` having reached the adapter. Offline for
+    // the same reason.
+    #[cfg(feature = "bedrock")]
+    #[tokio::test]
+    async fn bedrock_carries_the_aws_inputs_into_the_adapter() {
+        let reg = ComponentRegistry::with_builtins();
+        let mut ctx = test_ctx();
+        ctx.llm.provider = "bedrock".to_string();
+        ctx.llm.model = "eu.anthropic.claude-haiku-4-5-20251001-v1:0".to_string();
+        ctx.llm.api_key = String::new();
+        ctx.llm.aws.bearer_token = Some("test-token".to_string());
+        ctx.llm.aws.region = Some("Not A Region".to_string());
+
+        let err = match reg.build_llm(&ctx).await {
+            Ok(_) => panic!(
+                "the caller-supplied region never reached the adapter: an invalid region must \
+                 fail the §1.3 chain instead of falling through to the ambient one"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(&err, ComponentError::Llm(msg) if msg.contains("Not A Region")),
+            "expected the region validation error naming the supplied region, got: {err:?}"
+        );
+    }
+
+    // The companion to `bedrock_builds_without_an_api_key`: proves the factory
+    // reaches `BedrockAdapter::new` with an empty key rather than rejecting it
+    // first. An invoke-routed id is refused *inside* the adapter constructor
+    // before any region/credential resolution (plan §6.7), so the error shape
+    // distinguishes the two: `ComponentError::Llm` = the key was passed through;
+    // a `ComponentError::Config` naming an API key = an Anthropic-style
+    // key-required check crept in. Offline for the same reason — the route check
+    // is the first statement in `new`.
+    #[cfg(feature = "bedrock")]
+    #[tokio::test]
+    async fn bedrock_empty_api_key_is_never_a_config_rejection() {
+        let reg = ComponentRegistry::with_builtins();
+        let mut ctx = test_ctx();
+        ctx.llm.provider = "bedrock".to_string();
+        ctx.llm.model = "invoke/amazon.titan-text-express-v1".to_string();
+        ctx.llm.api_key = String::new();
+
+        let err = match reg.build_llm(&ctx).await {
+            Ok(_) => panic!("an invoke-routed chat model must be rejected by the adapter"),
+            Err(e) => e,
+        };
+        assert!(
+            !matches!(&err, ComponentError::Config(msg) if msg.contains("API key")),
+            "bedrock must not require an API key (plan §1.1): {err:?}"
+        );
+        assert!(
+            matches!(&err, ComponentError::Llm(msg) if msg.contains("Converse")),
+            "expected the adapter's route rejection, got: {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/embedding/Cargo.toml
+++ b/crates/embedding/Cargo.toml
@@ -32,10 +32,18 @@ onnx-dynamic = ["onnx", "ort/load-dynamic"]
 # Enable ort-cuda or ort-tensorrt when building for a machine with NVIDIA hardware.
 ort-cuda     = ["ort/cuda"]
 ort-tensorrt = ["ort/tensorrt"]
+# AWS Bedrock embedding engine (InvokeModel). Pulls in `cognee-llm`'s `bedrock`
+# feature for the shared AWS plumbing — the credential/region/endpoint chains,
+# the SigV4 signer and the transport seam all live in
+# `cognee_llm::adapters::bedrock::aws` (see that module's docs for why it is
+# homed there and not in `cognee-utils`). Non-default: the AWS stack is not free.
+bedrock      = ["dep:cognee-llm", "cognee-llm/bedrock"]
 
 [dependencies]
 async-trait = { workspace = true }
 cognee-utils = { path = "../utils", version = "0.2.0" }
+# Only for the Bedrock engine's shared AWS plumbing (feature `bedrock`).
+cognee-llm  = { path = "../llm", version = "0.2.0", optional = true }
 futures     = { workspace = true }
 tokio       = { workspace = true }
 serde       = { workspace = true }

--- a/crates/embedding/README.md
+++ b/crates/embedding/README.md
@@ -13,6 +13,13 @@ Selected via `EmbeddingProvider` (or the `EMBEDDING_PROVIDER` env var):
 - **`OpenAICompatibleEmbeddingEngine`** — OpenAI/Azure/vLLM/llama.cpp/TEI via HTTP
   (retry + input sanitization)
 - **`OllamaEmbeddingEngine`** — Ollama `/api/embed`
+- **`BedrockEmbeddingEngine`** (`bedrock` feature) — AWS Bedrock **InvokeModel**
+  (`POST {endpoint}/model/{modelId}/invoke`, never Converse). Covers the Titan
+  families (`amazon.titan-embed-text-v1`, `amazon.titan-embed-text-v2:0`,
+  `amazon.titan-embed-image-v1`; one request per text) and Cohere
+  (`cohere.embed-*`; batched). Output is always L2-normalised — Titan v2
+  server-side, the rest client-side. Shares the AWS plumbing (region/endpoint
+  chains, credential ladder, SigV4) with `cognee-llm`'s Bedrock adapter
 - **`MockEmbeddingEngine`** — zero vectors for testing (`MOCK_EMBEDDING=true`)
 
 The default provider is **OpenAI `text-embedding-3-small`** (1536-d) on host
@@ -21,6 +28,7 @@ platforms and local **ONNX** on Android (when the `onnx` feature is enabled).
 ## Features
 
 - **ONNX Runtime:** Efficient local inference via `ort` crate (behind the `onnx` feature)
+- **AWS Bedrock:** InvokeModel embeddings for the Titan and Cohere families (behind the `bedrock` feature)
 - **HuggingFace Tokenizers:** Proper BPE/WordPiece tokenization matching Python fastembed
 - **Batch Processing:** Process multiple texts in single inference call
 - **L2 Normalization:** Unit vectors for cosine similarity

--- a/crates/embedding/src/bedrock/cohere.rs
+++ b/crates/embedding/src/bedrock/cohere.rs
@@ -1,0 +1,103 @@
+//! Cohere InvokeModel wire shapes (`cohere.embed-*`).
+//!
+//! Port of litellm's `llms/bedrock/embed/cohere_transformation.py` (plan §1.5).
+//! Unlike the Titan families, Cohere takes **every text in one request** and
+//! answers with `{"embeddings": [[...]]}`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{EmbeddingError, EmbeddingResult};
+
+/// litellm's hard-coded `input_type` for the embedding path.
+///
+/// cognee embeds corpus text, not queries, and Python never exposes a knob for
+/// this — so it is a constant here too rather than a config field.
+pub(crate) const INPUT_TYPE_SEARCH_DOCUMENT: &str = "search_document";
+
+/// The Cohere embed body.
+///
+/// `embedding_types` and `output_dimension` are modelled (they are in the §1.5
+/// table) but never populated: `EmbeddingConfig` has no knob for either, and
+/// sending `embedding_types` would change the response envelope from a bare
+/// list to `{"float": [...]}` — see [`parse_response`].
+#[derive(Debug, Serialize)]
+pub(crate) struct CohereEmbeddingRequest<'a> {
+    texts: Vec<&'a str>,
+    input_type: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    embedding_types: Option<Vec<&'static str>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_dimension: Option<usize>,
+}
+
+impl<'a> CohereEmbeddingRequest<'a> {
+    /// A `search_document` request over the whole batch.
+    pub(crate) fn search_document(texts: &[&'a str]) -> Self {
+        Self {
+            texts: texts.to_vec(),
+            input_type: INPUT_TYPE_SEARCH_DOCUMENT,
+            embedding_types: None,
+            output_dimension: None,
+        }
+    }
+}
+
+/// `{"embeddings": [[...]]}`.
+#[derive(Debug, Deserialize)]
+struct CohereEmbeddingResponse {
+    embeddings: Vec<Vec<f32>>,
+}
+
+/// Parse `{"embeddings": [[...]]}`.
+///
+/// Only the bare-list envelope is accepted. Cohere switches to
+/// `{"embeddings": {"float": [[...]]}}` when the request sets
+/// `embedding_types`, which [`CohereEmbeddingRequest`] never does — so a body
+/// in that shape means the request was not the one this module built, and
+/// failing loudly beats guessing.
+pub(crate) fn parse_response(body: &[u8]) -> EmbeddingResult<Vec<Vec<f32>>> {
+    let parsed: CohereEmbeddingResponse = serde_json::from_slice(body).map_err(|e| {
+        EmbeddingError::ApiError(format!(
+            "Failed to parse the Cohere embedding response: {e}; body: {}",
+            String::from_utf8_lossy(body)
+        ))
+    })?;
+    Ok(parsed.embeddings)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn body_batches_every_text_with_the_search_document_input_type() {
+        let request = CohereEmbeddingRequest::search_document(&["alpha", "beta"]);
+        assert_eq!(
+            serde_json::to_value(&request).expect("request serialises"),
+            json!({ "texts": ["alpha", "beta"], "input_type": "search_document" }),
+            "embedding_types / output_dimension must stay absent"
+        );
+    }
+
+    #[test]
+    fn response_unwraps_the_embedding_list() {
+        let body = br#"{"embeddings":[[0.1,0.2],[0.3,0.4]]}"#;
+        assert_eq!(
+            parse_response(body).expect("parses"),
+            vec![vec![0.1, 0.2], vec![0.3, 0.4]]
+        );
+    }
+
+    #[test]
+    fn typed_embedding_envelope_is_rejected_rather_than_guessed() {
+        let err = parse_response(br#"{"embeddings":{"float":[[0.1]]}}"#)
+            .expect_err("we never ask for embedding_types");
+        assert!(matches!(err, EmbeddingError::ApiError(_)), "{err:?}");
+    }
+}

--- a/crates/embedding/src/bedrock/mod.rs
+++ b/crates/embedding/src/bedrock/mod.rs
@@ -1,0 +1,997 @@
+//! AWS Bedrock embedding engine (feature `bedrock`).
+//!
+//! [`BedrockEmbeddingEngine`] implements [`EmbeddingEngine`] against Bedrock's
+//! **InvokeModel** API — `POST {endpoint}/model/{modelId}/invoke` — which is
+//! where `litellm.aembedding` routes Bedrock embeddings. Converse is the chat
+//! API only and is never used here (plan §1.5).
+//!
+//! The shared AWS plumbing (env resolution, the region and endpoint chains, the
+//! credential ladder, SigV4 and the transport seam) is **not** duplicated: it
+//! lives in [`cognee_llm::adapters::bedrock::aws`], which is homed in
+//! `cognee-llm` precisely so both this engine and the chat adapter share one
+//! implementation. The wire shapes live beside this file in [`titan`] and
+//! [`cohere`].
+//!
+//! # Three rules that fail silently if forgotten
+//!
+//! 1. **The request URL keeps the original, un-normalised model id** (plan
+//!    §1.4.1). Normalisation picks the request family and nothing else.
+//! 2. **`EmbeddingConfig::endpoint` is not the Bedrock api_base.** It defaults
+//!    to `https://api.openai.com/v1` and nothing clears it when the provider is
+//!    switched, so passing it through blindly would POST Bedrock bodies at
+//!    OpenAI — see `bedrock_api_base`.
+//! 3. **Only Titan v2 normalises server-side.** The [`EmbeddingEngine`]
+//!    contract promises unit vectors, so g1, the multimodal variant and Cohere
+//!    are normalised client-side.
+//!
+//! # Auth
+//!
+//! cognee passes no AWS credentials on the embedding path (plan §1.5): the
+//! bearer `api_key` short-circuits to `Authorization: Bearer …` with no SigV4
+//! and no credential lookup, and when it is absent the ambient credential
+//! ladder runs. An absent key is a supported configuration, not an error.
+//!
+//! # Not implemented, on purpose
+//!
+//! litellm's `async_invoke/*` embedding branch keys on an explicit
+//! `async_invoke/` model prefix (`embed/embedding.py:392-394`). cognee ships no
+//! model in that family on either SDK, so the row is informational and this
+//! engine does not implement it (plan §1.5).
+
+// Both modules carry their own `//!` docs; see the note in `lib.rs` for why
+// they are not repeated as outer docs here.
+pub mod cohere;
+pub mod titan;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use cognee_llm::adapters::bedrock::aws::transport::{BedrockTransport, ReqwestBedrockTransport};
+use cognee_llm::adapters::bedrock::{aws, converse, model_id};
+use cognee_llm::error::LlmError;
+use futures::stream::{self, StreamExt, TryStreamExt};
+use tracing::debug;
+
+use crate::config::EmbeddingConfig;
+use crate::engine::EmbeddingEngine;
+use crate::error::{EmbeddingError, EmbeddingResult};
+use crate::utils::{handle_embedding_response, l2_normalize, sanitize_embedding_inputs};
+
+/// Maximum number of InvokeModel requests in flight from a single `embed` call.
+///
+/// The Titan families take one text per request (litellm's
+/// `_single_func_embeddings` loop), so a 36-text batch is 36 requests; this
+/// bounds them against Bedrock's per-account throttle. Mirrors the
+/// OpenAI-compatible engine's `MAX_CONCURRENT_BATCHES`.
+const MAX_CONCURRENT_REQUESTS: usize = 8;
+
+/// Per-request HTTP timeout, matching the sibling HTTP embedding engines.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default wall-clock budget for retrying transient failures, matching the
+/// OpenAI-compatible and Ollama engines.
+const DEFAULT_RETRY_BUDGET: Duration = Duration::from_secs(128);
+
+/// The Bedrock embedding request families cognee can reach.
+///
+/// Selected from the **normalised** model id (`bedrock/` prefix stripped, ARN
+/// unwrapped, suffixes removed) — the un-normalised id is what goes in the URL.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BedrockEmbeddingFamily {
+    /// `amazon.titan-embed-text-v1` — `{"inputText": …}`, no server-side
+    /// normalisation.
+    TitanTextG1,
+    /// `amazon.titan-embed-text-v2:0` — accepts `dimensions` / `normalize`.
+    TitanTextV2,
+    /// `amazon.titan-embed-image-v1` — the multimodal variant, driven with text
+    /// only here.
+    TitanMultimodal,
+    /// `cohere.embed-*` — the one family that batches.
+    Cohere,
+}
+
+impl BedrockEmbeddingFamily {
+    /// Pick the family for `model`.
+    ///
+    /// Mirrors litellm's prefix dispatch in `bedrock/embed/embedding.py`. An
+    /// id outside the four families is a configuration error rather than a
+    /// guess: sending a Titan body to an unknown model would fail at the first
+    /// vector write instead of at construction.
+    pub fn for_model(model: &str) -> EmbeddingResult<Self> {
+        let base = model_id::base_model(model).to_ascii_lowercase();
+        if base.contains("titan-embed-image") {
+            Ok(Self::TitanMultimodal)
+        } else if base.starts_with("amazon.titan-embed-text-v2") {
+            Ok(Self::TitanTextV2)
+        } else if base.starts_with("amazon.titan-embed") {
+            Ok(Self::TitanTextG1)
+        } else if base.starts_with("cohere.embed") {
+            Ok(Self::Cohere)
+        } else {
+            Err(EmbeddingError::ConfigError(format!(
+                "unsupported Bedrock embedding model '{model}' (normalised: '{base}'). \
+                 Supported families: amazon.titan-embed-text-v1, \
+                 amazon.titan-embed-text-v2:0, amazon.titan-embed-image-v1, cohere.embed-*."
+            )))
+        }
+    }
+
+    /// Whether Bedrock returns a unit-norm vector for this family, so the
+    /// client-side L2 pass can be skipped.
+    ///
+    /// Only Titan v2 does, and only because we send `normalize: true`. Cohere's
+    /// `float` embeddings are **not** documented as unit-norm (checked against
+    /// the Cohere embed API reference, which specifies neither a norm nor a
+    /// range), so they are normalised here.
+    fn normalizes_server_side(self) -> bool {
+        matches!(self, Self::TitanTextV2)
+    }
+}
+
+/// Embedding engine that calls Bedrock's InvokeModel endpoint.
+///
+/// Built by [`EmbeddingConfig::create_engine`] when the provider is
+/// [`crate::EmbeddingProvider::Bedrock`]. See the module docs for the wire spec
+/// it implements.
+pub struct BedrockEmbeddingEngine {
+    /// The model id **exactly as configured** — this is what goes in the
+    /// request URL, cross-region prefix and ARN wrapper included.
+    model: String,
+    /// Family resolved once from the §1.4.1-normalised id.
+    family: BedrockEmbeddingFamily,
+    /// Resolved runtime endpoint, without a trailing slash.
+    endpoint: String,
+    /// Resolved AWS region — diagnostics only; the transport holds its own copy
+    /// for signing.
+    region: String,
+    transport: Arc<dyn BedrockTransport>,
+    dimensions: usize,
+    batch_size: usize,
+    max_sequence_length: usize,
+    retry_budget: Duration,
+}
+
+impl BedrockEmbeddingEngine {
+    /// Build an engine from `config`.
+    ///
+    /// Runs the same chains as
+    /// [`cognee_llm::adapters::bedrock::BedrockAdapter::new`]: region → endpoint
+    /// → auth. `config.api_key` is the Bedrock API key; when set it
+    /// short-circuits to a bearer header with no SigV4 and no credential
+    /// lookup, and when unset the ambient ladder runs (plan §1.5).
+    ///
+    /// # Errors
+    ///
+    /// * [`EmbeddingError::ConfigError`] — empty or unsupported model id, an
+    ///   unresolvable region or credential chain, or a `reqwest` client that
+    ///   cannot be built.
+    pub async fn new(config: &EmbeddingConfig) -> EmbeddingResult<Self> {
+        let model = config.model.trim().to_string();
+        if model.is_empty() {
+            return Err(EmbeddingError::ConfigError(
+                "Bedrock embedding requires EMBEDDING_MODEL to be set (e.g. \
+                 amazon.titan-embed-text-v2:0)"
+                    .to_string(),
+            ));
+        }
+        let family = BedrockEmbeddingFamily::for_model(&model)?;
+
+        let settings = config.aws.resolve();
+        let region = aws::region::resolve_region(&settings, Some(&model))
+            .await
+            .map_err(embedding_error_from_llm)?;
+        let endpoint =
+            aws::endpoint::resolve_endpoint(bedrock_api_base(config), &settings, &region);
+        let auth = aws::credentials::resolve_auth(config.api_key.as_deref(), &settings, &region)
+            .await
+            .map_err(embedding_error_from_llm)?;
+
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|e| {
+                EmbeddingError::ConfigError(format!("Failed to build HTTP client: {e}"))
+            })?;
+        let transport = Arc::new(ReqwestBedrockTransport::new(client, auth, region.clone()));
+
+        debug!(
+            model = model.as_str(),
+            family = ?family,
+            region = region.as_str(),
+            endpoint = endpoint.as_str(),
+            dimensions = config.dimensions,
+            "built Bedrock embedding engine",
+        );
+
+        Ok(Self {
+            model,
+            family,
+            endpoint,
+            region,
+            transport,
+            dimensions: config.dimensions,
+            batch_size: config.batch_size,
+            max_sequence_length: config.max_completion_tokens,
+            retry_budget: DEFAULT_RETRY_BUDGET,
+        })
+    }
+
+    /// Set the wall-clock budget for retrying transient failures
+    /// (rate limits, 5xx, network errors). [`Duration::ZERO`] disables retry.
+    pub fn with_retry_budget(mut self, budget: Duration) -> Self {
+        self.retry_budget = budget;
+        self
+    }
+
+    /// The request family selected for the configured model.
+    pub fn family(&self) -> BedrockEmbeddingFamily {
+        self.family
+    }
+
+    /// The resolved AWS region.
+    pub fn region(&self) -> &str {
+        &self.region
+    }
+
+    /// The resolved runtime endpoint.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// The InvokeModel URL: `{endpoint}/model/{modelId}/invoke`.
+    ///
+    /// `modelId` is the **original** id, percent-encoded as one path segment by
+    /// the same helper the Converse path uses — that is what makes `…-v2:0` and
+    /// an inference-profile ARN usable here.
+    fn invoke_url(&self) -> String {
+        format!(
+            "{}/model/{}/invoke",
+            self.endpoint.trim_end_matches('/'),
+            converse::encode_model_id(&self.model)
+        )
+    }
+
+    /// POST `body` once and return the raw response body.
+    async fn post_once(&self, body: Vec<u8>) -> EmbeddingResult<Vec<u8>> {
+        let response = self
+            .transport
+            .post_json(&self.invoke_url(), body)
+            .await
+            .map_err(embedding_error_from_llm)?;
+
+        if !response.status.is_success() {
+            return Err(map_http_error(
+                response.status.as_u16(),
+                &response.body_lossy(),
+            ));
+        }
+        Ok(response.body)
+    }
+
+    /// POST with exponential-jitter retry on transient errors, mirroring the
+    /// sibling engines: the wait starts at 2 s and doubles up to 128 s, plus a
+    /// uniform jitter in `[0, wait)`, for up to [`Self::retry_budget`] total.
+    async fn post_with_retry(&self, body: Vec<u8>) -> EmbeddingResult<Vec<u8>> {
+        let start = Instant::now();
+        let mut wait_secs = 2u64;
+        loop {
+            match self.post_once(body.clone()).await {
+                Ok(response) => return Ok(response),
+                Err(e) if is_retryable(&e) && start.elapsed() < self.retry_budget => {
+                    let jitter = rand::random::<u64>() % wait_secs;
+                    tokio::time::sleep(Duration::from_secs(wait_secs + jitter)).await;
+                    wait_secs = (wait_secs * 2).min(128);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Serialise `request`, POST it and hand back the raw response body.
+    async fn invoke<T: serde::Serialize>(&self, request: &T) -> EmbeddingResult<Vec<u8>> {
+        let body = serde_json::to_vec(request).map_err(|e| {
+            EmbeddingError::ApiError(format!("Failed to serialize the Bedrock request: {e}"))
+        })?;
+        self.post_with_retry(body).await
+    }
+
+    /// One Titan request for one text.
+    async fn embed_titan_one(&self, text: &str) -> EmbeddingResult<Vec<f32>> {
+        let body = match self.family {
+            BedrockEmbeddingFamily::TitanTextG1 => {
+                self.invoke(&titan::TitanTextRequest::g1(text)).await?
+            }
+            BedrockEmbeddingFamily::TitanTextV2 => {
+                // `normalize: true` is what lets the client-side L2 pass be
+                // skipped for this family — the two must move together.
+                self.invoke(&titan::TitanTextRequest::v2(
+                    text,
+                    Some(self.dimensions),
+                    Some(true),
+                ))
+                .await?
+            }
+            BedrockEmbeddingFamily::TitanMultimodal => {
+                self.invoke(&titan::TitanMultimodalRequest::text(text, self.dimensions))
+                    .await?
+            }
+            BedrockEmbeddingFamily::Cohere => {
+                return Err(EmbeddingError::ConfigError(
+                    "the Cohere family batches; it must not reach the Titan per-text loop"
+                        .to_string(),
+                ));
+            }
+        };
+        titan::parse_response(&body)
+    }
+
+    /// The Titan `_single_func_embeddings` loop: one request per text, bounded
+    /// concurrency, results reassembled **in input order**.
+    async fn embed_titan(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
+        let requests: Vec<_> = texts
+            .iter()
+            .enumerate()
+            .map(
+                |(index, text)| async move { self.embed_titan_one(text).await.map(|v| (index, v)) },
+            )
+            .collect();
+
+        // `try_collect` over `buffer_unordered` aborts on the first failure —
+        // cancelling in-flight retries instead of waiting them out — and the
+        // index restores input order afterwards.
+        let mut indexed: Vec<(usize, Vec<f32>)> = stream::iter(requests)
+            .buffer_unordered(MAX_CONCURRENT_REQUESTS)
+            .try_collect()
+            .await?;
+        indexed.sort_by_key(|(index, _)| *index);
+        Ok(indexed.into_iter().map(|(_, vector)| vector).collect())
+    }
+
+    /// Cohere batches every text into one request.
+    async fn embed_cohere(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
+        let body = self
+            .invoke(&cohere::CohereEmbeddingRequest::search_document(texts))
+            .await?;
+        let vectors = cohere::parse_response(&body)?;
+        if vectors.len() != texts.len() {
+            return Err(EmbeddingError::ApiError(format!(
+                "Bedrock returned {} embeddings for {} texts",
+                vectors.len(),
+                texts.len()
+            )));
+        }
+        Ok(vectors)
+    }
+}
+
+#[async_trait]
+impl EmbeddingEngine for BedrockEmbeddingEngine {
+    async fn embed(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let sanitized = sanitize_embedding_inputs(texts);
+        let sanitized: Vec<&str> = sanitized.iter().map(|c| c.as_ref()).collect();
+
+        let vectors = match self.family {
+            BedrockEmbeddingFamily::Cohere => self.embed_cohere(&sanitized).await?,
+            _ => self.embed_titan(&sanitized).await?,
+        };
+
+        // The trait contract is "every returned embedding is L2-normalised".
+        let vectors: Vec<Vec<f32>> = if self.family.normalizes_server_side() {
+            vectors
+        } else {
+            vectors.iter().map(|v| l2_normalize(v)).collect()
+        };
+
+        Ok(handle_embedding_response(texts, vectors, self.dimensions))
+    }
+
+    fn dimension(&self) -> usize {
+        self.dimensions
+    }
+
+    /// `EmbeddingConfig::batch_size` verbatim.
+    ///
+    /// The Titan families issue one request per text regardless, so this is a
+    /// caller-facing chunk size rather than a wire batch size — reporting `1`
+    /// would make every caller chunk to single texts and lose the bounded
+    /// concurrency in `BedrockEmbeddingEngine::embed_titan`. Cohere really
+    /// does batch, so the configured value is the honest answer for it.
+    fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
+    fn max_sequence_length(&self) -> usize {
+        self.max_sequence_length
+    }
+}
+
+/// Hand-written so the resolved auth (held by the transport) can never reach a
+/// log line through `{:?}`; only the routing decisions are shown.
+impl std::fmt::Debug for BedrockEmbeddingEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BedrockEmbeddingEngine")
+            .field("model", &self.model)
+            .field("family", &self.family)
+            .field("region", &self.region)
+            .field("endpoint", &self.endpoint)
+            .field("dimensions", &self.dimensions)
+            .field("batch_size", &self.batch_size)
+            .finish_non_exhaustive()
+    }
+}
+
+// ─── Endpoint guard ───────────────────────────────────────────────────────────
+
+/// The Bedrock `api_base` to use, or `None` to let
+/// `AWS_BEDROCK_RUNTIME_ENDPOINT` / the regional default decide.
+///
+/// [`EmbeddingConfig::default`] sets `endpoint` to `https://api.openai.com/v1`
+/// off Android and **nothing clears it** when the provider is switched to
+/// bedrock (`EMBEDDING_ENDPOINT` merely overrides it). Feeding that through as
+/// the Bedrock api_base would POST InvokeModel bodies at OpenAI, so any
+/// `api.openai.com` endpoint is treated as "not configured for Bedrock" — the
+/// same class of trap `LlmInputs::anthropic_base_url` exists to avoid.
+fn bedrock_api_base(config: &EmbeddingConfig) -> Option<&str> {
+    config
+        .endpoint
+        .as_deref()
+        .map(str::trim)
+        .filter(|endpoint| !endpoint.is_empty())
+        .filter(|endpoint| !is_openai_host(endpoint))
+}
+
+/// Whether `endpoint`'s host is OpenAI's.
+fn is_openai_host(endpoint: &str) -> bool {
+    let authority = endpoint
+        .trim()
+        .trim_start_matches("https://")
+        .trim_start_matches("http://");
+    let host = authority.split(['/', ':', '?']).next().unwrap_or(authority);
+    host.eq_ignore_ascii_case("api.openai.com")
+}
+
+// ─── Error mapping ────────────────────────────────────────────────────────────
+
+/// Whether `error` is worth another attempt. Matches the sibling engines: only
+/// [`EmbeddingError::HttpError`] is transient.
+fn is_retryable(error: &EmbeddingError) -> bool {
+    matches!(error, EmbeddingError::HttpError(_))
+}
+
+/// Map a Bedrock HTTP failure onto the embedding taxonomy.
+///
+/// The exception-name rules — in particular that **Bedrock reports throttling
+/// as HTTP 400 `ThrottlingException` as well as 429** — are not re-derived
+/// here: they live in
+/// [`cognee_llm::adapters::bedrock::converse::map_error`] and stay in one
+/// place. Only the projection onto [`EmbeddingError`] is local, and 5xx is
+/// decided by status first because the LLM taxonomy folds server errors into
+/// its generic `ApiError`, which would otherwise read as terminal.
+fn map_http_error(status: u16, body: &str) -> EmbeddingError {
+    if status >= 500 {
+        return EmbeddingError::HttpError(format!("HTTP {status}: {body}"));
+    }
+    embedding_error_from_llm(converse::map_error(status, body))
+}
+
+/// Project an [`LlmError`] from the shared AWS module onto [`EmbeddingError`].
+///
+/// Rate limits, timeouts and network failures are transient
+/// ([`EmbeddingError::HttpError`], which the retry loop acts on); configuration
+/// and credential failures are [`EmbeddingError::ConfigError`]; everything else
+/// — other 4xx and unexpected response shapes — is a terminal
+/// [`EmbeddingError::ApiError`].
+fn embedding_error_from_llm(error: LlmError) -> EmbeddingError {
+    match error {
+        LlmError::RateLimitExceeded(message)
+        | LlmError::Timeout(message)
+        | LlmError::NetworkError(message) => EmbeddingError::HttpError(message),
+        LlmError::ConfigError(message) | LlmError::FeatureNotSupported(message) => {
+            EmbeddingError::ConfigError(message)
+        }
+        other => EmbeddingError::ApiError(other.to_string()),
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+    use crate::provider::EmbeddingProvider;
+    use crate::utils::compute_norm;
+
+    /// A config whose region is pinned and whose api_key is set, so neither the
+    /// ambient region chain nor the credential ladder is consulted (both would
+    /// reach the filesystem / IMDS on a developer machine).
+    fn config_for(server_url: &str, model: &str, dimensions: usize) -> EmbeddingConfig {
+        let mut config = EmbeddingConfig {
+            provider: EmbeddingProvider::Bedrock,
+            model: model.to_string(),
+            dimensions,
+            endpoint: Some(server_url.to_string()),
+            api_key: Some("bedrock-api-key".to_string()),
+            batch_size: 36,
+            ..EmbeddingConfig::default()
+        };
+        config.aws.region = Some("us-east-1".to_string());
+        config
+    }
+
+    async fn engine_for(
+        server_url: &str,
+        model: &str,
+        dimensions: usize,
+    ) -> BedrockEmbeddingEngine {
+        BedrockEmbeddingEngine::new(&config_for(server_url, model, dimensions))
+            .await
+            .expect("engine builds with a pinned region and a bearer key")
+            // Keep the round-trip tests fast: a transient failure must surface
+            // immediately instead of sleeping through the 128 s budget.
+            .with_retry_budget(Duration::ZERO)
+    }
+
+    // ── Family selection ─────────────────────────────────────────────────────
+
+    #[test]
+    fn family_selection_uses_the_normalised_id() {
+        for (model, expected) in [
+            (
+                "amazon.titan-embed-text-v1",
+                BedrockEmbeddingFamily::TitanTextG1,
+            ),
+            (
+                "amazon.titan-embed-text-v2:0",
+                BedrockEmbeddingFamily::TitanTextV2,
+            ),
+            (
+                "amazon.titan-embed-image-v1",
+                BedrockEmbeddingFamily::TitanMultimodal,
+            ),
+            ("cohere.embed-english-v3", BedrockEmbeddingFamily::Cohere),
+            // Normalisation is what makes these resolve at all.
+            (
+                "bedrock/amazon.titan-embed-text-v2:0",
+                BedrockEmbeddingFamily::TitanTextV2,
+            ),
+            (
+                "eu.amazon.titan-embed-text-v1",
+                BedrockEmbeddingFamily::TitanTextG1,
+            ),
+        ] {
+            assert_eq!(
+                BedrockEmbeddingFamily::for_model(model).expect("known family"),
+                expected,
+                "model {model}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unknown_family_is_a_config_error() {
+        let err = BedrockEmbeddingFamily::for_model("anthropic.claude-3-5-sonnet-20240620-v1:0")
+            .expect_err("not an embedding model");
+        assert!(matches!(err, EmbeddingError::ConfigError(_)), "{err:?}");
+    }
+
+    // ── Endpoint guard ───────────────────────────────────────────────────────
+
+    #[test]
+    fn the_openai_default_endpoint_is_never_adopted_as_the_bedrock_api_base() {
+        let config = EmbeddingConfig::default();
+        assert_eq!(
+            config.endpoint.as_deref(),
+            Some("https://api.openai.com/v1"),
+            "guard premise: the default config really does carry the OpenAI endpoint",
+        );
+        assert_eq!(
+            bedrock_api_base(&config),
+            None,
+            "the OpenAI default must not become the Bedrock api_base",
+        );
+
+        // …and the endpoint chain therefore falls through to the regional default.
+        let settings = cognee_llm::adapters::bedrock::aws::env::AwsInputs::default().resolve();
+        assert_eq!(
+            aws::endpoint::resolve_endpoint(bedrock_api_base(&config), &settings, "us-east-1"),
+            "https://bedrock-runtime.us-east-1.amazonaws.com",
+        );
+    }
+
+    /// The guard has to be *wired into the constructor*, not merely available.
+    /// Without this case, replacing `bedrock_api_base(config)` in
+    /// [`BedrockEmbeddingEngine::new`] with a bare `config.endpoint` leaves
+    /// every other test in this module green while the engine POSTs
+    /// InvokeModel bodies at api.openai.com.
+    #[tokio::test]
+    async fn the_constructor_applies_the_openai_endpoint_guard() {
+        let mut config = EmbeddingConfig {
+            provider: EmbeddingProvider::Bedrock,
+            model: "amazon.titan-embed-text-v2:0".to_string(),
+            dimensions: 1024,
+            api_key: Some("bedrock-api-key".to_string()),
+            ..EmbeddingConfig::default()
+        };
+        config.aws.region = Some("us-east-1".to_string());
+        assert_eq!(
+            config.endpoint.as_deref(),
+            Some("https://api.openai.com/v1"),
+            "guard premise: the default config really does carry the OpenAI endpoint",
+        );
+
+        let engine = BedrockEmbeddingEngine::new(&config)
+            .await
+            .expect("builds with a pinned region and a bearer key");
+
+        assert!(
+            !is_openai_host(engine.endpoint()),
+            "the OpenAI default leaked into the Bedrock runtime endpoint: {}",
+            engine.endpoint(),
+        );
+        // The exact fallback, unless the developer's own environment overrides
+        // the runtime endpoint — the chain in `aws::endpoint` reads it.
+        if std::env::var_os("AWS_BEDROCK_RUNTIME_ENDPOINT").is_none() {
+            assert_eq!(
+                engine.endpoint(),
+                "https://bedrock-runtime.us-east-1.amazonaws.com",
+            );
+            assert_eq!(
+                engine.invoke_url(),
+                "https://bedrock-runtime.us-east-1.amazonaws.com\
+                 /model/amazon.titan-embed-text-v2%3A0/invoke",
+            );
+        }
+    }
+
+    #[test]
+    fn an_explicit_non_openai_endpoint_is_passed_through() {
+        let config = EmbeddingConfig {
+            endpoint: Some("https://vpce-123.bedrock-runtime.us-east-1.vpce.amazonaws.com".into()),
+            ..EmbeddingConfig::default()
+        };
+        assert_eq!(
+            bedrock_api_base(&config),
+            Some("https://vpce-123.bedrock-runtime.us-east-1.vpce.amazonaws.com"),
+        );
+    }
+
+    #[test]
+    fn a_blank_endpoint_falls_through_to_the_regional_default() {
+        let config = EmbeddingConfig {
+            endpoint: Some("   ".to_string()),
+            ..EmbeddingConfig::default()
+        };
+        assert_eq!(bedrock_api_base(&config), None);
+    }
+
+    #[test]
+    fn is_openai_host_only_matches_the_openai_host() {
+        assert!(is_openai_host("https://api.openai.com/v1"));
+        assert!(is_openai_host("https://API.OpenAI.com"));
+        assert!(!is_openai_host(
+            "https://bedrock-runtime.us-east-1.amazonaws.com"
+        ));
+        assert!(!is_openai_host("http://127.0.0.1:1234"));
+    }
+
+    // ── Error mapping ────────────────────────────────────────────────────────
+
+    #[test]
+    fn a_400_throttling_exception_is_transient() {
+        let err = map_http_error(
+            400,
+            r#"{"__type":"ThrottlingException","message":"slow down"}"#,
+        );
+        assert!(
+            matches!(err, EmbeddingError::HttpError(_)),
+            "Bedrock reports throttling as a 400 too — it must stay retryable: {err:?}"
+        );
+        assert!(is_retryable(&err));
+    }
+
+    #[test]
+    fn a_plain_400_validation_exception_is_terminal() {
+        let err = map_http_error(
+            400,
+            r#"{"__type":"ValidationException","message":"bad body"}"#,
+        );
+        assert!(matches!(err, EmbeddingError::ApiError(_)), "{err:?}");
+        assert!(!is_retryable(&err));
+    }
+
+    #[test]
+    fn a_503_is_transient() {
+        let err = map_http_error(503, "ServiceUnavailableException");
+        assert!(matches!(err, EmbeddingError::HttpError(_)), "{err:?}");
+    }
+
+    #[test]
+    fn a_403_is_terminal() {
+        let err = map_http_error(403, r#"{"__type":"AccessDeniedException"}"#);
+        assert!(matches!(err, EmbeddingError::ApiError(_)), "{err:?}");
+    }
+
+    #[test]
+    fn credential_failures_become_config_errors() {
+        assert!(matches!(
+            embedding_error_from_llm(LlmError::ConfigError("no credentials".into())),
+            EmbeddingError::ConfigError(_)
+        ));
+    }
+
+    // ── URL construction ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn the_invoke_url_keeps_the_un_normalised_model_id() {
+        let engine = engine_for(
+            "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "eu.amazon.titan-embed-text-v2:0",
+            1024,
+        )
+        .await;
+        assert_eq!(
+            engine.invoke_url(),
+            "https://bedrock-runtime.us-east-1.amazonaws.com\
+             /model/eu.amazon.titan-embed-text-v2%3A0/invoke",
+            "the cross-region prefix stays and `:` is percent-encoded",
+        );
+        assert_eq!(engine.family(), BedrockEmbeddingFamily::TitanTextV2);
+        assert_eq!(engine.region(), "us-east-1");
+    }
+
+    // ── HTTP round-trips ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn titan_g1_sends_one_request_per_text_and_keeps_input_order() {
+        let mut server = mockito::Server::new_async().await;
+        let alpha = server
+            .mock("POST", "/model/eu.amazon.titan-embed-text-v1/invoke")
+            .match_header("authorization", "Bearer bedrock-api-key")
+            .match_header("x-amz-date", mockito::Matcher::Missing)
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"inputText": "alpha"}),
+            ))
+            .with_status(200)
+            .with_body(r#"{"embedding":[3.0,0.0],"inputTextTokenCount":1}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let beta = server
+            .mock("POST", "/model/eu.amazon.titan-embed-text-v1/invoke")
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"inputText": "beta"}),
+            ))
+            .with_status(200)
+            .with_body(r#"{"embedding":[0.0,4.0],"inputTextTokenCount":1}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        // The un-normalised id (with its `eu.` prefix) is what the URL carries.
+        let engine = engine_for(&server.url(), "eu.amazon.titan-embed-text-v1", 2).await;
+        let out = engine.embed(&["alpha", "beta"]).await.expect("embeds");
+
+        assert_eq!(
+            out,
+            vec![vec![1.0, 0.0], vec![0.0, 1.0]],
+            "results follow input order and are L2-normalised client-side",
+        );
+        alpha.assert_async().await;
+        beta.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn the_bearer_path_signs_nothing() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/model/amazon.titan-embed-text-v1/invoke")
+            .match_header("authorization", "Bearer bedrock-api-key")
+            .match_header("content-type", "application/json")
+            .match_header("x-amz-date", mockito::Matcher::Missing)
+            .match_header("x-amz-security-token", mockito::Matcher::Missing)
+            .with_status(200)
+            .with_body(r#"{"embedding":[1.0,0.0]}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let engine = engine_for(&server.url(), "amazon.titan-embed-text-v1", 2).await;
+        engine.embed(&["alpha"]).await.expect("embeds");
+
+        mock.assert_async().await;
+        // A SigV4 `Authorization` would start with AWS4-HMAC-SHA256; the header
+        // matcher above pins it to the bearer form, and no signature-only
+        // headers may appear alongside it.
+    }
+
+    #[tokio::test]
+    async fn titan_v2_asks_bedrock_to_normalize_and_skips_the_client_pass() {
+        let mut server = mockito::Server::new_async().await;
+        // The body assertion is the point: v2 must send `normalize: true`.
+        let mock = server
+            .mock("POST", "/model/amazon.titan-embed-text-v2%3A0/invoke")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "inputText": "alpha",
+                "dimensions": 2,
+                "normalize": true,
+            })))
+            .with_status(200)
+            // Deliberately not unit-norm: if the engine also normalised
+            // client-side, this would come back as [1.0, 0.0].
+            .with_body(r#"{"embedding":[3.0,0.0]}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let engine = engine_for(&server.url(), "amazon.titan-embed-text-v2:0", 2).await;
+        let out = engine.embed(&["alpha"]).await.expect("embeds");
+
+        assert_eq!(
+            out,
+            vec![vec![3.0, 0.0]],
+            "v2 normalises server-side, so the response is returned verbatim",
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn titan_multimodal_normalizes_client_side() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/model/amazon.titan-embed-image-v1/invoke")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "inputText": "alpha",
+                "embeddingConfig": { "outputEmbeddingLength": 2 },
+            })))
+            .with_status(200)
+            .with_body(r#"{"embedding":[3.0,4.0]}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let engine = engine_for(&server.url(), "amazon.titan-embed-image-v1", 2).await;
+        let out = engine.embed(&["alpha"]).await.expect("embeds");
+
+        assert!((compute_norm(&out[0]) - 1.0).abs() < 1e-6, "{:?}", out[0]);
+        assert!((out[0][0] - 0.6).abs() < 1e-6);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn cohere_batches_every_text_into_one_request_and_normalizes_client_side() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/model/cohere.embed-english-v3/invoke")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "texts": ["alpha", "beta"],
+                "input_type": "search_document",
+            })))
+            .with_status(200)
+            .with_body(r#"{"embeddings":[[3.0,4.0],[0.0,2.0]]}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let engine = engine_for(&server.url(), "cohere.embed-english-v3", 2).await;
+        let out = engine.embed(&["alpha", "beta"]).await.expect("embeds");
+
+        assert_eq!(out.len(), 2);
+        for vector in &out {
+            assert!((compute_norm(vector) - 1.0).abs() < 1e-6, "{vector:?}");
+        }
+        assert!((out[0][0] - 0.6).abs() < 1e-6);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn a_400_throttling_body_surfaces_as_a_retryable_http_error() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/model/amazon.titan-embed-text-v1/invoke")
+            .with_status(400)
+            .with_body(r#"{"__type":"ThrottlingException","message":"slow down"}"#)
+            // The retry budget is zero, so exactly one attempt is made.
+            .expect(1)
+            .create_async()
+            .await;
+
+        let engine = engine_for(&server.url(), "amazon.titan-embed-text-v1", 2).await;
+        let err = engine.embed(&["alpha"]).await.expect_err("must fail");
+
+        assert!(
+            matches!(err, EmbeddingError::HttpError(_)),
+            "a 400 ThrottlingException is retryable, not an ApiError: {err:?}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn empty_input_issues_no_request() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", mockito::Matcher::Any)
+            .with_status(200)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let engine = engine_for(&server.url(), "amazon.titan-embed-text-v1", 2).await;
+        assert!(engine.embed(&[]).await.expect("no-op").is_empty());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn blank_inputs_are_sanitized_and_zeroed() {
+        let mut server = mockito::Server::new_async().await;
+        // The sanitizer replaces the blank text with "." before it hits the wire.
+        let mock = server
+            .mock("POST", "/model/amazon.titan-embed-text-v1/invoke")
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"inputText": "."}),
+            ))
+            .with_status(200)
+            .with_body(r#"{"embedding":[3.0,4.0]}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let engine = engine_for(&server.url(), "amazon.titan-embed-text-v1", 2).await;
+        let out = engine.embed(&["   "]).await.expect("embeds");
+
+        assert_eq!(out, vec![vec![0.0, 0.0]], "an unembeddable slot is zeroed");
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn a_cohere_count_mismatch_is_an_api_error() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/model/cohere.embed-english-v3/invoke")
+            .with_status(200)
+            .with_body(r#"{"embeddings":[[1.0,0.0]]}"#)
+            .create_async()
+            .await;
+
+        let engine = engine_for(&server.url(), "cohere.embed-english-v3", 2).await;
+        let err = engine
+            .embed(&["alpha", "beta"])
+            .await
+            .expect_err("two texts, one embedding");
+        assert!(matches!(err, EmbeddingError::ApiError(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn an_empty_model_is_rejected_at_construction() {
+        let config = EmbeddingConfig {
+            provider: EmbeddingProvider::Bedrock,
+            model: "   ".to_string(),
+            ..EmbeddingConfig::default()
+        };
+        let err = BedrockEmbeddingEngine::new(&config)
+            .await
+            .expect_err("no model id");
+        assert!(matches!(err, EmbeddingError::ConfigError(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn trait_accessors_report_the_configured_values() {
+        let mut config = config_for("http://127.0.0.1:1", "amazon.titan-embed-text-v2:0", 1024);
+        config.batch_size = 12;
+        config.max_completion_tokens = 8191;
+        let engine = BedrockEmbeddingEngine::new(&config).await.expect("builds");
+
+        assert_eq!(engine.dimension(), 1024);
+        assert_eq!(engine.batch_size(), 12);
+        assert_eq!(engine.max_sequence_length(), 8191);
+    }
+}

--- a/crates/embedding/src/bedrock/mod.rs
+++ b/crates/embedding/src/bedrock/mod.rs
@@ -183,9 +183,10 @@ impl BedrockEmbeddingEngine {
             .map_err(embedding_error_from_llm)?;
         let endpoint =
             aws::endpoint::resolve_endpoint(bedrock_api_base(config), &settings, &region);
-        let auth = aws::credentials::resolve_auth(config.api_key.as_deref(), &settings, &region)
-            .await
-            .map_err(embedding_error_from_llm)?;
+        let auth =
+            aws::credentials::resolve_auth_provider(config.api_key.as_deref(), &settings, &region)
+                .await
+                .map_err(embedding_error_from_llm)?;
 
         let client = reqwest::Client::builder()
             .timeout(REQUEST_TIMEOUT)
@@ -193,7 +194,11 @@ impl BedrockEmbeddingEngine {
             .map_err(|e| {
                 EmbeddingError::ConfigError(format!("Failed to build HTTP client: {e}"))
             })?;
-        let transport = Arc::new(ReqwestBedrockTransport::new(client, auth, region.clone()));
+        let transport = Arc::new(ReqwestBedrockTransport::with_auth_provider(
+            client,
+            Arc::new(auth),
+            region.clone(),
+        ));
 
         debug!(
             model = model.as_str(),

--- a/crates/embedding/src/bedrock/mod.rs
+++ b/crates/embedding/src/bedrock/mod.rs
@@ -248,7 +248,7 @@ impl BedrockEmbeddingEngine {
         format!(
             "{}/model/{}/invoke",
             self.endpoint.trim_end_matches('/'),
-            converse::encode_model_id(&self.model)
+            converse::encode_model_id(model_id::wire_model_id(&self.model))
         )
     }
 

--- a/crates/embedding/src/bedrock/titan.rs
+++ b/crates/embedding/src/bedrock/titan.rs
@@ -1,0 +1,198 @@
+//! Titan InvokeModel wire shapes: `titan-embed-text-v1` (g1),
+//! `titan-embed-text-v2` and the `titan-embed-image-v1` multimodal variant.
+//!
+//! Port of litellm's `llms/bedrock/embed/amazon_titan_g1_transformation.py`,
+//! `amazon_titan_v2_transformation.py` and
+//! `amazon_titan_multimodal_transformation.py`, which is what Python cognee
+//! reaches through `litellm.aembedding` (plan §1.5).
+//!
+//! All three families take **one text per request** — litellm's
+//! `_single_func_embeddings` loop — and answer with the same
+//! `{"embedding": [...], "inputTextTokenCount": n}` envelope.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{EmbeddingError, EmbeddingResult};
+
+/// The Titan text body: `{"inputText": …}` for g1, plus the two v2-only knobs.
+///
+/// `dimensions` and `normalize` are serialised **only when set**, so the g1
+/// constructor produces exactly `{"inputText": …}` — g1 rejects unknown fields.
+#[derive(Debug, Serialize)]
+pub(crate) struct TitanTextRequest<'a> {
+    #[serde(rename = "inputText")]
+    input_text: &'a str,
+    /// v2 only — the requested output length (`1024` | `512` | `256`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dimensions: Option<usize>,
+    /// v2 only — ask Bedrock to return a unit-norm vector server-side.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    normalize: Option<bool>,
+}
+
+impl<'a> TitanTextRequest<'a> {
+    /// `amazon.titan-embed-text-v1` (g1): `{"inputText": …}` and nothing else.
+    pub(crate) fn g1(input_text: &'a str) -> Self {
+        Self {
+            input_text,
+            dimensions: None,
+            normalize: None,
+        }
+    }
+
+    /// `amazon.titan-embed-text-v2:0`: adds `dimensions` / `normalize` when
+    /// they are configured.
+    pub(crate) fn v2(
+        input_text: &'a str,
+        dimensions: Option<usize>,
+        normalize: Option<bool>,
+    ) -> Self {
+        Self {
+            input_text,
+            dimensions,
+            normalize,
+        }
+    }
+}
+
+/// `embeddingConfig` on the multimodal body.
+#[derive(Debug, Serialize)]
+pub(crate) struct TitanEmbeddingConfig {
+    #[serde(rename = "outputEmbeddingLength")]
+    output_embedding_length: usize,
+}
+
+/// The `amazon.titan-embed-image-v1` body.
+///
+/// litellm picks `inputImage` over `inputText` when the input parses as base64
+/// (`_is_base64`). That branch is unreachable here: [`crate::EmbeddingEngine`]
+/// is a *text* embedding contract — `embed(&[&str])` has no way to say "this
+/// string is an image" — so cognee's Rust path always fills `inputText`. The
+/// field is modelled anyway so the shape stays honest against the plan's §1.5
+/// table.
+#[derive(Debug, Serialize)]
+pub(crate) struct TitanMultimodalRequest<'a> {
+    #[serde(rename = "inputText", skip_serializing_if = "Option::is_none")]
+    input_text: Option<&'a str>,
+    #[serde(rename = "inputImage", skip_serializing_if = "Option::is_none")]
+    input_image: Option<&'a str>,
+    #[serde(rename = "embeddingConfig")]
+    embedding_config: TitanEmbeddingConfig,
+}
+
+impl<'a> TitanMultimodalRequest<'a> {
+    /// A text-only multimodal request asking for `output_embedding_length`
+    /// dimensions.
+    pub(crate) fn text(input_text: &'a str, output_embedding_length: usize) -> Self {
+        Self {
+            input_text: Some(input_text),
+            input_image: None,
+            embedding_config: TitanEmbeddingConfig {
+                output_embedding_length,
+            },
+        }
+    }
+}
+
+/// The response envelope shared by all three Titan families.
+#[derive(Debug, Deserialize)]
+struct TitanEmbeddingResponse {
+    embedding: Vec<f32>,
+    /// Reported by every Titan family; cognee has nowhere to put an embedding
+    /// token count, so it is parsed and dropped rather than silently ignored.
+    #[serde(rename = "inputTextTokenCount", default)]
+    #[allow(
+        dead_code,
+        reason = "documents the wire shape; cognee has no sink for it"
+    )]
+    input_text_token_count: Option<u64>,
+}
+
+/// Parse `{"embedding": [...], "inputTextTokenCount": n}`.
+///
+/// An unparseable or differently-shaped body is an
+/// [`EmbeddingError::ApiError`]: re-POSTing the same request cannot change a
+/// response shape, so it must not be classified as transient.
+pub(crate) fn parse_response(body: &[u8]) -> EmbeddingResult<Vec<f32>> {
+    let parsed: TitanEmbeddingResponse = serde_json::from_slice(body).map_err(|e| {
+        EmbeddingError::ApiError(format!(
+            "Failed to parse the Titan embedding response: {e}; body: {}",
+            String::from_utf8_lossy(body)
+        ))
+    })?;
+    Ok(parsed.embedding)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    fn body_of<T: Serialize>(request: &T) -> Value {
+        serde_json::to_value(request).expect("request serialises")
+    }
+
+    #[test]
+    fn g1_body_is_exactly_input_text() {
+        assert_eq!(
+            body_of(&TitanTextRequest::g1("hello")),
+            json!({ "inputText": "hello" })
+        );
+    }
+
+    #[test]
+    fn v2_body_omits_unconfigured_knobs() {
+        assert_eq!(
+            body_of(&TitanTextRequest::v2("hello", None, None)),
+            json!({ "inputText": "hello" })
+        );
+    }
+
+    #[test]
+    fn v2_body_carries_dimensions_and_normalize_when_configured() {
+        assert_eq!(
+            body_of(&TitanTextRequest::v2("hello", Some(1024), Some(true))),
+            json!({ "inputText": "hello", "dimensions": 1024, "normalize": true })
+        );
+    }
+
+    #[test]
+    fn multimodal_body_sends_input_text_and_the_embedding_config() {
+        assert_eq!(
+            body_of(&TitanMultimodalRequest::text("hello", 1024)),
+            json!({
+                "inputText": "hello",
+                "embeddingConfig": { "outputEmbeddingLength": 1024 },
+            }),
+            "inputImage must be absent — the text path never fills it"
+        );
+    }
+
+    #[test]
+    fn response_unwraps_the_embedding() {
+        let body = br#"{"embedding":[0.25,0.5],"inputTextTokenCount":3}"#;
+        assert_eq!(parse_response(body).expect("parses"), vec![0.25, 0.5]);
+    }
+
+    #[test]
+    fn response_without_a_token_count_still_parses() {
+        assert_eq!(
+            parse_response(br#"{"embedding":[1.0]}"#).expect("parses"),
+            vec![1.0]
+        );
+    }
+
+    #[test]
+    fn unexpected_response_shape_is_an_api_error() {
+        let err = parse_response(br#"{"embeddings":[[1.0]]}"#).expect_err("must not parse");
+        assert!(
+            matches!(err, EmbeddingError::ApiError(_)),
+            "a wrong shape is terminal, not transient: {err:?}"
+        );
+    }
+}

--- a/crates/embedding/src/config.rs
+++ b/crates/embedding/src/config.rs
@@ -48,7 +48,33 @@ pub fn known_model_dimensions(provider: EmbeddingProvider, model: &str) -> Optio
     // rsplit('/').next() is infallible for any &str (always yields ≥ 1 element).
     let bare = model.rsplit('/').next().unwrap_or(model);
     let key = bare.to_ascii_lowercase();
-    let dim = match key.as_str() {
+    // Bedrock ids may carry a cross-region inference prefix (`eu.`, `us.`, …)
+    // that is part of the id but not of the model family. The Bedrock engine's
+    // own family selector normalises it away, so this table has to as well —
+    // otherwise `eu.amazon.titan-embed-text-v2:0` misses, falls back to 384, and
+    // Titan v2 (which accepts only 1024/512/256) rejects every request.
+    let dim =
+        dimensions_for_key(&key).or_else(|| dimensions_for_key(strip_cross_region_prefix(&key)))?;
+    let _ = provider; // provider currently unused; kept for future provider-scoped dims
+    Some(dim)
+}
+
+/// Cross-region inference prefixes, mirroring the Bedrock adapter's
+/// `model_id::CROSS_REGION_PREFIXES` (plan §1.4.1). Duplicated rather than
+/// imported so the table works with the `bedrock` feature off.
+const CROSS_REGION_PREFIXES: [&str; 7] = ["global", "us", "eu", "apac", "jp", "au", "us-gov"];
+
+/// Drop a leading cross-region segment: `eu.amazon.titan-…` → `amazon.titan-…`.
+fn strip_cross_region_prefix(key: &str) -> &str {
+    match key.split_once('.') {
+        Some((head, rest)) if CROSS_REGION_PREFIXES.contains(&head) => rest,
+        _ => key,
+    }
+}
+
+/// The dimension table itself, keyed on an already-lowercased bare id.
+fn dimensions_for_key(key: &str) -> Option<usize> {
+    let dim = match key {
         // --- OpenAI models (verified via litellm registry) ---
         "text-embedding-3-large" => 3072,
         "text-embedding-3-small" => 1536,
@@ -75,7 +101,6 @@ pub fn known_model_dimensions(provider: EmbeddingProvider, model: &str) -> Optio
         "cohere.embed-english-v3" | "cohere.embed-multilingual-v3" => 1024,
         _ => return None,
     };
-    let _ = provider; // provider currently unused; kept for future provider-scoped dims
     Some(dim)
 }
 
@@ -873,6 +898,14 @@ mod tests {
             ("cohere.embed-multilingual-v3", 1024),
             // The `provider/` prefix is stripped by the shared rsplit.
             ("bedrock/amazon.titan-embed-text-v2:0", 1024),
+            // Cross-region inference prefixes are part of the id but not of the
+            // model family, and the Bedrock engine's family selector accepts
+            // them — so this table must too. Missing them fell back to 384, and
+            // Titan v2 accepts only 1024/512/256, so every embed call 400ed.
+            ("eu.amazon.titan-embed-text-v2:0", 1024),
+            ("us.amazon.titan-embed-text-v1", 1536),
+            ("apac.cohere.embed-english-v3", 1024),
+            ("bedrock/eu.amazon.titan-embed-image-v1", 1024),
         ] {
             assert_eq!(
                 known_model_dimensions(EmbeddingProvider::Ollama, model),

--- a/crates/embedding/src/config.rs
+++ b/crates/embedding/src/config.rs
@@ -62,6 +62,17 @@ pub fn known_model_dimensions(provider: EmbeddingProvider, model: &str) -> Optio
         // --- Common Ollama models ---
         "nomic-embed-text" => 768,
         "mxbai-embed-large" => 1024,
+        // --- AWS Bedrock (InvokeModel) ---
+        // Keyed on the bare id: the `rsplit('/')` above already strips a
+        // `bedrock/` prefix. Without these entries a Bedrock model would fall
+        // back to FALLBACK_DIMENSIONS with a warning and the first vector write
+        // would fail on a shape mismatch.
+        "amazon.titan-embed-text-v1" => 1536,
+        // v2's default; a request may narrow it via the `dimensions` field
+        // (512 / 256), in which case EMBEDDING_DIMENSIONS must say so.
+        "amazon.titan-embed-text-v2:0" => 1024,
+        "amazon.titan-embed-image-v1" => 1024,
+        "cohere.embed-english-v3" | "cohere.embed-multilingual-v3" => 1024,
         _ => return None,
     };
     let _ = provider; // provider currently unused; kept for future provider-scoped dims
@@ -202,6 +213,19 @@ pub struct EmbeddingConfig {
     /// HuggingFace tokenizer identifier for chunking token counting.
     /// When set, used by `HuggingFaceTokenCounter` in the chunking crate.
     pub huggingface_tokenizer: Option<String>,
+
+    /// AWS inputs for the Bedrock engine — the region/credential/endpoint
+    /// parameters litellm's `base_aws_llm` reads, before its uppercase-env
+    /// fallback loop runs. Only consulted when the provider is
+    /// [`EmbeddingProvider::Bedrock`]; `Default` means "resolve everything from
+    /// the ambient environment", which is Python's embedding-path behaviour.
+    ///
+    /// `#[serde(skip)]` is load-bearing twice over: the upstream type carries
+    /// no serde impls, and these are credentials that must never be serialised
+    /// into a persisted or logged config. Its `Debug` redacts every secret.
+    #[cfg(feature = "bedrock")]
+    #[serde(skip)]
+    pub aws: cognee_llm::adapters::bedrock::aws::env::AwsInputs,
 }
 
 impl Default for EmbeddingConfig {
@@ -259,6 +283,8 @@ impl Default for EmbeddingConfig {
             #[cfg(feature = "onnx")]
             onnx: OnnxEmbeddingConfig::default(),
             huggingface_tokenizer: None,
+            #[cfg(feature = "bedrock")]
+            aws: cognee_llm::adapters::bedrock::aws::env::AwsInputs::default(),
         }
     }
 }
@@ -299,6 +325,14 @@ impl EmbeddingConfig {
                 "openai" => config.provider = EmbeddingProvider::OpenAi,
                 "openai_compatible" => config.provider = EmbeddingProvider::OpenAiCompatible,
                 "ollama" => config.provider = EmbeddingProvider::Ollama,
+                // Ungated, for the same reason as `parse_embedding_provider`'s
+                // arm in cognee-components: the id must be recognised whatever
+                // the build's features are. Falling through to the `_` arm here
+                // would silently leave the platform default (OpenAI) selected
+                // and POST Titan bodies at api.openai.com; `create_engine`'s
+                // `NotImplemented` arm gives the honest error in a build
+                // without the `bedrock` feature.
+                "bedrock" => config.provider = EmbeddingProvider::Bedrock,
                 "mock" => {
                     config.mock = true;
                     config.provider = EmbeddingProvider::Mock;
@@ -486,6 +520,15 @@ impl EmbeddingConfig {
                 let engine = OllamaEmbeddingEngine::new(self)?;
                 Ok(Arc::new(engine))
             }
+            #[cfg(feature = "bedrock")]
+            EmbeddingProvider::Bedrock => {
+                let engine = crate::bedrock::BedrockEmbeddingEngine::new(self).await?;
+                Ok(Arc::new(engine))
+            }
+            #[cfg(not(feature = "bedrock"))]
+            EmbeddingProvider::Bedrock => Err(crate::error::EmbeddingError::NotImplemented(
+                "Bedrock embedding engine requires the `bedrock` crate feature".to_string(),
+            )),
             EmbeddingProvider::Mock => Ok(Arc::new(
                 MockEmbeddingEngine::new(self.dimensions).with_mode(self.mock_mode),
             )),
@@ -494,6 +537,11 @@ impl EmbeddingConfig {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code — panics are acceptable failures"
+)]
 mod tests {
     use super::*;
     use serial_test::serial;
@@ -809,5 +857,87 @@ mod tests {
             std::env::remove_var("EMBEDDING_MODEL");
         }
         assert_eq!(config.dimensions, FALLBACK_DIMENSIONS);
+    }
+
+    // ── Bedrock ──────────────────────────────────────────────────────────────
+
+    /// Without these entries a Bedrock model resolves to FALLBACK_DIMENSIONS
+    /// (384) and the first vector write fails on a shape mismatch.
+    #[test]
+    fn bedrock_models_resolve_their_dimensions() {
+        for (model, expected) in [
+            ("amazon.titan-embed-text-v1", 1536),
+            ("amazon.titan-embed-text-v2:0", 1024),
+            ("amazon.titan-embed-image-v1", 1024),
+            ("cohere.embed-english-v3", 1024),
+            ("cohere.embed-multilingual-v3", 1024),
+            // The `provider/` prefix is stripped by the shared rsplit.
+            ("bedrock/amazon.titan-embed-text-v2:0", 1024),
+        ] {
+            assert_eq!(
+                known_model_dimensions(EmbeddingProvider::Ollama, model),
+                Some(expected),
+                "model {model}",
+            );
+        }
+    }
+
+    /// `EMBEDDING_PROVIDER=bedrock` must survive the *other* provider
+    /// allowlist — the one inside `from_env`. Falling through its `_` arm
+    /// leaves the platform default (OpenAI) selected, which is silently wrong
+    /// rather than an error.
+    #[test]
+    #[serial]
+    fn from_env_recognises_the_bedrock_provider() {
+        // SAFETY: see test_from_env_mock_embedding_true
+        unsafe { std::env::set_var("EMBEDDING_PROVIDER", "bedrock") };
+        let config = EmbeddingConfig::from_env();
+        unsafe { std::env::remove_var("EMBEDDING_PROVIDER") };
+        assert_eq!(config.provider, EmbeddingProvider::Bedrock);
+        assert_eq!(config.effective_provider(), EmbeddingProvider::Bedrock);
+    }
+
+    /// A bedrock-provider config really does build an engine. The bearer key
+    /// keeps the credential ladder out of it and the pinned region keeps the
+    /// ambient region chain out of it, so the test needs no AWS access.
+    #[cfg(feature = "bedrock")]
+    #[tokio::test]
+    async fn create_engine_builds_the_bedrock_engine() {
+        let mut config = EmbeddingConfig {
+            provider: EmbeddingProvider::Bedrock,
+            model: "amazon.titan-embed-text-v2:0".to_string(),
+            dimensions: 1024,
+            api_key: Some("bedrock-api-key".to_string()),
+            ..EmbeddingConfig::default()
+        };
+        config.aws.region = Some("us-east-1".to_string());
+
+        let engine = config
+            .create_engine()
+            .await
+            .expect("bedrock engine should build");
+        assert_eq!(engine.dimension(), 1024);
+    }
+
+    /// The `#[cfg(not(feature = "bedrock"))]` arm: the provider id stays
+    /// recognised, and the error names the missing feature instead of falling
+    /// back to another engine.
+    #[cfg(not(feature = "bedrock"))]
+    #[tokio::test]
+    async fn create_engine_without_the_bedrock_feature_is_not_implemented() {
+        let config = EmbeddingConfig {
+            provider: EmbeddingProvider::Bedrock,
+            model: "amazon.titan-embed-text-v2:0".to_string(),
+            ..EmbeddingConfig::default()
+        };
+
+        match config.create_engine().await {
+            Err(crate::error::EmbeddingError::NotImplemented(message)) => assert!(
+                message.contains("bedrock"),
+                "the error must name the missing feature: {message}"
+            ),
+            Err(other) => panic!("expected NotImplemented, got {other:?}"),
+            Ok(_) => panic!("no bedrock feature, no engine"),
+        }
     }
 }

--- a/crates/embedding/src/lib.rs
+++ b/crates/embedding/src/lib.rs
@@ -1,4 +1,4 @@
-//! Multi-provider text-embedding engine (ONNX, OpenAI-compatible, Ollama, Mock).
+//! Multi-provider text-embedding engine (ONNX, OpenAI-compatible, Ollama, Bedrock, Mock).
 
 /// Embedding engine configuration.
 pub mod config;
@@ -17,6 +17,11 @@ pub mod provider;
 /// Shared utilities for embedding input sanitization and response handling.
 pub mod utils;
 
+// Module docs live in `bedrock/mod.rs`; an outer `///` here would merge with
+// them and make their intra-doc links resolve in *this* module's scope.
+#[cfg(feature = "bedrock")]
+pub mod bedrock;
+
 #[cfg(feature = "onnx")]
 /// Lazy model and tokenizer download from HuggingFace Hub.
 pub mod download;
@@ -32,6 +37,9 @@ pub use ollama::OllamaEmbeddingEngine;
 pub use openai_compatible::OpenAICompatibleEmbeddingEngine;
 pub use provider::EmbeddingProvider;
 pub use utils::{handle_embedding_response, is_embeddable, sanitize_embedding_inputs};
+
+#[cfg(feature = "bedrock")]
+pub use bedrock::{BedrockEmbeddingEngine, BedrockEmbeddingFamily};
 
 #[cfg(feature = "onnx")]
 pub use config::OnnxEmbeddingConfig;

--- a/crates/embedding/src/ollama.rs
+++ b/crates/embedding/src/ollama.rs
@@ -466,6 +466,8 @@ mod tests {
             #[cfg(feature = "onnx")]
             onnx: Default::default(),
             huggingface_tokenizer: None,
+            #[cfg(feature = "bedrock")]
+            aws: Default::default(),
         }
     }
 

--- a/crates/embedding/src/provider.rs
+++ b/crates/embedding/src/provider.rs
@@ -25,6 +25,11 @@ pub enum EmbeddingProvider {
     OpenAiCompatible,
     /// Ollama /api/embed endpoint (not OpenAI-compatible format).
     Ollama,
+    /// AWS Bedrock InvokeModel (`amazon.titan-embed-*`, `cohere.embed-*`).
+    /// In Python, EMBEDDING_PROVIDER=bedrock routes through LiteLLMEmbeddingEngine to
+    /// litellm's Bedrock embedding handler; in Rust we use a direct-HTTP engine over the
+    /// same wire shapes. Requires the `bedrock` crate feature.
+    Bedrock,
     /// Zero vectors; for testing. Activated by EMBEDDING_PROVIDER=mock or MOCK_EMBEDDING=true.
     Mock,
 }

--- a/crates/http-server/Cargo.toml
+++ b/crates/http-server/Cargo.toml
@@ -41,7 +41,7 @@ required-features = ["bin"]
 # --no-default-features for compile-time opt-out.
 # html-loader is on by default so the server binary supports URL ingestion and
 # HTML documents out of the box (parity with the Python `/add` URL path).
-default = ["telemetry", "html-loader", "onnx", "ladybug", "lancedb", "pgvector"]
+default = ["telemetry", "html-loader", "onnx", "ladybug", "lancedb", "pgvector", "bedrock"]
 # Embedded LanceDB vector store, forwarded to cognee-components + cognee-vector.
 # Default-on, so a plain build of this crate is unchanged; a consumer whose vector
 # backend is pgvector (or a closed adapter) can now drop the Arrow + lance native
@@ -58,6 +58,11 @@ pgvector = ["cognee-components/pgvector", "cognee-vector/pgvector"]
 # `graph_postgres_url: None`, so the standalone server does not use it — it is
 # here for consumers that build their own BackendBuildContext.
 pggraph = ["cognee-components/pggraph", "cognee-graph/postgres"]
+# AWS Bedrock LLM adapter + embedding engine (plan §2.3, §6.2). Default-on;
+# `--no-default-features` drops the whole AWS stack (aws-config + aws-sigv4).
+# `cognee-components` is depended on with `default-features = false`, so all
+# three forwards are required.
+bedrock = ["cognee-components/bedrock", "cognee-llm/bedrock", "cognee-embedding/bedrock"]
 # Enables the standalone-binary entry point and its arg-parsing deps.
 bin = [
     "dep:clap",

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -696,6 +696,7 @@ impl HttpServerConfig {
                 onnx_dimensions: self.embedding_dimensions as usize,
                 onnx_max_sequence_length,
                 onnx_batch_size,
+                aws: cognee_components::aws_inputs_from_env(),
             },
             llm: cognee_components::LlmInputs {
                 provider: self.llm_provider.to_ascii_lowercase(),
@@ -720,6 +721,7 @@ impl HttpServerConfig {
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),
+                aws: cognee_components::aws_inputs_from_env(),
             },
         }
     }

--- a/crates/http-server/src/dto/settings.rs
+++ b/crates/http-server/src/dto/settings.rs
@@ -54,9 +54,15 @@ pub struct LLMConfigInputDTO {
     pub api_key: String,
 }
 
-/// Provider enum for `LLMConfigInputDTO::provider`. Note that `bedrock`
-/// is **not** in this list — Python's GET advertises it but the save
-/// `Literal` rejects it (`routers/settings.md §6.4`).
+/// Provider enum for `LLMConfigInputDTO::provider`. `bedrock` **is** accepted
+/// on save here — it is advertised by `GET /api/v1/settings` and the Bedrock
+/// LLM provider is registered by default.
+///
+/// Python's `LLMConfigInputDTO.provider` `Literal` union does not include
+/// `bedrock` yet (`cognee/api/v1/settings/routers/get_settings_router.py`), so
+/// its save still rejects the value; closing that gap is the upstream edit
+/// tracked as `docs/roadmap/bedrock-provider-plan.md` §5 P1, which has not
+/// shipped in `topoteretes/cognee` as of this writing.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, ToSchema, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum LlmProvider {
@@ -65,6 +71,7 @@ pub enum LlmProvider {
     Anthropic,
     Gemini,
     Mistral,
+    Bedrock,
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -162,5 +169,23 @@ mod tests {
     #[test]
     fn should_persist_accepts_real_key() {
         assert!(should_persist_api_key("sk-real-key"));
+    }
+
+    #[test]
+    fn llm_provider_accepts_bedrock() {
+        let p: LlmProvider = serde_json::from_str("\"bedrock\"").expect("bedrock parses");
+        assert_eq!(p, LlmProvider::Bedrock);
+        // Round-trips back to the lowercase wire value Python uses.
+        assert_eq!(
+            serde_json::to_string(&LlmProvider::Bedrock).expect("serialize"),
+            "\"bedrock\""
+        );
+    }
+
+    #[test]
+    fn llm_provider_still_rejects_unknown_values() {
+        assert!(serde_json::from_str::<LlmProvider>("\"not-a-provider\"").is_err());
+        // Casing is significant: the enum is `rename_all = "lowercase"`.
+        assert!(serde_json::from_str::<LlmProvider>("\"Bedrock\"").is_err());
     }
 }

--- a/crates/http-server/src/routers/settings.rs
+++ b/crates/http-server/src/routers/settings.rs
@@ -57,7 +57,9 @@ fn llm_providers() -> Vec<ConfigChoice> {
         },
         ConfigChoice {
             value: "bedrock".into(),
-            label: "AWS Bedrock".into(),
+            // Python's label is exactly "Bedrock" (`get_settings.py` L79-L82);
+            // the cross-SDK settings parity test compares this entry verbatim.
+            label: "Bedrock".into(),
         },
     ]
 }

--- a/crates/http-server/src/routers/settings.rs
+++ b/crates/http-server/src/routers/settings.rs
@@ -160,10 +160,20 @@ fn llm_models() -> BTreeMap<String, Vec<ConfigChoice>> {
     );
     m.insert(
         "bedrock".into(),
-        vec![ConfigChoice {
-            value: "anthropic.claude-3-5-sonnet-20240620-v1:0".into(),
-            label: "anthropic.claude-3-5-sonnet-20240620-v1:0".into(),
-        }],
+        vec![
+            ConfigChoice {
+                value: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0".into(),
+                label: "Claude 4.5 Sonnet".into(),
+            },
+            ConfigChoice {
+                value: "eu.anthropic.claude-haiku-4-5-20251001-v1:0".into(),
+                label: "Claude 4.5 Haiku".into(),
+            },
+            ConfigChoice {
+                value: "eu.amazon.nova-lite-v1:0".into(),
+                label: "Amazon Nova Lite".into(),
+            },
+        ],
     );
     m
 }
@@ -294,6 +304,7 @@ pub async fn save_settings(
             crate::dto::settings::LlmProvider::Anthropic => "anthropic".into(),
             crate::dto::settings::LlmProvider::Gemini => "gemini".into(),
             crate::dto::settings::LlmProvider::Mistral => "mistral".into(),
+            crate::dto::settings::LlmProvider::Bedrock => "bedrock".into(),
         };
         current.model = model;
         if should_persist_api_key(&api_key) {

--- a/crates/http-server/tests/test_settings.rs
+++ b/crates/http-server/tests/test_settings.rs
@@ -1,0 +1,139 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Integration tests for `/api/v1/settings`, focused on the `bedrock` provider
+//! surface (`docs/roadmap/bedrock-provider-plan.md` §4 R7 + §5 P2).
+//!
+//! `HttpServerConfig::default()` leaves `require_authentication = false`, so
+//! `AuthenticatedUser` resolves to the synthetic default user and no auth
+//! header is needed.
+//!
+//! **Caution**: the settings store is a process-wide `OnceLock<SettingsStore>`
+//! shared by every test in this binary, so the POST cases below mutate state
+//! other tests can observe. All assertions here are therefore either on the
+//! static `llm_models()` output (which POST never mutates) or on the response
+//! status code.
+
+mod support;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+
+/// Python's current bedrock model list (`cognee/modules/settings/get_settings.py`),
+/// in Python's order, with Python's values *and* labels.
+const EXPECTED_BEDROCK_MODELS: &[(&str, &str)] = &[
+    (
+        "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "Claude 4.5 Sonnet",
+    ),
+    (
+        "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "Claude 4.5 Haiku",
+    ),
+    ("eu.amazon.nova-lite-v1:0", "Amazon Nova Lite"),
+];
+
+/// Build a settings POST request with the given JSON body.
+fn settings_post(body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/api/v1/settings")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request")
+}
+
+/// `GET /api/v1/settings` advertises exactly Python's three bedrock models,
+/// in Python's order, with matching `value` and `label` fields.
+#[tokio::test]
+async fn test_get_settings_lists_python_bedrock_models() {
+    let state = support::build_test_state().await;
+    let app = support::test_router(state).await;
+    let resp = support::oneshot_get(app, "/api/v1/settings").await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = support::body_json(resp).await;
+
+    let models = body["llm"]["models"]["bedrock"]
+        .as_array()
+        .expect("llm.models.bedrock is an array");
+
+    assert_eq!(
+        models.len(),
+        EXPECTED_BEDROCK_MODELS.len(),
+        "unexpected bedrock model count: {models:?}"
+    );
+
+    for (idx, (value, label)) in EXPECTED_BEDROCK_MODELS.iter().enumerate() {
+        assert_eq!(
+            models[idx]["value"].as_str(),
+            Some(*value),
+            "bedrock model {idx} value mismatch"
+        );
+        assert_eq!(
+            models[idx]["label"].as_str(),
+            Some(*label),
+            "bedrock model {idx} label mismatch"
+        );
+    }
+}
+
+/// `POST /api/v1/settings` accepts `provider: "bedrock"` (plan §4 R7). Python's
+/// save-side `Literal` does not include it yet — see §5 P1.
+///
+/// The follow-up `GET` pins the save-side match arm's snapshot string: a 200
+/// alone would also be returned if `LlmProvider::Bedrock` were mapped to some
+/// other provider name.
+#[tokio::test]
+async fn test_post_settings_accepts_bedrock_provider() {
+    let state = support::build_test_state().await;
+    let app = support::test_router(state).await;
+
+    let req = settings_post(serde_json::json!({
+        "llm": {
+            "provider": "bedrock",
+            "model": "eu.amazon.nova-lite-v1:0",
+            "api_key": "test-key",
+        }
+    }));
+    let resp = support::oneshot_request(app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Read the mutated snapshot back. Safe against the shared process-wide
+    // store: this is the only case in this binary that mutates the LLM
+    // snapshot (the unknown-provider POST is rejected by the extractor before
+    // the handler runs), and the GET case above asserts only on the static
+    // `llm_models()` output.
+    let state = support::build_test_state().await;
+    let app = support::test_router(state).await;
+    let body = support::body_json(support::oneshot_get(app, "/api/v1/settings").await).await;
+
+    assert_eq!(body["llm"]["provider"].as_str(), Some("bedrock"));
+    assert_eq!(
+        body["llm"]["model"].as_str(),
+        Some("eu.amazon.nova-lite-v1:0")
+    );
+}
+
+/// Negative control: the provider enum is still closed, so an unknown value is
+/// rejected by axum's `Json` extractor with 422 (what the handler's utoipa
+/// annotation documents) rather than being silently accepted.
+#[tokio::test]
+async fn test_post_settings_rejects_unknown_provider() {
+    let state = support::build_test_state().await;
+    let app = support::test_router(state).await;
+
+    let req = settings_post(serde_json::json!({
+        "llm": {
+            "provider": "not-a-provider",
+            "model": "eu.amazon.nova-lite-v1:0",
+            "api_key": "test-key",
+        }
+    }));
+    let resp = support::oneshot_request(app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -66,6 +66,7 @@ default = [
     "unstructured",
     "visualization",
     "mock-llm",
+    "bedrock",
     # decision 1: telemetry is ON by default in cognee. Disable with
     # --no-default-features for compile-time opt-out.
     "telemetry",
@@ -88,6 +89,11 @@ sqlite         = ["cognee-database/sqlite"]
 postgres       = ["cognee-database/postgres"]
 hf-tokenizer   = ["cognee-chunking/hf-tokenizer"]
 tiktoken       = ["cognee-chunking/tiktoken"]
+# AWS Bedrock LLM adapter + embedding engine (plan §2.3, §6.2). Default-on, like
+# the other shipped surfaces; `--no-default-features` drops the whole AWS stack
+# (aws-config + aws-sigv4). `cognee-components` is depended on with
+# `default-features = false`, so all three forwards are required.
+bedrock        = ["cognee-components/bedrock", "cognee-llm/bedrock", "cognee-embedding/bedrock"]
 
 # External telemetry event export (opt-in). When enabled, the high-level API
 # functions emit `tracing` events on the `cognee.telemetry` target so

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -845,6 +845,7 @@ impl Settings {
                 onnx_dimensions: self.embedding_dimensions as usize,
                 onnx_max_sequence_length: self.embedding_max_sequence_length as usize,
                 onnx_batch_size: self.embedding_onnx_batch_size as usize,
+                aws: cognee_components::aws_inputs_from_env(),
             },
             llm: cognee_components::LlmInputs {
                 provider: self.llm_provider.to_lowercase(),
@@ -862,6 +863,7 @@ impl Settings {
                 mock: self.llm_mock,
                 cassette: self.llm_cassette.clone(),
                 record_path: self.llm_record_path.clone(),
+                aws: cognee_components::aws_inputs_from_env(),
             },
         }
     }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -3017,13 +3017,15 @@ mod tests {
     /// through.
     #[test]
     fn bedrock_embeddings_do_not_inherit_a_foreign_llm_endpoint_or_key() {
-        let mut s = Settings::default();
-        s.embedding_provider = "bedrock".to_string();
-        s.llm_provider = "openai".to_string();
-        s.llm_endpoint = "https://llm-proxy.example.com/v1".to_string();
-        s.llm_api_key = "sk-openai-key".to_string();
-        s.embedding_endpoint = String::new();
-        s.embedding_api_key = String::new();
+        let mut s = Settings {
+            embedding_provider: "bedrock".to_string(),
+            llm_provider: "openai".to_string(),
+            llm_endpoint: "https://llm-proxy.example.com/v1".to_string(),
+            llm_api_key: "sk-openai-key".to_string(),
+            embedding_endpoint: String::new(),
+            embedding_api_key: String::new(),
+            ..Default::default()
+        };
 
         let ctx = s.backend_context();
         assert_eq!(

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -783,14 +783,36 @@ impl Settings {
 
         // Embedding endpoint/key fall back to the LLM provider's when no
         // embedding-specific values are set (shared OpenAI-compatible account).
-        let endpoint = [&self.embedding_endpoint, &self.llm_endpoint]
+        //
+        // That sharing only makes sense when both sides speak the same protocol.
+        // Bedrock does not: it takes AWS-signed InvokeModel bodies at a regional
+        // host, and its `api_key` is a *bearer token*. Inheriting an
+        // OpenAI-compatible `LLM_ENDPOINT` would POST InvokeModel at that host,
+        // and inheriting `LLM_API_KEY` would hand that provider's credential to
+        // AWS. `EMBEDDING_PROVIDER=bedrock` with a custom `LLM_ENDPOINT` /
+        // `OPENAI_URL` is an ordinary configuration, so this is reachable — the
+        // `api.openai.com` guard in the Bedrock engine only catches the default.
+        //
+        // Inherit only when the LLM side is Bedrock too, which is the case the
+        // "shared account" rationale actually covers.
+        let embedding_is_bedrock = self
+            .embedding_provider
+            .trim()
+            .eq_ignore_ascii_case("bedrock");
+        let inherit_from_llm =
+            !embedding_is_bedrock || self.llm_provider.trim().eq_ignore_ascii_case("bedrock");
+
+        let mut endpoint_sources = vec![&self.embedding_endpoint];
+        let mut api_key_sources = vec![&self.embedding_api_key];
+        if inherit_from_llm {
+            endpoint_sources.push(&self.llm_endpoint);
+            api_key_sources.push(&self.llm_api_key);
+        }
+        let endpoint = endpoint_sources
             .into_iter()
             .find(|v| !v.is_empty())
             .cloned();
-        let api_key = [&self.embedding_api_key, &self.llm_api_key]
-            .into_iter()
-            .find(|v| !v.is_empty())
-            .cloned();
+        let api_key = api_key_sources.into_iter().find(|v| !v.is_empty()).cloned();
 
         // MOCK_EMBEDDING: `deterministic`/`hash` selects SHA-256-derived
         // vectors; other truthy values keep the legacy zero-vector mode.
@@ -2984,6 +3006,53 @@ mod tests {
         assert_eq!(s.llm_args.get("top_p"), Some(&serde_json::json!(0.9)));
         // The lowered backend context carries the same map through to the factory.
         assert_eq!(s.backend_context().llm.llm_args, s.llm_args);
+    }
+
+    /// A Bedrock embedding provider must not inherit an OpenAI-compatible
+    /// `LLM_ENDPOINT` / `LLM_API_KEY`.
+    ///
+    /// The endpoint would receive AWS `InvokeModel` bodies, and the key would be
+    /// sent to AWS as a bearer token — the Bedrock engine's own guard only
+    /// rejects the `api.openai.com` default, so a custom proxy passed straight
+    /// through.
+    #[test]
+    fn bedrock_embeddings_do_not_inherit_a_foreign_llm_endpoint_or_key() {
+        let mut s = Settings::default();
+        s.embedding_provider = "bedrock".to_string();
+        s.llm_provider = "openai".to_string();
+        s.llm_endpoint = "https://llm-proxy.example.com/v1".to_string();
+        s.llm_api_key = "sk-openai-key".to_string();
+        s.embedding_endpoint = String::new();
+        s.embedding_api_key = String::new();
+
+        let ctx = s.backend_context();
+        assert_eq!(
+            ctx.embedding.endpoint, None,
+            "a non-Bedrock LLM endpoint must not become the Bedrock api_base",
+        );
+        assert_eq!(
+            ctx.embedding.api_key, None,
+            "a non-Bedrock LLM key must not become the Bedrock bearer token",
+        );
+
+        // The sharing rationale still applies when both sides are Bedrock.
+        s.llm_provider = "bedrock".to_string();
+        let shared = s.backend_context();
+        assert_eq!(
+            shared.embedding.api_key.as_deref(),
+            Some("sk-openai-key"),
+            "a Bedrock LLM key is still shared with Bedrock embeddings",
+        );
+
+        // And a non-Bedrock embedding provider keeps the original fallback.
+        s.embedding_provider = "openai".to_string();
+        s.llm_provider = "openai".to_string();
+        let inherited = s.backend_context();
+        assert_eq!(
+            inherited.embedding.endpoint.as_deref(),
+            Some("https://llm-proxy.example.com/v1"),
+            "the shared-account fallback must survive for OpenAI-compatible pairs",
+        );
     }
 
     #[test]

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -18,6 +18,19 @@ workspace = true
 default = []
 # Record/replay cassette-based mock LLM support.
 mock = ["dep:sha2"]
+# AWS Bedrock provider: shared AWS plumbing (`adapters::bedrock::aws`) plus the
+# Bedrock adapter built on it. Non-default because the AWS stack is not free —
+# see docs/roadmap/bedrock-provider-plan.md §2.3 and §3.
+bedrock = [
+    "dep:aws-config",
+    "dep:aws-credential-types",
+    "dep:aws-sigv4",
+    "dep:aws-smithy-runtime-api",
+    # Not imported by this crate — declared only to hold the MSRV pin on two
+    # transitive smithy crates. See the workspace manifest.
+    "dep:aws-smithy-async",
+    "dep:aws-smithy-types",
+]
 
 [dependencies]
 # Async runtime
@@ -51,9 +64,23 @@ cognee-utils = { path = "../utils", version = "0.2.0" }
 # Content hashing (cassette mock, feature-gated)
 sha2 = { workspace = true, optional = true }
 
+# AWS Bedrock stack (feature-gated). Versions are pinned in the workspace
+# manifest against the 1.91 MSRV — see the comment there before bumping.
+aws-config = { workspace = true, optional = true }
+aws-credential-types = { workspace = true, optional = true }
+aws-sigv4 = { workspace = true, optional = true }
+aws-smithy-async = { workspace = true, optional = true }
+aws-smithy-runtime-api = { workspace = true, optional = true }
+aws-smithy-types = { workspace = true, optional = true }
+
 [dev-dependencies]
+async-trait.workspace = true
 cognee-test-utils = { path = "../test-utils" }
 dotenv.workspace = true
 httpmock = "0.8"
+# The bedrock tests drive the signer and the transport seam directly, which is
+# the same reqwest surface the adapter (R3) will use.
+reqwest = { workspace = true }
+serial_test = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -65,7 +65,7 @@ cognee-utils = { path = "../utils", version = "0.2.0" }
 sha2 = { workspace = true, optional = true }
 
 # AWS Bedrock stack (feature-gated). Versions are pinned in the workspace
-# manifest against the 1.91 MSRV — see the comment there before bumping.
+# manifest against the 1.91.1 MSRV — see the comment there before bumping.
 aws-config = { workspace = true, optional = true }
 aws-credential-types = { workspace = true, optional = true }
 aws-sigv4 = { workspace = true, optional = true }

--- a/crates/llm/README.md
+++ b/crates/llm/README.md
@@ -211,10 +211,21 @@ Tests will automatically skip if environment variables are not set.
 
 Implemented:
 - **`OpenAIAdapter`** — OpenAI-compatible APIs (also works with Ollama/vLLM/LocalAI)
+- **`AnthropicAdapter`** — native Anthropic Messages API (`x-api-key`, hoisted
+  `system` field, structured output via a forced `tool_use`)
+- **`BedrockAdapter`** (`bedrock` feature) — AWS Bedrock over the **Converse**
+  API. Authenticates with a bearer token (`LLM_API_KEY` or
+  `AWS_BEARER_TOKEN_BEDROCK`, no signing) or falls through to SigV4 with the
+  full AWS credential ladder. Structured output is capability-gated per model:
+  native `outputConfig.textFormat` where the model supports it, otherwise a
+  synthetic `json_tool_call` tool. No streaming; `/invoke`-routed chat models are
+  rejected at construction. Image description (vision) is implemented over
+  Converse image blocks for models whose capability-table entry advertises it,
+  and therefore **exceeds** Python parity, where
+  `BedrockAdapter.transcribe_image` raises `NotImplementedError`.
 
 On-device LiteRT inference (Android) ships in the closed companion crate
 `cognee-llm-litert`.
 
 Planned:
-- Anthropic adapter (Claude with tool use)
 - Streaming support: real-time token streaming for all adapters

--- a/crates/llm/src/adapters/bedrock/aws/credentials.rs
+++ b/crates/llm/src/adapters/bedrock/aws/credentials.rs
@@ -28,7 +28,12 @@
 //! ([`CredentialLookup`]) is a trait so the bearer path can prove it performs
 //! no lookup.
 
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
 use async_trait::async_trait;
+use tokio::sync::RwLock;
+use tracing::debug;
 
 use super::env::{
     AwsSettings, ENV_DEFAULT_REGION, ENV_REGION, ENV_ROLE_ARN, ENV_WEB_IDENTITY_TOKEN_FILE,
@@ -573,6 +578,126 @@ impl CredentialLookup for AwsConfigCredentials {
     }
 }
 
+/// How close to expiry a credential set may get before it is re-resolved.
+///
+/// Mirrors the headroom `aws-config`'s lazy identity cache uses, so a request
+/// never starts with credentials that will expire while it is in flight.
+const REFRESH_MARGIN: Duration = Duration::from_secs(60);
+
+/// A [`BedrockAuth`] that re-resolves itself before its credentials expire.
+///
+/// Every non-static rung of the §1.2 ladder yields *temporary* credentials —
+/// `AssumeRole` and `AssumeRoleWithWebIdentity` default to an hour, and the
+/// default chain over IMDS/ECS/SSO is comparable. Resolving once at construction
+/// and signing every later request with that snapshot works until the lifetime
+/// runs out, at which point Bedrock answers 403 `ExpiredTokenException`, which
+/// classifies as a terminal [`LlmError::AuthenticationError`]. Because the built
+/// adapter is cached for the process lifetime, that is a permanent failure in
+/// any long-running host — while Python litellm keeps working, since boto3 hands
+/// it refreshable credentials.
+///
+/// The bearer rungs and static keys never expire; for them this is a clone of a
+/// cached value and no lookup ever runs again.
+pub struct BedrockAuthProvider {
+    api_key: Option<String>,
+    settings: AwsSettings,
+    region: String,
+    ambient: AmbientRoleIdentity,
+    lookup: Arc<dyn CredentialLookup>,
+    cached: RwLock<BedrockAuth>,
+}
+
+impl std::fmt::Debug for BedrockAuthProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BedrockAuthProvider")
+            .field("region", &self.region)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BedrockAuthProvider {
+    /// Build a provider around an already-resolved `auth`.
+    ///
+    /// The inputs are kept so the ladder can be re-run on expiry; re-running it
+    /// reaches the same rung, because the rung is chosen from `settings` and
+    /// `ambient`, neither of which changes over the process lifetime.
+    pub fn new(
+        api_key: Option<&str>,
+        settings: AwsSettings,
+        region: impl Into<String>,
+        ambient: AmbientRoleIdentity,
+        lookup: Arc<dyn CredentialLookup>,
+        auth: BedrockAuth,
+    ) -> Self {
+        Self {
+            api_key: api_key.map(str::to_string),
+            settings,
+            region: region.into(),
+            ambient,
+            lookup,
+            cached: RwLock::new(auth),
+        }
+    }
+
+    /// A provider that never refreshes — for tests and for callers that hold a
+    /// value with no expiry of its own.
+    pub fn fixed(auth: BedrockAuth, region: impl Into<String>) -> Self {
+        Self {
+            api_key: None,
+            settings: AwsSettings::default(),
+            region: region.into(),
+            ambient: AmbientRoleIdentity::default(),
+            lookup: Arc::new(AwsConfigCredentials),
+            cached: RwLock::new(auth),
+        }
+    }
+
+    /// The auth to sign the next request with, re-resolved if it is at or near
+    /// expiry.
+    pub async fn auth(&self) -> LlmResult<BedrockAuth> {
+        if let Some(fresh) = Self::still_fresh(&*self.cached.read().await) {
+            return Ok(fresh);
+        }
+
+        // Re-check under the write lock: several in-flight requests can observe
+        // the same expiry, and only the first should pay for the lookup.
+        let mut cached = self.cached.write().await;
+        if let Some(fresh) = Self::still_fresh(&cached) {
+            return Ok(fresh);
+        }
+
+        debug!(
+            region = self.region.as_str(),
+            "Bedrock credentials expired or near expiry — re-resolving the §1.2 ladder"
+        );
+        let refreshed = resolve_auth_with(
+            self.api_key.as_deref(),
+            &self.settings,
+            &self.region,
+            &self.ambient,
+            self.lookup.as_ref(),
+        )
+        .await?;
+        *cached = refreshed.clone();
+        Ok(refreshed)
+    }
+
+    /// `Some(clone)` while `auth` is safe to sign with, `None` when it must be
+    /// re-resolved. Bearer tokens and credentials without an expiry never age.
+    fn still_fresh(auth: &BedrockAuth) -> Option<BedrockAuth> {
+        match auth {
+            BedrockAuth::Bearer(_) => Some(auth.clone()),
+            BedrockAuth::SigV4(credentials) => match credentials.expiry() {
+                None => Some(auth.clone()),
+                Some(expiry) => (expiry
+                    .duration_since(SystemTime::now())
+                    .is_ok_and(|left| left > REFRESH_MARGIN))
+                .then(|| auth.clone()),
+            },
+        }
+    }
+}
+
 /// Resolve auth against the process environment and `aws-config`.
 ///
 /// `api_key` is the request-level Bedrock API key (rung 1); the
@@ -584,6 +709,28 @@ pub async fn resolve_auth(
 ) -> LlmResult<BedrockAuth> {
     let ambient = AmbientRoleIdentity::from_env(&ProcessEnv);
     resolve_auth_with(api_key, settings, region, &ambient, &AwsConfigCredentials).await
+}
+
+/// Resolve auth and wrap it in a provider that re-resolves before expiry.
+///
+/// This is what adapters should call: [`resolve_auth`] alone hands back a
+/// snapshot that silently stops working once temporary credentials age out.
+pub async fn resolve_auth_provider(
+    api_key: Option<&str>,
+    settings: &AwsSettings,
+    region: &str,
+) -> LlmResult<BedrockAuthProvider> {
+    let ambient = AmbientRoleIdentity::from_env(&ProcessEnv);
+    let lookup: Arc<dyn CredentialLookup> = Arc::new(AwsConfigCredentials);
+    let auth = resolve_auth_with(api_key, settings, region, &ambient, lookup.as_ref()).await?;
+    Ok(BedrockAuthProvider::new(
+        api_key,
+        settings.clone(),
+        region,
+        ambient,
+        lookup,
+        auth,
+    ))
 }
 
 /// Resolve auth with the ambient identity and the credential lookup injected.

--- a/crates/llm/src/adapters/bedrock/aws/credentials.rs
+++ b/crates/llm/src/adapters/bedrock/aws/credentials.rs
@@ -580,8 +580,12 @@ impl CredentialLookup for AwsConfigCredentials {
 
 /// How close to expiry a credential set may get before it is re-resolved.
 ///
-/// Mirrors the headroom `aws-config`'s lazy identity cache uses, so a request
-/// never starts with credentials that will expire while it is in flight.
+/// Chosen here rather than mirrored from anything: smithy's lazy identity cache
+/// uses a 10s buffer (`lazy.rs`, `DEFAULT_BUFFER_TIME`), which is tight for a
+/// path that may run an STS round trip. 60s does not guarantee a request outlives
+/// its credentials — SigV4 is validated when Bedrock receives the request, not
+/// for the life of the response — but it keeps re-resolution well clear of the
+/// expiry cliff.
 const REFRESH_MARGIN: Duration = Duration::from_secs(60);
 
 /// A [`BedrockAuth`] that re-resolves itself before its credentials expire.
@@ -605,6 +609,11 @@ pub struct BedrockAuthProvider {
     ambient: AmbientRoleIdentity,
     lookup: Arc<dyn CredentialLookup>,
     cached: RwLock<BedrockAuth>,
+    /// `false` for [`Self::fixed`], which must hand back exactly what it was
+    /// given. Without this the ladder inputs of a `fixed` provider are all
+    /// defaults, so a refresh would resolve the *ambient* default chain and
+    /// silently swap the caller's credentials for a different identity.
+    refreshable: bool,
 }
 
 impl std::fmt::Debug for BedrockAuthProvider {
@@ -636,11 +645,16 @@ impl BedrockAuthProvider {
             ambient,
             lookup,
             cached: RwLock::new(auth),
+            refreshable: true,
         }
     }
 
-    /// A provider that never refreshes — for tests and for callers that hold a
-    /// value with no expiry of its own.
+    /// A provider that hands back `auth` unchanged, forever.
+    ///
+    /// It carries none of the ladder inputs, so it must never re-resolve: doing
+    /// so would run the *ambient* default chain and return a different identity
+    /// than the caller asked for. Correct for a bearer token or static keys;
+    /// passing expiring credentials here means they are used until they fail.
     pub fn fixed(auth: BedrockAuth, region: impl Into<String>) -> Self {
         Self {
             api_key: None,
@@ -649,12 +663,17 @@ impl BedrockAuthProvider {
             ambient: AmbientRoleIdentity::default(),
             lookup: Arc::new(AwsConfigCredentials),
             cached: RwLock::new(auth),
+            refreshable: false,
         }
     }
 
     /// The auth to sign the next request with, re-resolved if it is at or near
     /// expiry.
     pub async fn auth(&self) -> LlmResult<BedrockAuth> {
+        if !self.refreshable {
+            return Ok(self.cached.read().await.clone());
+        }
+
         if let Some(fresh) = Self::still_fresh(&*self.cached.read().await) {
             return Ok(fresh);
         }

--- a/crates/llm/src/adapters/bedrock/aws/credentials.rs
+++ b/crates/llm/src/adapters/bedrock/aws/credentials.rs
@@ -1,0 +1,791 @@
+//! The §1.2 auth ladder.
+//!
+//! Port of `base_aws_llm.py::_sign_request` (`:1512`) and `get_credentials`
+//! (`:200`):
+//!
+//! ```text
+//! api_key given?                     → Authorization: Bearer <api_key>  (early return, NO SigV4)
+//! else AWS_BEARER_TOKEN_BEDROCK set? → Authorization: Bearer <env>      (early return, NO SigV4)
+//! else SigV4, credentials resolved in order:
+//!   web identity token + role + session → STS AssumeRoleWithWebIdentity
+//!   role_name                           → STS AssumeRole (skipped when already running as that role)
+//!   profile_name                        → shared-config profile
+//!   access key + secret (+ session token) → static credentials
+//!   otherwise                           → default chain (env / shared config / SSO / ECS / IMDS)
+//! ```
+//!
+//! Two properties of that ladder are easy to lose in a port and are asserted by
+//! tests rather than left to review:
+//!
+//! * the bearer branches are an **early return** — no credential lookup runs at
+//!   all, so a bearer-only deployment never needs AWS credentials present;
+//! * `AssumeRole` is **skipped when the process is already running as the
+//!   target role** (`base_aws_llm.py:1095`), otherwise an IRSA pod that already
+//!   holds the role would pointlessly (and often unpermittedly) assume itself.
+//!
+//! The decision half of the ladder ([`select_strategy`]) is a pure function so
+//! it can be tested exhaustively without AWS; the execution half
+//! ([`CredentialLookup`]) is a trait so the bearer path can prove it performs
+//! no lookup.
+
+use async_trait::async_trait;
+
+use super::env::{
+    AwsSettings, ENV_DEFAULT_REGION, ENV_REGION, ENV_ROLE_ARN, ENV_WEB_IDENTITY_TOKEN_FILE,
+    EnvSource, ProcessEnv,
+};
+use crate::error::{LlmError, LlmResult};
+
+/// AWS credentials as the signer consumes them.
+///
+/// Re-exported so callers (and tests) never need `aws-credential-types` in
+/// their own manifest, and so a future switch to `aws-sdk-bedrockruntime`
+/// (plan §3) can change the currency in one place.
+pub use aws_credential_types::Credentials as AwsCredentials;
+
+/// Provider label attached to credentials this module constructs itself.
+const STATIC_PROVIDER_NAME: &str = "cognee-bedrock-static";
+
+/// How a Bedrock request authenticates.
+#[derive(Clone, Debug)]
+pub enum BedrockAuth {
+    /// A Bedrock API key. Sent verbatim as `Authorization: Bearer …`; the
+    /// request is **not** signed and no credentials were looked up.
+    Bearer(String),
+    /// SigV4 with the resolved credentials.
+    SigV4(Box<AwsCredentials>),
+}
+
+impl BedrockAuth {
+    /// `true` for the bearer branches — used by the transport to skip signing.
+    pub fn is_bearer(&self) -> bool {
+        matches!(self, Self::Bearer(_))
+    }
+
+    /// The `Authorization` header value for a bearer auth, `None` for SigV4
+    /// (where the header is produced by the signer).
+    pub fn bearer_header_value(&self) -> Option<String> {
+        match self {
+            Self::Bearer(token) => Some(format!("Bearer {token}")),
+            Self::SigV4(_) => None,
+        }
+    }
+}
+
+/// Which credential source the ladder selected.
+///
+/// Borrows from the [`AwsSettings`] it was selected from — this is an
+/// intermediate, not a stored value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CredentialStrategy<'a> {
+    /// `sts:AssumeRoleWithWebIdentity`.
+    WebIdentity {
+        /// The OIDC token (see [`CredentialLookup`] for how it is read).
+        web_identity_token: &'a str,
+        /// Role to assume.
+        role_arn: &'a str,
+        /// STS session name.
+        session_name: &'a str,
+    },
+    /// `sts:AssumeRole`.
+    AssumeRole {
+        /// Role to assume.
+        role_arn: &'a str,
+        /// STS session name; the provider generates one when absent.
+        session_name: Option<&'a str>,
+    },
+    /// A role was requested but the process is already running as it, so the
+    /// ambient credentials are used directly (`base_aws_llm.py:1095`).
+    AmbientRole {
+        /// The role the process already holds.
+        role_arn: &'a str,
+    },
+    /// A named profile from the shared config/credentials files.
+    Profile(&'a str),
+    /// Static credentials supplied by the caller or the environment.
+    Static {
+        /// `aws_access_key_id`.
+        access_key_id: &'a str,
+        /// `aws_secret_access_key`.
+        secret_access_key: &'a str,
+        /// `aws_session_token`, when the caller supplied one.
+        session_token: Option<&'a str>,
+    },
+    /// boto3's `Session()` equivalent: env, shared config, SSO, ECS, IMDS.
+    DefaultChain,
+}
+
+/// What the process can tell about the role it is *already* running as.
+///
+/// Mirrors `base_aws_llm.py::_is_already_running_as_role` (`:717`), which has
+/// two legs: an env-only IRSA fast path, and an `sts:GetCallerIdentity` probe
+/// for ECS/EC2.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AmbientRoleIdentity {
+    /// `AWS_ROLE_ARN` — set by the EKS pod identity webhook.
+    pub role_arn: Option<String>,
+    /// `AWS_WEB_IDENTITY_TOKEN_FILE` — set alongside it.
+    pub web_identity_token_file: Option<String>,
+    /// ARN reported by `sts:GetCallerIdentity`, when a probe was able to run.
+    ///
+    /// Always `None` from [`AmbientRoleIdentity::from_env`]: `GetCallerIdentity`
+    /// is not reachable from the four AWS crates this feature depends on
+    /// (`aws-config` exposes credential providers, not an STS client), and
+    /// plan §3 fixes that dependency list. The field exists so the comparison
+    /// rule is implemented and tested now, and so wiring a probe later is a
+    /// one-line change rather than a re-port.
+    pub caller_arn: Option<String>,
+}
+
+impl AmbientRoleIdentity {
+    /// Read the IRSA fast-path variables. See [`Self::caller_arn`] for why the
+    /// `GetCallerIdentity` leg is absent.
+    pub fn from_env(env: &dyn EnvSource) -> Self {
+        Self {
+            role_arn: env.get(ENV_ROLE_ARN).filter(|v| !v.is_empty()),
+            web_identity_token_file: env
+                .get(ENV_WEB_IDENTITY_TOKEN_FILE)
+                .filter(|v| !v.is_empty()),
+            caller_arn: None,
+        }
+    }
+}
+
+/// Split an ARN into `(partition, account_id, role_name)`.
+///
+/// Port of `_parse_arn_account_and_role_name` (`:680`). Handles
+/// `arn:aws:iam::123456789012:role/MyRole`,
+/// `arn:aws:iam::123456789012:role/path/to/MyRole` and
+/// `arn:aws:sts::123456789012:assumed-role/MyRole/session-name`; anything else
+/// is `None`.
+pub fn parse_arn_account_and_role_name(arn: &str) -> Option<(&str, &str, &str)> {
+    let parts: Vec<&str> = arn.split(':').collect();
+    if parts.len() < 6 || parts[0] != "arn" {
+        return None;
+    }
+    let partition = parts[1];
+    let account_id = parts[4];
+    // The resource may itself contain colons, so rejoin from field 5 on. Only
+    // the borrowed prefix is needed, so slice the original string instead.
+    let resource_start = arn
+        .match_indices(':')
+        .nth(4)
+        .map(|(index, _)| index + 1)
+        .unwrap_or(arn.len());
+    let resource = &arn[resource_start..];
+
+    let role_name = if let Some(rest) = resource.strip_prefix("role/") {
+        rest.rsplit('/').next().filter(|name| !name.is_empty())?
+    } else if let Some(rest) = resource.strip_prefix("assumed-role/") {
+        rest.split('/').next().filter(|name| !name.is_empty())?
+    } else {
+        return None;
+    };
+
+    Some((partition, account_id, role_name))
+}
+
+/// Is the process already running as `target_role_arn`?
+///
+/// Port of `_is_already_running_as_role` (`:717`). Partition, account and role
+/// name are all compared, so a same-named role in another account is not a
+/// match.
+pub fn is_already_running_as_role(target_role_arn: &str, ambient: &AmbientRoleIdentity) -> bool {
+    let Some((target_partition, target_account, target_role)) =
+        parse_arn_account_and_role_name(target_role_arn)
+    else {
+        return false;
+    };
+
+    // Fast path: an IRSA pod publishes the role it holds, no API call needed.
+    if let (Some(current), Some(_token_file)) = (
+        ambient.role_arn.as_deref(),
+        ambient.web_identity_token_file.as_deref(),
+    ) {
+        return current == target_role_arn;
+    }
+
+    let Some((caller_partition, caller_account, caller_role)) = ambient
+        .caller_arn
+        .as_deref()
+        .and_then(parse_arn_account_and_role_name)
+    else {
+        return false;
+    };
+
+    caller_partition == target_partition
+        && caller_account == target_account
+        && caller_role == target_role
+}
+
+/// Host suffixes an STS endpoint may end in for its region label to be
+/// trustworthy (`_STS_REGION_FROM_ENDPOINT_PATTERN`, `base_aws_llm.py:41`).
+const STS_ENDPOINT_SUFFIXES: [&str; 3] =
+    ["amazonaws.com", "amazonaws.com.cn", "vpce.amazonaws.com"];
+
+/// Extract the region from an STS endpoint host.
+///
+/// Port of `_parse_sts_region_from_endpoint` (`:617`): matches
+/// `sts.{region}.amazonaws.com`, its `-fips` and `.cn` variants, and the
+/// `vpce-xxx.sts.{region}.vpce.amazonaws.com` PrivateLink shape.
+fn parse_sts_region_from_endpoint(endpoint: &str) -> Option<&str> {
+    let host = endpoint
+        .split_once("://")
+        .map_or(endpoint, |(_, rest)| rest)
+        .split(['/', '?', '#'])
+        .next()?
+        .rsplit('@')
+        .next()?
+        .split(':')
+        .next()?;
+
+    let labels: Vec<&str> = host.split('.').collect();
+    labels.iter().enumerate().find_map(|(index, label)| {
+        if *label != "sts" && *label != "sts-fips" {
+            return None;
+        }
+        let region = *labels.get(index + 1)?;
+        if region.is_empty()
+            || !region
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        {
+            return None;
+        }
+        let suffix = labels.get(index + 2..)?.join(".");
+        STS_ENDPOINT_SUFFIXES
+            .contains(&suffix.as_str())
+            .then_some(region)
+    })
+}
+
+/// The region the STS calls are signed in.
+///
+/// Port of `_resolve_sts_region` (`:627`) + `_build_sts_client_kwargs`
+/// (`:636`): litellm signs STS with the region parsed out of
+/// `aws_sts_endpoint`, else `AWS_REGION`, else `AWS_DEFAULT_REGION` —
+/// deliberately **not** the Bedrock region, which may have come from a model
+/// ARN in a different region and would then produce a signing-region mismatch
+/// against a regional or PrivateLink STS endpoint.
+///
+/// When none of those resolve, litellm lets boto3 pick its own default;
+/// `fallback` (the already-resolved §1.3 region) stands in for that.
+pub fn resolve_sts_region(
+    sts_endpoint: Option<&str>,
+    env: &dyn EnvSource,
+    fallback: &str,
+) -> String {
+    let clean = |value: Option<String>| -> Option<String> {
+        value
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    };
+
+    sts_endpoint
+        .and_then(parse_sts_region_from_endpoint)
+        .map(str::to_string)
+        .or_else(|| clean(env.get(ENV_REGION)))
+        .or_else(|| clean(env.get(ENV_DEFAULT_REGION)))
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+/// The SigV4 half of the §1.2 ladder, as a pure decision.
+pub fn select_strategy<'a>(
+    settings: &'a AwsSettings,
+    ambient: &AmbientRoleIdentity,
+) -> CredentialStrategy<'a> {
+    let role_name = settings.role_name.as_deref();
+
+    if let (Some(token), Some(role_arn), Some(session_name)) = (
+        settings.web_identity_token.as_deref(),
+        role_name,
+        settings.session_name.as_deref(),
+    ) {
+        return CredentialStrategy::WebIdentity {
+            web_identity_token: token,
+            role_arn,
+            session_name,
+        };
+    }
+
+    if let Some(role_arn) = role_name {
+        return if is_already_running_as_role(role_arn, ambient) {
+            CredentialStrategy::AmbientRole { role_arn }
+        } else {
+            CredentialStrategy::AssumeRole {
+                role_arn,
+                session_name: settings.session_name.as_deref(),
+            }
+        };
+    }
+
+    if let Some(profile) = settings.profile_name.as_deref() {
+        return CredentialStrategy::Profile(profile);
+    }
+
+    if let (Some(access_key_id), Some(secret_access_key)) = (
+        settings.access_key_id.as_deref(),
+        settings.secret_access_key.as_deref(),
+    ) {
+        return CredentialStrategy::Static {
+            access_key_id,
+            secret_access_key,
+            session_token: settings.session_token.as_deref(),
+        };
+    }
+
+    CredentialStrategy::DefaultChain
+}
+
+/// Execution half of the ladder: turn a [`CredentialStrategy`] into credentials.
+#[async_trait]
+pub trait CredentialLookup: Send + Sync {
+    /// Resolve `strategy`. `settings` carries the knobs the strategy does not
+    /// (STS endpoint, external id, the parent keys an `AssumeRole` starts from)
+    /// and `region` is the already-resolved §1.3 region.
+    async fn lookup(
+        &self,
+        strategy: CredentialStrategy<'_>,
+        settings: &AwsSettings,
+        region: &str,
+    ) -> LlmResult<AwsCredentials>;
+}
+
+/// [`CredentialLookup`] over `aws-config`'s providers — the Rust equivalent of
+/// the boto3 flows litellm uses.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct AwsConfigCredentials;
+
+impl AwsConfigCredentials {
+    /// Static credentials assembled from the caller's keys.
+    fn static_credentials(
+        access_key_id: &str,
+        secret_access_key: &str,
+        session_token: Option<&str>,
+    ) -> AwsCredentials {
+        AwsCredentials::new(
+            access_key_id,
+            secret_access_key,
+            session_token.map(str::to_string),
+            None,
+            STATIC_PROVIDER_NAME,
+        )
+    }
+
+    /// Base SDK config for the STS calls: signing region, optional STS
+    /// endpoint override, and the caller's static keys as the *parent*
+    /// identity when they supplied any (litellm passes the same three to
+    /// `boto3.client("sts")`).
+    ///
+    /// `sts_region` comes from [`resolve_sts_region`], not from the Bedrock
+    /// region — see that function for why the two can legitimately differ.
+    async fn sts_sdk_config(settings: &AwsSettings, sts_region: &str) -> aws_config::SdkConfig {
+        use aws_config::{BehaviorVersion, Region};
+
+        let mut loader = aws_config::defaults(BehaviorVersion::latest())
+            .region(Region::new(sts_region.to_string()));
+        if let Some(endpoint) = settings.sts_endpoint.as_deref() {
+            loader = loader.endpoint_url(endpoint);
+        }
+        if let (Some(access_key_id), Some(secret_access_key)) = (
+            settings.access_key_id.as_deref(),
+            settings.secret_access_key.as_deref(),
+        ) {
+            loader = loader.credentials_provider(Self::static_credentials(
+                access_key_id,
+                secret_access_key,
+                settings.session_token.as_deref(),
+            ));
+        }
+        loader.load().await
+    }
+
+    async fn assume_role(
+        settings: &AwsSettings,
+        region: &str,
+        role_arn: &str,
+        session_name: Option<&str>,
+    ) -> LlmResult<AwsCredentials> {
+        use aws_config::Region;
+        use aws_config::sts::AssumeRoleProvider;
+        use aws_credential_types::provider::ProvideCredentials;
+
+        let sts_region = resolve_sts_region(settings.sts_endpoint.as_deref(), &ProcessEnv, region);
+        let sdk_config = Self::sts_sdk_config(settings, &sts_region).await;
+        let mut builder = AssumeRoleProvider::builder(role_arn)
+            .configure(&sdk_config)
+            .region(Region::new(sts_region));
+        if let Some(session_name) = session_name {
+            builder = builder.session_name(session_name);
+        }
+        if let Some(external_id) = settings.external_id.as_deref() {
+            builder = builder.external_id(external_id);
+        }
+
+        builder
+            .build()
+            .await
+            .provide_credentials()
+            .await
+            .map_err(|error| {
+                LlmError::AuthenticationError(format!(
+                    "AWS AssumeRole for {role_arn} failed: {error}"
+                ))
+            })
+    }
+
+    async fn assume_role_with_web_identity(
+        settings: &AwsSettings,
+        region: &str,
+        web_identity_token: &str,
+        role_arn: &str,
+        session_name: &str,
+    ) -> LlmResult<AwsCredentials> {
+        use aws_config::Region;
+        use aws_config::provider_config::ProviderConfig;
+        use aws_config::web_identity_token::{
+            StaticConfiguration, WebIdentityTokenCredentialsProvider,
+        };
+        use aws_credential_types::provider::ProvideCredentials;
+
+        let token_file = std::path::Path::new(web_identity_token);
+        if !token_file.is_file() {
+            // Documented divergence: litellm resolves `aws_web_identity_token`
+            // through `get_secret()` and passes the token *value* straight to
+            // `sts:AssumeRoleWithWebIdentity`. The only web-identity provider
+            // reachable from the AWS crates this feature depends on reads the
+            // token from a **file** (the IRSA shape), and hand-rolling the STS
+            // call, or writing a caller-supplied JWT to disk, are both worse
+            // than saying so. Lifting this needs `aws-sdk-sts` on the
+            // dependency list — see plan §3.
+            return Err(LlmError::ConfigError(format!(
+                "AWS web-identity auth expects AWS_WEB_IDENTITY_TOKEN (or \
+                 aws_web_identity_token) to be a path to a readable OIDC token file; \
+                 {web_identity_token:?} is not one. Literal token values are not \
+                 supported by this provider."
+            )));
+        }
+
+        if settings.sts_endpoint.is_some() {
+            tracing::warn!(
+                "aws_sts_endpoint is ignored on the web-identity credential path: \
+                 the aws-config web-identity provider has no endpoint override"
+            );
+        }
+
+        let provider_config = ProviderConfig::without_region().with_region(Some(Region::new(
+            resolve_sts_region(settings.sts_endpoint.as_deref(), &ProcessEnv, region),
+        )));
+        let provider = WebIdentityTokenCredentialsProvider::builder()
+            .configure(&provider_config)
+            .static_configuration(StaticConfiguration {
+                web_identity_token_file: token_file.to_path_buf(),
+                role_arn: role_arn.to_string(),
+                session_name: session_name.to_string(),
+            })
+            .build();
+
+        provider.provide_credentials().await.map_err(|error| {
+            LlmError::AuthenticationError(format!(
+                "AWS AssumeRoleWithWebIdentity for {role_arn} failed: {error}"
+            ))
+        })
+    }
+
+    async fn profile(profile_name: &str) -> LlmResult<AwsCredentials> {
+        use aws_config::profile::ProfileFileCredentialsProvider;
+        use aws_credential_types::provider::ProvideCredentials;
+
+        ProfileFileCredentialsProvider::builder()
+            .profile_name(profile_name)
+            .build()
+            .provide_credentials()
+            .await
+            .map_err(|error| {
+                LlmError::AuthenticationError(format!(
+                    "AWS profile {profile_name:?} could not be resolved: {error}"
+                ))
+            })
+    }
+
+    async fn default_chain(region: &str) -> LlmResult<AwsCredentials> {
+        use aws_config::Region;
+        use aws_config::default_provider::credentials::DefaultCredentialsChain;
+        use aws_credential_types::provider::ProvideCredentials;
+
+        DefaultCredentialsChain::builder()
+            .region(Region::new(region.to_string()))
+            .build()
+            .await
+            .provide_credentials()
+            .await
+            .map_err(|error| {
+                LlmError::AuthenticationError(format!(
+                    "no AWS credentials found for Bedrock (env / shared config / SSO / ECS / IMDS): {error}"
+                ))
+            })
+    }
+}
+
+#[async_trait]
+impl CredentialLookup for AwsConfigCredentials {
+    async fn lookup(
+        &self,
+        strategy: CredentialStrategy<'_>,
+        settings: &AwsSettings,
+        region: &str,
+    ) -> LlmResult<AwsCredentials> {
+        match strategy {
+            CredentialStrategy::WebIdentity {
+                web_identity_token,
+                role_arn,
+                session_name,
+            } => {
+                Self::assume_role_with_web_identity(
+                    settings,
+                    region,
+                    web_identity_token,
+                    role_arn,
+                    session_name,
+                )
+                .await
+            }
+            CredentialStrategy::AssumeRole {
+                role_arn,
+                session_name,
+            } => Self::assume_role(settings, region, role_arn, session_name).await,
+            // Already running as the role: litellm falls back to the ambient
+            // identity (`_auth_with_env_vars`), which is this chain.
+            CredentialStrategy::AmbientRole { .. } | CredentialStrategy::DefaultChain => {
+                Self::default_chain(region).await
+            }
+            CredentialStrategy::Profile(profile_name) => Self::profile(profile_name).await,
+            CredentialStrategy::Static {
+                access_key_id,
+                secret_access_key,
+                session_token,
+            } => Ok(Self::static_credentials(
+                access_key_id,
+                secret_access_key,
+                session_token,
+            )),
+        }
+    }
+}
+
+/// Resolve auth against the process environment and `aws-config`.
+///
+/// `api_key` is the request-level Bedrock API key (rung 1); the
+/// `AWS_BEARER_TOKEN_BEDROCK` fallback (rung 2) already sits on `settings`.
+pub async fn resolve_auth(
+    api_key: Option<&str>,
+    settings: &AwsSettings,
+    region: &str,
+) -> LlmResult<BedrockAuth> {
+    let ambient = AmbientRoleIdentity::from_env(&ProcessEnv);
+    resolve_auth_with(api_key, settings, region, &ambient, &AwsConfigCredentials).await
+}
+
+/// Resolve auth with the ambient identity and the credential lookup injected.
+///
+/// The bearer rungs return **before** `lookup` is consulted — that early return
+/// is the behaviour, not an optimisation.
+pub async fn resolve_auth_with(
+    api_key: Option<&str>,
+    settings: &AwsSettings,
+    region: &str,
+    ambient: &AmbientRoleIdentity,
+    lookup: &dyn CredentialLookup,
+) -> LlmResult<BedrockAuth> {
+    let bearer = api_key
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(str::to_string)
+        .or_else(|| settings.bedrock_bearer_token.clone());
+
+    if let Some(token) = bearer {
+        return Ok(BedrockAuth::Bearer(token));
+    }
+
+    let strategy = select_strategy(settings, ambient);
+    let credentials = lookup.lookup(strategy, settings, region).await?;
+    Ok(BedrockAuth::SigV4(Box::new(credentials)))
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_role_and_assumed_role_arns() {
+        assert_eq!(
+            parse_arn_account_and_role_name("arn:aws:iam::123456789012:role/MyRole"),
+            Some(("aws", "123456789012", "MyRole"))
+        );
+        assert_eq!(
+            parse_arn_account_and_role_name("arn:aws:iam::123456789012:role/path/to/MyRole"),
+            Some(("aws", "123456789012", "MyRole"))
+        );
+        assert_eq!(
+            parse_arn_account_and_role_name(
+                "arn:aws:sts::123456789012:assumed-role/MyRole/session-name"
+            ),
+            Some(("aws", "123456789012", "MyRole"))
+        );
+        assert_eq!(
+            parse_arn_account_and_role_name("arn:aws-us-gov:iam::1:role/GovRole"),
+            Some(("aws-us-gov", "1", "GovRole"))
+        );
+    }
+
+    #[test]
+    fn rejects_arns_that_are_not_roles() {
+        assert_eq!(parse_arn_account_and_role_name("not-an-arn"), None);
+        assert_eq!(
+            parse_arn_account_and_role_name("arn:aws:iam::123456789012:user/Bob"),
+            None
+        );
+        assert_eq!(
+            parse_arn_account_and_role_name("arn:aws:iam::1:role/"),
+            None
+        );
+    }
+
+    fn env_of(pairs: &[(&'static str, &'static str)]) -> impl EnvSource + use<> {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect();
+        move |key: &str| {
+            owned
+                .iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value.to_string())
+        }
+    }
+
+    #[test]
+    fn parses_the_sts_region_out_of_regional_and_privatelink_endpoints() {
+        for (endpoint, expected) in [
+            ("https://sts.eu-west-1.amazonaws.com", Some("eu-west-1")),
+            (
+                "https://sts-fips.us-east-1.amazonaws.com",
+                Some("us-east-1"),
+            ),
+            (
+                "https://sts.cn-north-1.amazonaws.com.cn",
+                Some("cn-north-1"),
+            ),
+            (
+                "https://vpce-0abc.sts.eu-west-1.vpce.amazonaws.com",
+                Some("eu-west-1"),
+            ),
+            (
+                "https://sts.eu-west-1.amazonaws.com:443/",
+                Some("eu-west-1"),
+            ),
+            ("https://sts.amazonaws.com", None),
+            ("https://sts.eu-west-1.example.com", None),
+            ("not-a-url", None),
+        ] {
+            assert_eq!(
+                parse_sts_region_from_endpoint(endpoint),
+                expected,
+                "{endpoint}"
+            );
+        }
+    }
+
+    /// The Bedrock region can come from a model ARN in a *different* region;
+    /// signing STS with it would then be a signing-region mismatch.
+    #[test]
+    fn the_sts_region_prefers_the_endpoint_then_aws_region_then_the_fallback() {
+        let env = env_of(&[
+            ("AWS_REGION", "eu-west-2"),
+            ("AWS_DEFAULT_REGION", "eu-west-3"),
+        ]);
+
+        assert_eq!(
+            resolve_sts_region(
+                Some("https://sts.eu-west-1.amazonaws.com"),
+                &env,
+                "us-west-2"
+            ),
+            "eu-west-1"
+        );
+        assert_eq!(resolve_sts_region(None, &env, "us-west-2"), "eu-west-2");
+        assert_eq!(
+            resolve_sts_region(
+                None,
+                &env_of(&[("AWS_DEFAULT_REGION", "eu-west-3")]),
+                "us-west-2"
+            ),
+            "eu-west-3"
+        );
+        assert_eq!(
+            resolve_sts_region(None, &env_of(&[]), "ap-southeast-2"),
+            "ap-southeast-2",
+            "with nothing configured the resolved Bedrock region stands in for boto3's own default"
+        );
+        assert_eq!(
+            resolve_sts_region(Some("https://sts.amazonaws.com"), &env, "us-west-2"),
+            "eu-west-2",
+            "a global endpoint carries no region label"
+        );
+    }
+
+    /// The one rung of the real executor that needs no network.
+    #[tokio::test]
+    async fn the_static_rung_maps_keys_and_the_session_token_through() {
+        let settings = AwsSettings::default();
+
+        let credentials = AwsConfigCredentials
+            .lookup(
+                CredentialStrategy::Static {
+                    access_key_id: "AKIA_STATIC",
+                    secret_access_key: "secret-static",
+                    session_token: Some("session-static"),
+                },
+                &settings,
+                "us-east-1",
+            )
+            .await
+            .expect("static credentials need no lookup");
+
+        assert_eq!(credentials.access_key_id(), "AKIA_STATIC");
+        assert_eq!(credentials.secret_access_key(), "secret-static");
+        assert_eq!(credentials.session_token(), Some("session-static"));
+    }
+
+    /// The documented web-identity limitation must surface as a clear
+    /// configuration error, not as an obscure STS failure.
+    #[tokio::test]
+    async fn a_web_identity_token_that_is_not_a_file_is_a_config_error() {
+        let settings = AwsSettings::default();
+
+        let error = AwsConfigCredentials
+            .lookup(
+                CredentialStrategy::WebIdentity {
+                    web_identity_token: "eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJzdHMifQ.signature",
+                    role_arn: "arn:aws:iam::123456789012:role/BedrockRole",
+                    session_name: "cognee-session",
+                },
+                &settings,
+                "us-east-1",
+            )
+            .await
+            .expect_err("a literal token is not supported by this provider");
+
+        match error {
+            LlmError::ConfigError(message) => {
+                assert!(message.contains("readable OIDC token file"), "{message}");
+            }
+            other => panic!("expected a ConfigError, got {other:?}"),
+        }
+    }
+}

--- a/crates/llm/src/adapters/bedrock/aws/endpoint.rs
+++ b/crates/llm/src/adapters/bedrock/aws/endpoint.rs
@@ -1,0 +1,110 @@
+//! The §1.3 Bedrock runtime endpoint chain.
+//!
+//! Port of `base_aws_llm.py::get_runtime_endpoint` (`:1328`). In order:
+//!
+//! 1. `api_base` (the caller's explicit base URL),
+//! 2. `aws_bedrock_runtime_endpoint`,
+//! 3. `AWS_BEDROCK_RUNTIME_ENDPOINT`,
+//! 4. `https://bedrock-runtime.{region}.amazonaws.com`.
+//!
+//! Rungs 2 and 3 are already collapsed into
+//! [`AwsSettings::bedrock_runtime_endpoint`] by the env fallback loop, which is
+//! faithful: litellm checks the parameter first and the variable second, and
+//! neither can outrank `api_base`.
+//!
+//! Only the `runtime` endpoint type is ported. litellm's `agent` and
+//! `agentcore` hosts belong to routes cognee does not ship (plan §6.7).
+
+use super::env::AwsSettings;
+
+/// Build the runtime endpoint for `region`.
+fn default_endpoint(region: &str) -> String {
+    format!("https://bedrock-runtime.{region}.amazonaws.com")
+}
+
+/// Resolve the Bedrock runtime endpoint.
+///
+/// The result never has a trailing `/`: callers append `/model/{id}/converse`,
+/// and a `//` in the path would change the SigV4 canonical request (and so the
+/// signature) for no gain.
+pub fn resolve_endpoint(api_base: Option<&str>, settings: &AwsSettings, region: &str) -> String {
+    let chosen = api_base
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| settings.bedrock_runtime_endpoint.clone())
+        .unwrap_or_else(|| default_endpoint(region));
+
+    chosen.trim_end_matches('/').to_string()
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    fn settings_with_endpoint(endpoint: Option<&str>) -> AwsSettings {
+        AwsSettings {
+            bedrock_runtime_endpoint: endpoint.map(str::to_string),
+            ..AwsSettings::default()
+        }
+    }
+
+    #[test]
+    fn api_base_outranks_everything() {
+        let settings = settings_with_endpoint(Some("https://from-settings.example"));
+
+        assert_eq!(
+            resolve_endpoint(
+                Some("https://from-api-base.example"),
+                &settings,
+                "us-east-1"
+            ),
+            "https://from-api-base.example"
+        );
+    }
+
+    #[test]
+    fn settings_endpoint_outranks_the_regional_default() {
+        let settings = settings_with_endpoint(Some("https://vpce.example"));
+
+        assert_eq!(
+            resolve_endpoint(None, &settings, "us-east-1"),
+            "https://vpce.example"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_the_regional_default() {
+        assert_eq!(
+            resolve_endpoint(None, &settings_with_endpoint(None), "eu-central-1"),
+            "https://bedrock-runtime.eu-central-1.amazonaws.com"
+        );
+    }
+
+    #[test]
+    fn blank_api_base_does_not_shadow_the_next_rung() {
+        let settings = settings_with_endpoint(Some("https://vpce.example"));
+
+        assert_eq!(
+            resolve_endpoint(Some("   "), &settings, "us-east-1"),
+            "https://vpce.example"
+        );
+    }
+
+    #[test]
+    fn trailing_slashes_are_trimmed() {
+        assert_eq!(
+            resolve_endpoint(
+                Some("https://vpce.example/"),
+                &settings_with_endpoint(None),
+                "us-east-1"
+            ),
+            "https://vpce.example"
+        );
+    }
+}

--- a/crates/llm/src/adapters/bedrock/aws/env.rs
+++ b/crates/llm/src/adapters/bedrock/aws/env.rs
@@ -1,0 +1,448 @@
+//! Caller inputs plus litellm's uppercase-env fallback loop.
+//!
+//! Port of `base_aws_llm.py:222-247` (`get_credentials`'s `params_to_check`
+//! tuple): every `aws_*` parameter left `None` falls back to its **UPPERCASE**
+//! env var of the same name. Several of those names are not the ones a reader
+//! guesses — `AWS_PROFILE_NAME` (not the boto3-standard `AWS_PROFILE`),
+//! `AWS_REGION_NAME`, `AWS_ROLE_NAME`, `AWS_SESSION_NAME`,
+//! `AWS_WEB_IDENTITY_TOKEN`, `AWS_STS_ENDPOINT`, `AWS_EXTERNAL_ID` — so the
+//! names live here as constants and every one of them is covered by a test.
+
+use std::fmt;
+
+/// `aws_access_key_id`.
+pub const ENV_ACCESS_KEY_ID: &str = "AWS_ACCESS_KEY_ID";
+/// `aws_secret_access_key`.
+pub const ENV_SECRET_ACCESS_KEY: &str = "AWS_SECRET_ACCESS_KEY";
+/// `aws_session_token`.
+pub const ENV_SESSION_TOKEN: &str = "AWS_SESSION_TOKEN";
+/// `aws_region_name`. Consumed by [`crate::adapters::bedrock::aws::region`],
+/// not by [`AwsInputs::resolve_with`] — see [`AwsSettings::region`].
+pub const ENV_REGION_NAME: &str = "AWS_REGION_NAME";
+/// The boto3-standard region variable, one rung below [`ENV_REGION_NAME`] in
+/// the §1.3 chain.
+pub const ENV_REGION: &str = "AWS_REGION";
+/// boto3's other region variable. It takes no part in the §1.3 chain — only
+/// the STS signing region reads it (`_resolve_sts_region`).
+pub const ENV_DEFAULT_REGION: &str = "AWS_DEFAULT_REGION";
+/// `aws_session_name`.
+pub const ENV_SESSION_NAME: &str = "AWS_SESSION_NAME";
+/// `aws_profile_name` — note this is **not** `AWS_PROFILE`.
+pub const ENV_PROFILE_NAME: &str = "AWS_PROFILE_NAME";
+/// `aws_role_name`.
+pub const ENV_ROLE_NAME: &str = "AWS_ROLE_NAME";
+/// `aws_web_identity_token`.
+pub const ENV_WEB_IDENTITY_TOKEN: &str = "AWS_WEB_IDENTITY_TOKEN";
+/// `aws_sts_endpoint`.
+pub const ENV_STS_ENDPOINT: &str = "AWS_STS_ENDPOINT";
+/// `aws_external_id`.
+pub const ENV_EXTERNAL_ID: &str = "AWS_EXTERNAL_ID";
+/// `aws_bedrock_runtime_endpoint` (`get_runtime_endpoint`, §1.3).
+pub const ENV_BEDROCK_RUNTIME_ENDPOINT: &str = "AWS_BEDROCK_RUNTIME_ENDPOINT";
+/// Bedrock API-key bearer token (`_sign_request`, §1.2).
+pub const ENV_BEARER_TOKEN_BEDROCK: &str = "AWS_BEARER_TOKEN_BEDROCK";
+/// Ambient role ARN published by an IRSA/EKS pod identity.
+pub const ENV_ROLE_ARN: &str = "AWS_ROLE_ARN";
+/// Ambient web-identity token file published by an IRSA/EKS pod identity.
+pub const ENV_WEB_IDENTITY_TOKEN_FILE: &str = "AWS_WEB_IDENTITY_TOKEN_FILE";
+
+/// Read-only view over an environment.
+///
+/// Everything in this module takes the environment as a parameter rather than
+/// calling [`std::env::var`] directly, so the resolution rules can be tested
+/// without mutating shared process state (the workspace test runner is
+/// parallel; `set_var` in one test is visible to every other test in the same
+/// binary).
+pub trait EnvSource: Send + Sync {
+    /// Return the value of `key`, or `None` when it is unset.
+    fn get(&self, key: &str) -> Option<String>;
+}
+
+/// The real process environment.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ProcessEnv;
+
+impl EnvSource for ProcessEnv {
+    fn get(&self, key: &str) -> Option<String> {
+        std::env::var(key).ok()
+    }
+}
+
+impl<F> EnvSource for F
+where
+    F: Fn(&str) -> Option<String> + Send + Sync,
+{
+    fn get(&self, key: &str) -> Option<String> {
+        self(key)
+    }
+}
+
+/// Trim a value and treat the empty string as absent.
+///
+/// litellm relies on `os.getenv` returning `None`; an exported-but-empty
+/// variable is a common shell accident and would otherwise select a code path
+/// (e.g. "a profile name was given") with an unusable value.
+fn clean(value: Option<String>) -> Option<String> {
+    value
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Caller-supplied AWS parameters, before any env fallback.
+///
+/// This is the shape plan §2.1 puts on `BackendBuildContext` at R2
+/// (`crates/components/src/context.rs`); it is defined here so the module
+/// compiles and is testable standalone. R2 wires the context-side struct to
+/// this one rather than duplicating the resolution rules.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct AwsInputs {
+    /// `aws_region_name`.
+    pub region: Option<String>,
+    /// `aws_access_key_id`.
+    pub access_key_id: Option<String>,
+    /// `aws_secret_access_key`.
+    pub secret_access_key: Option<String>,
+    /// `aws_session_token`.
+    pub session_token: Option<String>,
+    /// `aws_profile_name`.
+    pub profile_name: Option<String>,
+    /// `aws_role_name` — an IAM role ARN to assume.
+    pub role_name: Option<String>,
+    /// `aws_session_name` — STS session name.
+    pub session_name: Option<String>,
+    /// `aws_web_identity_token`.
+    pub web_identity_token: Option<String>,
+    /// `aws_sts_endpoint`.
+    pub sts_endpoint: Option<String>,
+    /// `aws_external_id`.
+    pub external_id: Option<String>,
+    /// `aws_bedrock_runtime_endpoint`.
+    pub bedrock_runtime_endpoint: Option<String>,
+    /// `AWS_BEARER_TOKEN_BEDROCK`.
+    pub bearer_token: Option<String>,
+}
+
+/// [`AwsInputs`] after the uppercase-env fallback loop.
+///
+/// Field-for-field identical to [`AwsInputs`] except that every value has been
+/// trimmed, emptied-to-`None`, and backfilled from the environment. The one
+/// asymmetry is [`AwsSettings::region`], documented on the field.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct AwsSettings {
+    /// `aws_region_name` **exactly as the caller supplied it** — deliberately
+    /// *not* backfilled from `AWS_REGION_NAME` here.
+    ///
+    /// litellm resolves the region through `_get_aws_region_name` *before*
+    /// calling `get_credentials` (`base_aws_llm.py:1583`), and that chain ranks
+    /// a region embedded in a model ARN **above** `AWS_REGION_NAME` (§1.3).
+    /// Folding the env var in at this layer would silently invert that
+    /// precedence for ARN model ids, so the env legs live in
+    /// [`crate::adapters::bedrock::aws::region`] where the ARN leg can outrank
+    /// them.
+    pub region: Option<String>,
+    /// `aws_access_key_id` ← `AWS_ACCESS_KEY_ID`.
+    pub access_key_id: Option<String>,
+    /// `aws_secret_access_key` ← `AWS_SECRET_ACCESS_KEY`.
+    pub secret_access_key: Option<String>,
+    /// `aws_session_token` ← `AWS_SESSION_TOKEN`.
+    pub session_token: Option<String>,
+    /// `aws_profile_name` ← `AWS_PROFILE_NAME` (not `AWS_PROFILE`).
+    pub profile_name: Option<String>,
+    /// `aws_role_name` ← `AWS_ROLE_NAME`.
+    pub role_name: Option<String>,
+    /// `aws_session_name` ← `AWS_SESSION_NAME`.
+    pub session_name: Option<String>,
+    /// `aws_web_identity_token` ← `AWS_WEB_IDENTITY_TOKEN`.
+    pub web_identity_token: Option<String>,
+    /// `aws_sts_endpoint` ← `AWS_STS_ENDPOINT`.
+    pub sts_endpoint: Option<String>,
+    /// `aws_external_id` ← `AWS_EXTERNAL_ID`.
+    pub external_id: Option<String>,
+    /// `aws_bedrock_runtime_endpoint` ← `AWS_BEDROCK_RUNTIME_ENDPOINT`.
+    pub bedrock_runtime_endpoint: Option<String>,
+    /// Bearer token ← `AWS_BEARER_TOKEN_BEDROCK`. A request-level `api_key`
+    /// outranks it and is passed separately — see
+    /// [`crate::adapters::bedrock::aws::credentials::resolve_auth`].
+    pub bedrock_bearer_token: Option<String>,
+}
+
+/// Redacts the same fields as [`AwsSettings`]'s. R2 puts this struct on
+/// `BackendBuildContext`, whose sibling input structs are routinely rendered
+/// with `{:?}` in build-failure diagnostics, so a derived `Debug` here would
+/// be a secret-leak waiting to happen.
+impl fmt::Debug for AwsInputs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AwsInputs")
+            .field("region", &self.region)
+            .field("access_key_id", &shown(&self.access_key_id))
+            .field("secret_access_key", &shown(&self.secret_access_key))
+            .field("session_token", &shown(&self.session_token))
+            .field("profile_name", &self.profile_name)
+            .field("role_name", &self.role_name)
+            .field("session_name", &self.session_name)
+            .field("web_identity_token", &shown(&self.web_identity_token))
+            .field("sts_endpoint", &self.sts_endpoint)
+            .field("external_id", &self.external_id)
+            .field("bedrock_runtime_endpoint", &self.bedrock_runtime_endpoint)
+            .field("bearer_token", &shown(&self.bearer_token))
+            .finish()
+    }
+}
+
+/// `"set"` / `"unset"`, so a secret's presence can be debugged without the
+/// secret itself reaching a log line.
+fn shown(value: &Option<String>) -> &'static str {
+    if value.is_some() { "set" } else { "unset" }
+}
+
+/// Hand-written so credentials never reach a log line through `{:?}`.
+impl fmt::Debug for AwsSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AwsSettings")
+            .field("region", &self.region)
+            .field("access_key_id", &shown(&self.access_key_id))
+            .field("secret_access_key", &shown(&self.secret_access_key))
+            .field("session_token", &shown(&self.session_token))
+            .field("profile_name", &self.profile_name)
+            .field("role_name", &self.role_name)
+            .field("session_name", &self.session_name)
+            .field("web_identity_token", &shown(&self.web_identity_token))
+            .field("sts_endpoint", &self.sts_endpoint)
+            .field("external_id", &self.external_id)
+            .field("bedrock_runtime_endpoint", &self.bedrock_runtime_endpoint)
+            .field("bedrock_bearer_token", &shown(&self.bedrock_bearer_token))
+            .finish()
+    }
+}
+
+impl AwsInputs {
+    /// Resolve against the real process environment.
+    pub fn resolve(&self) -> AwsSettings {
+        self.resolve_with(&ProcessEnv)
+    }
+
+    /// Resolve against an arbitrary [`EnvSource`].
+    ///
+    /// Mirrors the `params_to_check` loop of `base_aws_llm.py:222-247`: a
+    /// supplied value wins, otherwise the uppercase variable of the same name.
+    pub fn resolve_with(&self, env: &dyn EnvSource) -> AwsSettings {
+        let pick = |value: &Option<String>, key: &str| -> Option<String> {
+            clean(value.clone()).or_else(|| clean(env.get(key)))
+        };
+
+        AwsSettings {
+            // No env leg on purpose — see the field docs.
+            region: clean(self.region.clone()),
+            access_key_id: pick(&self.access_key_id, ENV_ACCESS_KEY_ID),
+            secret_access_key: pick(&self.secret_access_key, ENV_SECRET_ACCESS_KEY),
+            session_token: pick(&self.session_token, ENV_SESSION_TOKEN),
+            profile_name: pick(&self.profile_name, ENV_PROFILE_NAME),
+            role_name: pick(&self.role_name, ENV_ROLE_NAME),
+            session_name: pick(&self.session_name, ENV_SESSION_NAME),
+            web_identity_token: pick(&self.web_identity_token, ENV_WEB_IDENTITY_TOKEN),
+            sts_endpoint: pick(&self.sts_endpoint, ENV_STS_ENDPOINT),
+            external_id: pick(&self.external_id, ENV_EXTERNAL_ID),
+            bedrock_runtime_endpoint: pick(
+                &self.bedrock_runtime_endpoint,
+                ENV_BEDROCK_RUNTIME_ENDPOINT,
+            ),
+            bedrock_bearer_token: pick(&self.bearer_token, ENV_BEARER_TOKEN_BEDROCK),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    /// Every uppercase name the fallback loop reads, paired with the
+    /// `AwsSettings` field it must land in.
+    fn env_of(pairs: &[(&'static str, &'static str)]) -> impl EnvSource + use<> {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |key: &str| {
+            owned
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.to_string())
+        }
+    }
+
+    #[test]
+    fn empty_inputs_fall_back_to_uppercase_env_vars() {
+        let env = env_of(&[
+            (ENV_ACCESS_KEY_ID, "AKIA_ENV"),
+            (ENV_SECRET_ACCESS_KEY, "secret-env"),
+            (ENV_SESSION_TOKEN, "token-env"),
+            (ENV_PROFILE_NAME, "profile-env"),
+            (ENV_ROLE_NAME, "arn:aws:iam::1:role/env"),
+            (ENV_SESSION_NAME, "session-env"),
+            (ENV_WEB_IDENTITY_TOKEN, "web-identity-env"),
+            (ENV_STS_ENDPOINT, "https://sts.example"),
+            (ENV_EXTERNAL_ID, "external-env"),
+            (ENV_BEDROCK_RUNTIME_ENDPOINT, "https://bedrock.example"),
+            (ENV_BEARER_TOKEN_BEDROCK, "bearer-env"),
+        ]);
+
+        let resolved = AwsInputs::default().resolve_with(&env);
+
+        assert_eq!(resolved.access_key_id.as_deref(), Some("AKIA_ENV"));
+        assert_eq!(resolved.secret_access_key.as_deref(), Some("secret-env"));
+        assert_eq!(resolved.session_token.as_deref(), Some("token-env"));
+        assert_eq!(resolved.profile_name.as_deref(), Some("profile-env"));
+        assert_eq!(
+            resolved.role_name.as_deref(),
+            Some("arn:aws:iam::1:role/env")
+        );
+        assert_eq!(resolved.session_name.as_deref(), Some("session-env"));
+        assert_eq!(
+            resolved.web_identity_token.as_deref(),
+            Some("web-identity-env")
+        );
+        assert_eq!(
+            resolved.sts_endpoint.as_deref(),
+            Some("https://sts.example")
+        );
+        assert_eq!(resolved.external_id.as_deref(), Some("external-env"));
+        assert_eq!(
+            resolved.bedrock_runtime_endpoint.as_deref(),
+            Some("https://bedrock.example")
+        );
+        assert_eq!(resolved.bedrock_bearer_token.as_deref(), Some("bearer-env"));
+    }
+
+    #[test]
+    fn supplied_values_outrank_the_environment() {
+        let env = env_of(&[
+            (ENV_ACCESS_KEY_ID, "AKIA_ENV"),
+            (ENV_PROFILE_NAME, "profile-env"),
+        ]);
+        let inputs = AwsInputs {
+            access_key_id: Some("AKIA_PARAM".to_string()),
+            profile_name: Some("profile-param".to_string()),
+            ..AwsInputs::default()
+        };
+
+        let resolved = inputs.resolve_with(&env);
+
+        assert_eq!(resolved.access_key_id.as_deref(), Some("AKIA_PARAM"));
+        assert_eq!(resolved.profile_name.as_deref(), Some("profile-param"));
+    }
+
+    /// The single most easily-missed name in the whole ladder.
+    #[test]
+    fn profile_name_reads_aws_profile_name_and_ignores_aws_profile() {
+        let env = env_of(&[("AWS_PROFILE", "boto3-standard-name")]);
+
+        let resolved = AwsInputs::default().resolve_with(&env);
+
+        assert_eq!(
+            resolved.profile_name, None,
+            "AWS_PROFILE is the boto3 name; litellm's loop reads AWS_PROFILE_NAME"
+        );
+        assert_eq!(ENV_PROFILE_NAME, "AWS_PROFILE_NAME");
+    }
+
+    #[test]
+    fn values_are_trimmed_and_empty_becomes_none() {
+        let env = env_of(&[
+            (ENV_SECRET_ACCESS_KEY, "   "),
+            (ENV_SESSION_NAME, "  padded  "),
+        ]);
+        let inputs = AwsInputs {
+            profile_name: Some("  spaced  ".to_string()),
+            role_name: Some(String::new()),
+            ..AwsInputs::default()
+        };
+
+        let resolved = inputs.resolve_with(&env);
+
+        assert_eq!(resolved.secret_access_key, None);
+        assert_eq!(resolved.session_name.as_deref(), Some("padded"));
+        assert_eq!(resolved.profile_name.as_deref(), Some("spaced"));
+        assert_eq!(resolved.role_name, None);
+    }
+
+    /// An empty *parameter* must not shadow a usable env value: `clean` maps it
+    /// to `None` before the fallback runs.
+    #[test]
+    fn empty_parameter_still_falls_back_to_the_environment() {
+        let env = env_of(&[(ENV_ROLE_NAME, "arn:aws:iam::1:role/env")]);
+        let inputs = AwsInputs {
+            role_name: Some("  ".to_string()),
+            ..AwsInputs::default()
+        };
+
+        assert_eq!(
+            inputs.resolve_with(&env).role_name.as_deref(),
+            Some("arn:aws:iam::1:role/env")
+        );
+    }
+
+    #[test]
+    fn region_has_no_env_leg_at_this_layer() {
+        let env = env_of(&[(ENV_REGION_NAME, "eu-central-1"), (ENV_REGION, "eu-west-1")]);
+
+        assert_eq!(
+            AwsInputs::default().resolve_with(&env).region,
+            None,
+            "the region chain owns the env legs so the model-ARN leg can outrank them"
+        );
+    }
+
+    /// `AwsInputs` is the struct R2 hangs off `BackendBuildContext`, so its
+    /// `Debug` must redact too — a derived one would print raw keys.
+    #[test]
+    fn the_input_struct_also_redacts_secrets() {
+        let inputs = AwsInputs {
+            access_key_id: Some("AKIA_VISIBLE".to_string()),
+            secret_access_key: Some("super-secret".to_string()),
+            session_token: Some("session-secret".to_string()),
+            bearer_token: Some("bearer-secret".to_string()),
+            web_identity_token: Some("jwt-secret".to_string()),
+            profile_name: Some("dev".to_string()),
+            ..AwsInputs::default()
+        };
+
+        let rendered = format!("{inputs:?}");
+
+        for secret in [
+            "super-secret",
+            "session-secret",
+            "bearer-secret",
+            "jwt-secret",
+            "AKIA_VISIBLE",
+        ] {
+            assert!(!rendered.contains(secret), "{secret} leaked: {rendered}");
+        }
+        assert!(rendered.contains("secret_access_key: \"set\""));
+        assert!(
+            rendered.contains("profile_name: Some(\"dev\")"),
+            "non-secret fields stay readable: {rendered}"
+        );
+    }
+
+    #[test]
+    fn debug_never_prints_secret_material() {
+        let inputs = AwsInputs {
+            secret_access_key: Some("super-secret".to_string()),
+            bearer_token: Some("bearer-secret".to_string()),
+            web_identity_token: Some("jwt-secret".to_string()),
+            ..AwsInputs::default()
+        };
+
+        let rendered = format!("{:?}", inputs.resolve_with(&|_: &str| None));
+
+        assert!(!rendered.contains("super-secret"));
+        assert!(!rendered.contains("bearer-secret"));
+        assert!(!rendered.contains("jwt-secret"));
+        assert!(rendered.contains("secret_access_key: \"set\""));
+    }
+}

--- a/crates/llm/src/adapters/bedrock/aws/mod.rs
+++ b/crates/llm/src/adapters/bedrock/aws/mod.rs
@@ -33,4 +33,4 @@ pub mod endpoint;
 pub mod env;
 pub mod region;
 pub mod signer;
-pub(crate) mod transport;
+pub mod transport;

--- a/crates/llm/src/adapters/bedrock/aws/mod.rs
+++ b/crates/llm/src/adapters/bedrock/aws/mod.rs
@@ -1,0 +1,36 @@
+//! Shared AWS plumbing for the Bedrock LLM adapter and the Bedrock embedding
+//! engine: one credential/region/endpoint resolver, one signer, one transport
+//! seam.
+//!
+//! # Why this lives in `cognee-llm` and not in `cognee-utils`
+//!
+//! `docs/roadmap/bedrock-provider-plan.md` §2.2 left the home of this module
+//! open ("decide at R1"). It is decided here, and the answer is `cognee-llm`:
+//!
+//! * `crates/utils` is deliberately **wasm32-buildable** — it carries a
+//!   `[target.'cfg(target_arch = "wasm32")'.dependencies] getrandom` shim, no
+//!   `reqwest`, and no library-level `tokio` (see its `Cargo.toml` comments and
+//!   `docs/spike-wasm-config1.md`). Pulling `aws-config` / `aws-sigv4` /
+//!   `reqwest` in there would destroy that property for every consumer of the
+//!   crate, feature-gated or not (the dep graph is what breaks, not the code).
+//! * `crates/embedding` does not depend on `cognee-llm` today, but plan §2.3
+//!   already specifies `bedrock = ["cognee-llm/bedrock"]` for it — so the
+//!   `cognee-embedding -> cognee-llm` edge is intended, and is added by R4
+//!   rather than avoided by relocating this module.
+//!
+//! R4 should not re-open the question.
+//!
+//! # Parity
+//!
+//! Every rule in here is a port of litellm's
+//! `litellm/llms/bedrock/base_aws_llm.py`, which is what Python cognee reaches
+//! through `litellm.completion`. The plan's §1.2 (auth ladder) and §1.3
+//! (region / endpoint chains) are the audited spec; individual functions cite
+//! the Python symbol they mirror.
+
+pub mod credentials;
+pub mod endpoint;
+pub mod env;
+pub mod region;
+pub mod signer;
+pub(crate) mod transport;

--- a/crates/llm/src/adapters/bedrock/aws/region.rs
+++ b/crates/llm/src/adapters/bedrock/aws/region.rs
@@ -23,6 +23,13 @@ use crate::error::{LlmError, LlmResult};
 pub const DEFAULT_AWS_REGION: &str = "us-west-2";
 
 /// The ARN prefix a Bedrock model ARN must contain for rung 2 to apply.
+///
+/// Commercial partition only, matching litellm's substring test verbatim
+/// (`base_aws_llm.py:351` — `if "arn:aws:bedrock" not in model: return None`).
+/// A GovCloud (`arn:aws-us-gov:bedrock:…`) or China (`arn:aws-cn:bedrock:…`) ARN
+/// therefore skips this rung and falls through to the env/profile/default
+/// region, on **both** SDKs. Widening it here would be a parity divergence, not
+/// a fix: do that only alongside the same change upstream.
 const BEDROCK_ARN_MARKER: &str = "arn:aws:bedrock";
 
 /// litellm's `_VALID_AWS_REGION_PATTERN` (`\A[a-z0-9-]+\Z`), hand-rolled

--- a/crates/llm/src/adapters/bedrock/aws/region.rs
+++ b/crates/llm/src/adapters/bedrock/aws/region.rs
@@ -1,0 +1,201 @@
+//! The §1.3 region chain.
+//!
+//! Port of `base_aws_llm.py::_get_aws_region_name` (`:542`) and
+//! `_get_aws_region_from_model_arn` (`:345`). In order:
+//!
+//! 1. the `aws_region_name` parameter,
+//! 2. a region embedded in a model ARN,
+//! 3. `AWS_REGION_NAME`,
+//! 4. `AWS_REGION`,
+//! 5. the profile / default region chain (boto3's `Session().region_name`),
+//! 6. the hard default `us-west-2`.
+//!
+//! Rung 2 outranking rung 3 is the reason [`AwsSettings::region`] carries the
+//! raw parameter instead of an env-backfilled value.
+
+use async_trait::async_trait;
+
+use super::env::{AwsSettings, ENV_REGION, ENV_REGION_NAME, EnvSource, ProcessEnv};
+use crate::error::{LlmError, LlmResult};
+
+/// litellm's last-resort region when nothing else resolves
+/// (`base_aws_llm.py:598`).
+pub const DEFAULT_AWS_REGION: &str = "us-west-2";
+
+/// The ARN prefix a Bedrock model ARN must contain for rung 2 to apply.
+const BEDROCK_ARN_MARKER: &str = "arn:aws:bedrock";
+
+/// litellm's `_VALID_AWS_REGION_PATTERN` (`\A[a-z0-9-]+\Z`), hand-rolled
+/// because `cognee-llm` does not depend on `regex`.
+fn is_valid_region(region: &str) -> bool {
+    !region.is_empty()
+        && region
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+fn validate(region: &str) -> LlmResult<()> {
+    if is_valid_region(region) {
+        Ok(())
+    } else {
+        Err(LlmError::ConfigError(format!(
+            "Invalid AWS region format: {region:?}. \
+             Region names must contain only lowercase letters, digits, and hyphens."
+        )))
+    }
+}
+
+/// Extract the region from a Bedrock model ARN, or `None` when `model` is not
+/// one (`_get_aws_region_from_model_arn`).
+///
+/// The ARN layout is `arn:PARTITION:SERVICE:REGION:ACCOUNT:RESOURCE`, so the
+/// region is the fourth colon-separated field. An ARN whose region field is
+/// empty or malformed is treated as "no region here" rather than an error,
+/// matching the Python `except: return None`.
+pub fn region_from_model_arn(model: &str) -> Option<&str> {
+    if !model.contains(BEDROCK_ARN_MARKER) {
+        return None;
+    }
+    let parts: Vec<&str> = model.split(':').collect();
+    if parts.len() < 4 {
+        return None;
+    }
+    let region = parts[3];
+    if !is_valid_region(region) {
+        return None;
+    }
+    Some(region)
+}
+
+/// Rungs 1-4: everything resolvable without touching the filesystem, the
+/// network or IMDS.
+///
+/// Returns `Err` only when the caller's *parameter* is malformed — litellm
+/// validates that one eagerly (`_validate_aws_region_name(aws_region_name)` at
+/// `base_aws_llm.py:560`) and lets a malformed env value fall through to the
+/// final validation instead.
+pub fn resolve_region_without_ambient(
+    settings: &AwsSettings,
+    model: Option<&str>,
+    env: &dyn EnvSource,
+) -> LlmResult<Option<String>> {
+    if let Some(param) = settings.region.as_deref() {
+        validate(param)?;
+        return Ok(Some(param.to_string()));
+    }
+    if let Some(from_arn) = model.and_then(region_from_model_arn) {
+        return Ok(Some(from_arn.to_string()));
+    }
+    // Each rung is trimmed and emptied-to-`None` *before* the next is tried,
+    // so an exported-but-empty `AWS_REGION_NAME` does not shadow `AWS_REGION`.
+    // litellm lets the empty string through here and then fails its own final
+    // `_validate_aws_region_name`; treating blank as unset matches this
+    // module's "empty ⇒ None" rule (see `env`) and turns a shell accident into
+    // the next rung instead of an error.
+    let clean = |value: Option<String>| -> Option<String> {
+        value
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    };
+    Ok(clean(env.get(ENV_REGION_NAME)).or_else(|| clean(env.get(ENV_REGION))))
+}
+
+/// Rung 5: the region boto3 would pick up from the shared config file, the
+/// profile, or IMDS.
+///
+/// Injectable so the "hard default" rung can be tested on a developer machine
+/// that has a perfectly good `~/.aws/config`.
+///
+/// Deliberate divergence: litellm calls a bare `boto3.Session()` here, which
+/// only honours the ambient `AWS_PROFILE`, so a caller-supplied
+/// `aws_profile_name` does not steer this rung upstream. Passing the resolved
+/// profile through is what the ladder below it already does (the credentials
+/// come from that profile), and picking the region from a *different* profile
+/// than the credentials would be a latent misconfiguration rather than
+/// parity.
+#[async_trait]
+pub trait AmbientRegion: Send + Sync {
+    /// Region configured for `profile_name` (or the default profile).
+    async fn region(&self, profile_name: Option<&str>) -> Option<String>;
+}
+
+/// [`AmbientRegion`] backed by `aws-config`'s `DefaultRegionChain` — the Rust
+/// equivalent of `boto3.Session().region_name`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DefaultChainRegion;
+
+#[async_trait]
+impl AmbientRegion for DefaultChainRegion {
+    async fn region(&self, profile_name: Option<&str>) -> Option<String> {
+        use aws_config::default_provider::region::DefaultRegionChain;
+
+        let mut builder = DefaultRegionChain::builder();
+        if let Some(profile) = profile_name {
+            builder = builder.profile_name(profile);
+        }
+        builder
+            .build()
+            .region()
+            .await
+            .map(|region| region.to_string())
+    }
+}
+
+/// The full §1.3 chain against the process environment and `aws-config`'s
+/// default region chain.
+pub async fn resolve_region(settings: &AwsSettings, model: Option<&str>) -> LlmResult<String> {
+    resolve_region_with(settings, model, &ProcessEnv, &DefaultChainRegion).await
+}
+
+/// The full §1.3 chain with both ambient sources injected.
+pub async fn resolve_region_with(
+    settings: &AwsSettings,
+    model: Option<&str>,
+    env: &dyn EnvSource,
+    ambient: &dyn AmbientRegion,
+) -> LlmResult<String> {
+    let resolved = match resolve_region_without_ambient(settings, model, env)? {
+        Some(region) => region,
+        None => ambient
+            .region(settings.profile_name.as_deref())
+            .await
+            .map(|region| region.trim().to_string())
+            .filter(|region| !region.is_empty())
+            .unwrap_or_else(|| DEFAULT_AWS_REGION.to_string()),
+    };
+    validate(&resolved)?;
+    Ok(resolved)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn region_from_arn_reads_the_fourth_field() {
+        assert_eq!(
+            region_from_model_arn(
+                "arn:aws:bedrock:eu-central-1:123456789012:inference-profile/eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+            ),
+            Some("eu-central-1")
+        );
+    }
+
+    #[test]
+    fn region_from_arn_rejects_non_bedrock_and_malformed_arns() {
+        assert_eq!(region_from_model_arn("anthropic.claude-3-5-sonnet"), None);
+        assert_eq!(region_from_model_arn("arn:aws:s3:eu-west-1:1:bucket"), None);
+        assert_eq!(region_from_model_arn("arn:aws:bedrock"), None);
+        assert_eq!(region_from_model_arn("arn:aws:bedrock::123:model/x"), None);
+        assert_eq!(
+            region_from_model_arn("arn:aws:bedrock:EU-WEST-1:123:model/x"),
+            None,
+            "uppercase fails litellm's region pattern"
+        );
+    }
+}

--- a/crates/llm/src/adapters/bedrock/aws/signer.rs
+++ b/crates/llm/src/adapters/bedrock/aws/signer.rs
@@ -1,0 +1,210 @@
+//! SigV4 over a `reqwest` request.
+//!
+//! Port of `base_aws_llm.py::_sign_request` (`:1512`) and
+//! `_filter_headers_for_aws_signature` (`:1484`). Three rules carry over
+//! verbatim, because getting any of them wrong produces a signature mismatch
+//! that only shows up as a 403 from Bedrock:
+//!
+//! * only a **filtered subset** of headers is signed — forwarded client
+//!   headers (`x-forwarded-*`, tracing headers, …) must not enter the canonical
+//!   request, or a proxy rewriting them breaks the signature;
+//! * headers outside that subset are **re-applied after** signing, so they
+//!   still reach Bedrock, just unsigned;
+//! * an explicit non-SigV4 `Authorization` header is **never overwritten**.
+//!
+//! The signing service name is `bedrock`.
+
+use std::time::SystemTime;
+
+use aws_credential_types::Credentials;
+use aws_sigv4::http_request::{SignableBody, SignableRequest, SigningSettings, sign};
+use aws_sigv4::sign::v4;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
+
+use crate::error::{LlmError, LlmResult};
+
+/// SigV4 signing service name for Bedrock.
+pub const BEDROCK_SIGNING_SERVICE: &str = "bedrock";
+
+/// Prefix of a SigV4 `Authorization` header.
+pub const SIGV4_AUTHORIZATION_PREFIX: &str = "AWS4-HMAC-SHA256";
+
+/// Headers SigV4 computes itself; re-applying the caller's copies of these
+/// after signing would clobber the signature (litellm's
+/// `SIGV4_COMPUTED_HEADERS`, `base_aws_llm.py:47`).
+const SIGV4_COMPUTED_HEADERS: [&str; 4] = [
+    "authorization",
+    "x-amz-date",
+    "x-amz-security-token",
+    "date",
+];
+
+/// The fixed part of litellm's signed-header allowlist. Anything starting with
+/// `x-amz-` or `x-amzn-` is allowed on top of these.
+const SIGNED_HEADER_ALLOWLIST: [&str; 10] = [
+    "host",
+    "content-type",
+    "date",
+    "x-amz-date",
+    "x-amz-security-token",
+    "x-amz-content-sha256",
+    "x-amz-algorithm",
+    "x-amz-credential",
+    "x-amz-signedheaders",
+    "x-amz-signature",
+];
+
+/// Is `name` part of the signed subset?
+fn is_signed_header(name: &str) -> bool {
+    let lowered = name.to_ascii_lowercase();
+    SIGNED_HEADER_ALLOWLIST.contains(&lowered.as_str())
+        || lowered.starts_with("x-amz-")
+        || lowered.starts_with("x-amzn-")
+}
+
+/// Port of `_filter_headers_for_aws_signature`: the subset of `headers` that
+/// takes part in the signature.
+pub fn filter_headers_for_aws_signature(headers: &HeaderMap) -> HeaderMap {
+    let mut filtered = HeaderMap::new();
+    for (name, value) in headers {
+        if is_signed_header(name.as_str()) {
+            filtered.insert(name.clone(), value.clone());
+        }
+    }
+    filtered
+}
+
+/// Sign `request` in place and return the hex signature.
+///
+/// `body` is passed separately because a `reqwest::Request` body may be a
+/// stream; Bedrock request bodies are always in-memory JSON, and the payload
+/// hash has to cover exactly the bytes that go on the wire.
+///
+/// `signing_time` is a parameter rather than `SystemTime::now()` so signatures
+/// are reproducible in tests (SigV4 is time-dependent by construction).
+pub fn sign_request(
+    request: &mut reqwest::Request,
+    body: &[u8],
+    credentials: &Credentials,
+    region: &str,
+    signing_time: SystemTime,
+) -> LlmResult<String> {
+    // litellm defaults Content-Type before filtering, so it is part of the
+    // signature rather than an unsigned extra.
+    if !request.headers().contains_key(CONTENT_TYPE) {
+        request
+            .headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    }
+
+    let original = request.headers().clone();
+    let filtered = filter_headers_for_aws_signature(&original);
+
+    let signable_headers: Vec<(&str, &str)> = filtered
+        .iter()
+        .map(|(name, value)| {
+            value
+                .to_str()
+                .map(|value| (name.as_str(), value))
+                .map_err(|_| {
+                    LlmError::ConfigError(format!(
+                        "header {} is not valid UTF-8 and cannot be SigV4-signed",
+                        name.as_str()
+                    ))
+                })
+        })
+        .collect::<LlmResult<Vec<_>>>()?;
+
+    let identity = credentials.clone().into();
+    let signing_params = v4::SigningParams::builder()
+        .identity(&identity)
+        .region(region)
+        .name(BEDROCK_SIGNING_SERVICE)
+        .time(signing_time)
+        .settings(SigningSettings::default())
+        .build()
+        .map_err(|error| {
+            LlmError::ConfigError(format!("could not build AWS SigV4 signing params: {error}"))
+        })?;
+
+    let signable = SignableRequest::new(
+        request.method().as_str(),
+        request.url().as_str(),
+        signable_headers.into_iter(),
+        SignableBody::Bytes(body),
+    )
+    .map_err(|error| {
+        LlmError::ConfigError(format!("request could not be made signable: {error}"))
+    })?;
+
+    let (instructions, signature) = sign(signable, &signing_params.into())
+        .map_err(|error| LlmError::ConfigError(format!("AWS SigV4 signing failed: {error}")))?
+        .into_parts();
+
+    // Rebuild the header map the way litellm does: the signed subset, then the
+    // headers SigV4 computed, then every unsigned header back on top.
+    let mut signed = filtered;
+    for (name, value) in instructions.headers() {
+        let name = HeaderName::try_from(name).map_err(|error| {
+            LlmError::ConfigError(format!(
+                "AWS SigV4 produced an invalid header name: {error}"
+            ))
+        })?;
+        let mut value = HeaderValue::from_str(value).map_err(|error| {
+            LlmError::ConfigError(format!(
+                "AWS SigV4 produced an invalid header value: {error}"
+            ))
+        })?;
+        value.set_sensitive(name == AUTHORIZATION);
+        signed.insert(name, value);
+    }
+
+    for (name, value) in &original {
+        if !SIGV4_COMPUTED_HEADERS.contains(&name.as_str()) {
+            signed.insert(name.clone(), value.clone());
+        }
+    }
+
+    // An explicit non-SigV4 Authorization header wins: litellm refuses to let
+    // signing overwrite a caller-supplied one.
+    if let Some(incoming) = original.get(AUTHORIZATION)
+        && !incoming
+            .to_str()
+            .is_ok_and(|value| value.starts_with(SIGV4_AUTHORIZATION_PREFIX))
+    {
+        signed.insert(AUTHORIZATION, incoming.clone());
+    }
+
+    *request.headers_mut() = signed;
+    Ok(signature)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_keeps_the_aws_subset_and_drops_forwarded_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert("host", HeaderValue::from_static("bedrock.example"));
+        headers.insert("x-amz-target", HeaderValue::from_static("Converse"));
+        headers.insert("x-amzn-trace", HeaderValue::from_static("root=1"));
+        headers.insert("x-forwarded-for", HeaderValue::from_static("10.0.0.1"));
+        headers.insert("user-agent", HeaderValue::from_static("cognee"));
+
+        let filtered = filter_headers_for_aws_signature(&headers);
+
+        assert!(filtered.contains_key(CONTENT_TYPE));
+        assert!(filtered.contains_key("host"));
+        assert!(filtered.contains_key("x-amz-target"));
+        assert!(filtered.contains_key("x-amzn-trace"));
+        assert!(!filtered.contains_key("x-forwarded-for"));
+        assert!(!filtered.contains_key("user-agent"));
+    }
+}

--- a/crates/llm/src/adapters/bedrock/aws/transport.rs
+++ b/crates/llm/src/adapters/bedrock/aws/transport.rs
@@ -8,12 +8,8 @@
 //! [`BedrockTransport::post_json`].
 //!
 //! Kept crate-internal on purpose: it is an implementation seam, not API. The
-//! adapter (R3) and the embedding engine (R4) consume it; nothing is
-//! re-exported from `lib.rs`.
-#![allow(
-    dead_code,
-    reason = "the seam is consumed by the Bedrock adapter (R3) and embedding engine (R4)"
-)]
+//! adapter ([`crate::adapters::bedrock::BedrockAdapter`]) and the embedding
+//! engine (R4) consume it; nothing is re-exported from `lib.rs`.
 
 use std::time::SystemTime;
 

--- a/crates/llm/src/adapters/bedrock/aws/transport.rs
+++ b/crates/llm/src/adapters/bedrock/aws/transport.rs
@@ -21,7 +21,9 @@ use std::time::SystemTime;
 use async_trait::async_trait;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderValue};
 
-use super::credentials::BedrockAuth;
+use std::sync::Arc;
+
+use super::credentials::{BedrockAuth, BedrockAuthProvider};
 use super::signer::sign_request;
 use crate::error::{LlmError, LlmResult};
 
@@ -56,17 +58,33 @@ pub trait BedrockTransport: Send + Sync {
 /// [`BedrockTransport`] over the crate's existing `reqwest` client.
 pub struct ReqwestBedrockTransport {
     client: reqwest::Client,
-    auth: BedrockAuth,
+    auth: Arc<BedrockAuthProvider>,
     region: String,
 }
 
 impl ReqwestBedrockTransport {
-    /// Build a transport that authenticates every request with `auth`.
+    /// Build a transport around a fixed `auth` that is never re-resolved.
     ///
-    /// `auth` is resolved once by the caller
-    /// ([`super::credentials::resolve_auth`]); credential refresh policy is the
-    /// adapter's decision, not the transport's.
+    /// Correct only for auth that cannot expire — a bearer token or static
+    /// keys. Anything resolved through the §1.2 ladder should come in via
+    /// [`Self::with_auth_provider`], because temporary credentials that age out
+    /// mid-process turn into a terminal `AuthenticationError`.
     pub fn new(client: reqwest::Client, auth: BedrockAuth, region: impl Into<String>) -> Self {
+        let region = region.into();
+        Self::with_auth_provider(
+            client,
+            Arc::new(BedrockAuthProvider::fixed(auth, region.clone())),
+            region,
+        )
+    }
+
+    /// Build a transport that asks `auth` for credentials on every request, so
+    /// temporary credentials are refreshed before they expire.
+    pub fn with_auth_provider(
+        client: reqwest::Client,
+        auth: Arc<BedrockAuthProvider>,
+        region: impl Into<String>,
+    ) -> Self {
         Self {
             client,
             auth,
@@ -88,7 +106,11 @@ impl BedrockTransport for ReqwestBedrockTransport {
                 LlmError::ConfigError(format!("could not build Bedrock request: {error}"))
             })?;
 
-        match &self.auth {
+        // Resolved per request: for a bearer token or static keys this is a
+        // cached clone, and for temporary credentials it refreshes near expiry.
+        let auth = self.auth.auth().await?;
+
+        match &auth {
             BedrockAuth::Bearer(token) => {
                 let mut value = HeaderValue::from_str(&format!("Bearer {token}")).map_err(|_| {
                     LlmError::ConfigError(

--- a/crates/llm/src/adapters/bedrock/aws/transport.rs
+++ b/crates/llm/src/adapters/bedrock/aws/transport.rs
@@ -175,6 +175,122 @@ mod tests {
         )
     }
 
+    /// Hands out a different access key on every resolution, so a signature can
+    /// be traced back to which one produced it.
+    struct RotatingLookup {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl crate::adapters::bedrock::aws::credentials::CredentialLookup for RotatingLookup {
+        async fn lookup(
+            &self,
+            _strategy: crate::adapters::bedrock::aws::credentials::CredentialStrategy<'_>,
+            _settings: &crate::adapters::bedrock::aws::env::AwsSettings,
+            _region: &str,
+        ) -> LlmResult<AwsCredentials> {
+            let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(AwsCredentials::new(
+                format!("AKIDGEN{n}"),
+                "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                None,
+                // Already expired, so the next request must re-resolve.
+                Some(SystemTime::now()),
+                "rotating",
+            ))
+        }
+    }
+
+    /// The transport must ask the provider on **every** request, not once at
+    /// construction — otherwise the refresh added alongside `BedrockAuthProvider`
+    /// is inert. Reverting the per-request `auth()` call must fail this test.
+    #[tokio::test]
+    async fn each_request_re_resolves_expired_credentials() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                // Only a *generated* key satisfies this: if the transport signed
+                // with the construction-time snapshot the mock would not match,
+                // the server would answer 404, and the status assertion below
+                // would fail.
+                when.method(POST)
+                    .path("/model/test-model/converse")
+                    .header_prefix("authorization", SIGV4_AUTHORIZATION_PREFIX)
+                    .header_includes("authorization", "AKIDGEN");
+                then.status(200).body("{}");
+            })
+            .await;
+
+        let lookup = Arc::new(RotatingLookup {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let initial = AwsCredentials::new(
+            "AKIDINITIAL",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            None,
+            Some(SystemTime::now()),
+            "initial",
+        );
+        let provider = Arc::new(BedrockAuthProvider::new(
+            None,
+            crate::adapters::bedrock::aws::env::AwsSettings::default(),
+            "us-east-1",
+            crate::adapters::bedrock::aws::credentials::AmbientRoleIdentity::default(),
+            lookup.clone(),
+            BedrockAuth::SigV4(Box::new(initial)),
+        ));
+        let transport = ReqwestBedrockTransport::with_auth_provider(
+            reqwest::Client::new(),
+            provider,
+            "us-east-1",
+        );
+
+        let url = format!("{}/model/test-model/converse", server.base_url());
+        for request in 0..3 {
+            let response = transport
+                .post_json(&url, b"{}".to_vec())
+                .await
+                .expect("round trip");
+            assert_eq!(
+                response.status,
+                reqwest::StatusCode::OK,
+                "request {request} was signed with the construction-time snapshot \
+                 instead of freshly resolved credentials",
+            );
+        }
+
+        mock.assert_calls_async(3).await;
+        assert_eq!(
+            lookup.calls.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "each request must re-resolve, since every credential set is expired",
+        );
+    }
+
+    /// `fixed` carries no ladder inputs, so it must hand back what it was given
+    /// even when that value is expired — never silently resolve a new identity.
+    #[tokio::test]
+    async fn a_fixed_provider_never_re_resolves() {
+        let expired = AwsCredentials::new(
+            "AKIDFIXED",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            None,
+            Some(SystemTime::now()),
+            "fixed",
+        );
+        let provider =
+            BedrockAuthProvider::fixed(BedrockAuth::SigV4(Box::new(expired)), "us-east-1");
+
+        for _ in 0..3 {
+            match provider.auth().await.expect("fixed auth") {
+                BedrockAuth::SigV4(credentials) => {
+                    assert_eq!(credentials.access_key_id(), "AKIDFIXED");
+                }
+                BedrockAuth::Bearer(_) => panic!("expected SigV4"),
+            }
+        }
+    }
+
     /// The mock only answers 200 when every matcher holds, so a wrong header
     /// shape shows up as a 404 here, not as a silently passing assertion.
     #[tokio::test]

--- a/crates/llm/src/adapters/bedrock/aws/transport.rs
+++ b/crates/llm/src/adapters/bedrock/aws/transport.rs
@@ -7,9 +7,14 @@
 //! byte that leaves the process for Bedrock goes through
 //! [`BedrockTransport::post_json`].
 //!
-//! Kept crate-internal on purpose: it is an implementation seam, not API. The
-//! adapter ([`crate::adapters::bedrock::BedrockAdapter`]) and the embedding
-//! engine (R4) consume it; nothing is re-exported from `lib.rs`.
+//! Shared with `cognee-embedding`, not crate-internal: the adapter
+//! ([`crate::adapters::bedrock::BedrockAdapter`]) and the Bedrock embedding
+//! engine (`cognee_embedding::bedrock`, plan §4 R4) both POST through it, and
+//! the engine lives in another crate — so [`BedrockTransport`],
+//! [`ReqwestBedrockTransport`] and [`BedrockHttpResponse`] are `pub`. It is
+//! still an implementation seam rather than headline API: nothing is
+//! re-exported from `lib.rs`, and the adapter's own `transport` field stays
+//! `pub(crate)` so the seam never appears in a public signature.
 
 use std::time::SystemTime;
 
@@ -26,7 +31,7 @@ use crate::error::{LlmError, LlmResult};
 /// [`LlmError`] taxonomy (e.g. `ThrottlingException` → `RateLimitExceeded`) is
 /// the adapter's job, not the transport's.
 #[derive(Clone, Debug)]
-pub(crate) struct BedrockHttpResponse {
+pub struct BedrockHttpResponse {
     /// HTTP status code.
     pub status: reqwest::StatusCode,
     /// Raw response body.
@@ -42,14 +47,14 @@ impl BedrockHttpResponse {
 
 /// POST a JSON body to a Bedrock runtime URL.
 #[async_trait]
-pub(crate) trait BedrockTransport: Send + Sync {
+pub trait BedrockTransport: Send + Sync {
     /// Send `body` to the absolute `url`, applying the §1.2 auth this
     /// transport was built with.
     async fn post_json(&self, url: &str, body: Vec<u8>) -> LlmResult<BedrockHttpResponse>;
 }
 
 /// [`BedrockTransport`] over the crate's existing `reqwest` client.
-pub(crate) struct ReqwestBedrockTransport {
+pub struct ReqwestBedrockTransport {
     client: reqwest::Client,
     auth: BedrockAuth,
     region: String,
@@ -61,11 +66,7 @@ impl ReqwestBedrockTransport {
     /// `auth` is resolved once by the caller
     /// ([`super::credentials::resolve_auth`]); credential refresh policy is the
     /// adapter's decision, not the transport's.
-    pub(crate) fn new(
-        client: reqwest::Client,
-        auth: BedrockAuth,
-        region: impl Into<String>,
-    ) -> Self {
+    pub fn new(client: reqwest::Client, auth: BedrockAuth, region: impl Into<String>) -> Self {
         Self {
             client,
             auth,

--- a/crates/llm/src/adapters/bedrock/aws/transport.rs
+++ b/crates/llm/src/adapters/bedrock/aws/transport.rs
@@ -1,0 +1,258 @@
+//! The transport seam.
+//!
+//! Plan §3 chose `aws-config` + `aws-sigv4` + the existing `reqwest` client
+//! over `aws-sdk-bedrockruntime`, and promised the decision would be cheap to
+//! reverse: "transport sits behind one internal trait, so swapping in
+//! `aws-sdk-bedrockruntime` later touches one file". This is that file — every
+//! byte that leaves the process for Bedrock goes through
+//! [`BedrockTransport::post_json`].
+//!
+//! Kept crate-internal on purpose: it is an implementation seam, not API. The
+//! adapter (R3) and the embedding engine (R4) consume it; nothing is
+//! re-exported from `lib.rs`.
+#![allow(
+    dead_code,
+    reason = "the seam is consumed by the Bedrock adapter (R3) and embedding engine (R4)"
+)]
+
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderValue};
+
+use super::credentials::BedrockAuth;
+use super::signer::sign_request;
+use crate::error::{LlmError, LlmResult};
+
+/// A Bedrock HTTP response, before any route-specific interpretation.
+///
+/// Status and body are handed back raw: mapping a Bedrock error body onto the
+/// [`LlmError`] taxonomy (e.g. `ThrottlingException` → `RateLimitExceeded`) is
+/// the adapter's job, not the transport's.
+#[derive(Clone, Debug)]
+pub(crate) struct BedrockHttpResponse {
+    /// HTTP status code.
+    pub status: reqwest::StatusCode,
+    /// Raw response body.
+    pub body: Vec<u8>,
+}
+
+impl BedrockHttpResponse {
+    /// Body as UTF-8, lossily — for error messages only.
+    pub fn body_lossy(&self) -> std::borrow::Cow<'_, str> {
+        String::from_utf8_lossy(&self.body)
+    }
+}
+
+/// POST a JSON body to a Bedrock runtime URL.
+#[async_trait]
+pub(crate) trait BedrockTransport: Send + Sync {
+    /// Send `body` to the absolute `url`, applying the §1.2 auth this
+    /// transport was built with.
+    async fn post_json(&self, url: &str, body: Vec<u8>) -> LlmResult<BedrockHttpResponse>;
+}
+
+/// [`BedrockTransport`] over the crate's existing `reqwest` client.
+pub(crate) struct ReqwestBedrockTransport {
+    client: reqwest::Client,
+    auth: BedrockAuth,
+    region: String,
+}
+
+impl ReqwestBedrockTransport {
+    /// Build a transport that authenticates every request with `auth`.
+    ///
+    /// `auth` is resolved once by the caller
+    /// ([`super::credentials::resolve_auth`]); credential refresh policy is the
+    /// adapter's decision, not the transport's.
+    pub(crate) fn new(
+        client: reqwest::Client,
+        auth: BedrockAuth,
+        region: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            auth,
+            region: region.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl BedrockTransport for ReqwestBedrockTransport {
+    async fn post_json(&self, url: &str, body: Vec<u8>) -> LlmResult<BedrockHttpResponse> {
+        let mut request = self
+            .client
+            .post(url)
+            .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .body(body.clone())
+            .build()
+            .map_err(|error| {
+                LlmError::ConfigError(format!("could not build Bedrock request: {error}"))
+            })?;
+
+        match &self.auth {
+            BedrockAuth::Bearer(token) => {
+                let mut value = HeaderValue::from_str(&format!("Bearer {token}")).map_err(|_| {
+                    LlmError::ConfigError(
+                        "Bedrock bearer token contains characters that are not valid in an HTTP header"
+                            .to_string(),
+                    )
+                })?;
+                value.set_sensitive(true);
+                request.headers_mut().insert(AUTHORIZATION, value);
+            }
+            BedrockAuth::SigV4(credentials) => {
+                sign_request(
+                    &mut request,
+                    &body,
+                    credentials,
+                    &self.region,
+                    SystemTime::now(),
+                )?;
+            }
+        }
+
+        let response = self.client.execute(request).await.map_err(|error| {
+            if error.is_timeout() {
+                LlmError::Timeout(format!("Bedrock request timed out: {error}"))
+            } else {
+                LlmError::NetworkError(format!("Bedrock request failed: {error}"))
+            }
+        })?;
+
+        let status = response.status();
+        let body = response
+            .bytes()
+            .await
+            .map_err(|error| {
+                LlmError::NetworkError(format!("could not read the Bedrock response body: {error}"))
+            })?
+            .to_vec();
+
+        Ok(BedrockHttpResponse { status, body })
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+    use crate::adapters::bedrock::aws::credentials::AwsCredentials;
+    use crate::adapters::bedrock::aws::signer::SIGV4_AUTHORIZATION_PREFIX;
+    use httpmock::prelude::*;
+
+    fn test_credentials() -> AwsCredentials {
+        AwsCredentials::new(
+            "AKIDEXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            None,
+            None,
+            "test",
+        )
+    }
+
+    /// The mock only answers 200 when every matcher holds, so a wrong header
+    /// shape shows up as a 404 here, not as a silently passing assertion.
+    #[tokio::test]
+    async fn sigv4_round_trip_signs_the_request_and_returns_the_body() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/model/test-model/converse")
+                    .header_exists("x-amz-date")
+                    .header_prefix("authorization", SIGV4_AUTHORIZATION_PREFIX)
+                    .header_includes("authorization", "/us-east-1/bedrock/aws4_request")
+                    .header("content-type", "application/json")
+                    .body(r#"{"ping":true}"#);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"pong":true}"#);
+            })
+            .await;
+
+        let transport = ReqwestBedrockTransport::new(
+            reqwest::Client::new(),
+            BedrockAuth::SigV4(Box::new(test_credentials())),
+            "us-east-1",
+        );
+
+        let response = transport
+            .post_json(
+                &format!("{}/model/test-model/converse", server.base_url()),
+                br#"{"ping":true}"#.to_vec(),
+            )
+            .await
+            .expect("transport round trip");
+
+        assert_eq!(response.status, reqwest::StatusCode::OK);
+        assert_eq!(response.body_lossy(), r#"{"pong":true}"#);
+        mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn bearer_round_trip_sends_a_plain_bearer_header_and_no_signature() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/model/test-model/converse")
+                    .header("authorization", "Bearer bedrock-api-key")
+                    .header_missing("x-amz-date")
+                    .header_missing("x-amz-security-token");
+                then.status(200).body("{}");
+            })
+            .await;
+
+        let transport = ReqwestBedrockTransport::new(
+            reqwest::Client::new(),
+            BedrockAuth::Bearer("bedrock-api-key".to_string()),
+            "us-east-1",
+        );
+
+        let response = transport
+            .post_json(
+                &format!("{}/model/test-model/converse", server.base_url()),
+                b"{}".to_vec(),
+            )
+            .await
+            .expect("transport round trip");
+
+        assert_eq!(response.status, reqwest::StatusCode::OK);
+        mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn transport_reports_a_non_success_status_instead_of_erroring() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(POST).path("/model/test-model/converse");
+                then.status(429)
+                    .body(r#"{"message":"ThrottlingException"}"#);
+            })
+            .await;
+
+        let transport = ReqwestBedrockTransport::new(
+            reqwest::Client::new(),
+            BedrockAuth::Bearer("bedrock-api-key".to_string()),
+            "us-east-1",
+        );
+
+        let response = transport
+            .post_json(
+                &format!("{}/model/test-model/converse", server.base_url()),
+                b"{}".to_vec(),
+            )
+            .await
+            .expect("a 429 is a response, not a transport failure");
+
+        assert_eq!(response.status, reqwest::StatusCode::TOO_MANY_REQUESTS);
+        assert!(response.body_lossy().contains("ThrottlingException"));
+    }
+}

--- a/crates/llm/src/adapters/bedrock/caps.rs
+++ b/crates/llm/src/adapters/bedrock/caps.rs
@@ -1,0 +1,390 @@
+//! Per-model capability and limit table — the Rust stand-in for litellm's
+//! `model_prices_and_context_window.json` (plan §1.4.3 / §4 R3 step 2).
+//!
+//! Three flags drive real wire differences:
+//!
+//! * `supports_native_structured_output` selects between Converse's
+//!   `outputConfig.textFormat` (native) and the synthetic `json_tool_call`
+//!   tool (fallback) — see [`super::converse::apply_structured_output`];
+//! * `supports_tool_choice` decides whether the fallback branch may *force*
+//!   `toolConfig.toolChoice`. `amazon.nova-lite-v1:0` does **not** advertise
+//!   it and is documented to reject a specific `toolChoice`, so forcing it
+//!   unconditionally 400s one of the three models cognee ships;
+//! * `max_output_tokens` is the cap `inferenceConfig.maxTokens` is clamped to
+//!   (§1.0).
+//!
+//! Against cognee's three shipped models this resolves exactly as plan §1.4.3's
+//! table says:
+//!
+//! | Model | Branch | `toolChoice` forced? |
+//! |---|---|---|
+//! | `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` | native `outputConfig` | n/a |
+//! | `eu.anthropic.claude-haiku-4-5-20251001-v1:0` | native `outputConfig` | n/a |
+//! | `eu.amazon.nova-lite-v1:0` | `json_tool_call` | **no** |
+//!
+//! # Keying
+//!
+//! Entries are keyed on the §1.4.1-**normalised** id and matched **exactly**,
+//! the way litellm keys `model_cost`. Do not reuse
+//! `AnthropicAdapter::model_max_output_tokens`
+//! (`crates/llm/src/adapters/anthropic.rs`): it substring-matches `claude-*`
+//! names and never matches a Bedrock id such as
+//! `anthropic.claude-sonnet-4-5-20250929-v1:0`.
+//!
+//! # Maintenance
+//!
+//! Hand-maintained, sourced from litellm's
+//! `model_prices_and_context_window.json`. Adding a model is a data edit here.
+//! An id that is not listed falls back to [`UNKNOWN_MODEL_CAPS`].
+
+use tracing::debug;
+
+/// Capabilities and limits for one Bedrock model.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ModelCaps {
+    /// Model accepts Converse's native `outputConfig.textFormat` structured
+    /// output. When `false`, structured output falls back to the synthetic
+    /// `json_tool_call` tool.
+    pub supports_native_structured_output: bool,
+    /// Model accepts a forced `toolConfig.toolChoice`.
+    pub supports_tool_choice: bool,
+    /// Documented output-token cap (`max_output_tokens`).
+    pub max_output_tokens: u32,
+    /// Documented context window (`max_input_tokens`).
+    pub max_input_tokens: u32,
+    /// Model accepts Converse `image` content blocks.
+    pub supports_vision: bool,
+}
+
+/// Caps applied to a model absent from [`MODEL_CAPS`].
+///
+/// Deliberately **conservative**, per plan §4 R3 step 2: no native structured
+/// output and no forced tool choice, because guessing `true` for either
+/// produces a request the model rejects — a terminal 400 — while guessing
+/// `false` only picks the more widely-supported shape. The 4 096-token output
+/// cap is the floor of the Bedrock converse families (Llama 3.1 caps at 2 048,
+/// Claude 3 and Llama 3.2 at 4 096), so an unlisted model under-budgets its
+/// output until the table below is refreshed rather than 400ing on
+/// `maxTokens > model limit`.
+pub const UNKNOWN_MODEL_CAPS: ModelCaps = ModelCaps {
+    supports_native_structured_output: false,
+    supports_tool_choice: false,
+    max_output_tokens: 4_096,
+    max_input_tokens: 128_000,
+    supports_vision: false,
+};
+
+/// Shorthand for a table row.
+const fn caps(
+    supports_native_structured_output: bool,
+    supports_tool_choice: bool,
+    max_output_tokens: u32,
+    max_input_tokens: u32,
+    supports_vision: bool,
+) -> ModelCaps {
+    ModelCaps {
+        supports_native_structured_output,
+        supports_tool_choice,
+        max_output_tokens,
+        max_input_tokens,
+        supports_vision,
+    }
+}
+
+/// Exact-match capability table, keyed on the normalised model id.
+///
+/// Columns: `supports_native_structured_output`, `supports_tool_choice`,
+/// `max_output_tokens`, `max_input_tokens`, `supports_vision` — every value
+/// copied from litellm's `model_prices_and_context_window.json`.
+pub const MODEL_CAPS: &[(&str, ModelCaps)] = &[
+    // ---- Anthropic (the two ids cognee ships are the first two rows) ----
+    (
+        "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        caps(true, true, 64_000, 200_000, true),
+    ),
+    (
+        "anthropic.claude-haiku-4-5-20251001-v1:0",
+        caps(true, true, 64_000, 200_000, true),
+    ),
+    (
+        "anthropic.claude-opus-4-5-20251101-v1:0",
+        caps(true, true, 64_000, 200_000, true),
+    ),
+    (
+        "anthropic.claude-opus-4-6-v1",
+        caps(true, true, 128_000, 1_000_000, true),
+    ),
+    // Not in litellm's pricing file under this exact spelling, but it is in
+    // BEDROCK_CONVERSE_MODELS; same model as the row above.
+    (
+        "anthropic.claude-opus-4-6-v1:0",
+        caps(true, true, 128_000, 1_000_000, true),
+    ),
+    (
+        "anthropic.claude-opus-4-7",
+        caps(true, true, 128_000, 1_000_000, true),
+    ),
+    (
+        "anthropic.claude-opus-4-8",
+        caps(true, true, 128_000, 1_000_000, true),
+    ),
+    (
+        "anthropic.claude-opus-5",
+        caps(true, true, 128_000, 1_000_000, true),
+    ),
+    (
+        "anthropic.claude-sonnet-5",
+        caps(true, true, 128_000, 1_000_000, true),
+    ),
+    (
+        "anthropic.claude-fable-5",
+        caps(true, true, 128_000, 1_000_000, true),
+    ),
+    (
+        "anthropic.claude-sonnet-4-6",
+        caps(true, true, 64_000, 1_000_000, true),
+    ),
+    (
+        "anthropic.claude-sonnet-4-20250514-v1:0",
+        caps(false, true, 64_000, 1_000_000, true),
+    ),
+    (
+        "anthropic.claude-opus-4-20250514-v1:0",
+        caps(false, true, 32_000, 200_000, true),
+    ),
+    (
+        "anthropic.claude-opus-4-1-20250805-v1:0",
+        caps(false, true, 32_000, 200_000, true),
+    ),
+    (
+        "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        caps(false, true, 8_192, 200_000, true),
+    ),
+    (
+        "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        caps(false, true, 8_192, 1_000_000, true),
+    ),
+    (
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        caps(false, true, 4_096, 1_000_000, true),
+    ),
+    (
+        "anthropic.claude-3-5-haiku-20241022-v1:0",
+        caps(false, true, 8_192, 200_000, false),
+    ),
+    (
+        "anthropic.claude-3-opus-20240229-v1:0",
+        caps(false, true, 4_096, 200_000, true),
+    ),
+    (
+        "anthropic.claude-3-sonnet-20240229-v1:0",
+        caps(false, true, 4_096, 200_000, true),
+    ),
+    (
+        "anthropic.claude-3-haiku-20240307-v1:0",
+        caps(false, true, 4_096, 200_000, true),
+    ),
+    (
+        "anthropic.claude-v2:1",
+        caps(false, true, 8_191, 100_000, false),
+    ),
+    // Absent from the pricing file; the v2 and v2:1 checkpoints share limits.
+    (
+        "anthropic.claude-v2",
+        caps(false, true, 8_191, 100_000, false),
+    ),
+    (
+        "anthropic.claude-v1",
+        caps(false, false, 8_191, 100_000, false),
+    ),
+    (
+        "anthropic.claude-instant-v1",
+        caps(false, true, 8_191, 100_000, false),
+    ),
+    // ---- Amazon Nova (nova-lite is the third id cognee ships) ----
+    (
+        "amazon.nova-lite-v1:0",
+        caps(false, false, 10_000, 300_000, true),
+    ),
+    (
+        "amazon.nova-pro-v1:0",
+        caps(false, false, 10_000, 300_000, true),
+    ),
+    (
+        "amazon.nova-micro-v1:0",
+        caps(false, false, 10_000, 128_000, false),
+    ),
+    (
+        "amazon.nova-2-lite-v1:0",
+        caps(false, false, 64_000, 1_000_000, true),
+    ),
+    (
+        "amazon.nova-2-pro-preview-20251202-v1:0",
+        caps(false, false, 64_000, 1_000_000, true),
+    ),
+    // ---- Meta Llama 3.x ----
+    (
+        "meta.llama3-70b-instruct-v1:0",
+        caps(false, false, 8_192, 8_192, false),
+    ),
+    (
+        "meta.llama3-8b-instruct-v1:0",
+        caps(false, false, 8_192, 8_192, false),
+    ),
+    (
+        "meta.llama3-1-8b-instruct-v1:0",
+        caps(false, false, 2_048, 128_000, false),
+    ),
+    (
+        "meta.llama3-1-70b-instruct-v1:0",
+        caps(false, false, 2_048, 128_000, false),
+    ),
+    (
+        "meta.llama3-1-405b-instruct-v1:0",
+        caps(false, false, 4_096, 128_000, false),
+    ),
+    (
+        "meta.llama3-2-1b-instruct-v1:0",
+        caps(false, false, 4_096, 128_000, false),
+    ),
+    (
+        "meta.llama3-2-3b-instruct-v1:0",
+        caps(false, false, 4_096, 128_000, false),
+    ),
+    (
+        "meta.llama3-2-11b-instruct-v1:0",
+        caps(false, false, 4_096, 128_000, true),
+    ),
+    (
+        "meta.llama3-2-90b-instruct-v1:0",
+        caps(false, false, 4_096, 128_000, true),
+    ),
+    // ---- Mistral ----
+    (
+        "mistral.mistral-large-2407-v1:0",
+        caps(false, true, 8_191, 128_000, false),
+    ),
+    (
+        "mistral.mistral-large-2402-v1:0",
+        caps(false, false, 8_191, 32_000, false),
+    ),
+    (
+        "mistral.mistral-small-2402-v1:0",
+        caps(false, false, 8_191, 32_000, false),
+    ),
+    // ---- DeepSeek / Qwen / OpenAI OSS ----
+    ("deepseek.v3-v1:0", caps(true, true, 81_920, 163_840, false)),
+    ("deepseek.v3.2", caps(true, true, 163_840, 163_840, false)),
+    (
+        "qwen.qwen3-coder-480b-a35b-v1:0",
+        caps(true, true, 65_536, 262_000, false),
+    ),
+    (
+        "qwen.qwen3-235b-a22b-2507-v1:0",
+        caps(true, true, 131_072, 262_144, false),
+    ),
+    (
+        "qwen.qwen3-coder-30b-a3b-v1:0",
+        caps(true, true, 131_072, 262_144, false),
+    ),
+    (
+        "qwen.qwen3-32b-v1:0",
+        caps(true, true, 16_384, 131_072, false),
+    ),
+    (
+        "qwen.qwen3-coder-next",
+        caps(false, true, 8_192, 262_144, false),
+    ),
+    (
+        "openai.gpt-oss-20b-1:0",
+        caps(false, true, 128_000, 128_000, false),
+    ),
+    (
+        "openai.gpt-oss-120b-1:0",
+        caps(false, true, 128_000, 128_000, false),
+    ),
+    // ---- AI21 Jamba ----
+    (
+        "ai21.jamba-instruct-v1:0",
+        caps(false, false, 4_096, 70_000, false),
+    ),
+    (
+        "ai21.jamba-1-5-mini-v1:0",
+        caps(false, false, 256_000, 256_000, false),
+    ),
+    (
+        "ai21.jamba-1-5-large-v1:0",
+        caps(false, false, 256_000, 256_000, false),
+    ),
+    // ---- Writer / MiniMax / Moonshot ----
+    (
+        "writer.palmyra-x4-v1:0",
+        caps(false, false, 8_192, 128_000, false),
+    ),
+    (
+        "writer.palmyra-x5-v1:0",
+        caps(false, false, 8_192, 1_000_000, false),
+    ),
+    (
+        "minimax.minimax-m2.1",
+        caps(false, true, 8_192, 196_000, false),
+    ),
+    (
+        "moonshotai.kimi-k2.5",
+        caps(false, true, 262_144, 262_144, true),
+    ),
+];
+
+/// Look up caps for an already-normalised base model id.
+pub fn caps_for_base_model(base_model: &str) -> ModelCaps {
+    match MODEL_CAPS.iter().find(|(id, _)| *id == base_model) {
+        Some((_, caps)) => *caps,
+        None => {
+            // Surfaced at debug level so the conservative fallback is
+            // diagnosable when tracing the LLM path, without warn-spamming a
+            // per-request log line.
+            debug!(
+                base_model,
+                "Bedrock model not in MODEL_CAPS; using the conservative capability defaults",
+            );
+            UNKNOWN_MODEL_CAPS
+        }
+    }
+}
+
+/// Look up caps for a raw model id, normalising it first (§1.4.1).
+pub fn caps_for(model: &str) -> ModelCaps {
+    caps_for_base_model(&super::model_id::base_model(model))
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_table_key_is_already_normalised() {
+        // A key that still carries a cross-region prefix, an ARN wrapper or a
+        // throughput suffix could never be hit, because the lookup normalises
+        // first. This pins the table against that silent dead entry.
+        for (id, _) in MODEL_CAPS {
+            assert_eq!(
+                &super::super::model_id::base_model(id),
+                id,
+                "capability key {id} is not in normalised form",
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_ids_take_the_conservative_defaults() {
+        let unknown = caps_for("eu.acme.some-future-model-v9:0");
+        assert_eq!(unknown, UNKNOWN_MODEL_CAPS);
+        assert!(!unknown.supports_native_structured_output);
+        assert!(!unknown.supports_tool_choice);
+    }
+}

--- a/crates/llm/src/adapters/bedrock/converse.rs
+++ b/crates/llm/src/adapters/bedrock/converse.rs
@@ -57,11 +57,17 @@ pub fn encode_model_id(model_id: &str) -> String {
 /// **`model` is the ORIGINAL, un-normalised id** — the cross-region prefix, ARN
 /// wrapper and any suffix all stay (plan §1.4.2). Normalisation feeds routing
 /// and the capability lookup only, never this path.
+///
+/// The one exception is litellm's own routing tokens — `bedrock/`, `converse/`,
+/// `invoke/` — which are configuration syntax rather than part of the Bedrock
+/// identifier. litellm strips them before building the URL and so does
+/// [`super::model_id::wire_model_id`]; leaving them on produces a 400 against
+/// `/model/bedrock%2F…/converse`.
 pub fn converse_url(endpoint: &str, model: &str) -> String {
     format!(
         "{}/model/{}/converse",
         endpoint.trim_end_matches('/'),
-        encode_model_id(model)
+        encode_model_id(super::model_id::wire_model_id(model))
     )
 }
 

--- a/crates/llm/src/adapters/bedrock/converse.rs
+++ b/crates/llm/src/adapters/bedrock/converse.rs
@@ -1,0 +1,652 @@
+//! Request / response transforms for `POST {endpoint}/model/{modelId}/converse`
+//! (plan §1.4.2 / §1.4.3).
+//!
+//! Everything in here is a **pure** function over `serde_json::Value`, so the
+//! wire shape is testable without a server (`crates/llm/tests/bedrock_*.rs`).
+//! The adapter in [`super`] owns the HTTP, retry and repair loops.
+//!
+//! Body shape (`converse_transformation.py::_transform_request_helper`):
+//!
+//! ```json
+//! { "messages": [...], "system": [...], "inferenceConfig": {...},
+//!   "additionalModelRequestFields": {...}, "toolConfig": {...},
+//!   "outputConfig": {...} }
+//! ```
+
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+
+use super::caps::ModelCaps;
+use crate::error::LlmError;
+use crate::types::{GenerationOptions, Message, MessageRole, TokenUsage};
+
+/// litellm's `RESPONSE_FORMAT_TOOL_NAME` (`constants.py`) — the name of the
+/// synthetic tool used by the §1.4.3 fallback branch. The exact spelling is
+/// wire-visible, so it must not drift.
+pub const RESPONSE_FORMAT_TOOL_NAME: &str = "json_tool_call";
+
+/// Prompt used by the vision path, matching the other adapters.
+pub const IMAGE_DESCRIPTION_PROMPT: &str = "What's in this image?";
+
+// ---------------------------------------------------------------------------
+// URL
+// ---------------------------------------------------------------------------
+
+/// Percent-encode a model id for use as a single URL path segment.
+///
+/// Port of `base_aws_llm.py::encode_model_id`, which is
+/// `urllib.parse.quote(model_id, safe="")` — i.e. **everything** outside
+/// Python's unreserved set (`A-Za-z0-9_.-~`) is escaped, `/` and `:` included.
+/// This is what makes an inference-profile ARN usable as one path segment, and
+/// what turns `…-v1:0` into `…-v1%3A0`.
+pub fn encode_model_id(model_id: &str) -> String {
+    let mut out = String::with_capacity(model_id.len());
+    for byte in model_id.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b'.' | b'-' | b'~' => {
+                out.push(*byte as char);
+            }
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
+    out
+}
+
+/// Build the Converse URL for `model`.
+///
+/// **`model` is the ORIGINAL, un-normalised id** — the cross-region prefix, ARN
+/// wrapper and any suffix all stay (plan §1.4.2). Normalisation feeds routing
+/// and the capability lookup only, never this path.
+pub fn converse_url(endpoint: &str, model: &str) -> String {
+    format!(
+        "{}/model/{}/converse",
+        endpoint.trim_end_matches('/'),
+        encode_model_id(model)
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+/// Split messages into Converse's top-level `system` blocks and its
+/// `user`/`assistant` turns.
+///
+/// The Converse API has **no system role inside `messages`**, so every system
+/// message is hoisted into the top-level `system` array as its own
+/// `{"text": …}` block. Non-system content becomes
+/// `{"role": …, "content": [{"text": …}]}`.
+pub fn split_messages(messages: &[Message]) -> (Vec<Value>, Vec<Value>) {
+    let mut system_blocks: Vec<Value> = Vec::new();
+    let mut turns: Vec<Value> = Vec::new();
+    for message in messages {
+        let role = match message.role {
+            MessageRole::System => {
+                system_blocks.push(json!({ "text": message.content }));
+                continue;
+            }
+            MessageRole::User => "user",
+            MessageRole::Assistant => "assistant",
+        };
+        turns.push(json!({
+            "role": role,
+            "content": [{ "text": message.content }],
+        }));
+    }
+    (system_blocks, turns)
+}
+
+/// The corrective re-ask text for the branch that produced the bad answer.
+///
+/// The failure preamble is shared with the other adapters
+/// ([`crate::schema::corrective_reason_detail`]); only the directive differs.
+/// The native branch must **not** be told to call a tool — there is none when
+/// the schema travels in `outputConfig`, and both Anthropic models cognee ships
+/// take that branch.
+pub fn corrective_instruction(reason: Option<&str>, native: bool) -> String {
+    let detail = crate::schema::corrective_reason_detail(reason);
+    if native {
+        format!(
+            "{detail}Reply with ONE complete JSON object that fills in every required field, \
+             strictly matching the schema. No extra text."
+        )
+    } else {
+        crate::schema::corrective_instruction(reason, RESPONSE_FORMAT_TOOL_NAME, "tool")
+    }
+}
+
+/// Append a corrective user turn to a Converse body.
+///
+/// The Converse analogue of [`crate::schema::append_corrective_instruction`]:
+/// the failure wording is shared but the append semantics are not, because
+/// Converse content is a **block array** rather than a string — the shared
+/// helper's string-content append would corrupt the body. Extends the last user
+/// turn with an extra `text` block when there is one, otherwise pushes a new
+/// user turn so the correction is never silently dropped.
+///
+/// `native` selects the directive; pass
+/// [`ModelCaps::supports_native_structured_output`].
+pub fn append_corrective_instruction(body: &mut Value, reason: Option<&str>, native: bool) {
+    let instruction = corrective_instruction(reason, native);
+    let Some(messages) = body["messages"].as_array_mut() else {
+        return;
+    };
+    match messages.last_mut() {
+        Some(last) if last["role"] == "user" => {
+            if let Some(content) = last["content"].as_array_mut() {
+                content.push(json!({ "text": instruction }));
+            } else {
+                last["content"] = json!([{ "text": instruction }]);
+            }
+        }
+        _ => messages.push(json!({
+            "role": "user",
+            "content": [{ "text": instruction }],
+        })),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Inference config / additional model request fields
+// ---------------------------------------------------------------------------
+
+/// Build `inferenceConfig` from `opts` with an already-clamped `max_tokens`.
+///
+/// `maxTokens` is `min(llm_max_completion_tokens, model cap)` (§1.0) and is
+/// computed by the adapter; `temperature`, `topP` and `stopSequences` come
+/// straight from [`GenerationOptions`]. Keys the caller did not set are
+/// omitted rather than sent as `null`, which Converse rejects.
+///
+/// `frequency_penalty` / `presence_penalty` have **no `inferenceConfig`
+/// analogue** — see [`penalty_model_fields`].
+pub fn inference_config(opts: &GenerationOptions, max_tokens: u32) -> Value {
+    let mut config = json!({ "maxTokens": max_tokens });
+    if let Some(temperature) = opts.temperature {
+        config["temperature"] = json!(temperature);
+    }
+    if let Some(top_p) = opts.top_p {
+        config["topP"] = json!(top_p);
+    }
+    if let Some(stop) = opts.stop.as_ref().filter(|stop| !stop.is_empty()) {
+        config["stopSequences"] = json!(stop);
+    }
+    config
+}
+
+/// The frequency/presence penalties, shaped for `additionalModelRequestFields`.
+///
+/// **Decision (plan §4 R3 step 6 leaves the choice open):** they are *routed
+/// through* `additionalModelRequestFields` rather than dropped. Converse's
+/// `inferenceConfig` has no analogue, and litellm's own transform sweeps every
+/// inference param it does not recognise into `additionalModelRequestFields`
+/// (`converse_transformation.py`: `additional_request_params = {k: v for k, v in
+/// inference_params.items() if k not in total_supported_params}`), so this is
+/// the parity-faithful destination. Both fields are `None` on every cognee call
+/// path today (`GenerationOptions::default()` leaves them unset and no caller in
+/// the workspace sets them), so a model that rejects the extra fields is only
+/// reachable by a caller that opted in.
+pub fn penalty_model_fields(opts: &GenerationOptions) -> Map<String, Value> {
+    let mut fields = Map::new();
+    if let Some(frequency_penalty) = opts.frequency_penalty {
+        fields.insert("frequency_penalty".to_string(), json!(frequency_penalty));
+    }
+    if let Some(presence_penalty) = opts.presence_penalty {
+        fields.insert("presence_penalty".to_string(), json!(presence_penalty));
+    }
+    fields
+}
+
+/// Merge `LLM_ARGS` and the adapter's explicit fields into
+/// `additionalModelRequestFields`, litellm-style `{**llm_args, **explicit}`.
+///
+/// `llm_args` fills gaps; every key in `explicit` wins. The key is omitted
+/// entirely when both are empty, because Converse rejects an empty object on
+/// some models.
+pub fn merge_additional_model_request_fields(
+    body: &mut Value,
+    llm_args: &Map<String, Value>,
+    explicit: &Map<String, Value>,
+) {
+    if llm_args.is_empty() && explicit.is_empty() {
+        return;
+    }
+    let mut merged = llm_args.clone();
+    for (key, value) in explicit {
+        merged.insert(key.clone(), value.clone());
+    }
+    body["additionalModelRequestFields"] = Value::Object(merged);
+}
+
+// ---------------------------------------------------------------------------
+// Structured output — the two §1.4.3 branches
+// ---------------------------------------------------------------------------
+
+/// Recursively force `"additionalProperties": false` onto **every** object node
+/// of a JSON schema.
+///
+/// Bedrock's native structured-output API returns a validation error unless the
+/// field is explicitly set on each object node
+/// (`_add_additional_properties_to_schema`). Recurses through `properties`,
+/// `items`, `$defs` / `definitions` and `anyOf` / `allOf` / `oneOf`.
+pub fn force_additional_properties_false(schema: &Value) -> Value {
+    let Some(object) = schema.as_object() else {
+        return schema.clone();
+    };
+    let mut out = object.clone();
+
+    if out.get("type").and_then(Value::as_str) == Some("object")
+        && !out.contains_key("additionalProperties")
+    {
+        out.insert("additionalProperties".to_string(), json!(false));
+    }
+
+    let recurse_map = |map: &Value| -> Value {
+        match map.as_object() {
+            Some(entries) => Value::Object(
+                entries
+                    .iter()
+                    .map(|(key, value)| (key.clone(), force_additional_properties_false(value)))
+                    .collect(),
+            ),
+            None => map.clone(),
+        }
+    };
+
+    if let Some(properties) = out.get("properties") {
+        let rewritten = recurse_map(properties);
+        out.insert("properties".to_string(), rewritten);
+    }
+    if let Some(items) = out.get("items").filter(|items| items.is_object()) {
+        let rewritten = force_additional_properties_false(items);
+        out.insert("items".to_string(), rewritten);
+    }
+    for defs_key in ["$defs", "definitions"] {
+        if let Some(defs) = out.get(defs_key) {
+            let rewritten = recurse_map(defs);
+            out.insert(defs_key.to_string(), rewritten);
+        }
+    }
+    for combinator in ["anyOf", "allOf", "oneOf"] {
+        if let Some(Value::Array(branches)) = out.get(combinator) {
+            let rewritten: Vec<Value> = branches
+                .iter()
+                .map(force_additional_properties_false)
+                .collect();
+            out.insert(combinator.to_string(), Value::Array(rewritten));
+        }
+    }
+
+    Value::Object(out)
+}
+
+/// Strip the `$schema` meta key, which Bedrock does not expect on a tool input
+/// schema or inside `outputConfig`.
+fn sanitize_schema(schema: &Value) -> Value {
+    let mut out = schema.clone();
+    if let Some(object) = out.as_object_mut() {
+        object.remove("$schema");
+    }
+    out
+}
+
+/// Build the **native** branch: `outputConfig.textFormat` carrying the schema.
+///
+/// Port of `_create_output_config_for_response_format`. The schema is embedded
+/// as a JSON **string**, and `additionalProperties: false` is forced onto every
+/// object node first.
+pub fn output_config_block(json_schema: &Value) -> Value {
+    let schema = force_additional_properties_false(&sanitize_schema(json_schema));
+    let schema_string = serde_json::to_string(&schema).unwrap_or_else(|_| "{}".to_string());
+    json!({
+        "textFormat": {
+            "type": "json_schema",
+            "structure": {
+                "jsonSchema": { "schema": schema_string }
+            }
+        }
+    })
+}
+
+/// Build the **fallback** branch: a `toolConfig` holding the synthetic
+/// [`RESPONSE_FORMAT_TOOL_NAME`] tool whose input schema *is* the response
+/// schema.
+///
+/// `toolChoice` is forced **only when** `force_tool_choice` — plan §1.4.3:
+/// litellm applies it only if the model advertises `supports_tool_choice`, and
+/// `amazon.nova-lite-v1:0` (one of cognee's three shipped models) does not.
+pub fn json_tool_config(json_schema: &Value, force_tool_choice: bool) -> Value {
+    let mut config = json!({
+        "tools": [{
+            "toolSpec": {
+                "name": RESPONSE_FORMAT_TOOL_NAME,
+                "description": "Return the extracted data in the required schema.",
+                "inputSchema": { "json": sanitize_schema(json_schema) },
+            }
+        }]
+    });
+    if force_tool_choice {
+        config["toolChoice"] = json!({ "tool": { "name": RESPONSE_FORMAT_TOOL_NAME } });
+    }
+    config
+}
+
+/// Whether the native `outputConfig` branch will be used for `caps`.
+///
+/// One place decides, so the request builder and the response unwrapper can
+/// never disagree about which shape they are dealing with.
+pub fn uses_native_structured_output(caps: &ModelCaps) -> bool {
+    caps.supports_native_structured_output
+}
+
+/// Apply §1.4.3's **capability-gated** structured-output shape to `body`.
+///
+/// Native models get `outputConfig`; everything else gets the `json_tool_call`
+/// tool, with `toolChoice` forced only when the model advertises
+/// `supports_tool_choice`. The branch is read from `caps` — never hard-coded.
+pub fn apply_structured_output(body: &mut Value, json_schema: &Value, caps: &ModelCaps) {
+    if uses_native_structured_output(caps) {
+        body["outputConfig"] = output_config_block(json_schema);
+    } else {
+        body["toolConfig"] = json_tool_config(json_schema, caps.supports_tool_choice);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vision
+// ---------------------------------------------------------------------------
+
+/// Map an `image/*` MIME type onto a Converse image `format` token.
+///
+/// Converse accepts exactly `png`, `jpeg`, `gif` and `webp`.
+pub fn image_format_for_mime(mime_type: &str) -> Option<&'static str> {
+    match mime_type.trim().to_ascii_lowercase().as_str() {
+        "image/png" => Some("png"),
+        "image/jpeg" | "image/jpg" => Some("jpeg"),
+        "image/gif" => Some("gif"),
+        "image/webp" => Some("webp"),
+        _ => None,
+    }
+}
+
+/// A single user turn holding the description prompt and a base64 image block.
+///
+/// Converse carries images as `{"image": {"format": …, "source": {"bytes": …}}}`
+/// — over the REST-JSON wire the blob is base64. Plan §6.5: this **exceeds**
+/// Python parity, whose `BedrockAdapter.transcribe_image` raises
+/// `NotImplementedError`.
+pub fn image_message(format: &str, base64_image: &str) -> Value {
+    json!({
+        "role": "user",
+        "content": [
+            { "text": IMAGE_DESCRIPTION_PROMPT },
+            { "image": { "format": format, "source": { "bytes": base64_image } } },
+        ],
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Response
+// ---------------------------------------------------------------------------
+
+/// A parsed Converse response.
+///
+/// `content` blocks stay raw `Value`s so `text`, `toolUse` and
+/// `reasoningContent` are all handled without an exhaustive enum, the same way
+/// the Anthropic adapter treats its content blocks.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConverseResponse {
+    /// `output.message.content[]`.
+    #[serde(default)]
+    pub output: ConverseOutput,
+    /// `end_turn` | `tool_use` | `max_tokens` | `stop_sequence` | …
+    #[serde(default)]
+    pub stop_reason: Option<String>,
+    /// Token counts.
+    #[serde(default)]
+    pub usage: Option<ConverseUsage>,
+}
+
+/// The `output` envelope.
+#[derive(Debug, Default, Deserialize)]
+pub struct ConverseOutput {
+    /// The assistant message.
+    #[serde(default)]
+    pub message: ConverseMessage,
+}
+
+/// The assistant message inside `output`.
+#[derive(Debug, Default, Deserialize)]
+pub struct ConverseMessage {
+    /// Raw content blocks.
+    #[serde(default)]
+    pub content: Vec<Value>,
+}
+
+/// Converse `usage`.
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConverseUsage {
+    /// Prompt tokens.
+    #[serde(default)]
+    pub input_tokens: u32,
+    /// Completion tokens.
+    #[serde(default)]
+    pub output_tokens: u32,
+    /// Total, when Bedrock reports one.
+    #[serde(default)]
+    pub total_tokens: u32,
+}
+
+impl From<ConverseUsage> for TokenUsage {
+    fn from(usage: ConverseUsage) -> Self {
+        let total = if usage.total_tokens > 0 {
+            usage.total_tokens
+        } else {
+            usage.input_tokens.saturating_add(usage.output_tokens)
+        };
+        TokenUsage {
+            prompt_tokens: usage.input_tokens,
+            completion_tokens: usage.output_tokens,
+            total_tokens: total,
+        }
+    }
+}
+
+impl ConverseResponse {
+    /// Concatenate every `text` content block.
+    pub fn text(&self) -> String {
+        self.output
+            .message
+            .content
+            .iter()
+            .filter_map(|block| block.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    /// The `input` of the first `toolUse` block named `tool_name`.
+    pub fn tool_input(&self, tool_name: &str) -> Option<Value> {
+        self.output.message.content.iter().find_map(|block| {
+            let tool_use = block.get("toolUse")?;
+            (tool_use.get("name").and_then(Value::as_str) == Some(tool_name))
+                .then(|| tool_use.get("input").cloned())
+                .flatten()
+        })
+    }
+
+    /// Whether generation stopped because the output budget ran out — i.e. the
+    /// object present in the response is incomplete.
+    pub fn is_truncated(&self) -> bool {
+        self.stop_reason.as_deref() == Some("max_tokens")
+    }
+
+    /// The structured payload for the branch `caps` selected: the parsed
+    /// `toolUse.input` for the fallback branch, or the text content parsed as
+    /// JSON for the native branch.
+    ///
+    /// `None` means "nothing usable came back", which the repair loop turns
+    /// into a corrective re-ask.
+    pub fn structured_payload(&self, caps: &ModelCaps) -> Option<Value> {
+        if uses_native_structured_output(caps) {
+            let text = self.text();
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            serde_json::from_str::<Value>(trimmed).ok()
+        } else {
+            self.tool_input(RESPONSE_FORMAT_TOOL_NAME)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Bedrock exception names that mean "retry later" (§4 R3 step 7).
+const THROTTLING_EXCEPTIONS: [&str; 2] = ["ThrottlingException", "ModelNotReadyException"];
+
+/// Bedrock exception names that mean "the caller is not allowed to do this".
+const AUTH_EXCEPTIONS: [&str; 4] = [
+    "AccessDeniedException",
+    "UnrecognizedClientException",
+    "ExpiredTokenException",
+    "IncompleteSignatureException",
+];
+
+/// Map a Bedrock HTTP status + error body onto the [`LlmError`] taxonomy.
+///
+/// The one non-obvious rule, and the reason this is not the 429-only mapping
+/// the other adapters use: **Bedrock signals throttling as HTTP 400
+/// `ThrottlingException` as well as 429** (plan §4 R3 step 7). Mapping the 400
+/// to a generic bad-request error strands the retry layer and turns a
+/// recoverable throttle into a hard pipeline failure.
+///
+/// The exception name is read from the body — `__type` / `code` when the
+/// AWS-JSON envelope is present, otherwise a substring scan of the raw body.
+/// The authoritative `x-amzn-errortype` **header** is not available here: the
+/// transport seam hands back status + body only, by design (mapping errors is
+/// the adapter's job, not the transport's). Every Bedrock runtime error body
+/// observed in practice names its own exception, and the status-code fallback
+/// below covers the rest.
+pub fn map_error(status: u16, body: &str) -> LlmError {
+    let named = |candidates: &[&str]| candidates.iter().any(|name| mentions(body, name));
+
+    if named(&THROTTLING_EXCEPTIONS) || status == 429 {
+        return LlmError::RateLimitExceeded(format!("HTTP {status}: {body}"));
+    }
+    if named(&AUTH_EXCEPTIONS) || matches!(status, 401 | 403) {
+        return LlmError::AuthenticationError(format!("HTTP {status}: {body}"));
+    }
+    if mentions(body, "ResourceNotFoundException") || status == 404 {
+        return LlmError::ModelNotFound(format!("HTTP {status}: {body}"));
+    }
+    if mentions(body, "ModelTimeoutException") || status == 408 {
+        return LlmError::Timeout(format!("HTTP {status}: {body}"));
+    }
+    if mentions(body, "ServiceUnavailableException")
+        || mentions(body, "InternalServerException")
+        || status >= 500
+    {
+        return LlmError::ApiError(format!("HTTP {status}: {body}"));
+    }
+    if mentions(body, "ValidationException") || status == 400 {
+        return LlmError::InvalidResponse(format!("Bad request (HTTP {status}): {body}"));
+    }
+    LlmError::ApiError(format!("HTTP {status}: {body}"))
+}
+
+/// Whether the error body names `exception`.
+///
+/// Checks the AWS-JSON `__type` / `code` fields first (where the value is
+/// often namespaced, e.g. `com.amazon.coral.service#ThrottlingException`) and
+/// falls back to a raw substring scan.
+fn mentions(body: &str, exception: &str) -> bool {
+    if let Ok(Value::Object(parsed)) = serde_json::from_str::<Value>(body) {
+        for key in ["__type", "code", "Code", "errorType", "type"] {
+            if let Some(value) = parsed.get(key).and_then(Value::as_str)
+                && value.contains(exception)
+            {
+                return true;
+            }
+        }
+    }
+    body.contains(exception)
+}
+
+/// Whether `error` is worth another transport attempt.
+///
+/// Terminal: auth, unknown model, and a `ValidationException` (re-POSTing an
+/// identical rejected body cannot start working). The structured-output repair
+/// loop still re-asks on `InvalidResponse` — with *changed* content — which is
+/// the "model rejected the schema" repair case.
+pub fn is_retryable(error: &LlmError) -> bool {
+    matches!(
+        error,
+        LlmError::RateLimitExceeded(_)
+            | LlmError::ApiError(_)
+            | LlmError::NetworkError(_)
+            | LlmError::Timeout(_)
+    )
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_id_is_percent_encoded_as_one_path_segment() {
+        assert_eq!(
+            encode_model_id("eu.anthropic.claude-sonnet-4-5-20250929-v1:0"),
+            "eu.anthropic.claude-sonnet-4-5-20250929-v1%3A0"
+        );
+        assert_eq!(
+            encode_model_id("arn:aws:bedrock:eu-west-1:1:application-inference-profile/abc"),
+            "arn%3Aaws%3Abedrock%3Aeu-west-1%3A1%3Aapplication-inference-profile%2Fabc"
+        );
+    }
+
+    #[test]
+    fn usage_total_falls_back_to_the_sum() {
+        let usage = TokenUsage::from(ConverseUsage {
+            input_tokens: 4,
+            output_tokens: 6,
+            total_tokens: 0,
+        });
+        assert_eq!(usage.total_tokens, 10);
+    }
+
+    #[test]
+    fn corrective_instruction_extends_the_last_user_turn_as_a_block() {
+        let mut body = json!({
+            "messages": [{ "role": "user", "content": [{ "text": "hi" }] }]
+        });
+        append_corrective_instruction(&mut body, Some("missing required field `x`"), false);
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2, "the correction is a second text block");
+        assert!(
+            content[1]["text"]
+                .as_str()
+                .unwrap()
+                .contains("missing required field `x`")
+        );
+    }
+
+    #[test]
+    fn corrective_instruction_pushes_a_user_turn_after_an_assistant_turn() {
+        let mut body = json!({
+            "messages": [{ "role": "assistant", "content": [{ "text": "prior" }] }]
+        });
+        append_corrective_instruction(&mut body, None, false);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1]["role"], "user");
+    }
+}

--- a/crates/llm/src/adapters/bedrock/converse.rs
+++ b/crates/llm/src/adapters/bedrock/converse.rs
@@ -59,10 +59,10 @@ pub fn encode_model_id(model_id: &str) -> String {
 /// and the capability lookup only, never this path.
 ///
 /// The one exception is litellm's own routing tokens — `bedrock/`, `converse/`,
-/// `invoke/` — which are configuration syntax rather than part of the Bedrock
-/// identifier. litellm strips them before building the URL and so does
-/// [`super::model_id::wire_model_id`]; leaving them on produces a 400 against
-/// `/model/bedrock%2F…/converse`.
+/// `invoke/` — plus the `nova/` / `nova-2/` custom-model spec prefix, none of
+/// which are part of the Bedrock identifier. litellm strips them before building
+/// the URL and so does [`super::model_id::wire_model_id`]; leaving them on
+/// produces a 400 against `/model/bedrock%2F…/converse`.
 pub fn converse_url(endpoint: &str, model: &str) -> String {
     format!(
         "{}/model/{}/converse",

--- a/crates/llm/src/adapters/bedrock/mod.rs
+++ b/crates/llm/src/adapters/bedrock/mod.rs
@@ -608,7 +608,11 @@ impl Llm for BedrockAdapter {
     ) -> LlmResult<String> {
         use base64::Engine as _;
 
-        if !mime_type.starts_with("image/") {
+        // Normalised the same way `image_format_for_mime` normalises, so a
+        // valid-but-oddly-cased `IMAGE/PNG` is not rejected here before the
+        // helper below ever gets to map it.
+        let normalised_mime = mime_type.trim().to_ascii_lowercase();
+        if !normalised_mime.starts_with("image/") {
             return Err(LlmError::InvalidResponse(format!(
                 "Expected image/* MIME type, got: {mime_type}"
             )));

--- a/crates/llm/src/adapters/bedrock/mod.rs
+++ b/crates/llm/src/adapters/bedrock/mod.rs
@@ -1,13 +1,756 @@
 //! AWS Bedrock provider (feature `bedrock`).
 //!
-//! Scope of this module today is the shared AWS plumbing in [`aws`]: env
+//! [`BedrockAdapter`] implements [`Llm`] against the Bedrock **Converse** API,
+//! `POST {endpoint}/model/{modelId}/converse`. The shared AWS plumbing — env
 //! resolution, the region and endpoint chains, the credential ladder, SigV4
-//! signing and the transport seam. The adapter itself (`BedrockAdapter`,
-//! model-id normalisation, route selection, the capability table and the
-//! Converse transforms) lands in a later step — see
-//! `docs/roadmap/bedrock-provider-plan.md` §4 R3.
+//! signing and the transport seam — lives in [`aws`]; the four modules beside
+//! it carry the chat-side wire spec:
 //!
-//! Nothing here is re-exported from `lib.rs` yet, deliberately: the public
-//! surface starts existing when the adapter does.
+//! | Module | Plan section | What it decides |
+//! |---|---|---|
+//! | [`model_id`] | §1.4.1 | normalisation, which runs **before** routing |
+//! | [`route`] | §1.4.2 | converse vs invoke (and the explicit route prefixes) |
+//! | [`caps`] | §1.4.3 / §1.0 | per-model capabilities and the output-token cap |
+//! | [`converse`] | §1.4.2 / §1.4.3 | the request/response transforms |
+//!
+//! # Two rules that fail silently if forgotten
+//!
+//! 1. **Normalisation feeds routing and the capability lookup only — the
+//!    request URL keeps the original id.** Every model cognee ships is
+//!    `eu.`-prefixed while litellm's converse table stores bare ids, so
+//!    skipping normalisation routes all three defaults to `invoke`
+//!    (`model_id`).
+//! 2. **Structured output is capability-gated, not hard-coded.** The synthetic
+//!    `json_tool_call` tool is the *fallback*; both Anthropic ids cognee ships
+//!    take Converse's native `outputConfig.textFormat` branch, and
+//!    `amazon.nova-lite-v1:0` takes the tool branch **without** a forced
+//!    `toolChoice` (`caps` + `converse::apply_structured_output`).
+//!
+//! # Scope
+//!
+//! * **No streaming** (plan §1.6): [`Llm::supports_streaming`] returns `false`.
+//! * **No `/invoke` chat** (plan §6.7): an invoke-routed chat model is rejected
+//!   at construction with [`LlmError::FeatureNotSupported`]. No model cognee
+//!   ships routes there, and the legacy per-family transforms were the largest
+//!   lump of code in the original plan.
+//! * **Vision exceeds Python parity, on purpose** (plan §6.5):
+//!   [`Llm::transcribe_image`] is implemented with Converse image blocks, while
+//!   Python's `BedrockAdapter.transcribe_image` raises `NotImplementedError`.
+//!   Plan P6 is the optional path to closing that gap from the Python side.
 
 pub mod aws;
+pub mod caps;
+pub mod converse;
+pub mod model_id;
+pub mod route;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Map, Value, json};
+use tracing::{debug, instrument, warn};
+
+use self::aws::env::AwsInputs;
+use self::aws::transport::{BedrockTransport, ReqwestBedrockTransport};
+use self::caps::ModelCaps;
+use self::converse::{ConverseResponse, RESPONSE_FORMAT_TOOL_NAME};
+use self::route::BedrockRoute;
+use crate::error::{LlmError, LlmResult};
+use crate::llm_trait::{Llm, StructuredOutputValidator};
+use crate::types::{GenerationOptions, GenerationResponse, Message, TokenUsage};
+
+/// Native adapter for the AWS Bedrock Converse API.
+///
+/// Built by `cognee-components`' Bedrock factory (plan §4 R5); see the module
+/// docs for the wire spec it implements.
+pub struct BedrockAdapter {
+    /// The model id **exactly as configured**. This is what goes in the request
+    /// URL — cross-region prefix, ARN wrapper and suffixes included.
+    model: String,
+    /// The §1.4.1-normalised id. Routing and the capability lookup key on this;
+    /// nothing on the wire does.
+    base_model: String,
+    /// Capabilities resolved once from [`base_model`](Self::base_model).
+    caps: ModelCaps,
+    /// Resolved runtime endpoint, without a trailing slash.
+    endpoint: String,
+    /// Resolved AWS region — kept for diagnostics; the transport holds its own
+    /// copy for signing.
+    region: String,
+    /// The §3 transport seam. `pub(crate)` by design, so it never appears in a
+    /// public signature of this adapter.
+    transport: Arc<dyn BedrockTransport>,
+    structured_output_retries: usize,
+    network_retries: usize,
+    /// Output-token ceiling (Python's `llm_max_completion_tokens`). The
+    /// per-request `inferenceConfig.maxTokens` is `min(this, the model cap)`.
+    max_completion_tokens: u32,
+    /// `LLM_ARGS`, merged into `additionalModelRequestFields`.
+    extra_args: Map<String, Value>,
+}
+
+impl BedrockAdapter {
+    /// Default structured-output repair retries (Python instructor parity: 5).
+    pub const DEFAULT_STRUCTURED_OUTPUT_RETRIES: usize = 5;
+    /// Default transient-network retries.
+    pub const DEFAULT_NETWORK_RETRIES: usize = 3;
+    /// Default output-token ceiling, aliasing the crate-wide
+    /// [`crate::DEFAULT_MAX_COMPLETION_TOKENS`] so it moves in lockstep with the
+    /// config and `GenerationOptions` defaults.
+    pub const DEFAULT_MAX_COMPLETION_TOKENS: u32 = crate::DEFAULT_MAX_COMPLETION_TOKENS;
+    /// Request timeout, matching the other adapters.
+    const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+
+    /// Build an adapter for `model`.
+    ///
+    /// * `api_key` is the Bedrock API key (`LLM_API_KEY`). When set it
+    ///   short-circuits to `Authorization: Bearer …` with **no** SigV4 and no
+    ///   credential lookup at all (plan §1.2); when unset, the credential ladder
+    ///   runs. Bedrock is exempt from cognee's API-key requirement (§1.1), so
+    ///   `None` is a supported configuration, not an error.
+    /// * `api_base` is the highest rung of the §1.3 endpoint chain. Pass `None`
+    ///   to let `AWS_BEDROCK_RUNTIME_ENDPOINT` / the regional default decide —
+    ///   in particular do **not** pass `LlmInputs::endpoint` through, which
+    ///   aliases `OPENAI_URL` (the same trap `anthropic_base_url` exists to
+    ///   avoid).
+    /// * `aws` carries the §2.1 env-resolved AWS inputs.
+    ///
+    /// Fails when the model does not route to Converse (plan §6.7), or when the
+    /// region / credential chains cannot resolve.
+    pub async fn new(
+        model: impl Into<String>,
+        api_key: Option<&str>,
+        api_base: Option<&str>,
+        aws: &AwsInputs,
+    ) -> LlmResult<Self> {
+        let model: String = model.into();
+
+        // Route first: an invoke-routed chat model must fail loudly here rather
+        // than POST a Converse body to an endpoint that cannot serve it.
+        let route = route::select_route(&model);
+        if route != BedrockRoute::Converse {
+            return Err(LlmError::FeatureNotSupported(format!(
+                "Bedrock model {model:?} routes to `{}`, and this adapter only implements the \
+                 Converse API. No model cognee ships routes elsewhere; see \
+                 docs/roadmap/bedrock-provider-plan.md §6.7.",
+                route.as_str()
+            )));
+        }
+
+        let settings = aws.resolve();
+        let region = aws::region::resolve_region(&settings, Some(&model)).await?;
+        let endpoint = aws::endpoint::resolve_endpoint(api_base, &settings, &region);
+        let auth = aws::credentials::resolve_auth(api_key, &settings, &region).await?;
+
+        let client = reqwest::Client::builder()
+            .timeout(Self::REQUEST_TIMEOUT)
+            .build()
+            .map_err(|e| LlmError::ConfigError(format!("Failed to create HTTP client: {e}")))?;
+        let transport = Arc::new(ReqwestBedrockTransport::new(client, auth, region.clone()));
+
+        let base_model = model_id::base_model(&model);
+        let caps = caps::caps_for_base_model(&base_model);
+        debug!(
+            model = model.as_str(),
+            base_model = base_model.as_str(),
+            region = region.as_str(),
+            endpoint = endpoint.as_str(),
+            native_structured_output = caps.supports_native_structured_output,
+            supports_tool_choice = caps.supports_tool_choice,
+            "built Bedrock Converse adapter",
+        );
+
+        Ok(Self {
+            model,
+            base_model,
+            caps,
+            endpoint,
+            region,
+            transport,
+            structured_output_retries: Self::DEFAULT_STRUCTURED_OUTPUT_RETRIES,
+            network_retries: Self::DEFAULT_NETWORK_RETRIES,
+            max_completion_tokens: Self::DEFAULT_MAX_COMPLETION_TOKENS,
+            extra_args: Map::new(),
+        })
+    }
+
+    /// Configure structured-output repair retries (floored at 1).
+    pub fn with_structured_output_retries(mut self, retries: u32) -> Self {
+        self.structured_output_retries = usize::try_from(retries).unwrap_or(usize::MAX).max(1);
+        self
+    }
+
+    /// Configure transient network/server retry attempts.
+    pub fn with_network_retries(mut self, retries: u32) -> Self {
+        self.network_retries = usize::try_from(retries).unwrap_or(usize::MAX);
+        self
+    }
+
+    /// Set the output-token ceiling (`llm_max_completion_tokens`). The
+    /// per-request `maxTokens` is still clamped to the model's documented cap.
+    pub fn with_max_completion_tokens(mut self, ceiling: u32) -> Self {
+        self.max_completion_tokens = ceiling;
+        self
+    }
+
+    /// Set `LLM_ARGS`, merged into `additionalModelRequestFields`. Explicit
+    /// keys the adapter sets always win (litellm's `{**llm_args, **kwargs}`).
+    pub fn with_extra_args(mut self, args: Map<String, Value>) -> Self {
+        self.extra_args = args;
+        self
+    }
+
+    /// The §1.4.1-normalised model id used for routing and the capability
+    /// lookup. Exposed for diagnostics and tests; never sent on the wire.
+    pub fn base_model(&self) -> &str {
+        &self.base_model
+    }
+
+    /// The resolved AWS region.
+    pub fn region(&self) -> &str {
+        &self.region
+    }
+
+    /// The resolved runtime endpoint.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Capabilities resolved for this model.
+    pub fn caps(&self) -> ModelCaps {
+        self.caps
+    }
+
+    /// The `inferenceConfig.maxTokens` to send: `min(caller value, configured
+    /// ceiling, model cap)`, floored at 1 (plan §1.0).
+    ///
+    /// The configured ceiling bounds **every** path, not only the
+    /// `max_tokens: None` one: `GenerationOptions::default()` carries
+    /// `Some(16384)`, so a default-options caller would otherwise silently
+    /// bypass a lower operator-configured ceiling. The model cap is applied last
+    /// so Bedrock never 400s on `maxTokens > model limit`.
+    fn effective_max_tokens(&self, opts: &GenerationOptions) -> u32 {
+        let requested = opts.max_tokens.map_or(self.max_completion_tokens, |value| {
+            value.min(self.max_completion_tokens)
+        });
+        requested.min(self.caps.max_output_tokens).max(1)
+    }
+
+    /// The output budget a truncation retry may raise to: the lesser of the
+    /// model cap and the configured ceiling.
+    fn effective_output_cap(&self) -> u32 {
+        self.caps
+            .max_output_tokens
+            .min(self.max_completion_tokens)
+            .max(1)
+    }
+
+    /// Build the Converse body shared by completion, structured output and the
+    /// repair loop.
+    fn base_request(&self, messages: &[Message], opts: &GenerationOptions) -> Value {
+        let (system, turns) = converse::split_messages(messages);
+        // Converse requires at least one user/assistant turn. When the caller
+        // passes only system messages, hoisting leaves `turns` empty and the API
+        // 400s on an empty `messages` array — so fold the system blocks into a
+        // single user turn instead, the way the Anthropic adapter does.
+        let (system, turns) = if turns.is_empty() && !system.is_empty() {
+            (
+                Vec::new(),
+                vec![json!({ "role": "user", "content": system })],
+            )
+        } else {
+            (system, turns)
+        };
+
+        let mut body = json!({ "messages": turns });
+        if !system.is_empty() {
+            body["system"] = json!(system);
+        }
+        body["inferenceConfig"] = converse::inference_config(opts, self.effective_max_tokens(opts));
+        converse::merge_additional_model_request_fields(
+            &mut body,
+            &self.extra_args,
+            &converse::penalty_model_fields(opts),
+        );
+        body
+    }
+
+    /// POST `request_body` to the Converse endpoint with a transient-retry
+    /// ladder and exponential backoff.
+    #[instrument(
+        name = "llm.api_call",
+        level = "info",
+        skip(self, request_body),
+        fields(
+            url = tracing::field::Empty,
+            cognee.llm.model = self.model.as_str(),
+            cognee.llm.provider = "bedrock",
+        ),
+    )]
+    async fn call_converse(&self, request_body: &Value) -> LlmResult<ConverseResponse> {
+        let url = converse::converse_url(&self.endpoint, &self.model);
+        tracing::Span::current().record("url", url.as_str());
+
+        let debug_enabled = std::env::var("COGNEE_DEBUG_LLM_REQUEST")
+            .map(|value| cognee_utils::parse_env_bool(&value))
+            .unwrap_or(false);
+        if debug_enabled {
+            let pretty = serde_json::to_string_pretty(request_body)
+                .unwrap_or_else(|_| request_body.to_string());
+            eprintln!("\n[COGNEE_DEBUG_LLM_REQUEST] POST {url}\n{pretty}\n");
+        }
+
+        let payload = serde_json::to_vec(request_body).map_err(|e| {
+            LlmError::SerializationError(format!("Failed to serialize Converse request: {e}"))
+        })?;
+
+        let mut last_error = LlmError::NetworkError("No attempt made".to_string());
+
+        for attempt in 0..=self.network_retries {
+            if attempt > 0 {
+                // Shared jittered backoff (issue #19): a batch of concurrent
+                // requests that all throttle at once must not retry in lockstep.
+                let delay = crate::retry::retry_backoff(attempt as u32);
+                warn!(
+                    attempt,
+                    network_retries = self.network_retries,
+                    delay_ms = delay.as_millis() as u64,
+                    error = %last_error,
+                    "Bedrock request failed, retrying",
+                );
+                tokio::time::sleep(delay).await;
+            }
+
+            let response = match self.transport.post_json(&url, payload.clone()).await {
+                Ok(response) => response,
+                Err(error) => {
+                    if !converse::is_retryable(&error) {
+                        return Err(error);
+                    }
+                    last_error = error;
+                    continue;
+                }
+            };
+
+            if !response.status.is_success() {
+                let error = converse::map_error(response.status.as_u16(), &response.body_lossy());
+                // Terminal: auth, unknown model, and a ValidationException —
+                // re-POSTing the identical body cannot start working.
+                if !converse::is_retryable(&error) {
+                    return Err(error);
+                }
+                last_error = error;
+                continue;
+            }
+
+            let body = response.body_lossy().into_owned();
+            if debug_enabled {
+                eprintln!("\n[COGNEE_DEBUG_LLM_RESPONSE] POST {url}\n{body}\n");
+            }
+            return serde_json::from_str::<ConverseResponse>(&body).map_err(|e| {
+                LlmError::DeserializationError(format!(
+                    "Failed to parse Converse response: {e}. Raw body: {body}"
+                ))
+            });
+        }
+
+        Err(LlmError::MaxRetriesExceeded(format!(
+            "Bedrock request failed after {} attempt(s): {}",
+            self.network_retries + 1,
+            last_error
+        )))
+    }
+
+    /// Shared structured-output loop with instructor-style corrective retries.
+    ///
+    /// A re-implementation of the Anthropic repair loop's *behaviour* over
+    /// Converse's JSON (`stopReason`, `toolUse.input`, native text format) —
+    /// plan §6.7 makes clear that loop is a pattern, not shared code. Invalid,
+    /// empty or validator-rejected output triggers a corrective re-ask inside
+    /// the same retry budget, with a backoff between re-asks; terminal provider
+    /// errors short-circuit instead of burning it.
+    async fn structured_output_impl(
+        &self,
+        messages: Vec<Message>,
+        json_schema: &Value,
+        options: Option<GenerationOptions>,
+        validator: Option<StructuredOutputValidator<'_>>,
+    ) -> LlmResult<Value> {
+        let opts = options.unwrap_or_default();
+        let mut body = self.base_request(&messages, &opts);
+        // §1.4.3: the branch is read from the capability table, never hard-coded.
+        converse::apply_structured_output(&mut body, json_schema, &self.caps);
+
+        let mut last_error =
+            LlmError::InvalidResponse("No structured-output attempt made".to_string());
+
+        for attempt in 0..self.structured_output_retries {
+            if attempt > 0 {
+                // `call_converse`'s ladder only covers transport retries inside
+                // a single attempt, so without this the outer loop would re-ask
+                // immediately (Python waits between structured retries via
+                // `wait_exponential_jitter`).
+                let delay = crate::retry::retry_backoff(attempt as u32);
+                debug!(
+                    attempt,
+                    delay_ms = delay.as_millis() as u64,
+                    "retrying Bedrock structured output",
+                );
+                tokio::time::sleep(delay).await;
+            }
+
+            match self.call_converse(&body).await {
+                Ok(response) => {
+                    let truncated = response.is_truncated();
+                    match response.structured_payload(&self.caps) {
+                        Some(_) if truncated => {
+                            // Cut off at maxTokens: present and JSON-parseable,
+                            // but incomplete. Matching the Python reference
+                            // (instructor), a length-truncated structured
+                            // response is rejected outright rather than returned
+                            // as a partial object — a shallow top-level check
+                            // cannot tell a complete object that happened to
+                            // finish at the budget from one whose nested
+                            // list/string was cut off. Re-asking with the SAME
+                            // budget would truncate at the same point, so raise
+                            // it toward the effective output budget. That budget
+                            // is the model cap bounded by the configured
+                            // `llm_max_completion_tokens` ceiling, which is an
+                            // upper bound on every path — so when we are already
+                            // at it, fail terminally rather than loop until
+                            // MaxRetriesExceeded.
+                            let cap = self.effective_output_cap();
+                            let current =
+                                body["inferenceConfig"]["maxTokens"].as_u64().unwrap_or(0) as u32;
+                            if current >= cap {
+                                return Err(LlmError::InvalidResponse(format!(
+                                    "Bedrock structured output was truncated at the effective \
+                                     {cap}-token output budget (the lesser of the \
+                                     llm_max_completion_tokens ceiling and the model cap) and \
+                                     cannot be completed within that budget"
+                                )));
+                            }
+                            body["inferenceConfig"]["maxTokens"] = json!(cap);
+                            let reason = "the previous answer was cut off at maxTokens before the \
+                                          object was complete";
+                            last_error = LlmError::InvalidResponse(format!(
+                                "Bedrock structured output truncated: {reason}"
+                            ));
+                            converse::append_corrective_instruction(
+                                &mut body,
+                                Some(reason),
+                                self.caps.supports_native_structured_output,
+                            );
+                        }
+                        Some(payload) => match validator.map(|validate| validate(&payload)) {
+                            None | Some(Ok(())) => return Ok(payload),
+                            Some(Err(reason)) => {
+                                last_error = LlmError::InvalidResponse(format!(
+                                    "Bedrock structured output failed validation: {reason}"
+                                ));
+                                converse::append_corrective_instruction(
+                                    &mut body,
+                                    Some(&reason),
+                                    self.caps.supports_native_structured_output,
+                                );
+                            }
+                        },
+                        None => {
+                            last_error = LlmError::InvalidResponse(
+                                if self.caps.supports_native_structured_output {
+                                    "Bedrock response did not contain parseable JSON in its text \
+                                 output"
+                                        .to_string()
+                                } else {
+                                    format!(
+                                        "Bedrock response did not contain a `{RESPONSE_FORMAT_TOOL_NAME}` toolUse block"
+                                    )
+                                },
+                            );
+                            converse::append_corrective_instruction(
+                                &mut body,
+                                None,
+                                self.caps.supports_native_structured_output,
+                            );
+                        }
+                    }
+                }
+                // Terminal: retrying cannot fix auth or an unknown model, and
+                // `call_converse` has already exhausted its own transport ladder
+                // when it returns MaxRetriesExceeded — re-entering it would
+                // restart backoff at attempt 0 and hammer a failing endpoint.
+                Err(
+                    e @ (LlmError::AuthenticationError(_)
+                    | LlmError::ModelNotFound(_)
+                    | LlmError::ConfigError(_)
+                    | LlmError::MaxRetriesExceeded(_)),
+                ) => return Err(e),
+                // What reaches here is a ValidationException (InvalidResponse):
+                // 429/5xx/network all exhaust inside `call_converse`. Retrying it
+                // is Python-faithful, but re-POSTing an identical body just fails
+                // the same way — so append the reason so the next attempt
+                // differs, the way instructor always reasks with changed content.
+                Err(e) => {
+                    converse::append_corrective_instruction(
+                        &mut body,
+                        Some(&e.to_string()),
+                        self.caps.supports_native_structured_output,
+                    );
+                    last_error = e;
+                }
+            }
+        }
+
+        Err(LlmError::MaxRetriesExceeded(format!(
+            "Bedrock structured output failed after {} attempt(s): {}",
+            self.structured_output_retries, last_error
+        )))
+    }
+}
+
+/// Hand-written so the resolved auth (held by the transport) can never reach a
+/// log line through `{:?}`; only the routing/limit decisions are shown.
+impl std::fmt::Debug for BedrockAdapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BedrockAdapter")
+            .field("model", &self.model)
+            .field("base_model", &self.base_model)
+            .field("region", &self.region)
+            .field("endpoint", &self.endpoint)
+            .field("caps", &self.caps)
+            .field("max_completion_tokens", &self.max_completion_tokens)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl Llm for BedrockAdapter {
+    async fn generate(
+        &self,
+        messages: Vec<Message>,
+        options: Option<GenerationOptions>,
+    ) -> LlmResult<GenerationResponse> {
+        let opts = options.unwrap_or_default();
+        let body = self.base_request(&messages, &opts);
+        let response = self.call_converse(&body).await?;
+        Ok(GenerationResponse {
+            content: response.text(),
+            // Converse echoes no model id, so report the one we addressed.
+            model: self.model.clone(),
+            finish_reason: response.stop_reason,
+            usage: response.usage.map(TokenUsage::from),
+        })
+    }
+
+    async fn create_structured_output_with_messages_raw(
+        &self,
+        messages: Vec<Message>,
+        json_schema: &Value,
+        options: Option<GenerationOptions>,
+    ) -> LlmResult<Value> {
+        // The raw path has no Rust type to deserialize into, so synthesise a
+        // schema-aware validator (shared with the OpenAI/Anthropic adapters): a
+        // payload omitting a required field drives a corrective retry instead of
+        // returning `Ok` and aborting the caller at deserialization.
+        let validator = crate::schema::schema_required_validator(json_schema);
+        self.structured_output_impl(messages, json_schema, options, Some(&validator))
+            .await
+    }
+
+    async fn create_structured_output_with_messages_raw_validated(
+        &self,
+        messages: Vec<Message>,
+        json_schema: &Value,
+        options: Option<GenerationOptions>,
+        validator: StructuredOutputValidator<'_>,
+    ) -> LlmResult<Value> {
+        self.structured_output_impl(messages, json_schema, options, Some(validator))
+            .await
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// `false` — Converse streaming uses the binary `vnd.amazon.eventstream`
+    /// framing, which is out of scope (plan §1.6).
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    fn supports_function_calling(&self) -> bool {
+        true
+    }
+
+    fn max_context_length(&self) -> u32 {
+        self.caps.max_input_tokens
+    }
+
+    fn supports_vision(&self) -> bool {
+        self.caps.supports_vision
+    }
+
+    /// Describe an image via Converse image content blocks.
+    ///
+    /// Plan §6.5: this **exceeds** Python parity, whose
+    /// `BedrockAdapter.transcribe_image` raises `NotImplementedError`. Without
+    /// it, a dataset containing an image would abort a whole cognify run under
+    /// `LLM_PROVIDER=bedrock`.
+    async fn transcribe_image(
+        &self,
+        image_bytes: &[u8],
+        mime_type: &str,
+        options: Option<GenerationOptions>,
+    ) -> LlmResult<String> {
+        use base64::Engine as _;
+
+        if !mime_type.starts_with("image/") {
+            return Err(LlmError::InvalidResponse(format!(
+                "Expected image/* MIME type, got: {mime_type}"
+            )));
+        }
+        let Some(format) = converse::image_format_for_mime(mime_type) else {
+            return Err(LlmError::FeatureNotSupported(format!(
+                "Bedrock Converse accepts png, jpeg, gif and webp images; got: {mime_type}"
+            )));
+        };
+        if !self.caps.supports_vision {
+            return Err(LlmError::FeatureNotSupported(format!(
+                "Vision is not supported by Bedrock model: {}",
+                self.model
+            )));
+        }
+
+        let encoded = base64::engine::general_purpose::STANDARD.encode(image_bytes);
+        // Clamp to the same effective budget as the chat path — the lesser of
+        // the model's documented output cap and the configured
+        // `llm_max_completion_tokens` ceiling. A caller passing
+        // GenerationOptions with the default max_tokens (16384) against a model
+        // that caps lower would otherwise 400, and would slip past an operator
+        // ceiling that bounds every other path. Floored at 1 so a zero never
+        // 400s either.
+        let max_tokens = options
+            .as_ref()
+            .and_then(|o| o.max_tokens)
+            .unwrap_or(300)
+            .min(self.effective_output_cap())
+            .max(1);
+
+        // Built directly rather than via `base_request`, so `LLM_ARGS` do not
+        // bleed into the description request (matching the other adapters).
+        let body = json!({
+            "messages": [converse::image_message(format, &encoded)],
+            "inferenceConfig": { "maxTokens": max_tokens },
+        });
+
+        let response = self.call_converse(&body).await?;
+        Ok(response.text())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    /// Offline construction: a bearer key short-circuits the credential ladder
+    /// and an explicit region short-circuits the region chain, so nothing here
+    /// touches the network or `~/.aws`.
+    async fn adapter(model: &str) -> BedrockAdapter {
+        let aws = AwsInputs {
+            region: Some("eu-central-1".to_string()),
+            ..AwsInputs::default()
+        };
+        BedrockAdapter::new(model, Some("bedrock-api-key"), None, &aws)
+            .await
+            .expect("adapter should build")
+    }
+
+    #[tokio::test]
+    async fn invoke_routed_chat_models_are_rejected_at_construction() {
+        let aws = AwsInputs {
+            region: Some("us-east-1".to_string()),
+            ..AwsInputs::default()
+        };
+        let error = BedrockAdapter::new("cohere.command-text-v14", Some("k"), None, &aws)
+            .await
+            .expect_err("an invoke-routed chat model is out of scope");
+        assert!(
+            matches!(error, LlmError::FeatureNotSupported(_)),
+            "{error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn max_tokens_is_clamped_to_the_model_cap() {
+        // nova-lite caps output at 10_000, below the 16_384 default ceiling.
+        let nova = adapter("eu.amazon.nova-lite-v1:0").await;
+        assert_eq!(
+            nova.effective_max_tokens(&GenerationOptions::default()),
+            10_000
+        );
+        // Sonnet 4.5 caps at 64_000, so the default ceiling passes under it.
+        let sonnet = adapter("eu.anthropic.claude-sonnet-4-5-20250929-v1:0").await;
+        assert_eq!(
+            sonnet.effective_max_tokens(&GenerationOptions::default()),
+            16_384
+        );
+        // A configured ceiling below the cap wins, on the default-options path
+        // too (GenerationOptions::default() carries Some(16384)).
+        let capped = adapter("eu.anthropic.claude-sonnet-4-5-20250929-v1:0")
+            .await
+            .with_max_completion_tokens(2_000);
+        assert_eq!(
+            capped.effective_max_tokens(&GenerationOptions::default()),
+            2_000
+        );
+        // A zero ceiling must not 400 every request.
+        let zeroed = adapter("eu.amazon.nova-lite-v1:0")
+            .await
+            .with_max_completion_tokens(0);
+        assert_eq!(
+            zeroed.effective_max_tokens(&GenerationOptions {
+                max_tokens: None,
+                ..Default::default()
+            }),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn base_request_folds_system_only_input_into_a_user_turn() {
+        let adapter = adapter("eu.amazon.nova-lite-v1:0").await;
+        let body = adapter.base_request(
+            &[Message::system("be terse")],
+            &GenerationOptions::default(),
+        );
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[0]["content"][0]["text"], "be terse");
+        assert!(body.get("system").is_none());
+    }
+
+    #[tokio::test]
+    async fn transcribe_image_rejects_non_image_and_unsupported_formats() {
+        let adapter = adapter("eu.amazon.nova-lite-v1:0").await;
+        let error = adapter
+            .transcribe_image(b"not an image", "text/plain", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, LlmError::InvalidResponse(_)), "{error:?}");
+
+        let error = adapter
+            .transcribe_image(b"x", "image/tiff", None)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, LlmError::FeatureNotSupported(_)),
+            "{error:?}"
+        );
+    }
+}

--- a/crates/llm/src/adapters/bedrock/mod.rs
+++ b/crates/llm/src/adapters/bedrock/mod.rs
@@ -1,0 +1,13 @@
+//! AWS Bedrock provider (feature `bedrock`).
+//!
+//! Scope of this module today is the shared AWS plumbing in [`aws`]: env
+//! resolution, the region and endpoint chains, the credential ladder, SigV4
+//! signing and the transport seam. The adapter itself (`BedrockAdapter`,
+//! model-id normalisation, route selection, the capability table and the
+//! Converse transforms) lands in a later step — see
+//! `docs/roadmap/bedrock-provider-plan.md` §4 R3.
+//!
+//! Nothing here is re-exported from `lib.rs` yet, deliberately: the public
+//! surface starts existing when the adapter does.
+
+pub mod aws;

--- a/crates/llm/src/adapters/bedrock/mod.rs
+++ b/crates/llm/src/adapters/bedrock/mod.rs
@@ -140,13 +140,17 @@ impl BedrockAdapter {
         let settings = aws.resolve();
         let region = aws::region::resolve_region(&settings, Some(&model)).await?;
         let endpoint = aws::endpoint::resolve_endpoint(api_base, &settings, &region);
-        let auth = aws::credentials::resolve_auth(api_key, &settings, &region).await?;
+        let auth = aws::credentials::resolve_auth_provider(api_key, &settings, &region).await?;
 
         let client = reqwest::Client::builder()
             .timeout(Self::REQUEST_TIMEOUT)
             .build()
             .map_err(|e| LlmError::ConfigError(format!("Failed to create HTTP client: {e}")))?;
-        let transport = Arc::new(ReqwestBedrockTransport::new(client, auth, region.clone()));
+        let transport = Arc::new(ReqwestBedrockTransport::with_auth_provider(
+            client,
+            Arc::new(auth),
+            region.clone(),
+        ));
 
         let base_model = model_id::base_model(&model);
         let caps = caps::caps_for_base_model(&base_model);

--- a/crates/llm/src/adapters/bedrock/model_id.rs
+++ b/crates/llm/src/adapters/bedrock/model_id.rs
@@ -1,0 +1,237 @@
+//! §1.4.1 model-id normalisation — the step that happens **before** routing.
+//!
+//! Port of litellm's `get_bedrock_base_model` (`llms/bedrock/common_utils.py`)
+//! and the four helpers it composes: `strip_bedrock_routing_prefix`,
+//! `extract_model_name_from_bedrock_arn`, `strip_bedrock_throughput_suffix`
+//! (which also strips the context-window suffix), and the cross-region
+//! inference-prefix strip.
+//!
+//! # Why this module exists
+//!
+//! `BEDROCK_CONVERSE_MODELS` (see [`super::route`]) stores only **bare** ids —
+//! `anthropic.claude-sonnet-4-5-20250929-v1:0`, never
+//! `eu.anthropic.claude-sonnet-4-5-20250929-v1:0`. Every model cognee ships by
+//! default is `eu.`-prefixed, so a port that looks the raw id up in that table
+//! routes 3 of 3 shipped models to `invoke` — i.e. the adapter fails on its own
+//! defaults. Plan §1.4.1 calls this "the single highest-consequence correction"
+//! in the whole plan.
+//!
+//! # The one rule that must not be forgotten
+//!
+//! **The normalised id feeds routing and the capability lookup only. The
+//! request URL keeps the ORIGINAL id, cross-region prefix included** — see
+//! [`super::converse::converse_url`] and plan §1.4.2 ("the URL carries the
+//! original id, prefix included — normalisation feeds the routing decision
+//! only, never the request path").
+//!
+//! # Deliberate omission
+//!
+//! litellm has a fifth leg: an id whose first `/`-segment is a *full* AWS
+//! region (`us-east-1/anthropic.claude-…`) has that segment stripped and reused
+//! as the region. It needs litellm's complete Bedrock region list to be exact,
+//! no model cognee ships uses that shape, and the failure mode of not porting
+//! it is loud rather than silent (the id falls through to `invoke`, which
+//! returns a clear `FeatureNotSupported`). Plan §4 R3 does not list it; it is
+//! left out on purpose.
+
+/// litellm routing prefixes stripped by `strip_bedrock_routing_prefix`,
+/// **in litellm's order** — the loop is sequential, so `bedrock/converse/x`
+/// loses both prefixes while `converse/bedrock/x` keeps the inner one.
+pub const ROUTING_PREFIXES: [&str; 6] = [
+    "bedrock/",
+    "converse/",
+    "invoke/",
+    "openai/",
+    "nova-2/",
+    "nova/",
+];
+
+/// Cross-region inference prefixes
+/// (`get_bedrock_cross_region_inference_regions`). These are the *abbreviated*
+/// geography prefixes, not AWS region names.
+pub const CROSS_REGION_PREFIXES: [&str; 7] = ["global", "us", "eu", "apac", "jp", "au", "us-gov"];
+
+/// Base id litellm reports for the `nova/` custom-model spec prefix.
+pub const NOVA_CUSTOM_BASE_MODEL: &str = "amazon.nova-custom";
+
+/// Base id litellm reports for the `nova-2/` custom-model spec prefix.
+pub const NOVA_2_CUSTOM_BASE_MODEL: &str = "amazon.nova-2-custom";
+
+/// Strip litellm routing prefixes, sequentially, in [`ROUTING_PREFIXES`] order.
+///
+/// Faithful to litellm's loop: it re-tests every prefix against the partially
+/// stripped value, so more than one can come off in a single call.
+pub fn strip_routing_prefix(model: &str) -> &str {
+    let mut model = model;
+    for prefix in ROUTING_PREFIXES {
+        if let Some(rest) = model.strip_prefix(prefix) {
+            model = rest;
+        }
+    }
+    model
+}
+
+/// Unwrap a Bedrock ARN to the bare model id: everything after the last `/`.
+///
+/// Faithful to `extract_model_name_from_bedrock_arn`, which triggers on the
+/// substring `arn` appearing **anywhere** in the (lowercased) id rather than on
+/// a real ARN parse. That looseness is upstream's, and it is kept so a shared
+/// id normalises identically on both SDKs.
+pub fn extract_model_name_from_arn(model: &str) -> &str {
+    if !model.to_ascii_lowercase().contains("arn") {
+        return model;
+    }
+    // `split('/').last()` on a value with no `/` is the value itself, matching
+    // Python's `model.split("/")[-1]`.
+    model.rsplit('/').next().unwrap_or(model)
+}
+
+/// Strip a provisioned-throughput suffix: `…:<digits>:<digits>k` → `…:<digits>`.
+///
+/// Hand-rolled port of litellm's `re.sub(r"(:\d+):\d+k$", r"\1", model)` —
+/// `cognee-llm` carries no `regex` dependency.
+pub fn strip_throughput_suffix(model: &str) -> &str {
+    let all_digits = |s: &str| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit());
+
+    let Some(last_colon) = model.rfind(':') else {
+        return model;
+    };
+    let Some(throughput) = model[last_colon + 1..].strip_suffix('k') else {
+        return model;
+    };
+    if !all_digits(throughput) {
+        return model;
+    }
+    let head = &model[..last_colon];
+    let Some(prev_colon) = head.rfind(':') else {
+        return model;
+    };
+    if !all_digits(&head[prev_colon + 1..]) {
+        return model;
+    }
+    head
+}
+
+/// Strip a context-window suffix: `…[1m]`, `…[200k]` → `…`.
+///
+/// Port of litellm's `re.sub(r"\[\w+\]$", "", model)`; `\w` is
+/// `[A-Za-z0-9_]`.
+pub fn strip_context_window_suffix(model: &str) -> &str {
+    let Some(without_bracket) = model.strip_suffix(']') else {
+        return model;
+    };
+    let Some(open) = without_bracket.rfind('[') else {
+        return model;
+    };
+    let inner = &without_bracket[open + 1..];
+    if inner.is_empty()
+        || !inner
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+    {
+        return model;
+    }
+    &model[..open]
+}
+
+/// Strip a cross-region inference prefix (`eu.`, `us.`, `apac.`, …).
+///
+/// Only the [`CROSS_REGION_PREFIXES`] set counts: `anthropic.claude-…` keeps
+/// its `anthropic.` provider segment because `anthropic` is not one of them.
+pub fn strip_cross_region_prefix(model: &str) -> &str {
+    match model.split_once('.') {
+        Some((prefix, rest)) if CROSS_REGION_PREFIXES.contains(&prefix) => rest,
+        _ => model,
+    }
+}
+
+/// The full §1.4.1 chain: routing prefixes → ARN unwrap → throughput suffix →
+/// context-window suffix → cross-region prefix.
+///
+/// The `nova/` and `nova-2/` custom-model spec prefixes short-circuit to their
+/// synthetic base ids first, exactly as `get_bedrock_base_model` does.
+pub fn base_model(model: &str) -> String {
+    // Nova spec prefixes are detected *before* the generic strip, because
+    // `strip_routing_prefix` would otherwise eat `nova/` and leave the opaque
+    // ARN behind.
+    let mut spec = model;
+    for prefix in ["bedrock/converse/", "bedrock/", "converse/"] {
+        if let Some(rest) = spec.strip_prefix(prefix) {
+            spec = rest;
+            break;
+        }
+    }
+    if spec.starts_with("nova-2/") {
+        return NOVA_2_CUSTOM_BASE_MODEL.to_string();
+    }
+    if spec.starts_with("nova/") {
+        return NOVA_CUSTOM_BASE_MODEL.to_string();
+    }
+
+    let stripped = strip_routing_prefix(model);
+    let stripped = extract_model_name_from_arn(stripped);
+    let stripped = strip_throughput_suffix(stripped);
+    let stripped = strip_context_window_suffix(stripped);
+    strip_cross_region_prefix(stripped).to_string()
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn routing_prefixes_come_off_sequentially() {
+        assert_eq!(strip_routing_prefix("bedrock/converse/x"), "x");
+        assert_eq!(strip_routing_prefix("bedrock/x"), "x");
+        assert_eq!(strip_routing_prefix("invoke/x"), "x");
+        // The loop is ordered, so an inner `bedrock/` is not reached.
+        assert_eq!(strip_routing_prefix("converse/bedrock/x"), "bedrock/x");
+        assert_eq!(strip_routing_prefix("x"), "x");
+    }
+
+    #[test]
+    fn throughput_suffix_needs_both_numeric_groups() {
+        assert_eq!(
+            strip_throughput_suffix("anthropic.claude-3-5-sonnet-20241022-v2:0:51k"),
+            "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        );
+        // Not a throughput suffix: no `:<digits>` before it.
+        assert_eq!(strip_throughput_suffix("model:51k"), "model:51k");
+        // Not a throughput suffix: the tail is not `<digits>k`.
+        assert_eq!(strip_throughput_suffix("model:0:v1k"), "model:0:v1k");
+        // A plain version suffix survives untouched.
+        assert_eq!(
+            strip_throughput_suffix("amazon.nova-lite-v1:0"),
+            "amazon.nova-lite-v1:0"
+        );
+    }
+
+    #[test]
+    fn context_window_suffix_only_matches_word_characters() {
+        assert_eq!(
+            strip_context_window_suffix("us.anthropic.claude-opus-4-6-v1[1m]"),
+            "us.anthropic.claude-opus-4-6-v1"
+        );
+        assert_eq!(strip_context_window_suffix("model[200k]"), "model");
+        assert_eq!(strip_context_window_suffix("model[]"), "model[]");
+        assert_eq!(strip_context_window_suffix("model[a-b]"), "model[a-b]");
+        assert_eq!(strip_context_window_suffix("model"), "model");
+    }
+
+    #[test]
+    fn nova_spec_prefixes_short_circuit_to_synthetic_base_ids() {
+        assert_eq!(
+            base_model("bedrock/nova-2/arn:aws:bedrock:us-east-1:1:custom-model/abc"),
+            NOVA_2_CUSTOM_BASE_MODEL
+        );
+        assert_eq!(
+            base_model("nova/arn:aws:bedrock:us-east-1:1:custom-model/abc"),
+            NOVA_CUSTOM_BASE_MODEL
+        );
+    }
+}

--- a/crates/llm/src/adapters/bedrock/model_id.rs
+++ b/crates/llm/src/adapters/bedrock/model_id.rs
@@ -71,6 +71,32 @@ pub fn strip_routing_prefix(model: &str) -> &str {
     model
 }
 
+/// Routing tokens that must never reach the wire.
+///
+/// A strict subset of [`ROUTING_PREFIXES`]: `nova/` and `nova-2/` are
+/// custom-model *spec* prefixes that identify the deployed model, and `openai/`
+/// selects a different handler entirely, so none of the three are stripped here.
+const WIRE_STRIPPED_PREFIXES: [&str; 3] = ["bedrock/", "converse/", "invoke/"];
+
+/// The model id as it must appear in a Bedrock request path.
+///
+/// litellm strips its own routing tokens before building the URL
+/// (`converse_handler.py:279-297`), and only those: a cross-region prefix
+/// (`eu.`, `us.`, …) and an ARN are part of the real Bedrock identifier and
+/// **must** survive. This is the §1.4.1 counterpart to [`base_model`] — that one
+/// normalises for the routing *decision*, this one for the request *path*.
+///
+/// Sequential like [`strip_routing_prefix`], so `bedrock/converse/x` loses both.
+pub fn wire_model_id(model: &str) -> &str {
+    let mut model = model;
+    for prefix in WIRE_STRIPPED_PREFIXES {
+        if let Some(rest) = model.strip_prefix(prefix) {
+            model = rest;
+        }
+    }
+    model
+}
+
 /// Unwrap a Bedrock ARN to the bare model id: everything after the last `/`.
 ///
 /// Faithful to `extract_model_name_from_bedrock_arn`, which triggers on the

--- a/crates/llm/src/adapters/bedrock/model_id.rs
+++ b/crates/llm/src/adapters/bedrock/model_id.rs
@@ -73,18 +73,30 @@ pub fn strip_routing_prefix(model: &str) -> &str {
 
 /// Routing tokens that must never reach the wire.
 ///
-/// A strict subset of [`ROUTING_PREFIXES`]: `nova/` and `nova-2/` are
-/// custom-model *spec* prefixes that identify the deployed model, and `openai/`
-/// selects a different handler entirely, so none of the three are stripped here.
-const WIRE_STRIPPED_PREFIXES: [&str; 3] = ["bedrock/", "converse/", "invoke/"];
+/// A strict subset of [`ROUTING_PREFIXES`]. `openai/` is excluded because it
+/// selects a different handler entirely (those ids are rejected in
+/// `BedrockAdapter::new`, so they never reach a URL).
+///
+/// `nova/` and `nova-2/` **are** stripped: they name a custom-model spec, and
+/// `converse_handler.py:293-296` removes them from the id it encodes into the
+/// path, exactly as it removes the route tokens.
+const WIRE_STRIPPED_PREFIXES: [&str; 5] = ["bedrock/", "converse/", "invoke/", "nova-2/", "nova/"];
 
 /// The model id as it must appear in a Bedrock request path.
 ///
-/// litellm strips its own routing tokens before building the URL
-/// (`converse_handler.py:279-297`), and only those: a cross-region prefix
-/// (`eu.`, `us.`, …) and an ARN are part of the real Bedrock identifier and
-/// **must** survive. This is the §1.4.1 counterpart to [`base_model`] — that one
-/// normalises for the routing *decision*, this one for the request *path*.
+/// litellm strips its own routing tokens and the nova custom-model spec prefix
+/// before building the URL (`converse_handler.py:278-296`), and only those: a
+/// cross-region prefix (`eu.`, `us.`, …) and an ARN are part of the real Bedrock
+/// identifier and **must** survive. This is the §1.4.1 counterpart to
+/// [`base_model`] — that one normalises for the routing *decision*, this one for
+/// the request *path*.
+///
+/// litellm applies the route tokens and the nova prefix in two separate passes
+/// over two different variables, which leaves `bedrock/` on the wire for the
+/// combined `bedrock/nova/x` spelling. That quirk is not reproduced: litellm's
+/// own router strips the provider prefix upstream, so the case never arises
+/// there in practice, and reproducing it here would put a token on the wire that
+/// Bedrock rejects.
 ///
 /// Sequential like [`strip_routing_prefix`], so `bedrock/converse/x` loses both.
 pub fn wire_model_id(model: &str) -> &str {

--- a/crates/llm/src/adapters/bedrock/route.rs
+++ b/crates/llm/src/adapters/bedrock/route.rs
@@ -146,6 +146,65 @@ pub const BEDROCK_CONVERSE_MODELS: &[&str] = &[
     "moonshotai.kimi-k2.5",
 ];
 
+/// litellm's *derived* half of the converse set.
+///
+/// `litellm/__init__.py` does not stop at the static constant above: at import
+/// time it adds every `model_prices_and_context_window.json` entry whose
+/// `litellm_provider` is `bedrock_converse` (`__init__.py:604`, `800-801`).
+/// [`BEDROCK_CONVERSE_MODELS`] alone is therefore only half the set litellm
+/// actually routes to Converse, and a model missing from both tables fails
+/// [`super::BedrockAdapter::new`] with a message claiming it is invoke-only.
+///
+/// Regenerate with the derivation rule that produced it — every
+/// `bedrock_converse` key, minus those carrying a `/` (provider-qualified), with
+/// any cross-region prefix stripped so the entries are **bare** ids like the
+/// table above:
+///
+/// ```text
+/// jq -r 'to_entries[] | select(.value.litellm_provider == "bedrock_converse") | .key' \
+///   model_prices_and_context_window.json
+/// ```
+pub const BEDROCK_CONVERSE_PRICING_MODELS: &[&str] = &[
+    "amazon.nova-micro-v1:0",
+    "amazon.nova-premier-v1:0",
+    "anthropic.claude-haiku-4-5@20251001",
+    "anthropic.claude-opus-4-5-20251101-v1:0",
+    "deepseek.r1-v1:0",
+    "google.gemma-3-12b-it",
+    "google.gemma-3-27b-it",
+    "google.gemma-3-4b-it",
+    "meta.llama3-3-70b-instruct-v1:0",
+    "meta.llama4-maverick-17b-instruct-v1:0",
+    "meta.llama4-scout-17b-instruct-v1:0",
+    "minimax.minimax-m2",
+    "minimax.minimax-m2.5",
+    "mistral.devstral-2-123b",
+    "mistral.magistral-small-2509",
+    "mistral.ministral-3-14b-instruct",
+    "mistral.ministral-3-3b-instruct",
+    "mistral.ministral-3-8b-instruct",
+    "mistral.mistral-large-3-675b-instruct",
+    "mistral.pixtral-large-2502-v1:0",
+    "mistral.voxtral-mini-3b-2507",
+    "mistral.voxtral-small-24b-2507",
+    "moonshot.kimi-k2-thinking",
+    "nvidia.nemotron-nano-12b-v2",
+    "nvidia.nemotron-nano-3-30b",
+    "nvidia.nemotron-nano-9b-v2",
+    "nvidia.nemotron-super-3-120b",
+    "openai.gpt-5.6-luna",
+    "openai.gpt-5.6-sol",
+    "openai.gpt-5.6-terra",
+    "openai.gpt-oss-safeguard-120b",
+    "openai.gpt-oss-safeguard-20b",
+    "qwen.qwen3-next-80b-a3b",
+    "qwen.qwen3-vl-235b-a22b",
+    "xai.grok-4.6",
+    "zai.glm-4.7",
+    "zai.glm-4.7-flash",
+    "zai.glm-5",
+];
+
 /// Whether a route token appears as a leading path segment of `model`.
 ///
 /// Port of `_model_has_route_prefix`: a plain `contains` would match the
@@ -164,7 +223,9 @@ pub fn is_application_inference_profile_arn(model: &str) -> bool {
 pub fn is_converse_model(model: &str) -> bool {
     let base = super::model_id::base_model(model);
     let alt = super::model_id::strip_routing_prefix(model);
-    BEDROCK_CONVERSE_MODELS.contains(&base.as_str()) || BEDROCK_CONVERSE_MODELS.contains(&alt)
+    [BEDROCK_CONVERSE_MODELS, BEDROCK_CONVERSE_PRICING_MODELS]
+        .iter()
+        .any(|table| table.contains(&base.as_str()) || table.contains(&alt))
 }
 
 /// Select the Bedrock route for `model` (§1.4.2).

--- a/crates/llm/src/adapters/bedrock/route.rs
+++ b/crates/llm/src/adapters/bedrock/route.rs
@@ -1,0 +1,227 @@
+//! §1.4.2 route selection: which Bedrock API a model id resolves to.
+//!
+//! Port of litellm's `BedrockModelInfo.get_bedrock_route`
+//! (`llms/bedrock/common_utils.py`). The order matters:
+//!
+//! 1. an explicit route prefix wins (`converse/`, `invoke/`, `converse_like/`,
+//!    `agent/`, `agentcore/`, `async_invoke/`, `openai/`, `claude_platform/`,
+//!    `mantle/`), matched only as a **leading path segment**;
+//! 2. the `nova/` / `nova-2/` custom-model spec prefixes → converse;
+//! 3. an **application-inference-profile ARN** → converse (a common enterprise
+//!    deployment shape: the ARN ends in an opaque id with no provider
+//!    substring, so only the provider-free converse route can serve it);
+//! 4. otherwise the §1.4.1-**normalised** id (or the merely prefix-stripped id)
+//!    is looked up in [`BEDROCK_CONVERSE_MODELS`] → converse;
+//! 5. else → invoke.
+//!
+//! Step 4 is the one that must not be skipped — see [`super::model_id`].
+//!
+//! # Scope
+//!
+//! Only [`BedrockRoute::Converse`] is implemented by this adapter. Per plan
+//! §6.7 the legacy `/invoke` **chat** transforms are deliberately out of scope
+//! ("no model cognee ships routes to invoke"), so an invoke-routed chat model
+//! gets a clear [`crate::error::LlmError::FeatureNotSupported`] rather than a
+//! silently wrong request. The InvokeModel *embedding* bodies are R4's, not
+//! this module's.
+
+/// Which Bedrock API a model id routes to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BedrockRoute {
+    /// `POST /model/{id}/converse` — the only route this adapter implements.
+    Converse,
+    /// `POST /model/{id}/invoke` — legacy per-family chat transforms, out of
+    /// scope (plan §6.7).
+    Invoke,
+    /// litellm's `converse_like/` passthrough.
+    ConverseLike,
+    /// Bedrock Agents.
+    Agent,
+    /// Bedrock AgentCore.
+    AgentCore,
+    /// Asynchronous InvokeModel.
+    AsyncInvoke,
+    /// OpenAI-shaped Bedrock endpoint.
+    OpenAi,
+    /// Claude Platform on AWS.
+    ClaudePlatform,
+    /// bedrock-mantle Anthropic `/messages` endpoint.
+    Mantle,
+}
+
+impl BedrockRoute {
+    /// The route token as litellm spells it, for error messages.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Converse => "converse",
+            Self::Invoke => "invoke",
+            Self::ConverseLike => "converse_like",
+            Self::Agent => "agent",
+            Self::AgentCore => "agentcore",
+            Self::AsyncInvoke => "async_invoke",
+            Self::OpenAi => "openai",
+            Self::ClaudePlatform => "claude_platform",
+            Self::Mantle => "mantle",
+        }
+    }
+}
+
+/// Explicit route prefixes, in litellm's `route_mappings` order.
+const ROUTE_PREFIXES: [(&str, BedrockRoute); 9] = [
+    ("invoke/", BedrockRoute::Invoke),
+    ("claude_platform/", BedrockRoute::ClaudePlatform),
+    ("converse_like/", BedrockRoute::ConverseLike),
+    ("converse/", BedrockRoute::Converse),
+    ("agent/", BedrockRoute::Agent),
+    ("agentcore/", BedrockRoute::AgentCore),
+    ("async_invoke/", BedrockRoute::AsyncInvoke),
+    ("openai/", BedrockRoute::OpenAi),
+    ("mantle/", BedrockRoute::Mantle),
+];
+
+/// The marker that identifies an application-inference-profile ARN.
+const APPLICATION_INFERENCE_PROFILE: &str = ":application-inference-profile/";
+
+/// litellm's `BEDROCK_CONVERSE_MODELS` (`litellm/constants.py`), verbatim.
+///
+/// Hand-maintained: these are **bare** ids, so anything with a cross-region
+/// prefix, an ARN wrapper or a throughput/context suffix must be normalised by
+/// [`super::model_id::base_model`] before it is looked up here.
+pub const BEDROCK_CONVERSE_MODELS: &[&str] = &[
+    "qwen.qwen3-coder-480b-a35b-v1:0",
+    "qwen.qwen3-coder-next",
+    "qwen.qwen3-235b-a22b-2507-v1:0",
+    "qwen.qwen3-coder-30b-a3b-v1:0",
+    "qwen.qwen3-32b-v1:0",
+    "deepseek.v3-v1:0",
+    "deepseek.v3.2",
+    "openai.gpt-oss-20b-1:0",
+    "openai.gpt-oss-120b-1:0",
+    "anthropic.claude-haiku-4-5-20251001-v1:0",
+    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "anthropic.claude-fable-5",
+    "anthropic.claude-sonnet-5",
+    "anthropic.claude-opus-5",
+    "anthropic.claude-opus-4-8",
+    "anthropic.claude-opus-4-7",
+    "anthropic.claude-opus-4-6-v1:0",
+    "anthropic.claude-opus-4-6-v1",
+    "anthropic.claude-sonnet-4-6",
+    "anthropic.claude-opus-4-1-20250805-v1:0",
+    "anthropic.claude-opus-4-20250514-v1:0",
+    "anthropic.claude-sonnet-4-20250514-v1:0",
+    "anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "anthropic.claude-3-5-haiku-20241022-v1:0",
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "anthropic.claude-3-opus-20240229-v1:0",
+    "anthropic.claude-3-sonnet-20240229-v1:0",
+    "anthropic.claude-3-haiku-20240307-v1:0",
+    "anthropic.claude-v2",
+    "anthropic.claude-v2:1",
+    "anthropic.claude-v1",
+    "anthropic.claude-instant-v1",
+    "ai21.jamba-instruct-v1:0",
+    "ai21.jamba-1-5-mini-v1:0",
+    "ai21.jamba-1-5-large-v1:0",
+    "meta.llama3-70b-instruct-v1:0",
+    "meta.llama3-8b-instruct-v1:0",
+    "meta.llama3-1-8b-instruct-v1:0",
+    "meta.llama3-1-70b-instruct-v1:0",
+    "meta.llama3-1-405b-instruct-v1:0",
+    "mistral.mistral-large-2407-v1:0",
+    "mistral.mistral-large-2402-v1:0",
+    "mistral.mistral-small-2402-v1:0",
+    "meta.llama3-2-1b-instruct-v1:0",
+    "meta.llama3-2-3b-instruct-v1:0",
+    "meta.llama3-2-11b-instruct-v1:0",
+    "meta.llama3-2-90b-instruct-v1:0",
+    "amazon.nova-lite-v1:0",
+    "amazon.nova-2-lite-v1:0",
+    "amazon.nova-2-pro-preview-20251202-v1:0",
+    "amazon.nova-pro-v1:0",
+    "writer.palmyra-x4-v1:0",
+    "writer.palmyra-x5-v1:0",
+    "minimax.minimax-m2.1",
+    "moonshotai.kimi-k2.5",
+];
+
+/// Whether a route token appears as a leading path segment of `model`.
+///
+/// Port of `_model_has_route_prefix`: a plain `contains` would match the
+/// `bedrock_mantle/` *provider* prefix against the `mantle/` *route*, so the
+/// token is anchored to the start or to a `/` boundary.
+pub fn has_route_prefix(model: &str, prefix: &str) -> bool {
+    model.starts_with(prefix) || model.contains(&format!("/{prefix}"))
+}
+
+/// Whether `model` is an application-inference-profile ARN.
+pub fn is_application_inference_profile_arn(model: &str) -> bool {
+    model.contains(APPLICATION_INFERENCE_PROFILE)
+}
+
+/// Whether the §1.4.1-normalised `model` is served by the Converse API.
+pub fn is_converse_model(model: &str) -> bool {
+    let base = super::model_id::base_model(model);
+    let alt = super::model_id::strip_routing_prefix(model);
+    BEDROCK_CONVERSE_MODELS.contains(&base.as_str()) || BEDROCK_CONVERSE_MODELS.contains(&alt)
+}
+
+/// Select the Bedrock route for `model` (§1.4.2).
+pub fn select_route(model: &str) -> BedrockRoute {
+    for (prefix, route) in ROUTE_PREFIXES {
+        if has_route_prefix(model, prefix) {
+            return route;
+        }
+    }
+
+    // `nova/` and `nova-2/` name a custom-model spec, not a route token, so
+    // they are checked after one leading `bedrock/` comes off.
+    let after_bedrock = model.strip_prefix("bedrock/").unwrap_or(model);
+    if after_bedrock.starts_with("nova-2/") || after_bedrock.starts_with("nova/") {
+        return BedrockRoute::Converse;
+    }
+
+    if is_application_inference_profile_arn(model) {
+        return BedrockRoute::Converse;
+    }
+
+    if is_converse_model(model) {
+        BedrockRoute::Converse
+    } else {
+        BedrockRoute::Invoke
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn route_prefix_is_anchored_to_a_path_segment() {
+        assert!(has_route_prefix("mantle/x", "mantle/"));
+        assert!(has_route_prefix("bedrock/mantle/x", "mantle/"));
+        // The `bedrock_mantle/` provider prefix must not be read as the
+        // `mantle/` route.
+        assert!(!has_route_prefix(
+            "bedrock_mantle/openai.gpt-oss-20b-1:0",
+            "mantle/"
+        ));
+    }
+
+    #[test]
+    fn converse_table_lookup_uses_the_normalised_id() {
+        assert!(is_converse_model(
+            "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        ));
+        assert!(is_converse_model(
+            "anthropic.claude-sonnet-4-5-20250929-v1:0"
+        ));
+        assert!(!is_converse_model("cohere.command-text-v14"));
+    }
+}

--- a/crates/llm/src/adapters/mod.rs
+++ b/crates/llm/src/adapters/mod.rs
@@ -4,12 +4,14 @@
 //! for various providers (OpenAI, Anthropic, Ollama, local models, etc.).
 
 pub mod anthropic;
-// AWS Bedrock provider — shared AWS plumbing today, the adapter at R3.
-// Feature-gated: the AWS credential/signing stack is not free (plan §2.3).
-// (Module docs live in `bedrock/mod.rs`.)
+// AWS Bedrock provider: the Converse adapter plus the shared AWS plumbing it
+// is built on. Feature-gated: the AWS credential/signing stack is not free
+// (plan §2.3). (Module docs live in `bedrock/mod.rs`.)
 #[cfg(feature = "bedrock")]
 pub mod bedrock;
 pub mod openai;
 
 pub use anthropic::AnthropicAdapter;
+#[cfg(feature = "bedrock")]
+pub use bedrock::BedrockAdapter;
 pub use openai::OpenAIAdapter;

--- a/crates/llm/src/adapters/mod.rs
+++ b/crates/llm/src/adapters/mod.rs
@@ -4,6 +4,11 @@
 //! for various providers (OpenAI, Anthropic, Ollama, local models, etc.).
 
 pub mod anthropic;
+// AWS Bedrock provider — shared AWS plumbing today, the adapter at R3.
+// Feature-gated: the AWS credential/signing stack is not free (plan §2.3).
+// (Module docs live in `bedrock/mod.rs`.)
+#[cfg(feature = "bedrock")]
+pub mod bedrock;
 pub mod openai;
 
 pub use anthropic::AnthropicAdapter;

--- a/crates/llm/src/schema.rs
+++ b/crates/llm/src/schema.rs
@@ -215,6 +215,45 @@ pub fn schema_required_validator(schema: &Value) -> impl Fn(&Value) -> Result<()
     }
 }
 
+/// The corrective-retry instruction text, without touching any request body.
+///
+/// Split out of [`append_corrective_instruction`] so providers whose message
+/// content is **not** a plain string can reuse the exact wording while applying
+/// their own append semantics — Bedrock Converse carries
+/// `content: [{"text": …}]` blocks, so the string-content append below would
+/// corrupt its body (plan §6.7: the Anthropic repair loop is a pattern, and only
+/// this helper and [`schema_required_validator`] are genuinely reusable).
+///
+/// `tool_name` / `tool_kind` name the forced extractor as the provider addresses
+/// it — e.g. `"extract_structured_data"` + `"tool"` for Anthropic,
+/// `"json_tool_call"` + `"tool"` for Bedrock Converse, or `+ "function"` for
+/// OpenAI.
+pub fn corrective_instruction(reason: Option<&str>, tool_name: &str, tool_kind: &str) -> String {
+    let detail = corrective_reason_detail(reason);
+    format!(
+        "{detail}Call the `{tool_name}` {tool_kind} again and return ONE complete object that \
+         fills in every required field, strictly matching the schema. No extra text."
+    )
+}
+
+/// The "why the previous attempt failed" preamble shared by every corrective
+/// re-ask, ending in a trailing space so a directive can be appended to it.
+///
+/// Exists so a provider whose structured output does **not** travel through a
+/// tool can state its own directive without re-inventing (or drifting from) this
+/// wording: Bedrock Converse's native `outputConfig.textFormat` branch has no
+/// tool to call, so telling the model to call one would be actively misleading
+/// on the branch both shipped Anthropic models take
+/// (`adapters::bedrock::converse::append_corrective_instruction`).
+pub fn corrective_reason_detail(reason: Option<&str>) -> String {
+    match reason {
+        Some(r) => format!("Your previous response failed validation: {r}. "),
+        None => {
+            "Your previous response could not be parsed into the required structure. ".to_string()
+        }
+    }
+}
+
 /// Append a corrective instruction to a chat request's `messages` array so the
 /// next structured-output attempt carries the failure reason, the way instructor
 /// reasks with the validation error. When `reason` is `Some`, it is surfaced
@@ -236,16 +275,7 @@ pub fn append_corrective_instruction(
     tool_name: &str,
     tool_kind: &str,
 ) {
-    let detail = match reason {
-        Some(r) => format!("Your previous response failed validation: {r}. "),
-        None => {
-            "Your previous response could not be parsed into the required structure. ".to_string()
-        }
-    };
-    let instruction = format!(
-        "{detail}Call the `{tool_name}` {tool_kind} again and return ONE complete object that \
-         fills in every required field, strictly matching the schema. No extra text."
-    );
+    let instruction = corrective_instruction(reason, tool_name, tool_kind);
     let Some(messages) = request["messages"].as_array_mut() else {
         return;
     };

--- a/crates/llm/tests/bedrock_converse_transform.rs
+++ b/crates/llm/tests/bedrock_converse_transform.rs
@@ -1,0 +1,268 @@
+//! Converse request/response transforms and the Bedrock error taxonomy
+//! (plan §1.4.2 / §4 R3 steps 3, 5, 6, 7).
+#![cfg(feature = "bedrock")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+
+use cognee_llm::adapters::bedrock::converse::{
+    ConverseResponse, inference_config, is_retryable, map_error,
+    merge_additional_model_request_fields, penalty_model_fields, split_messages,
+};
+use cognee_llm::error::LlmError;
+use cognee_llm::types::{GenerationOptions, Message, TokenUsage};
+use serde_json::{Map, Value, json};
+
+#[test]
+fn system_messages_are_hoisted_into_the_top_level_system_blocks() {
+    // Converse has no `system` role inside `messages`.
+    let (system, turns) = split_messages(&[
+        Message::system("be terse"),
+        Message::user("hello"),
+        Message::assistant("hi"),
+        Message::system("and helpful"),
+    ]);
+
+    assert_eq!(
+        system,
+        vec![
+            json!({ "text": "be terse" }),
+            json!({ "text": "and helpful" })
+        ],
+        "each system message becomes its own top-level block",
+    );
+    assert_eq!(turns.len(), 2, "no system turn survives in `messages`");
+    assert_eq!(turns[0]["role"], "user");
+    assert_eq!(
+        turns[0]["content"],
+        json!([{ "text": "hello" }]),
+        "content is a block array, not a bare string",
+    );
+    assert_eq!(turns[1]["role"], "assistant");
+    assert!(
+        turns.iter().all(|turn| turn["role"] != "system"),
+        "a system role inside `messages` would be rejected by Converse",
+    );
+}
+
+#[test]
+fn inference_config_carries_the_clamped_budget_and_the_sampling_params() {
+    let opts = GenerationOptions {
+        temperature: Some(0.25),
+        max_tokens: Some(99_999),
+        top_p: Some(0.9),
+        stop: Some(vec!["STOP".to_string()]),
+        ..Default::default()
+    };
+    // The adapter clamps before calling this; the transform reports what it is
+    // handed, under Converse's camelCase names.
+    let config = inference_config(&opts, 10_000);
+
+    assert_eq!(config["maxTokens"], json!(10_000));
+    assert_eq!(config["temperature"], json!(0.25));
+    // `GenerationOptions` carries `f32`, so the JSON number is the widened
+    // `f32` — the same thing the OpenAI and Anthropic adapters put on the wire.
+    assert_eq!(config["topP"], json!(0.9_f32));
+    assert_eq!(config["stopSequences"], json!(["STOP"]));
+    // `max_tokens` is never echoed under its OpenAI name.
+    assert!(config.get("max_tokens").is_none());
+}
+
+#[test]
+fn unset_and_empty_sampling_params_are_omitted_rather_than_sent_as_null() {
+    let opts = GenerationOptions {
+        temperature: None,
+        max_tokens: None,
+        top_p: None,
+        stop: Some(Vec::new()),
+        ..Default::default()
+    };
+    let config = inference_config(&opts, 512);
+
+    assert_eq!(config["maxTokens"], json!(512));
+    for omitted in ["temperature", "topP", "stopSequences"] {
+        assert!(
+            config.get(omitted).is_none(),
+            "{omitted} must be omitted, not null: {config}",
+        );
+    }
+}
+
+/// Documented decision: Converse's `inferenceConfig` has no frequency/presence
+/// penalty, so they are routed through `additionalModelRequestFields` — the
+/// destination litellm's own transform uses for inference params it does not
+/// recognise.
+#[test]
+fn frequency_and_presence_penalties_go_to_additional_model_request_fields() {
+    let none = penalty_model_fields(&GenerationOptions::default());
+    assert!(
+        none.is_empty(),
+        "the default options set neither penalty, so nothing is added",
+    );
+
+    let opts = GenerationOptions {
+        frequency_penalty: Some(0.25),
+        presence_penalty: Some(0.5),
+        ..Default::default()
+    };
+    let fields = penalty_model_fields(&opts);
+    assert_eq!(fields["frequency_penalty"], json!(0.25));
+    assert_eq!(fields["presence_penalty"], json!(0.5));
+
+    // They never leak into `inferenceConfig`, which would 400.
+    let config = inference_config(&opts, 512);
+    assert!(config.get("frequency_penalty").is_none());
+    assert!(config.get("presence_penalty").is_none());
+}
+
+#[test]
+fn llm_args_fill_additional_model_request_fields_but_explicit_keys_win() {
+    let llm_args: Map<String, Value> = json!({ "top_k": 40, "frequency_penalty": 0.9 })
+        .as_object()
+        .unwrap()
+        .clone();
+    let explicit: Map<String, Value> = json!({ "frequency_penalty": 0.1 })
+        .as_object()
+        .unwrap()
+        .clone();
+
+    let mut body = json!({ "messages": [] });
+    merge_additional_model_request_fields(&mut body, &llm_args, &explicit);
+
+    let fields = &body["additionalModelRequestFields"];
+    // LLM_ARGS fills a gap the adapter never sets.
+    assert_eq!(fields["top_k"], json!(40));
+    // ...but an explicit key wins (litellm's `{**llm_args, **kwargs}`).
+    assert_eq!(
+        fields["frequency_penalty"],
+        json!(0.1),
+        "the explicit value must beat LLM_ARGS",
+    );
+}
+
+#[test]
+fn additional_model_request_fields_is_omitted_when_there_is_nothing_to_send() {
+    let mut body = json!({ "messages": [] });
+    merge_additional_model_request_fields(&mut body, &Map::new(), &Map::new());
+    assert!(
+        body.get("additionalModelRequestFields").is_none(),
+        "an empty object is rejected by some models, so the key is dropped",
+    );
+}
+
+#[test]
+fn the_response_maps_text_and_usage() {
+    let response: ConverseResponse = serde_json::from_value(json!({
+        "output": { "message": { "role": "assistant", "content": [
+            { "text": "Hello " },
+            { "text": "world" }
+        ]}},
+        "stopReason": "end_turn",
+        "usage": { "inputTokens": 11, "outputTokens": 3, "totalTokens": 14 }
+    }))
+    .unwrap();
+
+    assert_eq!(response.text(), "Hello world");
+    assert_eq!(response.stop_reason.as_deref(), Some("end_turn"));
+    let usage = TokenUsage::from(response.usage.unwrap());
+    assert_eq!(usage.prompt_tokens, 11);
+    assert_eq!(usage.completion_tokens, 3);
+    assert_eq!(usage.total_tokens, 14);
+}
+
+/// The mapping the plan singles out: **Bedrock signals throttling as HTTP 400
+/// `ThrottlingException` as well as 429.** Mapping the 400 to a generic
+/// bad-request error strands the retry layer.
+#[test]
+fn throttling_at_http_400_maps_to_rate_limit_exceeded() {
+    let error = map_error(
+        400,
+        r#"{"__type":"ThrottlingException","message":"Too many requests, please wait before trying again."}"#,
+    );
+    assert!(
+        matches!(error, LlmError::RateLimitExceeded(_)),
+        "a 400 ThrottlingException must be a rate limit, not a generic request error: {error:?}",
+    );
+    assert!(
+        is_retryable(&error),
+        "the retry layer must engage on a throttle",
+    );
+
+    // The plain 429 form maps the same way...
+    assert!(matches!(
+        map_error(429, r#"{"message":"Too many requests"}"#),
+        LlmError::RateLimitExceeded(_)
+    ));
+    // ...as does a namespaced `__type`, which is how the AWS-JSON envelope
+    // usually spells it.
+    assert!(matches!(
+        map_error(
+            400,
+            r#"{"__type":"com.amazon.coral.availability#ThrottlingException","message":"slow down"}"#
+        ),
+        LlmError::RateLimitExceeded(_)
+    ));
+    // ModelNotReadyException is the other transient 400/429 shape.
+    assert!(matches!(
+        map_error(
+            400,
+            r#"{"__type":"ModelNotReadyException","message":"warming up"}"#
+        ),
+        LlmError::RateLimitExceeded(_)
+    ));
+}
+
+#[test]
+fn the_remaining_bedrock_exceptions_map_to_their_taxonomy_slots() {
+    let validation = map_error(
+        400,
+        r#"{"__type":"ValidationException","message":"maxTokens exceeds the model limit"}"#,
+    );
+    assert!(
+        matches!(validation, LlmError::InvalidResponse(_)),
+        "{validation:?}"
+    );
+    assert!(
+        !is_retryable(&validation),
+        "re-POSTing an identical rejected body cannot start working",
+    );
+
+    let denied = map_error(
+        403,
+        r#"{"__type":"AccessDeniedException","message":"not authorized to invoke this model"}"#,
+    );
+    assert!(
+        matches!(denied, LlmError::AuthenticationError(_)),
+        "{denied:?}"
+    );
+    assert!(!is_retryable(&denied));
+
+    let unavailable = map_error(
+        503,
+        r#"{"__type":"ServiceUnavailableException","message":"try again"}"#,
+    );
+    assert!(
+        matches!(unavailable, LlmError::ApiError(_)),
+        "{unavailable:?}"
+    );
+    assert!(is_retryable(&unavailable), "a 503 is transient");
+
+    let missing = map_error(
+        404,
+        r#"{"__type":"ResourceNotFoundException","message":"no such model"}"#,
+    );
+    assert!(matches!(missing, LlmError::ModelNotFound(_)), "{missing:?}");
+    assert!(!is_retryable(&missing));
+
+    // Bodies with no `__type` still map off the status code.
+    assert!(matches!(
+        map_error(500, "internal failure"),
+        LlmError::ApiError(_)
+    ));
+    assert!(matches!(
+        map_error(401, "missing credentials"),
+        LlmError::AuthenticationError(_)
+    ));
+}

--- a/crates/llm/tests/bedrock_credentials_ladder.rs
+++ b/crates/llm/tests/bedrock_credentials_ladder.rs
@@ -11,12 +11,14 @@
     reason = "integration test code: panics are acceptable"
 )]
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 use cognee_llm::adapters::bedrock::aws::credentials::{
-    AmbientRoleIdentity, AwsCredentials, BedrockAuth, CredentialLookup, CredentialStrategy,
-    resolve_auth_with, select_strategy,
+    AmbientRoleIdentity, AwsCredentials, BedrockAuth, BedrockAuthProvider, CredentialLookup,
+    CredentialStrategy, resolve_auth_with, select_strategy,
 };
 use cognee_llm::adapters::bedrock::aws::env::{AwsInputs, AwsSettings, EnvSource};
 use cognee_llm::error::LlmResult;
@@ -480,4 +482,129 @@ fn the_process_environment_is_read_under_the_documented_names() {
 
     assert_eq!(settings.profile_name.as_deref(), Some("from-real-env"));
     assert_eq!(settings.role_name.as_deref(), Some(ROLE_ARN));
+}
+
+// ---------------------------------------------------------------------------
+// Credential lifetime — `BedrockAuthProvider` (review finding 1).
+// ---------------------------------------------------------------------------
+
+/// Hands out credentials that expire `ttl` from now, counting resolutions.
+struct ExpiringLookup {
+    calls: AtomicUsize,
+    ttl: Duration,
+}
+
+impl ExpiringLookup {
+    fn new(ttl: Duration) -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+            ttl,
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl CredentialLookup for ExpiringLookup {
+    async fn lookup(
+        &self,
+        _strategy: CredentialStrategy<'_>,
+        _settings: &AwsSettings,
+        _region: &str,
+    ) -> LlmResult<AwsCredentials> {
+        let n = self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(AwsCredentials::new(
+            format!("AKIA_GENERATION_{n}"),
+            "secret",
+            Some("session-token".to_string()),
+            Some(SystemTime::now() + self.ttl),
+            "expiring-lookup",
+        ))
+    }
+}
+
+fn access_key_of(auth: &BedrockAuth) -> String {
+    match auth {
+        BedrockAuth::SigV4(credentials) => credentials.access_key_id().to_string(),
+        BedrockAuth::Bearer(_) => panic!("expected SigV4 auth"),
+    }
+}
+
+/// Credentials that are already past their expiry are re-resolved.
+///
+/// The defect this covers: the ladder ran once at construction and every later
+/// request was signed with that snapshot, so an `AssumeRole`/IMDS deployment
+/// started returning a terminal 403 `ExpiredTokenException` about an hour in and
+/// never recovered — the built adapter is cached for the process lifetime.
+#[tokio::test]
+async fn expired_credentials_are_re_resolved() {
+    let settings = AwsSettings::default();
+    let ambient = AmbientRoleIdentity::default();
+    // Already expired: one second in the past.
+    let lookup = Arc::new(ExpiringLookup::new(Duration::from_secs(0)));
+
+    let initial = resolve_auth_with(None, &settings, REGION, &ambient, lookup.as_ref())
+        .await
+        .expect("initial resolution");
+    assert_eq!(lookup.calls(), 1);
+    assert_eq!(access_key_of(&initial), "AKIA_GENERATION_0");
+
+    let provider =
+        BedrockAuthProvider::new(None, settings, REGION, ambient, lookup.clone(), initial);
+
+    let refreshed = provider.auth().await.expect("refresh");
+    assert_eq!(
+        lookup.calls(),
+        2,
+        "expired credentials must trigger exactly one re-resolution",
+    );
+    assert_eq!(
+        access_key_of(&refreshed),
+        "AKIA_GENERATION_1",
+        "the refreshed credentials must be the new ones, not the cached snapshot",
+    );
+}
+
+/// Long-lived credentials are reused: refreshing is expiry-driven, not
+/// per-request.
+#[tokio::test]
+async fn unexpired_credentials_are_reused_without_a_lookup() {
+    let settings = AwsSettings::default();
+    let ambient = AmbientRoleIdentity::default();
+    let lookup = Arc::new(ExpiringLookup::new(Duration::from_secs(3600)));
+
+    let initial = resolve_auth_with(None, &settings, REGION, &ambient, lookup.as_ref())
+        .await
+        .expect("initial resolution");
+    let provider =
+        BedrockAuthProvider::new(None, settings, REGION, ambient, lookup.clone(), initial);
+
+    for _ in 0..5 {
+        let auth = provider.auth().await.expect("cached auth");
+        assert_eq!(access_key_of(&auth), "AKIA_GENERATION_0");
+    }
+    assert_eq!(lookup.calls(), 1, "no extra lookups for fresh credentials");
+}
+
+/// A bearer token has no expiry and must never trigger a credential lookup —
+/// the §1.2 early return still holds through the provider.
+#[tokio::test]
+async fn a_bearer_token_never_triggers_a_lookup() {
+    let lookup = Arc::new(ExpiringLookup::new(Duration::from_secs(0)));
+    let provider = BedrockAuthProvider::new(
+        Some("bedrock-api-key"),
+        AwsSettings::default(),
+        REGION,
+        AmbientRoleIdentity::default(),
+        lookup.clone(),
+        BedrockAuth::Bearer("bedrock-api-key".to_string()),
+    );
+
+    for _ in 0..3 {
+        assert!(provider.auth().await.expect("bearer").is_bearer());
+    }
+    assert_eq!(lookup.calls(), 0);
 }

--- a/crates/llm/tests/bedrock_credentials_ladder.rs
+++ b/crates/llm/tests/bedrock_credentials_ladder.rs
@@ -1,0 +1,483 @@
+//! The §1.2 credential ladder: precedence, the uppercase-env fallbacks, the
+//! bearer early return, and "skip AssumeRole when already running as that
+//! role".
+//!
+//! The lookup half is stubbed so these tests never touch AWS; what they assert
+//! is which rung the ladder *chose*, which is exactly what a port gets wrong.
+#![cfg(feature = "bedrock")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use cognee_llm::adapters::bedrock::aws::credentials::{
+    AmbientRoleIdentity, AwsCredentials, BedrockAuth, CredentialLookup, CredentialStrategy,
+    resolve_auth_with, select_strategy,
+};
+use cognee_llm::adapters::bedrock::aws::env::{AwsInputs, AwsSettings, EnvSource};
+use cognee_llm::error::LlmResult;
+
+const REGION: &str = "us-east-1";
+const ROLE_ARN: &str = "arn:aws:iam::123456789012:role/BedrockRole";
+
+/// Counts lookups so the bearer path can prove it performed none, and records
+/// the strategy it was handed.
+#[derive(Default)]
+struct RecordingLookup {
+    calls: AtomicUsize,
+}
+
+impl RecordingLookup {
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl CredentialLookup for RecordingLookup {
+    async fn lookup(
+        &self,
+        _strategy: CredentialStrategy<'_>,
+        _settings: &AwsSettings,
+        _region: &str,
+    ) -> LlmResult<AwsCredentials> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(AwsCredentials::new(
+            "AKIA_FROM_LOOKUP",
+            "secret",
+            None,
+            None,
+            "recording-lookup",
+        ))
+    }
+}
+
+fn env_of(pairs: &[(&'static str, &'static str)]) -> impl EnvSource + use<> {
+    let owned: Vec<(String, String)> = pairs
+        .iter()
+        .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+        .collect();
+    move |key: &str| {
+        owned
+            .iter()
+            .find(|(name, _)| name == key)
+            .map(|(_, value)| value.to_string())
+    }
+}
+
+fn settings_from_env(pairs: &[(&'static str, &'static str)]) -> AwsSettings {
+    AwsInputs::default().resolve_with(&env_of(pairs))
+}
+
+#[test]
+fn web_identity_wins_when_token_role_and_session_are_all_present() {
+    let settings = settings_from_env(&[
+        ("AWS_WEB_IDENTITY_TOKEN", "/var/run/token"),
+        ("AWS_ROLE_NAME", ROLE_ARN),
+        ("AWS_SESSION_NAME", "cognee-session"),
+        ("AWS_PROFILE_NAME", "ignored"),
+        ("AWS_ACCESS_KEY_ID", "AKIA_IGNORED"),
+        ("AWS_SECRET_ACCESS_KEY", "ignored"),
+    ]);
+
+    assert_eq!(
+        select_strategy(&settings, &AmbientRoleIdentity::default()),
+        CredentialStrategy::WebIdentity {
+            web_identity_token: "/var/run/token",
+            role_arn: ROLE_ARN,
+            session_name: "cognee-session",
+        }
+    );
+}
+
+#[test]
+fn a_web_identity_token_without_role_and_session_does_not_select_that_rung() {
+    let settings = settings_from_env(&[
+        ("AWS_WEB_IDENTITY_TOKEN", "/var/run/token"),
+        ("AWS_PROFILE_NAME", "dev"),
+    ]);
+
+    assert_eq!(
+        select_strategy(&settings, &AmbientRoleIdentity::default()),
+        CredentialStrategy::Profile("dev")
+    );
+}
+
+#[test]
+fn role_name_selects_assume_role_over_profile_and_static_keys() {
+    let settings = settings_from_env(&[
+        ("AWS_ROLE_NAME", ROLE_ARN),
+        ("AWS_SESSION_NAME", "cognee-session"),
+        ("AWS_PROFILE_NAME", "ignored"),
+        ("AWS_ACCESS_KEY_ID", "AKIA_IGNORED"),
+        ("AWS_SECRET_ACCESS_KEY", "ignored"),
+    ]);
+
+    assert_eq!(
+        select_strategy(&settings, &AmbientRoleIdentity::default()),
+        CredentialStrategy::AssumeRole {
+            role_arn: ROLE_ARN,
+            session_name: Some("cognee-session"),
+        }
+    );
+}
+
+#[test]
+fn assume_role_without_a_session_name_lets_the_provider_generate_one() {
+    let settings = settings_from_env(&[("AWS_ROLE_NAME", ROLE_ARN)]);
+
+    assert_eq!(
+        select_strategy(&settings, &AmbientRoleIdentity::default()),
+        CredentialStrategy::AssumeRole {
+            role_arn: ROLE_ARN,
+            session_name: None,
+        }
+    );
+}
+
+/// `base_aws_llm.py:1095` — an IRSA pod that already holds the role must not
+/// try to assume it.
+#[test]
+fn assume_role_is_skipped_when_the_irsa_environment_already_holds_the_role() {
+    let settings = settings_from_env(&[("AWS_ROLE_NAME", ROLE_ARN)]);
+    let ambient = AmbientRoleIdentity {
+        role_arn: Some(ROLE_ARN.to_string()),
+        web_identity_token_file: Some("/var/run/secrets/token".to_string()),
+        caller_arn: None,
+    };
+
+    assert_eq!(
+        select_strategy(&settings, &ambient),
+        CredentialStrategy::AmbientRole { role_arn: ROLE_ARN }
+    );
+}
+
+#[test]
+fn the_irsa_fast_path_needs_both_variables() {
+    let settings = settings_from_env(&[("AWS_ROLE_NAME", ROLE_ARN)]);
+    let ambient = AmbientRoleIdentity {
+        role_arn: Some(ROLE_ARN.to_string()),
+        web_identity_token_file: None,
+        caller_arn: None,
+    };
+
+    assert_eq!(
+        select_strategy(&settings, &ambient),
+        CredentialStrategy::AssumeRole {
+            role_arn: ROLE_ARN,
+            session_name: None,
+        },
+        "AWS_ROLE_ARN without a token file is not an IRSA identity"
+    );
+}
+
+#[test]
+fn a_different_role_in_the_irsa_environment_still_assumes() {
+    let settings = settings_from_env(&[("AWS_ROLE_NAME", ROLE_ARN)]);
+    let ambient = AmbientRoleIdentity {
+        role_arn: Some("arn:aws:iam::123456789012:role/OtherRole".to_string()),
+        web_identity_token_file: Some("/var/run/secrets/token".to_string()),
+        caller_arn: None,
+    };
+
+    assert_eq!(
+        select_strategy(&settings, &ambient),
+        CredentialStrategy::AssumeRole {
+            role_arn: ROLE_ARN,
+            session_name: None,
+        }
+    );
+}
+
+#[test]
+fn a_caller_identity_already_in_the_role_skips_assume_role() {
+    let settings = settings_from_env(&[("AWS_ROLE_NAME", ROLE_ARN)]);
+    let ambient = AmbientRoleIdentity {
+        caller_arn: Some("arn:aws:sts::123456789012:assumed-role/BedrockRole/i-0abc".to_string()),
+        ..AmbientRoleIdentity::default()
+    };
+
+    assert_eq!(
+        select_strategy(&settings, &ambient),
+        CredentialStrategy::AmbientRole { role_arn: ROLE_ARN }
+    );
+}
+
+/// Same role name, different account: assuming is still required.
+#[test]
+fn a_same_named_role_in_another_account_is_not_a_match() {
+    let settings = settings_from_env(&[("AWS_ROLE_NAME", ROLE_ARN)]);
+    let ambient = AmbientRoleIdentity {
+        caller_arn: Some("arn:aws:sts::999999999999:assumed-role/BedrockRole/i-0abc".to_string()),
+        ..AmbientRoleIdentity::default()
+    };
+
+    assert_eq!(
+        select_strategy(&settings, &ambient),
+        CredentialStrategy::AssumeRole {
+            role_arn: ROLE_ARN,
+            session_name: None,
+        }
+    );
+}
+
+#[test]
+fn profile_outranks_static_keys() {
+    let settings = settings_from_env(&[
+        ("AWS_PROFILE_NAME", "bedrock-profile"),
+        ("AWS_ACCESS_KEY_ID", "AKIA_IGNORED"),
+        ("AWS_SECRET_ACCESS_KEY", "ignored"),
+    ]);
+
+    assert_eq!(
+        select_strategy(&settings, &AmbientRoleIdentity::default()),
+        CredentialStrategy::Profile("bedrock-profile")
+    );
+}
+
+/// litellm reads `AWS_PROFILE_NAME`, **not** the boto3-standard `AWS_PROFILE`.
+#[test]
+fn the_profile_rung_reads_aws_profile_name_only() {
+    let with_boto3_name = settings_from_env(&[("AWS_PROFILE", "boto3-name")]);
+    assert_eq!(
+        select_strategy(&with_boto3_name, &AmbientRoleIdentity::default()),
+        CredentialStrategy::DefaultChain,
+        "AWS_PROFILE must not select the profile rung"
+    );
+
+    let with_litellm_name = settings_from_env(&[("AWS_PROFILE_NAME", "litellm-name")]);
+    assert_eq!(
+        select_strategy(&with_litellm_name, &AmbientRoleIdentity::default()),
+        CredentialStrategy::Profile("litellm-name")
+    );
+}
+
+#[test]
+fn static_keys_with_a_session_token_are_selected_before_plain_keys() {
+    let settings = settings_from_env(&[
+        ("AWS_ACCESS_KEY_ID", "AKIA_ENV"),
+        ("AWS_SECRET_ACCESS_KEY", "secret-env"),
+        ("AWS_SESSION_TOKEN", "session-env"),
+    ]);
+
+    assert_eq!(
+        select_strategy(&settings, &AmbientRoleIdentity::default()),
+        CredentialStrategy::Static {
+            access_key_id: "AKIA_ENV",
+            secret_access_key: "secret-env",
+            session_token: Some("session-env"),
+        }
+    );
+}
+
+#[test]
+fn static_keys_without_a_session_token() {
+    let settings = settings_from_env(&[
+        ("AWS_ACCESS_KEY_ID", "AKIA_ENV"),
+        ("AWS_SECRET_ACCESS_KEY", "secret-env"),
+    ]);
+
+    assert_eq!(
+        select_strategy(&settings, &AmbientRoleIdentity::default()),
+        CredentialStrategy::Static {
+            access_key_id: "AKIA_ENV",
+            secret_access_key: "secret-env",
+            session_token: None,
+        }
+    );
+}
+
+#[test]
+fn a_key_without_its_secret_falls_through_to_the_default_chain() {
+    let settings = settings_from_env(&[("AWS_ACCESS_KEY_ID", "AKIA_ENV")]);
+
+    assert_eq!(
+        select_strategy(&settings, &AmbientRoleIdentity::default()),
+        CredentialStrategy::DefaultChain
+    );
+}
+
+#[test]
+fn nothing_configured_falls_through_to_the_default_chain() {
+    assert_eq!(
+        select_strategy(&AwsSettings::default(), &AmbientRoleIdentity::default()),
+        CredentialStrategy::DefaultChain
+    );
+}
+
+#[test]
+fn caller_parameters_outrank_the_environment_on_every_rung() {
+    let inputs = AwsInputs {
+        profile_name: Some("param-profile".to_string()),
+        ..AwsInputs::default()
+    };
+    let settings = inputs.resolve_with(&env_of(&[
+        ("AWS_PROFILE_NAME", "env-profile"),
+        ("AWS_ACCESS_KEY_ID", "AKIA_ENV"),
+        ("AWS_SECRET_ACCESS_KEY", "secret-env"),
+    ]));
+
+    assert_eq!(
+        select_strategy(&settings, &AmbientRoleIdentity::default()),
+        CredentialStrategy::Profile("param-profile")
+    );
+}
+
+#[tokio::test]
+async fn an_api_key_short_circuits_the_ladder_without_any_credential_lookup() {
+    // Every SigV4 rung is configured; none of them may be consulted.
+    let settings = settings_from_env(&[
+        ("AWS_ROLE_NAME", ROLE_ARN),
+        ("AWS_SESSION_NAME", "cognee-session"),
+        ("AWS_PROFILE_NAME", "dev"),
+        ("AWS_ACCESS_KEY_ID", "AKIA_ENV"),
+        ("AWS_SECRET_ACCESS_KEY", "secret-env"),
+    ]);
+    let lookup = RecordingLookup::default();
+
+    let auth = resolve_auth_with(
+        Some("bedrock-api-key"),
+        &settings,
+        REGION,
+        &AmbientRoleIdentity::default(),
+        &lookup,
+    )
+    .await
+    .expect("bearer auth resolves");
+
+    assert!(matches!(&auth, BedrockAuth::Bearer(token) if token == "bedrock-api-key"));
+    assert!(auth.is_bearer());
+    assert_eq!(
+        auth.bearer_header_value().as_deref(),
+        Some("Bearer bedrock-api-key")
+    );
+    assert_eq!(
+        lookup.calls(),
+        0,
+        "the bearer branch must be an early return: no credential lookup at all"
+    );
+}
+
+#[tokio::test]
+async fn aws_bearer_token_bedrock_short_circuits_the_ladder_too() {
+    let settings = settings_from_env(&[
+        ("AWS_BEARER_TOKEN_BEDROCK", "env-bearer"),
+        ("AWS_ACCESS_KEY_ID", "AKIA_ENV"),
+        ("AWS_SECRET_ACCESS_KEY", "secret-env"),
+    ]);
+    let lookup = RecordingLookup::default();
+
+    let auth = resolve_auth_with(
+        None,
+        &settings,
+        REGION,
+        &AmbientRoleIdentity::default(),
+        &lookup,
+    )
+    .await
+    .expect("bearer auth resolves");
+
+    assert!(matches!(&auth, BedrockAuth::Bearer(token) if token == "env-bearer"));
+    assert_eq!(lookup.calls(), 0);
+}
+
+#[tokio::test]
+async fn an_api_key_outranks_the_environment_bearer_token() {
+    let settings = settings_from_env(&[("AWS_BEARER_TOKEN_BEDROCK", "env-bearer")]);
+    let lookup = RecordingLookup::default();
+
+    let auth = resolve_auth_with(
+        Some("param-bearer"),
+        &settings,
+        REGION,
+        &AmbientRoleIdentity::default(),
+        &lookup,
+    )
+    .await
+    .expect("bearer auth resolves");
+
+    assert!(matches!(&auth, BedrockAuth::Bearer(token) if token == "param-bearer"));
+    assert_eq!(lookup.calls(), 0);
+}
+
+#[tokio::test]
+async fn a_blank_api_key_does_not_shadow_the_environment_bearer_token() {
+    let settings = settings_from_env(&[("AWS_BEARER_TOKEN_BEDROCK", "env-bearer")]);
+    let lookup = RecordingLookup::default();
+
+    let auth = resolve_auth_with(
+        Some("   "),
+        &settings,
+        REGION,
+        &AmbientRoleIdentity::default(),
+        &lookup,
+    )
+    .await
+    .expect("bearer auth resolves");
+
+    assert!(matches!(&auth, BedrockAuth::Bearer(token) if token == "env-bearer"));
+    assert_eq!(lookup.calls(), 0);
+}
+
+#[tokio::test]
+async fn without_a_bearer_token_the_ladder_does_look_credentials_up() {
+    let settings = settings_from_env(&[
+        ("AWS_ACCESS_KEY_ID", "AKIA_ENV"),
+        ("AWS_SECRET_ACCESS_KEY", "secret-env"),
+    ]);
+    let lookup = RecordingLookup::default();
+
+    let auth = resolve_auth_with(
+        None,
+        &settings,
+        REGION,
+        &AmbientRoleIdentity::default(),
+        &lookup,
+    )
+    .await
+    .expect("sigv4 auth resolves");
+
+    match auth {
+        BedrockAuth::SigV4(credentials) => {
+            assert_eq!(credentials.access_key_id(), "AKIA_FROM_LOOKUP");
+        }
+        BedrockAuth::Bearer(_) => panic!("expected SigV4 auth"),
+    }
+    assert_eq!(lookup.calls(), 1);
+}
+
+/// The one test that touches the real process environment, so it is serialised
+/// against every other env-mutating test in this binary.
+#[test]
+#[serial_test::serial]
+fn the_process_environment_is_read_under_the_documented_names() {
+    let restore = ["AWS_PROFILE_NAME", "AWS_PROFILE", "AWS_ROLE_NAME"]
+        .map(|key| (key, std::env::var(key).ok()));
+
+    // SAFETY: this test is `#[serial]`, so no other test in this binary is
+    // reading or writing the environment concurrently.
+    unsafe {
+        std::env::set_var("AWS_PROFILE_NAME", "from-real-env");
+        std::env::set_var("AWS_PROFILE", "boto3-name");
+        std::env::set_var("AWS_ROLE_NAME", ROLE_ARN);
+    }
+
+    let settings = AwsInputs::default().resolve();
+
+    // SAFETY: same as above.
+    unsafe {
+        for (key, value) in restore {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
+    assert_eq!(settings.profile_name.as_deref(), Some("from-real-env"));
+    assert_eq!(settings.role_name.as_deref(), Some(ROLE_ARN));
+}

--- a/crates/llm/tests/bedrock_integration.rs
+++ b/crates/llm/tests/bedrock_integration.rs
@@ -1,0 +1,651 @@
+//! End-to-end `BedrockAdapter` behaviour against an `httpmock` server, plus
+//! `#[ignore]`d live tests (one per auth mode).
+//!
+//! The transport seam (`BedrockTransport`) is deliberately `pub(crate)`, so an
+//! integration test cannot inject a fake transport — and it must not be widened
+//! to `pub` just to be tested. Instead the adapter's **resolved endpoint** is
+//! pointed at the mock server through `AwsInputs::bedrock_runtime_endpoint`
+//! (rung 2 of the §1.3 endpoint chain), which exercises the real chain rather
+//! than bypassing it.
+//!
+//! Every mock declares its matchers on `when`, so a wrong URL, header or body
+//! shape shows up as a `404` from the mock server (and a failing
+//! `assert_calls_async(1)`) rather than as a silently passing assertion.
+#![cfg(feature = "bedrock")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+
+use cognee_llm::adapters::bedrock::BedrockAdapter;
+use cognee_llm::adapters::bedrock::aws::env::AwsInputs;
+use cognee_llm::adapters::bedrock::converse::encode_model_id;
+use cognee_llm::error::LlmError;
+use cognee_llm::llm_trait::Llm;
+use cognee_llm::types::{GenerationOptions, Message};
+use httpmock::prelude::*;
+use serde_json::{Value, json};
+
+/// A bearer key short-circuits the §1.2 credential ladder before any lookup, so
+/// these tests never touch AWS, `~/.aws` or IMDS.
+const BEARER_KEY: &str = "test-bedrock-key";
+
+const SONNET: &str = "eu.anthropic.claude-sonnet-4-5-20250929-v1:0";
+const NOVA_LITE: &str = "eu.amazon.nova-lite-v1:0";
+
+/// Build an adapter whose endpoint is the mock server.
+///
+/// `region` is supplied explicitly (rung 1 of the §1.3 region chain) so the
+/// chain never falls through to `aws-config`'s default region provider — this
+/// stays hermetic on a developer machine with a populated `~/.aws/config`.
+async fn adapter(server: &MockServer, model: &str) -> BedrockAdapter {
+    let aws = AwsInputs {
+        region: Some("eu-central-1".to_string()),
+        bedrock_runtime_endpoint: Some(server.base_url()),
+        ..AwsInputs::default()
+    };
+    BedrockAdapter::new(model, Some(BEARER_KEY), None, &aws)
+        .await
+        .expect("adapter builds offline under bearer auth")
+        // One mocked exchange per test.
+        .with_network_retries(0)
+        .with_structured_output_retries(1)
+}
+
+/// The Converse path for `model`, with the id percent-encoded as one segment.
+fn converse_path(model: &str) -> String {
+    format!("/model/{}/converse", encode_model_id(model))
+}
+
+fn schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"]
+    })
+}
+
+#[tokio::test]
+async fn generate_posts_converse_with_the_un_normalised_id_and_a_clamped_budget() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                // The exact, *un-normalised* path: `eu.` survives and `:` is
+                // percent-encoded. A normalised id here would 404.
+                .path(converse_path(NOVA_LITE))
+                // Bearer auth: a plain header, no SigV4 (plan §1.2).
+                .header("authorization", format!("Bearer {BEARER_KEY}"))
+                .header_excludes("authorization", "AWS4-HMAC-SHA256")
+                // nova-lite caps output at 10_000, below the 16_384 default
+                // ceiling — so the budget is clamped, not forwarded.
+                .body_includes(r#""maxTokens":10000"#)
+                // System messages are hoisted out of `messages` into `system`.
+                .body_includes(r#""system":[{"text":"be terse"}]"#)
+                .body_includes(r#""content":[{"text":"hello"}]"#)
+                .body_excludes(r#""role":"system""#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "output": { "message": { "role": "assistant", "content": [
+                            { "text": "Hello " }, { "text": "world" }
+                        ]}},
+                        "stopReason": "end_turn",
+                        "usage": { "inputTokens": 11, "outputTokens": 3, "totalTokens": 14 }
+                    }"#,
+                );
+        })
+        .await;
+
+    let response = adapter(&server, NOVA_LITE)
+        .await
+        .generate(
+            vec![Message::system("be terse"), Message::user("hello")],
+            None,
+        )
+        .await
+        .expect("generate should succeed");
+
+    assert_eq!(response.content, "Hello world");
+    assert_eq!(response.model, NOVA_LITE);
+    assert_eq!(response.finish_reason.as_deref(), Some("end_turn"));
+    let usage = response.usage.expect("usage is reported");
+    assert_eq!(usage.prompt_tokens, 11);
+    assert_eq!(usage.completion_tokens, 3);
+    assert_eq!(usage.total_tokens, 14);
+    mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn structured_output_uses_the_native_output_config_for_the_shipped_anthropic_model() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(converse_path(SONNET))
+                .body_includes(r#""outputConfig""#)
+                .body_includes(r#""type":"json_schema""#)
+                // The native branch injects no synthetic tool.
+                .body_excludes("toolConfig")
+                .body_excludes("json_tool_call");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "output": { "message": { "role": "assistant", "content": [
+                            { "text": "{\"name\":\"Ada\"}" }
+                        ]}},
+                        "stopReason": "end_turn"
+                    }"#,
+                );
+        })
+        .await;
+
+    let value = adapter(&server, SONNET)
+        .await
+        .create_structured_output_with_messages_raw(vec![Message::user("who?")], &schema(), None)
+        .await
+        .expect("structured output should succeed");
+
+    assert_eq!(value["name"], "Ada");
+    mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn structured_output_falls_back_to_json_tool_call_without_forcing_tool_choice_on_nova() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(converse_path(NOVA_LITE))
+                .body_includes(r#""json_tool_call""#)
+                .body_includes(r#""toolConfig""#)
+                // nova-lite does not advertise `supports_tool_choice` and is
+                // documented to 400 on a specific `toolChoice`.
+                .body_excludes("toolChoice")
+                .body_excludes("outputConfig");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                        "output": { "message": { "role": "assistant", "content": [
+                            { "toolUse": {
+                                "toolUseId": "tu_1",
+                                "name": "json_tool_call",
+                                "input": { "name": "Grace" }
+                            }}
+                        ]}},
+                        "stopReason": "tool_use"
+                    }"#,
+                );
+        })
+        .await;
+
+    let value = adapter(&server, NOVA_LITE)
+        .await
+        .create_structured_output_with_messages_raw(vec![Message::user("who?")], &schema(), None)
+        .await
+        .expect("structured output should succeed");
+
+    assert_eq!(value["name"], "Grace");
+    mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn llm_args_reach_additional_model_request_fields_on_the_wire() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(converse_path(NOVA_LITE))
+                .body_includes(r#""additionalModelRequestFields""#)
+                .body_includes(r#""top_k":40"#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"output":{"message":{"content":[{"text":"ok"}]}},"stopReason":"end_turn"}"#,
+                );
+        })
+        .await;
+
+    let extra = json!({ "top_k": 40 }).as_object().unwrap().clone();
+    let response = adapter(&server, NOVA_LITE)
+        .await
+        .with_extra_args(extra)
+        .generate(vec![Message::user("hi")], None)
+        .await
+        .expect("generate should succeed");
+
+    assert_eq!(response.content, "ok");
+    mock.assert_calls_async(1).await;
+}
+
+/// A 400 `ThrottlingException` must engage the retry layer, not be reported as
+/// a terminal bad request (plan §4 R3 step 7).
+#[tokio::test]
+async fn a_400_throttling_exception_is_retried_and_surfaces_as_a_rate_limit() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST).path(converse_path(NOVA_LITE));
+            then.status(400)
+                .header("content-type", "application/json")
+                .body(r#"{"__type":"ThrottlingException","message":"Too many requests"}"#);
+        })
+        .await;
+
+    // Two attempts: the initial one plus one retry, which only happens because
+    // the throttle was classified as retryable.
+    let error = adapter(&server, NOVA_LITE)
+        .await
+        .with_network_retries(1)
+        .generate(vec![Message::user("hi")], None)
+        .await
+        .expect_err("a throttled request fails");
+
+    assert!(
+        matches!(error, LlmError::MaxRetriesExceeded(_)),
+        "the transport ladder must exhaust rather than return terminally: {error:?}",
+    );
+    assert!(
+        error.to_string().contains("Rate limit exceeded"),
+        "the underlying error must be a rate limit, not a generic bad request: {error}",
+    );
+    mock.assert_calls_async(2).await;
+}
+
+/// The counterpart: a 400 `ValidationException` is terminal, so it must *not*
+/// burn the retry budget.
+#[tokio::test]
+async fn a_400_validation_exception_is_terminal() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST).path(converse_path(NOVA_LITE));
+            then.status(400)
+                .header("content-type", "application/json")
+                .body(r#"{"__type":"ValidationException","message":"bad maxTokens"}"#);
+        })
+        .await;
+
+    let error = adapter(&server, NOVA_LITE)
+        .await
+        .with_network_retries(3)
+        .generate(vec![Message::user("hi")], None)
+        .await
+        .expect_err("a validation failure fails");
+
+    assert!(matches!(error, LlmError::InvalidResponse(_)), "{error:?}");
+    mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn transcribe_image_sends_a_converse_image_block() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(converse_path(NOVA_LITE))
+                .body_includes(r#""image":{"format":"png""#)
+                // 1x1-ish payload, base64 of "PNGDATA".
+                .body_includes(r#""bytes":"UE5HREFUQQ==""#)
+                .body_includes(r#""text":"What's in this image?""#)
+                .body_includes(r#""maxTokens":300"#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"output":{"message":{"content":[{"text":"a cat"}]}},"stopReason":"end_turn"}"#,
+                );
+        })
+        .await;
+
+    let description = adapter(&server, NOVA_LITE)
+        .await
+        .transcribe_image(b"PNGDATA", "image/png", None)
+        .await
+        .expect("vision should succeed");
+
+    assert_eq!(description, "a cat");
+    mock.assert_calls_async(1).await;
+}
+
+/// The vision path is bounded by the same effective budget as the chat path:
+/// the lesser of the model cap and the configured `llm_max_completion_tokens`
+/// ceiling. A caller-supplied `max_tokens` must not slip past that ceiling.
+#[tokio::test]
+async fn transcribe_image_clamps_to_the_configured_ceiling() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(converse_path(NOVA_LITE))
+                .body_includes(r#""maxTokens":64"#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"output":{"message":{"content":[{"text":"a cat"}]}},"stopReason":"end_turn"}"#,
+                );
+        })
+        .await;
+
+    let description = adapter(&server, NOVA_LITE)
+        .await
+        .with_max_completion_tokens(64)
+        .transcribe_image(
+            b"PNGDATA",
+            "image/png",
+            Some(GenerationOptions {
+                // Well above both the ceiling and nova-lite's 10_000 cap.
+                max_tokens: Some(16_384),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("vision should succeed");
+
+    assert_eq!(description, "a cat");
+    mock.assert_calls_async(1).await;
+}
+
+// ---------------------------------------------------------------------------
+// Live tests — one per auth mode. `#[ignore]`d; run by hand against a real
+// account with `cargo test -p cognee-llm --features bedrock --test
+// bedrock_integration -- --ignored --nocapture`.
+// ---------------------------------------------------------------------------
+
+/// Model id for the live tests, e.g. `eu.amazon.nova-lite-v1:0`.
+const LIVE_MODEL_ENV: &str = "COGNEE_BEDROCK_LIVE_MODEL";
+
+fn live_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// Resolve the live model id, or explain the skip.
+fn live_model(auth_mode: &str, required: &[&str]) -> Option<String> {
+    let Some(model) = live_env(LIVE_MODEL_ENV) else {
+        eprintln!("skipping live {auth_mode} test: {LIVE_MODEL_ENV} is unset");
+        return None;
+    };
+    for name in required {
+        if live_env(name).is_none() {
+            eprintln!("skipping live {auth_mode} test: {name} is unset");
+            return None;
+        }
+    }
+    Some(model)
+}
+
+async fn live_round_trip(adapter: BedrockAdapter, auth_mode: &str) {
+    let response = adapter
+        .generate(
+            vec![Message::user("Reply with the single word: pong")],
+            Some(GenerationOptions {
+                max_tokens: Some(16),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("live {auth_mode} request failed: {error}"));
+    assert!(
+        !response.content.trim().is_empty(),
+        "live {auth_mode} request returned empty content",
+    );
+}
+
+#[tokio::test]
+#[ignore = "live AWS Bedrock: needs a real account and AWS_BEARER_TOKEN_BEDROCK"]
+async fn live_bearer_token_auth() {
+    let Some(model) = live_model("bearer", &["AWS_BEARER_TOKEN_BEDROCK"]) else {
+        return;
+    };
+    let token = live_env("AWS_BEARER_TOKEN_BEDROCK").expect("checked above");
+    let adapter = BedrockAdapter::new(model, Some(&token), None, &AwsInputs::default())
+        .await
+        .expect("adapter should build");
+    live_round_trip(adapter, "bearer").await;
+}
+
+#[tokio::test]
+#[ignore = "live AWS Bedrock: needs a real account and AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY"]
+async fn live_static_key_auth() {
+    let Some(model) = live_model(
+        "static keys",
+        &["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+    ) else {
+        return;
+    };
+    // Left empty on purpose: `AwsInputs::resolve` backfills the static keys (and
+    // the region) from the uppercase environment, which is the §1.2 ladder this
+    // test is here to exercise. `api_key: None` keeps the bearer rungs out of it
+    // so SigV4 actually runs.
+    let adapter = BedrockAdapter::new(model, None, None, &AwsInputs::default())
+        .await
+        .expect("adapter should build");
+    live_round_trip(adapter, "static keys").await;
+}
+
+#[tokio::test]
+#[ignore = "live AWS Bedrock: needs a real account and AWS_PROFILE_NAME"]
+async fn live_profile_auth() {
+    let Some(model) = live_model("profile", &["AWS_PROFILE_NAME"]) else {
+        return;
+    };
+    // Note the spelling: litellm reads `AWS_PROFILE_NAME`, not `AWS_PROFILE`.
+    let adapter = BedrockAdapter::new(model, None, None, &AwsInputs::default())
+        .await
+        .expect("adapter should build");
+    live_round_trip(adapter, "profile").await;
+}
+
+/// The repair loop: an unusable first answer drives a corrective re-ask inside
+/// the same retry budget, and the correction is actually on the second request.
+///
+/// The two mocks are disambiguated by the correction itself — the first only
+/// matches a body *without* it, the second only a body *with* it — so a loop
+/// that re-POSTed an identical body would never reach the second mock.
+#[tokio::test]
+async fn an_unparseable_answer_drives_a_corrective_re_ask_that_then_succeeds() {
+    let server = MockServer::start_async().await;
+    let first = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(converse_path(SONNET))
+                .body_excludes("could not be parsed");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"output":{"message":{"content":[{"text":"sorry, no JSON here"}]}},
+                        "stopReason":"end_turn"}"#,
+                );
+        })
+        .await;
+    let repaired = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(converse_path(SONNET))
+                .body_includes("could not be parsed")
+                // The native branch must not be told to call a tool.
+                .body_excludes("json_tool_call");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"output":{"message":{"content":[{"text":"{\"name\":\"Ada\"}"}]}},
+                        "stopReason":"end_turn"}"#,
+                );
+        })
+        .await;
+
+    let value = adapter(&server, SONNET)
+        .await
+        .with_structured_output_retries(3)
+        .create_structured_output_with_messages_raw(vec![Message::user("who?")], &schema(), None)
+        .await
+        .expect("the repair loop should recover");
+
+    assert_eq!(value["name"], "Ada");
+    first.assert_calls_async(1).await;
+    repaired.assert_calls_async(1).await;
+}
+
+/// The `_validated` override is a **defaulted** trait method that ignores its
+/// validator unless an adapter overrides it — so this proves the override is
+/// real: a well-formed JSON object that the caller's validator rejects must
+/// drive a corrective re-ask carrying the validator's own reason, not be
+/// returned as `Ok` (which would abort the caller at deserialization).
+#[tokio::test]
+async fn a_validator_rejection_drives_a_corrective_re_ask_carrying_its_reason() {
+    let server = MockServer::start_async().await;
+    let rejected = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(converse_path(SONNET))
+                .body_excludes("name must not be empty");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"output":{"message":{"content":[{"text":"{\"name\":\"\"}"}]}},
+                        "stopReason":"end_turn"}"#,
+                );
+        })
+        .await;
+    let accepted = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(converse_path(SONNET))
+                // The validator's reason is quoted back to the model verbatim.
+                .body_includes("name must not be empty");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"output":{"message":{"content":[{"text":"{\"name\":\"Ada\"}"}]}},
+                        "stopReason":"end_turn"}"#,
+                );
+        })
+        .await;
+
+    // Passes `schema_required_validator`, so only this closure can reject an
+    // object that already carries every required field.
+    let validate = |value: &Value| -> Result<(), String> {
+        if value["name"].as_str().is_some_and(|name| name.is_empty()) {
+            return Err("name must not be empty".to_string());
+        }
+        Ok(())
+    };
+
+    let value = adapter(&server, SONNET)
+        .await
+        .with_structured_output_retries(3)
+        .create_structured_output_with_messages_raw_validated(
+            vec![Message::user("who?")],
+            &schema(),
+            None,
+            &validate,
+        )
+        .await
+        .expect("the validator-driven repair loop should recover");
+
+    assert_eq!(value["name"], "Ada");
+    rejected.assert_calls_async(1).await;
+    accepted.assert_calls_async(1).await;
+}
+
+/// A `stopReason: max_tokens` answer is incomplete even though it parses, so it
+/// is re-asked with a raised budget rather than returned as a partial object.
+#[tokio::test]
+async fn a_truncated_answer_is_re_asked_with_a_raised_budget() {
+    let server = MockServer::start_async().await;
+    let truncated = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(converse_path(NOVA_LITE))
+                .body_includes(r#""maxTokens":1000"#)
+                .body_excludes("cut off at maxTokens");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"output":{"message":{"content":[{"toolUse":{
+                        "toolUseId":"tu_1","name":"json_tool_call","input":{"name":"Ad"}}}]}},
+                        "stopReason":"max_tokens"}"#,
+                );
+        })
+        .await;
+    // The raised budget is the *effective* cap: min(model cap 10_000, ceiling
+    // 16_384). It must never exceed the configured ceiling.
+    let retried = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(converse_path(NOVA_LITE))
+                .body_includes(r#""maxTokens":10000"#)
+                .body_includes("cut off at maxTokens");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"output":{"message":{"content":[{"toolUse":{
+                        "toolUseId":"tu_2","name":"json_tool_call","input":{"name":"Ada"}}}]}},
+                        "stopReason":"tool_use"}"#,
+                );
+        })
+        .await;
+
+    let value = adapter(&server, NOVA_LITE)
+        .await
+        .with_structured_output_retries(3)
+        .create_structured_output_with_messages_raw(
+            vec![Message::user("who?")],
+            &schema(),
+            Some(GenerationOptions {
+                max_tokens: Some(1_000),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("the raised budget should complete the object");
+
+    assert_eq!(value["name"], "Ada");
+    truncated.assert_calls_async(1).await;
+    retried.assert_calls_async(1).await;
+}
+
+/// ...but truncation *at* the effective cap is unrecoverable by design: raising
+/// the budget further would breach the `llm_max_completion_tokens` ceiling, so
+/// it fails terminally instead of looping until the retry budget is gone.
+#[tokio::test]
+async fn truncation_at_the_effective_cap_fails_terminally() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST).path(converse_path(NOVA_LITE));
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"output":{"message":{"content":[{"toolUse":{
+                        "toolUseId":"tu_1","name":"json_tool_call","input":{"name":"Ad"}}}]}},
+                        "stopReason":"max_tokens"}"#,
+                );
+        })
+        .await;
+
+    let error = adapter(&server, NOVA_LITE)
+        .await
+        .with_structured_output_retries(5)
+        .create_structured_output_with_messages_raw(
+            // nova-lite's 10_000 cap is already the effective budget.
+            vec![Message::user("who?")],
+            &schema(),
+            None,
+        )
+        .await
+        .expect_err("a truncation at the cap cannot be repaired");
+
+    assert!(matches!(error, LlmError::InvalidResponse(_)), "{error:?}");
+    assert!(
+        error.to_string().contains("truncated"),
+        "the error must name the cause: {error}",
+    );
+    mock.assert_calls_async(1).await;
+}

--- a/crates/llm/tests/bedrock_model_id_normalisation.rs
+++ b/crates/llm/tests/bedrock_model_id_normalisation.rs
@@ -1,0 +1,278 @@
+//! §1.4.1 model-id normalisation and §1.4.2 route selection.
+//!
+//! This suite exists for one regression above all: **every model cognee ships
+//! by default is `eu.`-prefixed, while litellm's converse table stores only
+//! bare ids.** A port that looks the raw id up in that table routes 3 of 3
+//! shipped models to `invoke` — the adapter fails on its own defaults. Plan
+//! §1.4.1 calls that the single highest-consequence correction in the plan, and
+//! [`the_three_shipped_models_route_to_converse`] is the test that catches it.
+#![cfg(feature = "bedrock")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+
+use cognee_llm::adapters::bedrock::converse::converse_url;
+use cognee_llm::adapters::bedrock::model_id::{
+    CROSS_REGION_PREFIXES, NOVA_2_CUSTOM_BASE_MODEL, NOVA_CUSTOM_BASE_MODEL, base_model,
+    extract_model_name_from_arn, strip_context_window_suffix, strip_cross_region_prefix,
+    strip_routing_prefix, strip_throughput_suffix,
+};
+use cognee_llm::adapters::bedrock::route::{BEDROCK_CONVERSE_MODELS, BedrockRoute, select_route};
+
+/// The three models cognee's `/settings` endpoint offers today (plan §P2).
+const SHIPPED_MODELS: [&str; 3] = [
+    "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "eu.amazon.nova-lite-v1:0",
+];
+
+#[test]
+fn the_three_shipped_models_route_to_converse() {
+    for model in SHIPPED_MODELS {
+        assert_eq!(
+            select_route(model),
+            BedrockRoute::Converse,
+            "{model} must route to converse — it only does so via §1.4.1 normalisation",
+        );
+    }
+}
+
+/// The mirror image of the test above: proves it can actually fail. If the raw
+/// ids were in the table, normalisation could be deleted and the routing test
+/// would still pass.
+#[test]
+fn the_raw_shipped_ids_are_absent_from_the_converse_table() {
+    for model in SHIPPED_MODELS {
+        assert!(
+            !BEDROCK_CONVERSE_MODELS.contains(&model),
+            "{model} is stored bare in BEDROCK_CONVERSE_MODELS — the normalisation \
+             regression test above would no longer be able to fail",
+        );
+        // ...and the normalised form *is* in the table.
+        assert!(
+            BEDROCK_CONVERSE_MODELS.contains(&base_model(model).as_str()),
+            "normalised {model} is missing from BEDROCK_CONVERSE_MODELS",
+        );
+    }
+}
+
+#[test]
+fn foundation_model_and_inference_profile_arns_unwrap_to_the_bare_id() {
+    assert_eq!(
+        base_model(
+            "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0"
+        ),
+        "anthropic.claude-3-haiku-20240307-v1:0"
+    );
+    assert_eq!(
+        base_model(
+            "arn:aws:bedrock:eu-central-1:123456789012:inference-profile/eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+        ),
+        "anthropic.claude-haiku-4-5-20251001-v1:0"
+    );
+    // The helper is a "last path segment" grab, exactly as upstream.
+    assert_eq!(
+        extract_model_name_from_arn(
+            "arn:aws:bedrock:us-east-1::foundation-model/meta.llama3-8b-instruct-v1:0"
+        ),
+        "meta.llama3-8b-instruct-v1:0"
+    );
+    // A non-ARN id is returned untouched.
+    assert_eq!(
+        extract_model_name_from_arn("amazon.nova-lite-v1:0"),
+        "amazon.nova-lite-v1:0"
+    );
+}
+
+#[test]
+fn every_cross_region_inference_prefix_is_stripped() {
+    for prefix in CROSS_REGION_PREFIXES {
+        let prefixed = format!("{prefix}.anthropic.claude-sonnet-4-5-20250929-v1:0");
+        assert_eq!(
+            base_model(&prefixed),
+            "anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "the {prefix}. cross-region prefix was not stripped",
+        );
+        assert_eq!(
+            select_route(&prefixed),
+            BedrockRoute::Converse,
+            "{prefixed} must route to converse",
+        );
+    }
+    // A provider segment that merely *looks* like a prefix is not stripped.
+    assert_eq!(
+        strip_cross_region_prefix("anthropic.claude-v2"),
+        "anthropic.claude-v2"
+    );
+    assert_eq!(
+        strip_cross_region_prefix("amazon.nova-lite-v1:0"),
+        "amazon.nova-lite-v1:0"
+    );
+}
+
+#[test]
+fn provisioned_throughput_and_context_window_suffixes_are_stripped() {
+    assert_eq!(
+        base_model("anthropic.claude-3-5-sonnet-20241022-v2:0:51k"),
+        "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    );
+    assert_eq!(
+        base_model("us.anthropic.claude-opus-4-6-v1[1m]"),
+        "anthropic.claude-opus-4-6-v1"
+    );
+    assert_eq!(
+        strip_throughput_suffix("anthropic.claude-3-5-sonnet-20241022-v2:0:18k"),
+        "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    );
+    assert_eq!(
+        strip_context_window_suffix("anthropic.claude-opus-4-6-v1[200k]"),
+        "anthropic.claude-opus-4-6-v1"
+    );
+    // A bare version suffix must survive — stripping it would break every id.
+    assert_eq!(
+        strip_throughput_suffix("amazon.nova-lite-v1:0"),
+        "amazon.nova-lite-v1:0"
+    );
+    // Both suffixed forms still route to converse.
+    assert_eq!(
+        select_route("anthropic.claude-3-5-sonnet-20241022-v2:0:51k"),
+        BedrockRoute::Converse
+    );
+    assert_eq!(
+        select_route("us.anthropic.claude-opus-4-6-v1[1m]"),
+        BedrockRoute::Converse
+    );
+}
+
+#[test]
+fn a_leading_bedrock_prefix_is_stripped() {
+    assert_eq!(
+        base_model("bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0"),
+        "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    );
+    assert_eq!(
+        strip_routing_prefix("bedrock/converse/amazon.nova-lite-v1:0"),
+        "amazon.nova-lite-v1:0"
+    );
+    assert_eq!(
+        select_route("bedrock/eu.amazon.nova-lite-v1:0"),
+        BedrockRoute::Converse
+    );
+}
+
+#[test]
+fn nova_spec_prefixes_normalise_to_the_synthetic_custom_ids() {
+    assert_eq!(
+        base_model("nova/arn:aws:bedrock:us-east-1:1:custom-model/abc"),
+        NOVA_CUSTOM_BASE_MODEL
+    );
+    assert_eq!(
+        base_model("bedrock/nova-2/arn:aws:bedrock:us-east-1:1:custom-model/abc"),
+        NOVA_2_CUSTOM_BASE_MODEL
+    );
+}
+
+#[test]
+fn every_explicit_route_prefix_wins() {
+    let cases: [(&str, BedrockRoute); 9] = [
+        // `converse/` on a model the table does NOT contain — so the route can
+        // only come from the explicit prefix.
+        ("converse/cohere.command-text-v14", BedrockRoute::Converse),
+        // `invoke/` on a model the table DOES contain — the prefix must beat the
+        // table lookup, or the check is vacuous.
+        (
+            "invoke/anthropic.claude-sonnet-4-5-20250929-v1:0",
+            BedrockRoute::Invoke,
+        ),
+        (
+            "converse_like/cohere.command-text-v14",
+            BedrockRoute::ConverseLike,
+        ),
+        ("agent/my-agent-id", BedrockRoute::Agent),
+        ("agentcore/my-runtime", BedrockRoute::AgentCore),
+        (
+            "async_invoke/amazon.nova-lite-v1:0",
+            BedrockRoute::AsyncInvoke,
+        ),
+        ("openai/openai.gpt-oss-20b-1:0", BedrockRoute::OpenAi),
+        (
+            "claude_platform/anthropic.claude-sonnet-4-5-20250929-v1:0",
+            BedrockRoute::ClaudePlatform,
+        ),
+        ("mantle/anthropic.claude-opus-4-6-v1", BedrockRoute::Mantle),
+    ];
+    for (model, expected) in cases {
+        assert_eq!(select_route(model), expected, "route for {model}");
+    }
+    // A prefix is honoured after a leading `bedrock/` too, because it is matched
+    // as a path segment rather than only at position 0.
+    assert_eq!(
+        select_route("bedrock/invoke/anthropic.claude-sonnet-4-5-20250929-v1:0"),
+        BedrockRoute::Invoke
+    );
+    // ...but the `bedrock_mantle/` *provider* prefix is not the `mantle/` route.
+    assert_ne!(
+        select_route("bedrock_mantle/openai.gpt-oss-20b-1:0"),
+        BedrockRoute::Mantle
+    );
+}
+
+#[test]
+fn application_inference_profile_arns_route_to_converse() {
+    // The ARN ends in an opaque id with no provider substring, so it is not in
+    // the converse table and only the dedicated branch can route it.
+    let arn =
+        "arn:aws:bedrock:eu-central-1:123456789012:application-inference-profile/ab12cd34ef56";
+    assert!(
+        !BEDROCK_CONVERSE_MODELS.contains(&base_model(arn).as_str()),
+        "the opaque profile id must not be table-resolvable, or this test is vacuous",
+    );
+    assert_eq!(select_route(arn), BedrockRoute::Converse);
+}
+
+#[test]
+fn models_outside_the_converse_table_route_to_invoke() {
+    assert_eq!(
+        select_route("cohere.command-text-v14"),
+        BedrockRoute::Invoke
+    );
+    assert_eq!(
+        select_route("amazon.titan-text-express-v1"),
+        BedrockRoute::Invoke
+    );
+}
+
+/// Plan §1.4.2: "the URL carries the **original** id, prefix included —
+/// normalisation feeds the routing decision only, never the request path."
+#[test]
+fn the_request_url_keeps_the_un_normalised_id() {
+    let endpoint = "https://bedrock-runtime.eu-central-1.amazonaws.com";
+    let url = converse_url(endpoint, "eu.anthropic.claude-sonnet-4-5-20250929-v1:0");
+
+    assert_eq!(
+        url,
+        "https://bedrock-runtime.eu-central-1.amazonaws.com\
+         /model/eu.anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse"
+    );
+    assert!(
+        url.contains("/model/eu.anthropic."),
+        "the cross-region prefix must survive into the URL: {url}",
+    );
+    assert!(
+        !url.contains("/model/anthropic."),
+        "the URL must NOT carry the normalised id: {url}",
+    );
+
+    // An ARN survives whole, as a single percent-encoded path segment.
+    let arn = "arn:aws:bedrock:eu-central-1:123456789012:application-inference-profile/ab12cd34";
+    let arn_url = converse_url(endpoint, arn);
+    assert!(
+        arn_url.ends_with(
+            "/model/arn%3Aaws%3Abedrock%3Aeu-central-1%3A123456789012\
+             %3Aapplication-inference-profile%2Fab12cd34/converse"
+        ),
+        "{arn_url}",
+    );
+}

--- a/crates/llm/tests/bedrock_model_id_normalisation.rs
+++ b/crates/llm/tests/bedrock_model_id_normalisation.rs
@@ -13,11 +13,12 @@
     reason = "integration test code: panics are acceptable"
 )]
 
+use cognee_llm::adapters::bedrock::caps::MODEL_CAPS;
 use cognee_llm::adapters::bedrock::converse::converse_url;
 use cognee_llm::adapters::bedrock::model_id::{
     CROSS_REGION_PREFIXES, NOVA_2_CUSTOM_BASE_MODEL, NOVA_CUSTOM_BASE_MODEL, base_model,
     extract_model_name_from_arn, strip_context_window_suffix, strip_cross_region_prefix,
-    strip_routing_prefix, strip_throughput_suffix,
+    strip_routing_prefix, strip_throughput_suffix, wire_model_id,
 };
 use cognee_llm::adapters::bedrock::route::{BEDROCK_CONVERSE_MODELS, BedrockRoute, select_route};
 
@@ -274,5 +275,90 @@ fn the_request_url_keeps_the_un_normalised_id() {
              %3Aapplication-inference-profile%2Fab12cd34/converse"
         ),
         "{arn_url}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Table drift and wire-id stripping — the two model-id defects found in review.
+// ---------------------------------------------------------------------------
+
+/// Every model with a capability row must be routable to Converse.
+///
+/// The defect this catches: `MODEL_CAPS` gained rows for models missing from
+/// the converse tables, so `BedrockAdapter::new` rejected them at construction
+/// with a message asserting they were invoke-only — while litellm routed them
+/// to Converse. The caps rows were simultaneously dead code.
+#[test]
+fn every_capability_row_routes_to_converse() {
+    for (model, _caps) in MODEL_CAPS {
+        assert_eq!(
+            select_route(model),
+            BedrockRoute::Converse,
+            "`{model}` has a MODEL_CAPS row but does not route to Converse — \
+             either add it to a converse table or drop the caps row",
+        );
+    }
+}
+
+/// litellm extends its static constant with the pricing file at import time, so
+/// the static table alone is only half the set. Both halves must be consulted.
+#[test]
+fn the_derived_converse_table_covers_the_pricing_file_models() {
+    for model in [
+        "amazon.nova-micro-v1:0",
+        "anthropic.claude-opus-4-5-20251101-v1:0",
+        "meta.llama3-3-70b-instruct-v1:0",
+        "zai.glm-5",
+    ] {
+        assert!(
+            !BEDROCK_CONVERSE_MODELS.contains(&model),
+            "`{model}` is expected to come from the derived table, not the \
+             verbatim constant — this test is asserting the wrong thing",
+        );
+        assert_eq!(
+            select_route(model),
+            BedrockRoute::Converse,
+            "`{model}` is bedrock_converse in the pricing file and must route \
+             to Converse",
+        );
+        // The cross-region form must work too — that is §1.4.1's whole point.
+        assert_eq!(select_route(&format!("eu.{model}")), BedrockRoute::Converse);
+    }
+}
+
+/// Routing tokens are configuration syntax and must not reach the wire.
+///
+/// The defect this catches: `bedrock/…` routed and constructed fine, then 400ed
+/// on every request against `/model/bedrock%2F…/converse`.
+#[test]
+fn routing_tokens_are_stripped_from_the_url_but_real_id_parts_survive() {
+    let endpoint = "https://bedrock-runtime.eu-central-1.amazonaws.com";
+
+    for configured in [
+        "bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "converse/eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "bedrock/converse/eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    ] {
+        let url = converse_url(endpoint, configured);
+        assert!(
+            !url.contains("bedrock%2F") && !url.contains("converse%2F"),
+            "routing token leaked into the URL for `{configured}`: {url}",
+        );
+        assert!(
+            url.contains("/model/eu.anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse"),
+            "the real id must survive intact for `{configured}`: {url}",
+        );
+    }
+
+    // `nova/` is a custom-model spec, not a routing token: it stays.
+    assert!(
+        converse_url(endpoint, "nova/my-custom-model").contains("/model/nova%2Fmy-custom-model/"),
+        "the nova/ spec prefix must survive into the URL",
+    );
+
+    // A cross-region prefix and an ARN are part of the identifier: unchanged.
+    assert_eq!(
+        wire_model_id("eu.amazon.nova-lite-v1:0"),
+        "eu.amazon.nova-lite-v1:0",
     );
 }

--- a/crates/llm/tests/bedrock_model_id_normalisation.rs
+++ b/crates/llm/tests/bedrock_model_id_normalisation.rs
@@ -350,13 +350,25 @@ fn routing_tokens_are_stripped_from_the_url_but_real_id_parts_survive() {
         );
     }
 
-    // `nova/` is a custom-model spec, not a routing token: it stays.
-    assert!(
-        converse_url(endpoint, "nova/my-custom-model").contains("/model/nova%2Fmy-custom-model/"),
-        "the nova/ spec prefix must survive into the URL",
-    );
+    // The `nova/` custom-model spec prefix comes off too: litellm removes it
+    // from the id it encodes into the path (`converse_handler.py:293-296`).
+    for (configured, expected) in [
+        ("nova/my-custom-model", "/model/my-custom-model/converse"),
+        ("nova-2/my-custom-model", "/model/my-custom-model/converse"),
+        (
+            "bedrock/nova/my-custom-model",
+            "/model/my-custom-model/converse",
+        ),
+    ] {
+        let url = converse_url(endpoint, configured);
+        assert!(
+            url.ends_with(expected),
+            "the nova spec prefix must be stripped for `{configured}`: {url}",
+        );
+    }
 
     // A cross-region prefix and an ARN are part of the identifier: unchanged.
+    // `nova-lite` only *contains* "nova"; nothing is stripped from it.
     assert_eq!(
         wire_model_id("eu.amazon.nova-lite-v1:0"),
         "eu.amazon.nova-lite-v1:0",

--- a/crates/llm/tests/bedrock_region_endpoint.rs
+++ b/crates/llm/tests/bedrock_region_endpoint.rs
@@ -1,0 +1,295 @@
+//! The §1.3 region and runtime-endpoint chains.
+//!
+//! Both ambient sources (the environment and `aws-config`'s default region
+//! chain) are injected, so the tests assert the *chain* rather than whatever
+//! the machine running them happens to have in `~/.aws/config`.
+#![cfg(feature = "bedrock")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+
+use async_trait::async_trait;
+use cognee_llm::adapters::bedrock::aws::endpoint::resolve_endpoint;
+use cognee_llm::adapters::bedrock::aws::env::{AwsInputs, AwsSettings, EnvSource};
+use cognee_llm::adapters::bedrock::aws::region::{
+    AmbientRegion, DEFAULT_AWS_REGION, region_from_model_arn, resolve_region_with,
+};
+use cognee_llm::error::LlmError;
+
+const MODEL_ARN: &str =
+    "arn:aws:bedrock:ap-southeast-2:123456789012:inference-profile/apac.amazon.nova-lite-v1:0";
+
+/// Stand-in for `boto3.Session().region_name`.
+struct FixedAmbientRegion(Option<&'static str>);
+
+#[async_trait]
+impl AmbientRegion for FixedAmbientRegion {
+    async fn region(&self, _profile_name: Option<&str>) -> Option<String> {
+        self.0.map(str::to_string)
+    }
+}
+
+/// Records the profile name the chain asked about.
+struct ProfileRecordingRegion(std::sync::Mutex<Option<String>>);
+
+#[async_trait]
+impl AmbientRegion for ProfileRecordingRegion {
+    async fn region(&self, profile_name: Option<&str>) -> Option<String> {
+        // lock poison is unrecoverable
+        *self.0.lock().unwrap() = profile_name.map(str::to_string);
+        Some("sa-east-1".to_string())
+    }
+}
+
+fn env_of(pairs: &[(&'static str, &'static str)]) -> impl EnvSource + use<> {
+    let owned: Vec<(String, String)> = pairs
+        .iter()
+        .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+        .collect();
+    move |key: &str| {
+        owned
+            .iter()
+            .find(|(name, _)| name == key)
+            .map(|(_, value)| value.to_string())
+    }
+}
+
+fn settings(region: Option<&str>, env: &[(&'static str, &'static str)]) -> AwsSettings {
+    AwsInputs {
+        region: region.map(str::to_string),
+        ..AwsInputs::default()
+    }
+    .resolve_with(&env_of(env))
+}
+
+async fn region_of(
+    settings: &AwsSettings,
+    model: Option<&str>,
+    env: &[(&'static str, &'static str)],
+    ambient: Option<&'static str>,
+) -> String {
+    resolve_region_with(settings, model, &env_of(env), &FixedAmbientRegion(ambient))
+        .await
+        .expect("region resolves")
+}
+
+#[tokio::test]
+async fn the_parameter_outranks_every_other_rung() {
+    let settings = settings(Some("us-east-2"), &[]);
+
+    assert_eq!(
+        region_of(
+            &settings,
+            Some(MODEL_ARN),
+            &[
+                ("AWS_REGION_NAME", "eu-west-1"),
+                ("AWS_REGION", "eu-west-2")
+            ],
+            Some("eu-west-3"),
+        )
+        .await,
+        "us-east-2"
+    );
+}
+
+/// The rung that is easy to invert: a region inside a model ARN beats
+/// `AWS_REGION_NAME`.
+#[tokio::test]
+async fn a_model_arn_outranks_aws_region_name() {
+    let settings = settings(None, &[("AWS_REGION_NAME", "eu-west-1")]);
+
+    assert_eq!(
+        region_of(
+            &settings,
+            Some(MODEL_ARN),
+            &[("AWS_REGION_NAME", "eu-west-1")],
+            Some("eu-west-3"),
+        )
+        .await,
+        "ap-southeast-2"
+    );
+}
+
+#[tokio::test]
+async fn aws_region_name_outranks_aws_region() {
+    let settings = settings(None, &[]);
+
+    assert_eq!(
+        region_of(
+            &settings,
+            Some("anthropic.claude-haiku-4-5-20251001-v1:0"),
+            &[
+                ("AWS_REGION_NAME", "eu-west-1"),
+                ("AWS_REGION", "eu-west-2")
+            ],
+            Some("eu-west-3"),
+        )
+        .await,
+        "eu-west-1"
+    );
+}
+
+#[tokio::test]
+async fn aws_region_is_used_when_aws_region_name_is_absent() {
+    let settings = settings(None, &[]);
+
+    assert_eq!(
+        region_of(
+            &settings,
+            None,
+            &[("AWS_REGION", "eu-west-2")],
+            Some("eu-west-3")
+        )
+        .await,
+        "eu-west-2"
+    );
+}
+
+#[tokio::test]
+async fn the_ambient_chain_is_used_when_nothing_is_configured() {
+    let settings = settings(None, &[]);
+
+    assert_eq!(
+        region_of(&settings, None, &[], Some("eu-west-3")).await,
+        "eu-west-3"
+    );
+}
+
+/// litellm's hard default (`base_aws_llm.py:598`).
+#[tokio::test]
+async fn the_hard_default_is_us_west_2() {
+    let settings = settings(None, &[]);
+
+    assert_eq!(region_of(&settings, None, &[], None).await, "us-west-2");
+    assert_eq!(DEFAULT_AWS_REGION, "us-west-2");
+}
+
+#[tokio::test]
+async fn an_empty_ambient_region_still_falls_back_to_the_hard_default() {
+    let settings = settings(None, &[]);
+
+    assert_eq!(
+        region_of(&settings, None, &[], Some("   ")).await,
+        "us-west-2"
+    );
+}
+
+#[tokio::test]
+async fn a_blank_env_region_does_not_shadow_the_next_rung() {
+    let settings = settings(None, &[]);
+
+    assert_eq!(
+        region_of(
+            &settings,
+            None,
+            &[("AWS_REGION_NAME", "  "), ("AWS_REGION", "eu-west-2")],
+            None,
+        )
+        .await,
+        "eu-west-2"
+    );
+}
+
+#[tokio::test]
+async fn the_ambient_chain_is_asked_about_the_configured_profile() {
+    let settings = settings(None, &[("AWS_PROFILE_NAME", "bedrock-profile")]);
+    let ambient = ProfileRecordingRegion(std::sync::Mutex::new(None));
+
+    let region = resolve_region_with(&settings, None, &env_of(&[]), &ambient)
+        .await
+        .expect("region resolves");
+
+    assert_eq!(region, "sa-east-1");
+    // lock poison is unrecoverable
+    assert_eq!(
+        ambient.0.lock().unwrap().as_deref(),
+        Some("bedrock-profile")
+    );
+}
+
+#[tokio::test]
+async fn a_malformed_region_parameter_is_a_config_error() {
+    let settings = settings(Some("US-East-1"), &[]);
+
+    let error = resolve_region_with(&settings, None, &env_of(&[]), &FixedAmbientRegion(None))
+        .await
+        .expect_err("an invalid region must not be accepted");
+
+    assert!(matches!(error, LlmError::ConfigError(_)), "{error:?}");
+}
+
+#[tokio::test]
+async fn a_malformed_env_region_is_rejected_by_the_final_validation() {
+    let settings = settings(None, &[]);
+
+    let error = resolve_region_with(
+        &settings,
+        None,
+        &env_of(&[("AWS_REGION_NAME", "not a region")]),
+        &FixedAmbientRegion(None),
+    )
+    .await
+    .expect_err("an invalid region must not be accepted");
+
+    assert!(matches!(error, LlmError::ConfigError(_)), "{error:?}");
+}
+
+#[test]
+fn a_non_arn_model_id_contributes_no_region() {
+    assert_eq!(
+        region_from_model_arn("eu.anthropic.claude-sonnet-4-5-20250929-v1:0"),
+        None
+    );
+    assert_eq!(region_from_model_arn(MODEL_ARN), Some("ap-southeast-2"));
+}
+
+#[test]
+fn the_endpoint_chain_prefers_api_base_then_settings_then_the_regional_default() {
+    let with_endpoint = settings(
+        None,
+        &[("AWS_BEDROCK_RUNTIME_ENDPOINT", "https://from-env")],
+    );
+
+    assert_eq!(
+        resolve_endpoint(Some("https://from-api-base"), &with_endpoint, "us-east-1"),
+        "https://from-api-base"
+    );
+    assert_eq!(
+        resolve_endpoint(None, &with_endpoint, "us-east-1"),
+        "https://from-env"
+    );
+    assert_eq!(
+        resolve_endpoint(None, &settings(None, &[]), "us-east-1"),
+        "https://bedrock-runtime.us-east-1.amazonaws.com"
+    );
+}
+
+#[test]
+fn an_endpoint_parameter_outranks_the_endpoint_environment_variable() {
+    let settings = AwsInputs {
+        bedrock_runtime_endpoint: Some("https://from-param".to_string()),
+        ..AwsInputs::default()
+    }
+    .resolve_with(&env_of(&[(
+        "AWS_BEDROCK_RUNTIME_ENDPOINT",
+        "https://from-env",
+    )]));
+
+    assert_eq!(
+        resolve_endpoint(None, &settings, "us-east-1"),
+        "https://from-param"
+    );
+}
+
+#[tokio::test]
+async fn the_endpoint_default_follows_the_resolved_region() {
+    let settings = settings(None, &[]);
+    let region = region_of(&settings, Some(MODEL_ARN), &[], None).await;
+
+    assert_eq!(
+        resolve_endpoint(None, &settings, &region),
+        "https://bedrock-runtime.ap-southeast-2.amazonaws.com"
+    );
+}

--- a/crates/llm/tests/bedrock_sigv4_golden.rs
+++ b/crates/llm/tests/bedrock_sigv4_golden.rs
@@ -1,0 +1,354 @@
+//! SigV4 golden vectors for the Bedrock signer.
+//!
+//! The expected signatures are **not** recorded from this implementation. They
+//! were computed from the AWS SigV4 specification with an independent
+//! HMAC-SHA256 script, which was first validated against the published
+//! `aws-sig-v4-test-suite` `get-vanilla` vector (`AKIDEXAMPLE` /
+//! `wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY`, `20150830T123600Z`,
+//! `us-east-1`, service `service`, expected signature
+//! `5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31`) before
+//! being re-run for service `bedrock`. A regression in canonicalisation,
+//! header filtering or the signing key derivation therefore fails these tests
+//! instead of quietly agreeing with itself.
+#![cfg(feature = "bedrock")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use cognee_llm::adapters::bedrock::aws::credentials::AwsCredentials;
+use cognee_llm::adapters::bedrock::aws::signer::{
+    BEDROCK_SIGNING_SERVICE, SIGV4_AUTHORIZATION_PREFIX, filter_headers_for_aws_signature,
+    sign_request,
+};
+
+/// `20150830T123600Z`, the timestamp of the published test-suite vectors.
+const SIGNING_EPOCH_SECONDS: u64 = 1_440_938_160;
+const ACCESS_KEY_ID: &str = "AKIDEXAMPLE";
+const SECRET_ACCESS_KEY: &str = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+const URL: &str = "https://bedrock-runtime.us-east-1.amazonaws.com/model/test-model/converse";
+const BODY: &[u8] = br#"{"messages":[]}"#;
+const REGION: &str = "us-east-1";
+
+/// Independently computed: signed headers `content-type;host;x-amz-date`.
+const GOLDEN_SIGNATURE: &str = "0611ae6836657f6bbf1c486af29ce1d33875ac2ef36ba01bb92c7489129ec8c8";
+/// Same request plus `x-amz-security-token: SESSIONTOKEN123`.
+const GOLDEN_SIGNATURE_WITH_SESSION_TOKEN: &str =
+    "2439791548d7af89dadd1a02fd00bb13d7106e10ba230035de6d2cee1b4f3505";
+
+fn signing_time() -> SystemTime {
+    UNIX_EPOCH + Duration::from_secs(SIGNING_EPOCH_SECONDS)
+}
+
+fn credentials(session_token: Option<&str>) -> AwsCredentials {
+    AwsCredentials::new(
+        ACCESS_KEY_ID,
+        SECRET_ACCESS_KEY,
+        session_token.map(str::to_string),
+        None,
+        "golden-vector",
+    )
+}
+
+fn request_with_headers(headers: &[(&str, &str)]) -> reqwest::Request {
+    let mut builder = reqwest::Client::new().post(URL).body(BODY.to_vec());
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    builder.build().expect("build the signable request")
+}
+
+#[test]
+fn signature_matches_the_reference_vector() {
+    let mut request = request_with_headers(&[("content-type", "application/json")]);
+
+    let signature = sign_request(
+        &mut request,
+        BODY,
+        &credentials(None),
+        REGION,
+        signing_time(),
+    )
+    .expect("sign the request");
+
+    assert_eq!(signature, GOLDEN_SIGNATURE);
+
+    let authorization = request
+        .headers()
+        .get("authorization")
+        .expect("the signer set an Authorization header")
+        .to_str()
+        .expect("ASCII header");
+    assert_eq!(
+        authorization,
+        format!(
+            "{SIGV4_AUTHORIZATION_PREFIX} \
+             Credential={ACCESS_KEY_ID}/20150830/{REGION}/{BEDROCK_SIGNING_SERVICE}/aws4_request, \
+             SignedHeaders=content-type;host;x-amz-date, Signature={GOLDEN_SIGNATURE}"
+        )
+    );
+    assert_eq!(
+        request
+            .headers()
+            .get("x-amz-date")
+            .and_then(|value| value.to_str().ok()),
+        Some("20150830T123600Z")
+    );
+}
+
+#[test]
+fn signature_matches_the_reference_vector_with_a_session_token() {
+    let mut request = request_with_headers(&[("content-type", "application/json")]);
+
+    let signature = sign_request(
+        &mut request,
+        BODY,
+        &credentials(Some("SESSIONTOKEN123")),
+        REGION,
+        signing_time(),
+    )
+    .expect("sign the request");
+
+    assert_eq!(signature, GOLDEN_SIGNATURE_WITH_SESSION_TOKEN);
+    assert_ne!(
+        signature, GOLDEN_SIGNATURE,
+        "the session token must take part in the signature"
+    );
+    assert_eq!(
+        request
+            .headers()
+            .get("x-amz-security-token")
+            .and_then(|value| value.to_str().ok()),
+        Some("SESSIONTOKEN123")
+    );
+    let authorization = request
+        .headers()
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .expect("Authorization header");
+    assert!(
+        authorization.contains("SignedHeaders=content-type;host;x-amz-date;x-amz-security-token"),
+        "unexpected signed header set: {authorization}"
+    );
+}
+
+#[test]
+fn the_signer_defaults_content_type_so_it_is_signed() {
+    let mut request = request_with_headers(&[]);
+
+    let signature = sign_request(
+        &mut request,
+        BODY,
+        &credentials(None),
+        REGION,
+        signing_time(),
+    )
+    .expect("sign the request");
+
+    assert_eq!(
+        signature, GOLDEN_SIGNATURE,
+        "a defaulted Content-Type must land inside the canonical request"
+    );
+    assert_eq!(
+        request
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("application/json")
+    );
+}
+
+#[test]
+fn forwarded_headers_are_excluded_from_the_signature_but_still_sent() {
+    let mut request = request_with_headers(&[
+        ("content-type", "application/json"),
+        ("x-forwarded-for", "10.0.0.1"),
+        ("x-request-id", "abc-123"),
+    ]);
+
+    let signature = sign_request(
+        &mut request,
+        BODY,
+        &credentials(None),
+        REGION,
+        signing_time(),
+    )
+    .expect("sign the request");
+
+    assert_eq!(
+        signature, GOLDEN_SIGNATURE,
+        "unsigned forwarded headers must not change the signature"
+    );
+    assert_eq!(
+        request
+            .headers()
+            .get("x-forwarded-for")
+            .and_then(|value| value.to_str().ok()),
+        Some("10.0.0.1"),
+        "unsigned headers are re-applied after signing"
+    );
+    assert_eq!(
+        request
+            .headers()
+            .get("x-request-id")
+            .and_then(|value| value.to_str().ok()),
+        Some("abc-123")
+    );
+}
+
+#[test]
+fn an_x_amz_header_does_change_the_signature() {
+    let mut request = request_with_headers(&[
+        ("content-type", "application/json"),
+        ("x-amz-target", "Converse"),
+    ]);
+
+    let signature = sign_request(
+        &mut request,
+        BODY,
+        &credentials(None),
+        REGION,
+        signing_time(),
+    )
+    .expect("sign the request");
+
+    assert_ne!(
+        signature, GOLDEN_SIGNATURE,
+        "x-amz-* headers are part of the signed subset"
+    );
+}
+
+#[test]
+fn an_explicit_non_sigv4_authorization_header_is_never_overwritten() {
+    let mut request = request_with_headers(&[
+        ("content-type", "application/json"),
+        ("authorization", "Bearer caller-supplied"),
+    ]);
+
+    sign_request(
+        &mut request,
+        BODY,
+        &credentials(None),
+        REGION,
+        signing_time(),
+    )
+    .expect("sign the request");
+
+    assert_eq!(
+        request
+            .headers()
+            .get("authorization")
+            .and_then(|value| value.to_str().ok()),
+        Some("Bearer caller-supplied")
+    );
+}
+
+#[test]
+fn a_previous_sigv4_authorization_header_is_replaced() {
+    let mut request = request_with_headers(&[
+        ("content-type", "application/json"),
+        (
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=stale/20150830/us-east-1/bedrock/aws4_request",
+        ),
+    ]);
+
+    sign_request(
+        &mut request,
+        BODY,
+        &credentials(None),
+        REGION,
+        signing_time(),
+    )
+    .expect("sign the request");
+
+    let authorization = request
+        .headers()
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .expect("Authorization header");
+    assert!(authorization.contains(GOLDEN_SIGNATURE), "{authorization}");
+}
+
+#[test]
+fn the_signature_is_time_dependent() {
+    let mut request = request_with_headers(&[("content-type", "application/json")]);
+
+    let signature = sign_request(
+        &mut request,
+        BODY,
+        &credentials(None),
+        REGION,
+        signing_time() + Duration::from_secs(60),
+    )
+    .expect("sign the request");
+
+    assert_ne!(signature, GOLDEN_SIGNATURE);
+}
+
+#[test]
+fn the_signature_is_region_dependent() {
+    let mut request = request_with_headers(&[("content-type", "application/json")]);
+
+    let signature = sign_request(
+        &mut request,
+        BODY,
+        &credentials(None),
+        "eu-central-1",
+        signing_time(),
+    )
+    .expect("sign the request");
+
+    assert_ne!(signature, GOLDEN_SIGNATURE);
+}
+
+#[test]
+fn the_signature_covers_the_body() {
+    let mut request = request_with_headers(&[("content-type", "application/json")]);
+
+    let signature = sign_request(
+        &mut request,
+        br#"{"messages":[{"role":"user"}]}"#,
+        &credentials(None),
+        REGION,
+        signing_time(),
+    )
+    .expect("sign the request");
+
+    assert_ne!(signature, GOLDEN_SIGNATURE);
+}
+
+#[test]
+fn the_filter_matches_litellms_allowlist() {
+    let request = request_with_headers(&[
+        ("content-type", "application/json"),
+        ("host", "bedrock-runtime.us-east-1.amazonaws.com"),
+        ("date", "Sun, 30 Aug 2015 12:36:00 GMT"),
+        ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
+        ("x-amzn-bedrock-guardrail", "on"),
+        ("x-forwarded-proto", "https"),
+        ("user-agent", "cognee"),
+        ("accept", "application/json"),
+    ]);
+
+    let filtered = filter_headers_for_aws_signature(request.headers());
+
+    for kept in [
+        "content-type",
+        "host",
+        "date",
+        "x-amz-content-sha256",
+        "x-amzn-bedrock-guardrail",
+    ] {
+        assert!(filtered.contains_key(kept), "{kept} should be signed");
+    }
+    for dropped in ["x-forwarded-proto", "user-agent", "accept"] {
+        assert!(
+            !filtered.contains_key(dropped),
+            "{dropped} should not be signed"
+        );
+    }
+}

--- a/crates/llm/tests/bedrock_structured_output.rs
+++ b/crates/llm/tests/bedrock_structured_output.rs
@@ -1,0 +1,267 @@
+//! §1.4.3 structured output: the branch is chosen from the capability table,
+//! never hard-coded.
+//!
+//! The plan is explicit that the forced `json_tool_call` tool is the
+//! **fallback**, not the primary: "an R3 that implements only the forced tool
+//! diverges from Python on all three defaults — and, since Nova is documented
+//! to reject a specific `toolChoice`, may 400 outright on nova-lite."
+#![cfg(feature = "bedrock")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+
+use cognee_llm::adapters::bedrock::caps::{UNKNOWN_MODEL_CAPS, caps_for};
+use cognee_llm::adapters::bedrock::converse::{
+    ConverseResponse, RESPONSE_FORMAT_TOOL_NAME, apply_structured_output, corrective_instruction,
+    force_additional_properties_false,
+};
+use serde_json::{Value, json};
+
+const SONNET: &str = "eu.anthropic.claude-sonnet-4-5-20250929-v1:0";
+const HAIKU: &str = "eu.anthropic.claude-haiku-4-5-20251001-v1:0";
+const NOVA_LITE: &str = "eu.amazon.nova-lite-v1:0";
+/// Advertises `supports_tool_choice` but **not** native structured output — the
+/// only combination that produces a forced `toolChoice`.
+const TOOL_CHOICE_ONLY: &str = "eu.anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+fn schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "friends": {
+                "type": "array",
+                "items": { "type": "object", "properties": { "name": { "type": "string" } } }
+            }
+        },
+        "required": ["name"]
+    })
+}
+
+fn structured_body(model: &str) -> Value {
+    let mut body = json!({ "messages": [], "inferenceConfig": { "maxTokens": 1024 } });
+    apply_structured_output(&mut body, &schema(), &caps_for(model));
+    body
+}
+
+#[test]
+fn both_shipped_anthropic_models_take_the_native_output_config_branch() {
+    for model in [SONNET, HAIKU] {
+        let caps = caps_for(model);
+        assert!(
+            caps.supports_native_structured_output,
+            "{model} must advertise native structured output",
+        );
+
+        let body = structured_body(model);
+        assert_eq!(
+            body["outputConfig"]["textFormat"]["type"], "json_schema",
+            "{model} must use outputConfig.textFormat",
+        );
+        assert!(
+            body.get("toolConfig").is_none(),
+            "{model} must NOT fall back to the synthetic tool",
+        );
+
+        // The schema travels as a JSON string inside the text format.
+        let embedded = body["outputConfig"]["textFormat"]["structure"]["jsonSchema"]["schema"]
+            .as_str()
+            .expect("the schema is embedded as a JSON string");
+        let parsed: Value = serde_json::from_str(embedded).unwrap();
+        assert_eq!(parsed["properties"]["name"]["type"], "string");
+        assert!(
+            parsed.get("$schema").is_none(),
+            "the `$schema` meta key is not expected by Bedrock",
+        );
+    }
+}
+
+/// The case plan §1.4.3 says a naive port breaks.
+#[test]
+fn nova_lite_takes_the_json_tool_call_branch_without_a_forced_tool_choice() {
+    let caps = caps_for(NOVA_LITE);
+    assert!(!caps.supports_native_structured_output);
+    assert!(
+        !caps.supports_tool_choice,
+        "nova-lite does not advertise supports_tool_choice and is documented to \
+         400 on a specific toolChoice",
+    );
+
+    let body = structured_body(NOVA_LITE);
+    assert!(
+        body.get("outputConfig").is_none(),
+        "nova-lite has no native structured output",
+    );
+    assert_eq!(
+        body["toolConfig"]["tools"][0]["toolSpec"]["name"],
+        RESPONSE_FORMAT_TOOL_NAME
+    );
+    // The tool's input schema IS the response schema.
+    assert_eq!(
+        body["toolConfig"]["tools"][0]["toolSpec"]["inputSchema"]["json"]["properties"]["name"]["type"],
+        "string"
+    );
+    assert!(
+        body["toolConfig"].get("toolChoice").is_none(),
+        "toolChoice must NOT be forced for nova-lite: {}",
+        body["toolConfig"],
+    );
+}
+
+#[test]
+fn a_model_advertising_tool_choice_gets_the_forced_tool_choice() {
+    let caps = caps_for(TOOL_CHOICE_ONLY);
+    assert!(!caps.supports_native_structured_output);
+    assert!(caps.supports_tool_choice);
+
+    let body = structured_body(TOOL_CHOICE_ONLY);
+    assert_eq!(
+        body["toolConfig"]["toolChoice"]["tool"]["name"],
+        RESPONSE_FORMAT_TOOL_NAME
+    );
+}
+
+#[test]
+fn an_unknown_model_takes_the_conservative_default_branch() {
+    let caps = caps_for("eu.acme.some-future-model-v9:0");
+    assert_eq!(caps, UNKNOWN_MODEL_CAPS);
+
+    let body = structured_body("eu.acme.some-future-model-v9:0");
+    assert!(
+        body.get("outputConfig").is_none(),
+        "an unlisted model must not be assumed to support native structured output",
+    );
+    assert_eq!(
+        body["toolConfig"]["tools"][0]["toolSpec"]["name"],
+        RESPONSE_FORMAT_TOOL_NAME
+    );
+    assert!(
+        body["toolConfig"].get("toolChoice").is_none(),
+        "an unlisted model must not be assumed to accept a forced toolChoice",
+    );
+}
+
+#[test]
+fn the_native_branch_forces_additional_properties_false_on_every_object_node() {
+    let forced = force_additional_properties_false(&json!({
+        "type": "object",
+        "properties": {
+            "nested": { "type": "object", "properties": {} },
+            "list": { "type": "array", "items": { "type": "object", "properties": {} } }
+        },
+        "$defs": { "Extra": { "type": "object", "properties": {} } },
+        "anyOf": [{ "type": "object", "properties": {} }]
+    }));
+
+    assert_eq!(forced["additionalProperties"], json!(false));
+    assert_eq!(
+        forced["properties"]["nested"]["additionalProperties"],
+        json!(false)
+    );
+    assert_eq!(
+        forced["properties"]["list"]["items"]["additionalProperties"],
+        json!(false)
+    );
+    assert_eq!(
+        forced["$defs"]["Extra"]["additionalProperties"],
+        json!(false)
+    );
+    assert_eq!(forced["anyOf"][0]["additionalProperties"], json!(false));
+    // A non-object node is untouched.
+    assert!(
+        forced["properties"]["list"]
+            .get("additionalProperties")
+            .is_none(),
+        "an array node must not get additionalProperties",
+    );
+
+    // ...and an explicit `true` set by the caller is respected, not overwritten.
+    let explicit = force_additional_properties_false(
+        &json!({ "type": "object", "additionalProperties": true }),
+    );
+    assert_eq!(explicit["additionalProperties"], json!(true));
+}
+
+#[test]
+fn the_payload_is_unwrapped_from_the_branch_that_produced_it() {
+    // Native branch: the object comes back as text and is parsed as JSON.
+    let native: ConverseResponse = serde_json::from_value(json!({
+        "output": { "message": { "content": [{ "text": "{\"name\":\"Ada\"}" }] } },
+        "stopReason": "end_turn"
+    }))
+    .unwrap();
+    let payload = native
+        .structured_payload(&caps_for(SONNET))
+        .expect("native text output parses as JSON");
+    assert_eq!(payload["name"], "Ada");
+
+    // Fallback branch: the object is the tool input.
+    let tool_use: ConverseResponse = serde_json::from_value(json!({
+        "output": { "message": { "content": [
+            { "text": "ignored preamble" },
+            { "toolUse": {
+                "toolUseId": "tu_1",
+                "name": RESPONSE_FORMAT_TOOL_NAME,
+                "input": { "name": "Grace" }
+            }}
+        ]}},
+        "stopReason": "tool_use"
+    }))
+    .unwrap();
+    let payload = tool_use
+        .structured_payload(&caps_for(NOVA_LITE))
+        .expect("the toolUse input is the payload");
+    assert_eq!(payload["name"], "Grace");
+
+    // Each branch only reads its own shape: a tool-only response yields nothing
+    // for a native model, and vice versa. That mismatch is what drives the
+    // repair loop's corrective re-ask.
+    assert!(tool_use.structured_payload(&caps_for(SONNET)).is_none());
+    assert!(native.structured_payload(&caps_for(NOVA_LITE)).is_none());
+}
+
+#[test]
+fn truncation_is_reported_from_the_converse_stop_reason() {
+    let truncated: ConverseResponse = serde_json::from_value(json!({
+        "output": { "message": { "content": [{ "text": "{\"name\":\"Ad" }] } },
+        "stopReason": "max_tokens"
+    }))
+    .unwrap();
+    assert!(truncated.is_truncated());
+
+    let complete: ConverseResponse = serde_json::from_value(json!({
+        "output": { "message": { "content": [{ "text": "{}" }] } },
+        "stopReason": "end_turn"
+    }))
+    .unwrap();
+    assert!(!complete.is_truncated());
+}
+
+/// The corrective re-ask must address the branch that actually failed: on the
+/// native branch there is no tool to call, so telling the model to call one
+/// would be actively misleading — and that is the branch both shipped Anthropic
+/// models take.
+#[test]
+fn the_corrective_re_ask_matches_the_branch_that_failed() {
+    let reason = Some("missing required field `name`");
+
+    let native = corrective_instruction(reason, true);
+    assert!(
+        native.contains("missing required field `name`"),
+        "the failure reason is surfaced verbatim: {native}",
+    );
+    assert!(
+        !native.contains(RESPONSE_FORMAT_TOOL_NAME),
+        "the native branch has no tool to call: {native}",
+    );
+
+    let fallback = corrective_instruction(reason, false);
+    assert!(
+        fallback.contains(RESPONSE_FORMAT_TOOL_NAME),
+        "the fallback branch re-asks for the synthetic tool: {fallback}",
+    );
+    assert!(fallback.contains("missing required field `name`"));
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,8 +27,8 @@ cognee-rs/
 │   ├── cognify/                # Full cognify pipeline + memify enrichment pipeline
 │   ├── search/                 # Search pipeline with multiple retrieval strategies
 │   ├── session/                # Session management and session store
-│   ├── embedding/              # Multi-provider embedding engine (ONNX, OpenAI, Ollama, Mock)
-│   ├── llm/                    # LLM provider abstraction (OpenAI-compatible API adapter)
+│   ├── embedding/              # Multi-provider embedding engine (ONNX, OpenAI, Ollama, Bedrock, Mock)
+│   ├── llm/                    # LLM provider abstraction (OpenAI-compatible, Anthropic, Bedrock adapters)
 │   ├── graph/                  # Graph DB abstraction (Ladybug embedded graph)
 │   ├── vector/                 # Vector DB abstraction (LanceDB default; brute-force on Android; pgvector feature-gated)
 │   ├── ontology/               # Ontology resolution (RDF/JSON-LD loader, NoOp resolver)
@@ -78,9 +78,9 @@ cognee-rs/
 
 **cognee-session** — Session management and QA-history storage. Trait: `SessionStore`. Impls: `FsSessionStore`, `RedisSessionStore`, `SeaOrmSessionStore`.
 
-**cognee-embedding** — Text vectorization engine. Trait: `EmbeddingEngine`. Impls: `OnnxEmbeddingEngine` (local ONNX Runtime, BGE-Small-v1.5), `OpenAICompatibleEmbeddingEngine` (OpenAI/Azure/vLLM/llama.cpp/TEI via HTTP), `OllamaEmbeddingEngine`, `MockEmbeddingEngine`. `EmbeddingConfig::from_env()` + `create_engine()` factory select the provider. See [configuration.md](configuration.md#embedding).
+**cognee-embedding** — Text vectorization engine. Trait: `EmbeddingEngine`. Impls: `OnnxEmbeddingEngine` (local ONNX Runtime, BGE-Small-v1.5), `OpenAICompatibleEmbeddingEngine` (OpenAI/Azure/vLLM/llama.cpp/TEI via HTTP), `OllamaEmbeddingEngine`, `BedrockEmbeddingEngine` (AWS Bedrock InvokeModel — Titan + Cohere families, `bedrock` feature), `MockEmbeddingEngine`. `EmbeddingConfig::from_env()` + `create_engine()` factory select the provider. See [configuration.md](configuration.md#embedding).
 
-**cognee-llm** — Async LLM abstraction with structured JSON output. Trait: `Llm` (+ auto-implemented `LlmExt`). Impls: `OpenAIAdapter` (OpenAI-compatible APIs, works with Ollama/vLLM), `MockLlm` (cassette-backed, `testing` feature). The on-device LiteRT adapter lives in the closed `cognee-llm-litert` crate shipped as part of `cognee-cloud-rs` and is not part of OSS.
+**cognee-llm** — Async LLM abstraction with structured JSON output. Trait: `Llm` (+ auto-implemented `LlmExt`). Impls: `OpenAIAdapter` (OpenAI-compatible APIs, works with Ollama/vLLM/Azure), `AnthropicAdapter` (native Messages API), `BedrockAdapter` (AWS Bedrock Converse, `bedrock` feature), `MockLlm` (cassette-backed, `testing` feature). The on-device LiteRT adapter lives in the closed `cognee-llm-litert` crate shipped as part of `cognee-cloud-rs` and is not part of OSS.
 
 **cognee-graph** — Graph database abstraction for knowledge-graph storage and traversal. Trait: `GraphDBTrait` (+ `GraphDBTraitExt`), including the batched `get_neighborhood(ids, depth) -> (nodes, edges)` method that expands a set of seed nodes and returns the **true stored edge direction** (unlike `get_connections`, whose Ladybug impl reports the queried node as the source regardless of stored direction — see `crates/graph/src/traits.rs` and the `get_neighborhood_preserves_edge_direction` test in `crates/graph/src/mock.rs`). Impls: `LadybugAdapter` (embedded Ladybug), `PgGraphAdapter` (feature `postgres`), `MockGraphDB`. Concurrency: Rust matches Python's default single-owning-process model for file-backed Ladybug; cross-process locking is intentionally out of scope (see [roadmap/](roadmap/README.md)).
 
@@ -141,6 +141,7 @@ cognee-rs/
 | `ort` (ONNX Runtime) | Local model inference (embeddings) |
 | `lbug` | Embedded graph database (Ladybug) |
 | `reqwest` (rustls-tls) | HTTP client (URL crawling, LLM/embedding APIs) |
+| `aws-config` / `aws-sigv4` / `aws-credential-types` / `aws-smithy-*` | AWS credential resolution + SigV4 request signing for Bedrock (`bedrock` feature; versions pinned exactly — see the note in the workspace `Cargo.toml`) |
 | `scraper` | HTML parsing for URL ingestion |
 | `sophia` / `sophia_turtle` / `sophia_jsonld` | RDF/OWL ontology parsing |
 | `uuid` (v4, v5) / `sha2` | ID generation / content hashing |
@@ -177,7 +178,7 @@ from `cognee` (the facade) and follow the re-exports.
 | Cognify / memify | `cognee-cognify` | `cognify`, `memify`, `CognifyConfig` |
 | Search | `cognee-search` | `SearchBuilder`, `SearchType`, `HybridRetriever` |
 | Embedding | `cognee-embedding` | `EmbeddingEngine`, `EmbeddingConfig` |
-| LLM | `cognee-llm` | `Llm`, `OpenAIAdapter` |
+| LLM | `cognee-llm` | `Llm`, `OpenAIAdapter`, `AnthropicAdapter`, `BedrockAdapter` |
 | Graph | `cognee-graph` | `GraphDBTrait`, `LadybugAdapter` |
 | Vector | `cognee-vector` | `VectorDB`, `BruteForceVectorDB`, `PgVectorAdapter` |
 | Delete | `cognee-delete` | `DeleteService` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,10 +54,14 @@ benchmark — see [performance/mock-benchmark.md](performance/mock-benchmark.md)
 
 Several providers are OpenAI-compatible HTTP endpoints, so they route through the
 same adapter — differing only in base URL and litellm-style model-prefix stripping.
-`LLM_API_KEY` is required for every provider (matching the Python SDK's
-`_API_KEY_REQUIRED_PROVIDERS`; for a local Ollama any non-empty value works). The
-OpenAI-only request quirks are gated on the `api.openai.com` host, so they never
-fire against another endpoint.
+`LLM_API_KEY` is required for every provider **except `bedrock`** (matching the
+Python SDK, whose `_API_KEY_REQUIRED_PROVIDERS` omits Bedrock and lists it under
+`_NO_API_KEY_PROVIDERS` instead; for a local Ollama any non-empty value works).
+On `bedrock` an unset or empty `LLM_API_KEY` is a supported configuration — it
+falls through to SigV4 signing rather than erroring (see
+[Bedrock](#bedrock-llm_providerbedrock) below). The OpenAI-only request quirks
+are gated on the `api.openai.com` host, so they never fire against another
+endpoint.
 
 | `LLM_PROVIDER` | `LLM_API_KEY` | `LLM_ENDPOINT` default | Model prefix stripped |
 |---|---|---|---|
@@ -70,7 +74,8 @@ fire against another endpoint.
 
 `LLM_ENDPOINT` always overrides the default when set. Audio transcription
 (Whisper) is wired only for `openai` and `custom`/`openai_compatible` (which may
-expose `/audio/transcriptions`); `ollama`/`mistral`/`gemini` get graceful no-audio.
+expose `/audio/transcriptions`); `ollama`/`mistral`/`gemini`/`bedrock` get
+graceful no-audio.
 
 `anthropic` uses a **native Messages-API adapter** (not the OpenAI-compatible
 factory): it authenticates with `x-api-key`, hoists the system prompt into the
@@ -96,6 +101,95 @@ selects the parameter shape, so for an o-series/`gpt-5` deployment set `LLM_MODE
 to the underlying model name (the adapter also treats a `.../deployments/o3` style
 deployment segment as reasoning), or pin it explicitly with `LLM_REASONING`.
 
+### Bedrock (`LLM_PROVIDER=bedrock`)
+
+`bedrock` is a **native adapter over Amazon Bedrock's Converse API**
+(`POST {endpoint}/model/{modelId}/converse`), not an OpenAI-compatible endpoint.
+Everything it needs beyond `LLM_MODEL` comes from the ambient `AWS_*`
+environment — deliberately, so AWS configuration never has to travel through
+`Settings` or the language bindings. The names mirror the ones litellm reads, and
+several of them are *not* the boto3-standard spellings:
+
+| Env var | Purpose |
+|---|---|
+| `AWS_ACCESS_KEY_ID` | Static access key |
+| `AWS_SECRET_ACCESS_KEY` | Static secret key |
+| `AWS_SESSION_TOKEN` | Session token accompanying temporary static credentials |
+| `AWS_REGION_NAME` | Region — the first env rung of the region chain below |
+| `AWS_REGION` | Region — one rung below `AWS_REGION_NAME` |
+| `AWS_DEFAULT_REGION` | Not part of the region chain; read only when resolving the STS signing region |
+| `AWS_PROFILE_NAME` | Shared-config profile. **Not** the boto3-standard `AWS_PROFILE`, which this path ignores |
+| `AWS_ROLE_NAME` | Role ARN to assume via STS |
+| `AWS_ROLE_ARN` | Ambient role ARN published by an IRSA / EKS pod identity |
+| `AWS_SESSION_NAME` | STS session name |
+| `AWS_WEB_IDENTITY_TOKEN` | OIDC web-identity token (inline) |
+| `AWS_WEB_IDENTITY_TOKEN_FILE` | Ambient web-identity token file published by an IRSA / EKS pod identity |
+| `AWS_STS_ENDPOINT` | Override the STS endpoint |
+| `AWS_EXTERNAL_ID` | `ExternalId` passed to `AssumeRole` |
+| `AWS_BEDROCK_RUNTIME_ENDPOINT` | Override the Bedrock runtime host |
+| `AWS_BEARER_TOKEN_BEDROCK` | Bedrock API key, used as a bearer token |
+
+**Auth ladder.** `LLM_API_KEY`, when set, is sent verbatim as
+`Authorization: Bearer <key>` and the request is **not** signed — no credential
+lookup runs at all, so a bearer-only deployment needs no AWS credentials
+present. Otherwise `AWS_BEARER_TOKEN_BEDROCK` takes the same short-circuit. Only
+when both are absent does the request fall through to SigV4 (signing service
+`bedrock`), whose credentials resolve in this order:
+
+1. web-identity token + role + session name → STS `AssumeRoleWithWebIdentity`;
+2. role ARN → STS `AssumeRole` — **skipped when the process is already running
+   as that role**, so an IRSA pod that already holds it does not assume itself;
+3. profile name → the shared-config profile;
+4. static access key + secret (plus session token when present);
+5. otherwise the default chain (env / shared config / SSO / ECS / IMDS).
+
+**Region and endpoint.** The region resolves as: an explicitly configured
+region → a region embedded in a model ARN → `AWS_REGION_NAME` → `AWS_REGION` →
+the profile / default chain → the hard default **`us-west-2`**. The ARN rung
+outranks the env vars, matching litellm. The endpoint resolves as: an explicit
+API base → `AWS_BEDROCK_RUNTIME_ENDPOINT` →
+`https://bedrock-runtime.{region}.amazonaws.com`.
+
+`LLM_ENDPOINT` is **not** that API base: like the Anthropic path above, the
+Bedrock factory deliberately passes no base URL, so a stray `LLM_ENDPOINT` (which
+aliases `OPENAI_URL`) cannot misroute Bedrock traffic to an OpenAI host. Point a
+Bedrock deployment at a custom runtime host with `AWS_BEDROCK_RUNTIME_ENDPOINT`
+instead.
+
+**Converse only.** Every model cognee ships routes to Converse — but only after
+the model id is normalised (an ARN wrapper is unwrapped, a cross-region
+inference prefix such as `eu.`/`us.`/`apac.` is stripped, as are provisioned-
+throughput and context-window suffixes). Normalisation feeds the routing and
+capability decisions only; the request URL always carries the model id exactly as
+configured. A model that routes to Bedrock's legacy `invoke` API for **chat** is
+unsupported by design: construction fails with a clear
+`LlmError::FeatureNotSupported` rather than posting a Converse body to an
+endpoint that cannot serve it. (Embeddings are a separate path and *do* go over
+InvokeModel — see [Embedding](#embedding).)
+
+**Capabilities.** No streaming. No audio transcription (Bedrock has no Whisper
+equivalent, so the transcriber is simply absent). Image description (vision)
+**is** implemented, over Converse image blocks — this deliberately *exceeds*
+Python parity, where `BedrockAdapter.transcribe_image` raises
+`NotImplementedError`. It is gated on a per-model capability table, though: a
+model the table does not list is treated conservatively as text-only, and asking
+it for image description returns `LlmError::FeatureNotSupported` rather than a
+request the model would reject. Structured output is capability-gated per model
+from the same table: models
+that advertise native structured output get Converse's `outputConfig.textFormat`
+carrying the JSON schema, and the rest get a synthetic `json_tool_call` tool
+whose input schema is the response schema (with `toolChoice` forced only for
+models that support tool choice).
+
+**Feature gating.** The adapter and the embedding engine live behind the
+`bedrock` Cargo feature. It is **non-default** on the two leaf crates that carry
+the code, `cognee-llm` and `cognee-embedding` — the AWS crate stack is not free —
+but it **is** in the `default` feature list of `cognee-components`, `cognee`,
+`cognee-http-server` and `cognee-cli`, so every shipped binary has Bedrock
+available. Building any of those with `--no-default-features` (or without
+`bedrock` in the feature list) drops the whole AWS stack, and
+`LLM_PROVIDER=bedrock` then reports an unsupported provider.
+
 ### Reasoning-model parameters (`LLM_REASONING`)
 
 OpenAI reasoning families (`o1*`, `o3*`, `o4*`, `gpt-5*`) require a different
@@ -110,8 +204,6 @@ shape). `LLM_REASONING` overrides that detection:
 - `never` — force the legacy `max_tokens`+`temperature` shape (e.g. a remote
   OpenAI-compatible gateway serving a reasoning-*named* model that only accepts
   the legacy parameters).
-
-Native Bedrock adapters are tracked separately in issue #17.
 
 > **Ollama embeddings:** set `EMBEDDING_ENDPOINT` explicitly when using
 > `EMBEDDING_PROVIDER=ollama`. The Ollama embedder needs the `/api/embed` route, and
@@ -137,7 +229,32 @@ Read by `EmbeddingConfig::from_env()` ([`crates/embedding/src/config.rs`](../cra
 | `EMBEDDING_ONNX_BATCH_SIZE` | `embedding_onnx_batch_size` | `32` (ONNX inference batch size; independent of `EMBEDDING_BATCH_SIZE`. Lower it under memory pressure on edge devices) |
 | `MOCK_EMBEDDING` | _(provider override)_ | `false` (also accepts `deterministic`) |
 
-Provider values: `onnx`, `fastembed`, `openai`, `openai_compatible`, `ollama`, `mock`.
+Provider values: `onnx`, `fastembed`, `openai`, `openai_compatible`, `ollama`,
+`bedrock`, `mock`.
+
+`EMBEDDING_PROVIDER=bedrock` uses Amazon Bedrock's **InvokeModel** API
+(`POST {endpoint}/model/{modelId}/invoke`) — Converse is the chat API and is
+never used here. Two model families are supported, selected from the normalised
+model id: **Titan** (`amazon.titan-embed-text-v1`,
+`amazon.titan-embed-text-v2:0`, `amazon.titan-embed-image-v1`), which takes one
+text per request, and **Cohere** (`cohere.embed-*`), which batches. Set
+`EMBEDDING_MODEL` to the Bedrock model id; `EMBEDDING_DIMENSIONS` drives the
+engine's reported `dimension()` and is sent as `dimensions` on Titan v2, so it
+must match what the model actually returns. AWS configuration comes from the
+same `AWS_*` environment variables as the LLM path
+(see [Bedrock](#bedrock-llm_providerbedrock)) — the engine and the chat adapter
+share one AWS implementation — and `EMBEDDING_API_KEY` (falling back to
+`LLM_API_KEY`) is the Bedrock API key, which short-circuits to a bearer header
+with no SigV4; leaving it unset is supported and runs the ambient credential
+ladder. Returned vectors are always L2-normalised: Titan v2 normalises
+server-side (the engine sends `normalize: true`), and the families that do not
+are normalised client-side.
+
+> **Bedrock embeddings and `EMBEDDING_ENDPOINT`:** `EMBEDDING_ENDPOINT` defaults
+> to the OpenAI base URL and nothing clears it when the provider changes, so the
+> Bedrock engine ignores an endpoint that still points at OpenAI rather than
+> POSTing Bedrock bodies there. Set it only to a real Bedrock runtime host (or
+> use `AWS_BEDROCK_RUNTIME_ENDPOINT`).
 
 ## Vector database
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,7 +122,7 @@ several of them are *not* the boto3-standard spellings:
 | `AWS_ROLE_NAME` | Role ARN to assume via STS |
 | `AWS_ROLE_ARN` | Ambient role ARN published by an IRSA / EKS pod identity |
 | `AWS_SESSION_NAME` | STS session name |
-| `AWS_WEB_IDENTITY_TOKEN` | OIDC web-identity token (inline) |
+| `AWS_WEB_IDENTITY_TOKEN` | **Path to** a readable OIDC web-identity token file. A literal token value is rejected with a config error — a documented divergence from litellm, which resolves this through `get_secret()` and passes the token *value* to `sts:AssumeRoleWithWebIdentity`. See `aws/credentials.rs` for why |
 | `AWS_WEB_IDENTITY_TOKEN_FILE` | Ambient web-identity token file published by an IRSA / EKS pod identity |
 | `AWS_STS_ENDPOINT` | Override the STS endpoint |
 | `AWS_EXTERNAL_ID` | `ExternalId` passed to `AssumeRole` |

--- a/docs/http-server/routers/settings.md
+++ b/docs/http-server/routers/settings.md
@@ -264,20 +264,48 @@ pub fn should_persist_api_key(submitted: &str) -> bool {
      *(implemented)*
    - `test_post_settings_rejects_unknown_provider` — negative control: the enum is still closed, so
      a value outside it is rejected before the handler runs. *(implemented)*
-8. Cross-SDK parity test in `e2e-cross-sdk/harness/test_http_settings.py`: GET response from Python
-   and Rust must be byte-equal modulo the API-key portion (which depends on configured key), plus a
-   `POST provider: "bedrock"` leg. **Still to be written** — this is plan task
+8. Cross-SDK parity test in `e2e-cross-sdk/harness/test_http_settings.py` — *written* as plan task
    [§5 P4](../../roadmap/bedrock-provider-plan.md); it is the guard that keeps the provider/model
-   lists and the save-side enum from re-diverging. Whoever writes it: the POST leg can only assert
-   that *Rust* returns `200`, because upstream Python returns `400` until plan §5 P1 ships.
+   lists and the save-side enum from re-diverging. It runs in the secret-free Phase-1a lane of
+   `.github/workflows/http-parity.yml`. It builds on `py_client`/`rs_client` and **not** on
+   `authed_clients`, which skips whenever `/api/v1/auth/*` is missing — always true for the OSS
+   Rust build, so using it would silently void the gate. Authentication is asymmetric instead: the
+   Rust server answers unauthenticated (`require_authentication` defaults to false and
+   `start_servers.sh` does not set `REQUIRE_AUTHENTICATION`), while upstream Python's
+   `get_authenticated_user` computes `REQUIRE_AUTHENTICATION` as *true* when both
+   `REQUIRE_AUTHENTICATION` and `ENABLE_BACKEND_ACCESS_CONTROL` are unset — which is the harness's
+   configuration — so it answers `401`. A module-local `py_settings_client` fixture registers and
+   logs in on the Python side only, and asserts (rather than skips) if that login fails. Six cases:
+   - `test_settings_bedrock_provider_choice_matches` — the `bedrock` entry of `llm.providers` is
+     equal on both sides, `value` and `label`. (Rust's label was `"AWS Bedrock"` against Python's
+     `"Bedrock"`; the Rust literal was corrected to Python's, which is the parity source of truth.)
+   - `test_settings_bedrock_model_list_matches` — `llm.models["bedrock"]` equal element-for-element
+     and in order.
+   - `test_settings_llm_provider_value_set_matches` — `llm.providers[*].value` identical, same order.
+   - `test_settings_get_full_body_parity` — the whole GET body, ignoring the environment-dependent
+     scalars (`llm.provider`/`model`/`endpoint`/`apiVersion`/`apiKey`, `vectorDb.provider`/`url`/
+     `apiKey` — the two servers run from separate `/py` and `/rs` workspaces). Note the wire keys
+     are camelCase on **both** sides (Rust's `#[serde(rename_all = "camelCase")]`; Python's `OutDTO`
+     `alias_generator=to_camel` plus FastAPI's default `response_model_by_alias=True`), so the
+     `strip_paths` patterns must spell them that way — `$..api_key` would match nothing.
+     `xfail(strict=False)`
+     for now: the non-bedrock `llm.models.{openai,anthropic,gemini,mistral}` and
+     `vector_db.providers` lists diverged long before this plan and are out of its scope; the marker
+     comes off when they are aligned.
+   - `test_settings_post_bedrock_accepted_by_rust` — `POST provider: "bedrock"` → `200`, reflected on
+     the next `GET`.
+   - `test_settings_post_bedrock_accepted_by_python` — the same POST against Python,
+     `xfail(strict=True)`: upstream returns a 4xx until plan §5 P1 lands and the
+     `topoteretes/cognee` pin (`b9014c16`) in `.github/workflows/http-parity.yml` is bumped, at
+     which point the case XPASSes loudly and the marker should be deleted.
 
 ## 6. Open questions
 
 1. **Vector-DB key empty-handling** — Python's [`get_settings.py` L184-L187](https://github.com/topoteretes/cognee/blob/main/cognee/modules/settings/get_settings.py#L184-L187) does *not* short-circuit on empty `vector_config.vector_db_key`, which would crash on `len("") - 10 = -10` followed by `"*" * -10 == ""`. Python coincidentally gets away with returning the empty string + zero stars; Rust matches (returns empty string rather than `null`) to avoid divergence.
 2. **Atomicity across sub-saves** — `save_llm_config` and `save_vector_db_config` are independent; a failure on the second leaves a half-applied state in the process-singleton. Python has the same behavior; Rust matches. No fix proposed.
 3. **`endpoint` and `api_version` fields are read-only** — surfaced on `GET` but not in the input DTO. Match Python exactly: input DTO does not accept these fields.
-4. **`bedrock` asymmetry** — *Resolved on the Rust side during R7 (commit b76a216d)*: the original answer ("replicate Python's asymmetry verbatim; the frontend treats `bedrock` as read-only") is retired. `LlmProvider` now carries a `Bedrock` variant and the router's save arm maps it to `"bedrock"`, so Rust accepts the provider it advertises. The gap that remains is one-way and upstream: Python's `LLMConfigInputDTO.provider` `Literal` still omits `bedrock`, so its POST answers `400`. Adding it there is the edit tracked as [`bedrock-provider-plan.md` §5 P1](../../roadmap/bedrock-provider-plan.md), which cannot land from this repository. The guard against the two sides drifting again is the cross-SDK parity test in §5 item 8 (plan §5 P4, not yet written).
-5. **No admin gate** — Python lets any authenticated user rewrite the global LLM / vector-DB config. Rust matches. The cross-SDK parity test confirms a non-superuser can save without 403.
+4. **`bedrock` asymmetry** — *Resolved on the Rust side during R7 (commit b76a216d)*: the original answer ("replicate Python's asymmetry verbatim; the frontend treats `bedrock` as read-only") is retired. `LlmProvider` now carries a `Bedrock` variant and the router's save arm maps it to `"bedrock"`, so Rust accepts the provider it advertises. The gap that remains is one-way and upstream: Python's `LLMConfigInputDTO.provider` `Literal` still omits `bedrock`, so its POST answers `400`. Adding it there is the edit tracked as [`bedrock-provider-plan.md` §5 P1](../../roadmap/bedrock-provider-plan.md), which cannot land from this repository. The guard against the two sides drifting again is the cross-SDK parity test in §5 item 8 (plan §5 P4), now written as `e2e-cross-sdk/harness/test_http_settings.py`; its `test_settings_post_bedrock_accepted_by_python` case is `xfail(strict=True)` and turns red the moment upstream accepts the value.
+5. **No admin gate** — Python lets any authenticated user rewrite the global LLM / vector-DB config. Rust matches. **No test asserts this.** The §5 item 8 parity test saves as an ordinary registered user on the Python side and as the synthetic default user on the Rust side, but its only POST assertion is the status code — and its Python leg is `xfail` today for an unrelated reason (the `bedrock` `Literal` gap). Confirming "a non-superuser can save without 403" would need a dedicated case that logs in as both a superuser and a non-superuser on Python.
 6. **Settings-singleton placement** — *Resolved during P5 (commit 2652aea)*: the spec called for a `cognee::settings` façade that the router thinly wraps, but `cognee`'s `server` feature already gates `cognee-http-server`, so a back-edge from `cognee::settings` to the router would create a feature cycle. The process-singleton `SettingsStore` therefore lives directly in `crates/http-server/src/routers/settings.rs`. Wire shape, redaction policy, and provider/model lists still match Python verbatim. If a non-HTTP consumer ever needs these settings, lift the singleton into a sibling `cognee-settings` crate without churning HTTP code.
 
 ## 7. References

--- a/docs/http-server/routers/settings.md
+++ b/docs/http-server/routers/settings.md
@@ -45,7 +45,7 @@ Companion docs: [../architecture.md](../architecture.md),
   [../observability.md §5](../observability.md#5-secret-redaction).
 - **Python parity notes**:
   - **API-key redaction policy on read**: Python masks the key as `key[0:10] + "*" * (len(key) - 10)` ([`get_settings.py` L94-L96](https://github.com/topoteretes/cognee/blob/main/cognee/modules/settings/get_settings.py#L94-L96), [L184-L187](https://github.com/topoteretes/cognee/blob/main/cognee/modules/settings/get_settings.py#L184-L187)). Replicate exactly: emit the first 10 chars of the configured key followed by N stars, where N is `len(key) - 10`. If the key is missing/empty, emit `null` for `llm.api_key` (Python's ternary returns `None`); the vector-DB branch in Python crashes when the key is empty, so we must handle the empty case defensively (Python fix candidate — see open question §6.4).
-  - **Provider/model lists are server-rendered constants**: Python hard-codes the lists of available providers and per-provider model lists in the response body. We mirror the lists verbatim from [`get_settings.py` L60-L179](https://github.com/topoteretes/cognee/blob/main/cognee/modules/settings/get_settings.py#L60-L179) so the Cognee frontend renders identically. **The lists must stay literal-equal to Python.**
+  - **Provider/model lists are server-rendered constants**: Python hard-codes the lists of available providers and per-provider model lists in the response body. We mirror the lists verbatim from [`get_settings.py` L60-L179](https://github.com/topoteretes/cognee/blob/main/cognee/modules/settings/get_settings.py#L60-L179) so the Cognee frontend renders identically. **The lists must stay literal-equal to Python.** They drifted apart once (Rust carried a single stale bedrock model) and were re-aligned in plan task P2; the bedrock entry is now Python's three, in this order: `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` / `Claude 4.5 Sonnet`, `eu.anthropic.claude-haiku-4-5-20251001-v1:0` / `Claude 4.5 Haiku`, `eu.amazon.nova-lite-v1:0` / `Amazon Nova Lite`.
 
 ### 2.2 `POST /` — save (partial-update) settings
 
@@ -68,10 +68,15 @@ Companion docs: [../architecture.md](../architecture.md),
   `cognee::settings::save_vector_db_config(...)`. Each invoked only when the corresponding
   optional field is `Some`.
 - **Validation rules**:
-  - `llm.provider ∈ {"openai", "ollama", "anthropic", "gemini", "mistral"}` (Python's `Literal`
-    union at [`get_settings_router.py` L23-L31](https://github.com/topoteretes/cognee/blob/main/cognee/api/v1/settings/routers/get_settings_router.py#L23-L31)). Note: the GET response advertises **`bedrock`** as a provider but `LLMConfigInputDTO`'s
-    `Literal` does **not** accept it on save. We replicate this asymmetry; the frontend treats
-    `bedrock` as read-only in v1.
+  - `llm.provider ∈ {"openai", "ollama", "anthropic", "gemini", "mistral", "bedrock"}` — the
+    shipped `LlmProvider` enum in `crates/http-server/src/dto/settings.rs`. Python's `Literal`
+    union at [`get_settings_router.py` L23-L31](https://github.com/topoteretes/cognee/blob/main/cognee/api/v1/settings/routers/get_settings_router.py#L23-L31)
+    is no longer the source of truth for this set. Note the one remaining **`bedrock`
+    asymmetry**, which now runs the other way: both SDKs advertise `bedrock` on `GET`, Rust
+    **accepts** it on save (task R7, `200`), but upstream Python's `Literal` still omits it and
+    rejects the value with `400`. Closing that is the upstream edit tracked as
+    [`bedrock-provider-plan.md` §5 P1](../../roadmap/bedrock-provider-plan.md) — see open
+    question §6.4.
   - `vector_db.provider ∈ {"lancedb", "chromadb", "pgvector"}` ([L36-L40](https://github.com/topoteretes/cognee/blob/main/cognee/api/v1/settings/routers/get_settings_router.py#L36-L40)). Note: the GET advertises only `lancedb` and `pgvector`; the save accepts `chromadb` too.
   - When `vector_db` is present, `url` and `api_key` must be present (Pydantic enforces).
   - When `llm` is present, `provider`, `model`, and `api_key` must be present.
@@ -159,10 +164,13 @@ pub struct SettingsDTO {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct LLMConfigInputDTO {
-    /// One of `"openai" | "ollama" | "anthropic" | "gemini" | "mistral"`.
-    /// Note: `"bedrock"` is **not** accepted on save even though the GET
-    /// advertises it. Match Python's Literal union at
-    /// [`get_settings_router.py` L23-L31](https://github.com/topoteretes/cognee/blob/main/cognee/api/v1/settings/routers/get_settings_router.py#L23-L31).
+    /// One of `"openai" | "ollama" | "anthropic" | "gemini" | "mistral" |
+    /// "bedrock"`. Note: `"bedrock"` **is** accepted here — it is advertised
+    /// by the GET response and the Bedrock provider is registered by default.
+    /// Python's Literal union at
+    /// [`get_settings_router.py` L23-L31](https://github.com/topoteretes/cognee/blob/main/cognee/api/v1/settings/routers/get_settings_router.py#L23-L31)
+    /// does not include it yet, so Python's save still rejects it; that gap is
+    /// plan §5 P1 and is the only remaining divergence in this enum.
     pub provider: LlmProvider,
     pub model: String,
     /// May be a redacted echo from the GET response. Drop the value if it
@@ -178,6 +186,7 @@ pub enum LlmProvider {
     Anthropic,
     Gemini,
     Mistral,
+    Bedrock,
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -242,22 +251,32 @@ pub fn should_persist_api_key(submitted: &str) -> bool {
 4. Add handlers in `crates/http-server/src/routers/settings.rs`. Both are `#[tracing::instrument(skip(state))]`.
 5. OpenAPI annotations; explicitly document the redaction/echo policy in the description.
 6. Unit tests: `redact_api_key()` empty/short/long; `should_persist_api_key()` for `""`, `"   "`, `"sk-real-key"`, `"sk-prefix*****abc"`, `"AAAAAAAAAA*****"`.
-7. Integration tests in `crates/http-server/tests/test_settings.rs`:
+7. Integration tests in `crates/http-server/tests/test_settings.rs` (the file exists; the bedrock
+   cases landed with R7):
    - `GET` with no key configured → `llm.api_key == null`.
    - `GET` with key `"sk-1234567890XYZ"` → `"sk-12345678***"` (10 chars + 5 stars).
    - `POST` with `api_key: "sk-real"` then `GET` → mask reflects `"sk-real"`.
    - `POST` with `api_key: "sk-12345***"` (echo) → key is *not* overwritten.
    - `POST` with only `llm` → `vector_db` unchanged.
-   - `POST` with `provider: "bedrock"` → `400` (literal-not-accepted).
+   - `test_get_settings_lists_python_bedrock_models` — the three bedrock models from §2.1, asserted
+     by `value`, `label`, and order. *(implemented)*
+   - `test_post_settings_accepts_bedrock_provider` — `POST` with `provider: "bedrock"` → `200`.
+     *(implemented)*
+   - `test_post_settings_rejects_unknown_provider` — negative control: the enum is still closed, so
+     a value outside it is rejected before the handler runs. *(implemented)*
 8. Cross-SDK parity test in `e2e-cross-sdk/harness/test_http_settings.py`: GET response from Python
-   and Rust must be byte-equal modulo the API-key portion (which depends on configured key).
+   and Rust must be byte-equal modulo the API-key portion (which depends on configured key), plus a
+   `POST provider: "bedrock"` leg. **Still to be written** — this is plan task
+   [§5 P4](../../roadmap/bedrock-provider-plan.md); it is the guard that keeps the provider/model
+   lists and the save-side enum from re-diverging. Whoever writes it: the POST leg can only assert
+   that *Rust* returns `200`, because upstream Python returns `400` until plan §5 P1 ships.
 
 ## 6. Open questions
 
 1. **Vector-DB key empty-handling** — Python's [`get_settings.py` L184-L187](https://github.com/topoteretes/cognee/blob/main/cognee/modules/settings/get_settings.py#L184-L187) does *not* short-circuit on empty `vector_config.vector_db_key`, which would crash on `len("") - 10 = -10` followed by `"*" * -10 == ""`. Python coincidentally gets away with returning the empty string + zero stars; Rust matches (returns empty string rather than `null`) to avoid divergence.
 2. **Atomicity across sub-saves** — `save_llm_config` and `save_vector_db_config` are independent; a failure on the second leaves a half-applied state in the process-singleton. Python has the same behavior; Rust matches. No fix proposed.
 3. **`endpoint` and `api_version` fields are read-only** — surfaced on `GET` but not in the input DTO. Match Python exactly: input DTO does not accept these fields.
-4. **`bedrock` asymmetry** — `bedrock` is in the GET-advertised providers but not the POST `Literal`. Replicate the asymmetry verbatim. The frontend treats `bedrock` as read-only.
+4. **`bedrock` asymmetry** — *Resolved on the Rust side during R7 (commit b76a216d)*: the original answer ("replicate Python's asymmetry verbatim; the frontend treats `bedrock` as read-only") is retired. `LlmProvider` now carries a `Bedrock` variant and the router's save arm maps it to `"bedrock"`, so Rust accepts the provider it advertises. The gap that remains is one-way and upstream: Python's `LLMConfigInputDTO.provider` `Literal` still omits `bedrock`, so its POST answers `400`. Adding it there is the edit tracked as [`bedrock-provider-plan.md` §5 P1](../../roadmap/bedrock-provider-plan.md), which cannot land from this repository. The guard against the two sides drifting again is the cross-SDK parity test in §5 item 8 (plan §5 P4, not yet written).
 5. **No admin gate** — Python lets any authenticated user rewrite the global LLM / vector-DB config. Rust matches. The cross-SDK parity test confirms a non-superuser can save without 403.
 6. **Settings-singleton placement** — *Resolved during P5 (commit 2652aea)*: the spec called for a `cognee::settings` façade that the router thinly wraps, but `cognee`'s `server` feature already gates `cognee-http-server`, so a back-edge from `cognee::settings` to the router would create a feature cycle. The process-singleton `SettingsStore` therefore lives directly in `crates/http-server/src/routers/settings.rs`. Wire shape, redaction policy, and provider/model lists still match Python verbatim. If a non-HTTP consumer ever needs these settings, lift the singleton into a sibling `cognee-settings` crate without churning HTTP code.
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -24,6 +24,12 @@ Each plan has an index doc plus one sub-document per remaining work item.
 | [cognify-compatibility-plan.md](cognify-compatibility-plan.md) | Index + decision log. Items 1, 2, 4, 5 have landed; only **Item 3** remains. |
 | [pghybrid-full-adapter.md](pghybrid-full-adapter.md) | Item 3 — full `PgHybridAdapter` + unified-engine wiring (the one remaining milestone). |
 
+### AWS Bedrock provider (issue #17)
+
+| Doc | Role |
+|-----|------|
+| [bedrock-provider-plan.md](bedrock-provider-plan.md) | The remaining tier of issue #17 (Tier 2 Anthropic and Tier 3 Azure shipped). Wire spec read out of Python + litellm, the Rust work breakdown, and the Python-side edits needed for two-way parity. |
+
 ## Conventions
 
 - When a planned item lands, delete its sub-document (the code is the record) and

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -28,7 +28,7 @@ Each plan has an index doc plus one sub-document per remaining work item.
 
 | Doc | Role |
 |-----|------|
-| [bedrock-provider-plan.md](bedrock-provider-plan.md) | The remaining tier of issue #17 (Tier 2 Anthropic and Tier 3 Azure shipped). Wire spec read out of Python + litellm, the Rust work breakdown, and the Python-side edits needed for two-way parity. |
+| [bedrock-provider-plan.md](bedrock-provider-plan.md) | The last tier of issue #17. **All of the Rust work (R1–R8) and the in-repo parity work (P2, P3, P4) have landed**; the doc stays for the one item that has not — **§5 P1**, adding `Literal["bedrock"]` to Python's `LLMConfigInputDTO.provider` in `topoteretes/cognee`, which cannot land from this repository — plus the optional **§5 P6**. Its §1 (wire spec) and §6 (decisions/caveats) remain the reference that the Bedrock source comments, `docs/http-server/routers/settings.md` and the cross-SDK parity test link into, so it is not deleted until P1 lands and those references are re-pointed. |
 
 ## Conventions
 

--- a/docs/roadmap/bedrock-provider-plan.md
+++ b/docs/roadmap/bedrock-provider-plan.md
@@ -477,15 +477,21 @@ in the lock today. (The closed `cognee-cloud-rust` workspace also carries a
 `hyper 0.14` qdrant fork under `[patch.crates-io]`; the two already coexist
 there, so this does not disturb the closed build either.)
 
-**MSRV ceiling — [R1].** The workspace pins rustc **1.91**
-(`rust-toolchain.toml:2`, `Cargo.toml:55` `rust-version = "1.91"`), but
-`aws-config` ≥ 1.9.0 and `aws-sigv4` 1.5.x require **1.94.1**. The newest
-compatible line is `aws-config 1.8.18` / `aws-sigv4 1.4.5` /
-`aws-credential-types 1.2.14` (MSRV 1.91.1). `resolver = "3"` selects these
-automatically, so the build works — but the adapter is **frozen on a mid-2026
-AWS release line until the toolchain moves**. Pin those versions explicitly with
-a comment pointing here, so the next `cargo update` doesn't produce a confusing
-MSRV failure.
+**MSRV ceiling — [R1].** `aws-config` ≥ 1.9.0 and `aws-sigv4` 1.5.x require
+rustc **1.94.1**. The newest compatible line is `aws-config 1.8.18` /
+`aws-sigv4 1.4.5` / `aws-credential-types 1.2.14`, whose MSRV is **1.91.1**.
+Pin those versions explicitly with a comment pointing here, so the next
+`cargo update` doesn't produce a confusing MSRV failure — `resolver = "3"` does
+**not** rescue this on its own, as the workspace manifest records. The adapter is
+**frozen on that AWS release line until the toolchain reaches 1.94.1**.
+
+> The workspace pinned `1.91`, which resolves to **1.91.0** — one patch below
+> what these crates require. The first draft of this note read "1.91" as
+> satisfying "1.91.1" and called the pin compatible; CI's `MSRV` lane caught it
+> with `rustc 1.91.0 is not supported by ... aws-config@1.8.18 requires rustc
+> 1.91.1`. The pin is now `1.91.1` everywhere (`rust-toolchain.toml`, all four
+> `rust-version` declarations, the `msrv` CI lane, `ios.yml`). When comparing an
+> MSRV against a pin, compare all three components.
 
 Also: the SigV4 fallback's SSO leg needs `aws-config`'s `sso` feature turned on
 explicitly — verify it is not in the default set before relying on §1.2's

--- a/docs/roadmap/bedrock-provider-plan.md
+++ b/docs/roadmap/bedrock-provider-plan.md
@@ -1,0 +1,792 @@
+# AWS Bedrock provider — implementation plan
+
+Status: proposed · Scope: **OSS `cognee-rs`**, plus a small set of Python-side
+edits for two-way parity · Tracking: issue **#17** (the remaining tier —
+`docs/configuration.md:114` "Native Bedrock adapters are tracked separately in
+issue #17"; Tier 2 = Anthropic, Tier 3 = Azure, both shipped).
+
+Parity baseline: Python `cognee` and the `litellm` it depends on, read directly
+rather than assumed. §1 is the wire spec; everything after implements it.
+
+> **Review pass (2026-08-24).** §1 was audited line-by-line against
+> `topoteretes/cognee` and `BerriAI/litellm` at HEAD. The spec held, with three
+> corrections now folded in: the default cognee path is `litellm_native`, not
+> the instructor adapter (§1.0); routing strips cross-region prefixes before the
+> converse-table lookup (§1.4.1); and structured output is
+> **capability-gated** — the forced `json_tool_call` tool is the *fallback*
+> branch, not the primary one (§1.4.3). Upstream line numbers below are as of
+> that pass. Findings that changed the work breakdown are marked
+> **[R]** where they land.
+
+---
+
+## 1. What Python actually does
+
+### 1.0 Which adapter actually runs
+
+`cognee/infrastructure/llm/config.py:90` — `structured_output_framework:
+str = "litellm_native"`. **The instructor `BedrockAdapter` of §1.1 is not the
+default path.** `LLMGateway.py:120` dispatches on that setting:
+
+| Framework | Module | Default? |
+|---|---|---|
+| `litellm_native` | `litellm_native/get_native_client.py` → `NativeLiteLLMAdapter` | **yes** |
+| `litellm_instructor` | `litellm_instructor/llm/bedrock/adapter.py` → `BedrockAdapter` | no |
+
+`NativeLiteLLMAdapter` (`get_native_client.py:33-62`, `native_adapter.py:80-96`,
+`231-240`) differs from §1.1 in ways that matter:
+
+* it passes **no** `aws_*` parameters, no `custom_llm_provider`, and no
+  `drop_params` — AWS auth is resolved entirely by litellm's uppercase-env
+  fallbacks (§1.2), never by cognee;
+* it qualifies the model as `bedrock/{model}`;
+* it sends litellm's own `response_format` (a strict Pydantic class, or
+  `_nonstrict_response_format`) rather than an instructor-shaped
+  `json_schema` — litellm translates either through the same §1.4.3 branch;
+* it clamps `max_completion_tokens = min(litellm model cap, user cap)`
+  (`get_native_client.py:88-92`) — the origin of R3's cap requirement.
+
+**Consequence for this plan:** the `AwsInputs`-from-env design (§2.1) is
+*more* correct than §1.1 implied — the default Python path has no cognee-side
+credential threading at all, so env-only resolution is exact parity rather than
+an approximation. But P5's acceptance criteria must be read against §1.2/§1.4,
+not against `get_s3_config()`.
+
+### 1.1 The cognee-side adapter (`litellm_instructor`, non-default)
+
+`cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/bedrock/adapter.py`
+
+* `BedrockAdapter` wraps `instructor.from_litellm(litellm.acompletion)` with
+  `custom_llm_provider="bedrock"` and `drop_params=True`.
+* Instructor mode **`json_schema_mode`** (`instructor_modes.py` →
+  `INSTRUCTOR_MODE_TABLE["bedrock"]`): instructor emits an OpenAI-shaped
+  `response_format={"type":"json_schema","json_schema":{...}}`, which litellm
+  then translates (§1.4).
+* Messages are always exactly `[{system}, {user}]`.
+* `max_retries = 2` inside instructor, wrapped by tenacity
+  (`wait_exponential_jitter(8, 128)`).
+* Auth params come from `get_s3_config()` — a `pydantic-settings` object read
+  **inside the adapter**, never threaded through `llm_config`. Precedence:
+  1. `self.api_key` (`LLM_API_KEY`) → litellm `api_key`
+  2. else `aws_access_key_id` + `aws_secret_access_key` (+ optional
+     `aws_session_token`)
+  3. else `aws_profile_name`
+  * plus, whenever set: `aws_region_name`, `aws_bedrock_runtime_endpoint`.
+* **`create_transcript` and `transcribe_image` both `raise NotImplementedError`**
+  (see §6.5).
+* Bedrock is exempt from the API-key requirement: absent from
+  `_API_KEY_REQUIRED_PROVIDERS` (`get_llm_client.py:98`) and listed in
+  `_NO_API_KEY_PROVIDERS` (`get_native_client.py:20`). **This exemption holds on
+  both framework paths** — it is the one §1.1 fact that is load-bearing for the
+  default flow too (R5).
+
+Env vars cognee itself reads (`S3Config`): `AWS_REGION`, `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_PROFILE_NAME`,
+`AWS_BEDROCK_RUNTIME_ENDPOINT`, `AWS_ENDPOINT_URL`. Per §1.0 these are read
+**only** on the instructor path; on the default path the same variables reach
+Bedrock through litellm's own env fallbacks (§1.2), which is why the two paths
+converge on the same wire behaviour despite the different plumbing.
+
+### 1.2 Auth resolution inside litellm
+
+`litellm/llms/bedrock/base_aws_llm.py::_sign_request` + `get_credentials`:
+
+```
+api_key given?                          → Authorization: Bearer <api_key>   (early return, NO SigV4)
+else AWS_BEARER_TOKEN_BEDROCK set?      → Authorization: Bearer <env>       (early return, NO SigV4)
+else SigV4, credentials resolved in order:
+  web_identity_token + role + session   → STS AssumeRoleWithWebIdentity
+  role_name                             → STS AssumeRole (skipped when already running as that role)
+  profile_name                          → boto3 profile
+  access_key + secret + session_token   → static session credentials
+  access_key + secret + region          → static credentials
+  otherwise                             → boto3.Session() default chain
+                                          (env / shared config / SSO / ECS / IMDS)
+```
+
+Every `aws_*` parameter left `None` falls back to its **UPPERCASE** env var of
+the same name (the `params_to_check` loop). Note the non-obvious names:
+`AWS_PROFILE_NAME` (not `AWS_PROFILE`), `AWS_REGION_NAME`, `AWS_ROLE_NAME`,
+`AWS_SESSION_NAME`, `AWS_WEB_IDENTITY_TOKEN`, `AWS_STS_ENDPOINT`,
+`AWS_EXTERNAL_ID`.
+
+Signing service name is `bedrock`. SigV4 signs a filtered header subset
+(`_filter_headers_for_aws_signature`); unsigned headers are re-applied
+afterwards, and an explicit `Authorization` is never overwritten.
+
+### 1.3 Region and endpoint chains
+
+Region (`_get_aws_region_name`): `aws_region_name` param → region embedded in a
+model ARN → `AWS_REGION_NAME` → `AWS_REGION` → `boto3.Session().region_name` →
+hard default **`us-west-2`**.
+
+Endpoint (`get_runtime_endpoint`): `api_base` → `aws_bedrock_runtime_endpoint`
+→ `AWS_BEDROCK_RUNTIME_ENDPOINT` →
+`https://bedrock-runtime.{region}.amazonaws.com`.
+
+### 1.4 Chat: route selection and wire shape
+
+#### 1.4.1 Model-id normalisation happens *before* routing — **[R3]**
+
+This step was missing from the first draft of this plan and is the single
+highest-consequence correction in it. `get_bedrock_route`
+(`common_utils.py:926`) does not look the raw model id up in the converse
+table. It first calls `get_bedrock_base_model` (`common_utils.py:685`), which
+strips, in order:
+
+1. an ARN wrapper (foundation-model / inference-profile ARNs → the bare id);
+2. a **cross-region inference prefix** —
+   `global|us|eu|apac|jp|au|us-gov` (`get_bedrock_cross_region_inference_regions`);
+3. a provisioned-**throughput** suffix such as `:0:51k`
+   (`strip_bedrock_throughput_suffix`);
+4. a **context-window** suffix such as `[1m]`.
+
+`BEDROCK_CONVERSE_MODELS` (`constants.py:1192`) stores only the *bare* ids —
+`anthropic.claude-sonnet-4-5-20250929-v1:0`, never
+`eu.anthropic.claude-sonnet-4-5-20250929-v1:0`.
+
+> **Every model in P2's refreshed dropdown is `eu.`-prefixed.** The claim "all
+> three models cognee ships route to converse" is true, but *only* via this
+> normalisation. A port that looks the raw id up in the table routes 3 of 3
+> shipped models to `invoke` — i.e. the adapter fails on its own defaults.
+> `route.rs` implements normalisation **and** lookup, and R8 tests the prefixed
+> ids specifically.
+
+#### 1.4.2 Route selection
+
+* explicit prefixes win: `converse/`, `invoke/`, `converse_like/`, `agent/`,
+  `agentcore/`, `async_invoke/`, `openai/`, plus `claude_platform/` and
+  `mantle/` (`common_utils.py:630-636`) — the last two were missing from the
+  first draft;
+* an **application-inference-profile ARN** → converse
+  (`common_utils.py:981-982`) — a common enterprise deployment shape, also
+  missing from the first draft;
+* `nova/` and `nova-2/` → converse;
+* else normalised base model ∈ `litellm.bedrock_converse_models` → **converse**,
+  otherwise → **invoke**.
+
+`BEDROCK_CONVERSE_MODELS` covers all Anthropic Claude (v1 → 4.6), Nova, Llama
+3.x, Mistral large/small, DeepSeek, Qwen3, `openai.gpt-oss-*`, AI21 Jamba.
+
+URL (`converse_handler.py:353-363`):
+`POST {endpoint}/model/{modelId}/converse` (`/converse-stream` when streaming).
+Note the URL carries the **original** id, prefix included — normalisation feeds
+the routing decision only, never the request path.
+
+Body (`converse_transformation.py:1616-1679`):
+
+```json
+{ "messages": [...], "system": [...], "inferenceConfig": {...},
+  "additionalModelRequestFields": {...}, "toolConfig": {...} }
+```
+
+#### 1.4.3 Structured output is capability-gated — **[R3]**
+
+`_translate_response_format_param` (`converse_transformation.py:1007-1075`)
+picks one of two shapes per model, reading capability flags out of
+`model_prices_and_context_window.json`:
+
+* `supports_native_structured_output` → **`outputConfig.textFormat`** carrying
+  the JSON schema, with `additionalProperties: false` forced onto every object
+  node;
+* **otherwise** → inject a synthetic tool named **`json_tool_call`**
+  (`RESPONSE_FORMAT_TOOL_NAME`, `constants.py:1342`) whose input schema *is* the
+  response schema. The forcing `toolChoice: {tool: {name}}` is applied **only
+  when** `supports_tool_choice(model)` **and** thinking is not enabled
+  (`converse_transformation.py:1057-1063`).
+
+Either way `json_mode = True`, and the result is unwrapped from the tool input /
+text format.
+
+Against cognee's own three shipped models this resolves as:
+
+| Model | Branch | `toolChoice` forced? |
+|---|---|---|
+| `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` | native `outputConfig` | n/a |
+| `eu.anthropic.claude-haiku-4-5-20251001-v1:0` | native `outputConfig` | n/a |
+| `eu.amazon.nova-lite-v1:0` | `json_tool_call` | **no** — no `supports_tool_choice` |
+
+> So the forced-tool path is the **fallback**, and it is not exercised by either
+> Anthropic model cognee ships. An R3 that implements only the forced tool
+> diverges from Python on all three defaults — and, since Nova is documented to
+> reject a specific `toolChoice`, may 400 outright on nova-lite. R3 carries a
+> small capability table and both branches.
+
+The fallback form is structurally what `AnthropicAdapter` already does with its
+forced `extract_structured_data` tool. Its repair loop is the right *pattern* to
+follow, but see §6.7 — it is not reusable code.
+
+### 1.5 Embeddings
+
+`EMBEDDING_PROVIDER=bedrock` falls through `get_embedding_engine.py` to
+`LiteLLMEmbeddingEngine` → `litellm.aembedding`, which routes Bedrock embeddings
+to **InvokeModel**, not Converse: `POST {endpoint}/model/{modelId}/invoke`, one
+request per input text for the Titan families (`_single_func_embeddings` loops),
+batched for Cohere.
+
+| Family | Request | Response |
+|---|---|---|
+| `amazon.titan-embed-text-v1` (g1) | `{"inputText": str}` | `{"embedding": [...], "inputTextTokenCount": n}` |
+| `amazon.titan-embed-text-v2:0` | `{"inputText": str, "dimensions"?, "normalize"?}` | same |
+| `amazon.titan-embed-image-v1` | `{"inputText"?, "inputImage"?, "embeddingConfig"}` | same |
+| `cohere.embed-*` | `{"texts": [...], "input_type": "search_document", "embedding_types"?, "output_dimension"?}` | `{"embeddings": [[...]]}` |
+| `async_invoke/*` (incl. some nova / twelvelabs ids) | async-invoke variants | — |
+
+(The async-invoke branch keys on an explicit `async_invoke/` model prefix,
+`embed/embedding.py:392-394` — it is not an inherent property of the nova or
+twelvelabs embedding families, as the first draft implied. cognee ships
+neither, so this row is informational.)
+
+cognee passes no AWS credentials on the embedding path — only `api_key`
+(bearer) and `endpoint`; everything else comes from the ambient env / boto3
+chain.
+
+### 1.6 Streaming
+
+`converse-stream` uses the binary `vnd.amazon.eventstream` framing. No OSS Rust
+adapter actually streams today (`OpenAIAdapter::supports_streaming()` returns
+`true`, but nothing parses a stream). **Out of scope** —
+`supports_streaming()` returns `false`.
+
+---
+
+## 2. Where it lands in the tree
+
+The provider seam already exists and needs no new abstraction:
+
+* `cognee_components::LlmFactory` — `provider() -> &str` + `build(ctx)`; the
+  Anthropic (Tier 2) and Azure (Tier 3) factories in
+  `crates/components/src/builtins/llm.rs` are the template.
+* `ComponentRegistry::with_builtins()` registers built-ins per enabled feature;
+  `register_llm` is a plain `HashMap<String, Arc<dyn LlmFactory>>` with no enum
+  validation, so `LLM_PROVIDER=bedrock` resolves as soon as the factory is
+  registered.
+* Embedding provider selection is an exhaustive match on `EmbeddingProvider`
+  inside `EmbeddingConfig::create_engine`
+  (`crates/embedding/src/config.rs:468`) — a new variant is a compile-checked
+  edit.
+* `LlmProvider::Bedrock` already exists in `cognee_llm::config::LlmProvider`
+  (unused) — that enum needs no change.
+
+### 2.1 AWS config plumbing — the `anthropic_base_url` precedent
+
+`BackendBuildContext` deliberately keeps factories env-free: "all
+environment-variable reads happen when a caller lowers its config into a
+`BackendBuildContext`" (`crates/components/src/context.rs`). The existing
+precedent for provider-specific, env-only config is
+`anthropic_base_url_from_env()` — a helper in that same module, carried as a
+field on `LlmInputs`, called from both lowering sites, and **not** a `Settings`
+field.
+
+Bedrock follows it exactly:
+
+```rust
+// crates/components/src/context.rs
+#[derive(Clone, Default)]
+pub struct AwsInputs {
+    pub region: Option<String>,
+    pub access_key_id: Option<String>,
+    pub secret_access_key: Option<String>,
+    pub session_token: Option<String>,
+    pub profile_name: Option<String>,
+    pub role_name: Option<String>,
+    pub session_name: Option<String>,
+    pub web_identity_token: Option<String>,
+    pub sts_endpoint: Option<String>,
+    pub external_id: Option<String>,
+    pub bedrock_runtime_endpoint: Option<String>,
+    pub bearer_token: Option<String>,   // AWS_BEARER_TOKEN_BEDROCK
+}
+
+pub fn aws_inputs_from_env() -> AwsInputs { /* §1.2 / §1.3 names, trimmed, empty ⇒ None */ }
+```
+
+`LlmInputs` and `EmbeddingInputs` each gain `pub aws: AwsInputs`, populated by
+`aws_inputs_from_env()` at both lowering sites
+(`crates/lib/src/config.rs:850` and `crates/http-server/src/config.rs:700`).
+
+This matters for scope: because Python resolves these from the environment and
+never threads them through its LLM config (§1.0 — the default path does not even
+read `S3Config`), **no `Settings` fields are added — and therefore no binding
+setters, no `to_dict`/`from_map` entries, and no wrapper-gate regeneration.**
+That is both correct parity and the cheapest surface.
+
+Audited and confirmed: `Settings.llm_provider` / `embedding_provider` are plain
+`String`s (`crates/lib/src/config.rs:232`), the bindings pass provider ids as
+strings (e.g. `ts/src/cognee.ts:128` — `setEmbeddingProvider(v: string)`), and
+`to_dict`/`from_map` (config.rs:1035, 2058) key on existing fields only. R7's
+DTO enum is server-internal, and `test_http_openapi.py:135-147` compares
+`components.schemas` **key sets** only — so the enum-value change trips no
+gate. **The bet holds; nothing crosses a binding boundary.**
+
+Two internal costs the first draft priced at zero, though:
+
+* `LlmInputs` and `EmbeddingInputs` are `#[derive(Clone)]` with **no `Default`**
+  (`crates/components/src/context.rs:96`), and are built as exhaustive struct
+  literals in eight places — `registry.rs:408,427`,
+  `builtins/database.rs:114,133`, `builtins/embedding.rs:195`,
+  `lib/src/config.rs:830,849`, `http-server/src/config.rs:681,700`. Adding a
+  field is `E0063` at every one of them. Mechanical, but not free (R2).
+* Default-on Bedrock (§6.2) means every default build compiles the
+  aws-config/smithy tree — including the binding prebuild legs.
+
+### 2.2 Crate layout
+
+Adapters live inside `cognee-llm`, so Bedrock does too — feature-gated because
+the AWS deps are not free:
+
+```
+crates/llm/src/adapters/
+  bedrock/
+    mod.rs          BedrockAdapter (impl Llm) — re-exported as adapters::BedrockAdapter
+    aws/
+      env.rs        AwsInputs → resolved settings; the S3Config analogue
+      region.rs     §1.3 region chain incl. the us-west-2 hard default
+      endpoint.rs   §1.3 runtime-endpoint chain
+      credentials.rs the §1.2 precedence ladder over aws-config providers
+      signer.rs     SigV4 over a reqwest::Request via aws-sigv4 (service "bedrock")
+      transport.rs  trait BedrockTransport — the seam isolating the §3 decision
+    model_id.rs     §1.4.1 normalisation: ARN unwrap, cross-region prefix,
+                    throughput + context suffixes
+    route.rs        §1.4.2 routing over the normalised id + BEDROCK_CONVERSE_MODELS
+    caps.rs         per-model capability + limit table: supports_native_structured_output,
+                    supports_tool_choice, max output tokens (§1.4.3, R3)
+    converse.rs     request/response transform for /converse (both structured-output branches)
+
+crates/embedding/src/
+  provider.rs       + EmbeddingProvider::Bedrock
+  config.rs         + create_engine arm, + aws: AwsInputs on EmbeddingConfig
+  bedrock/
+    mod.rs          BedrockEmbeddingEngine (impl EmbeddingEngine)
+    titan.rs        g1 / v2 / multimodal
+    cohere.rs
+
+crates/components/src/builtins/llm.rs
+                    + BEDROCK_PROVIDER, BedrockLlmFactory
+crates/components/src/builtins/embedding.rs
+                    + parse_embedding_provider arm, + aws on build_embedding_config
+crates/components/src/registry.rs
+                    + #[cfg(feature = "bedrock")] registration in with_builtins()
+                    + bedrock assertion in builtins_register_documented_providers
+```
+
+Three touch points the first draft omitted, all inside `cognee-components`:
+
+* **`parse_embedding_provider`** (`builtins/embedding.rs:62-72`) is a hard
+  allowlist match — the declared single source of truth for provider ids.
+  Without a `"bedrock"` arm, `EMBEDDING_PROVIDER=bedrock` is rejected as a
+  misconfiguration no matter what `EmbeddingProvider` gains (R4).
+* **`EmbeddingConfig` has no `aws` field today** — `build_embedding_config` must
+  carry `AwsInputs` across (R4).
+* **`builtins_register_documented_providers`** (`registry.rs:318-374`) is a
+  drift guard over the registered provider set; it wants a bedrock assertion
+  (R5).
+
+The chat-side `/invoke` transforms are deliberately **not** in this tree — see
+§6.7.
+
+The `aws/` module is shared by the LLM adapter and the embedding engine — one
+credential/region/endpoint resolver, one signer. It lives under `cognee-llm`
+and is re-exported for `cognee-embedding` to depend on (or, if that edge is
+unwanted, factored into `cognee-utils` — decide at R1).
+
+### 2.3 Feature wiring
+
+Leaf crates expose `bedrock` as a non-default feature; the shipped surfaces turn
+it on by default, exactly as `lancedb` / `onnx` / `ladybug` are handled today:
+
+```toml
+# crates/llm/Cargo.toml
+bedrock = ["dep:aws-config", "dep:aws-credential-types", "dep:aws-sigv4",
+           "dep:aws-smithy-runtime-api"]
+
+# crates/embedding/Cargo.toml
+bedrock = ["cognee-llm/bedrock"]
+
+# crates/components/Cargo.toml
+default = [..., "bedrock"]
+bedrock = ["cognee-llm/bedrock", "cognee-embedding/bedrock"]
+
+# crates/lib/Cargo.toml and crates/http-server/Cargo.toml
+default = [..., "bedrock"]
+bedrock = ["cognee-components/bedrock", "cognee-llm/bedrock", "cognee-embedding/bedrock"]
+```
+
+Consumers that do not want the AWS stack (wasm, Android, slim binding builds)
+drop it with `--no-default-features` plus explicit forwarding, the same way they
+already drop `lancedb`.
+
+These entries do **not** all land in one late step — the `cognee-llm` half is a
+prerequisite of R1 and the `cognee-components` half of R5. See §6.8.
+
+---
+
+## 3. Transport decision
+
+**Recommendation: `aws-config` (credential + region resolution) + `aws-sigv4`
+(signing) + the existing `reqwest` client**, hand-writing the Converse /
+InvokeModel JSON — rather than `aws-sdk-bedrockruntime`.
+
+* The Bearer path must be a plain header with **no** SigV4 and no credential
+  lookup at all (litellm early-returns, §1.2). Hand-rolled that is a two-line
+  branch; through the SDK it is a fight with the auth-scheme resolver.
+* The SigV4 fallback must reach the full boto3-equivalent chain — env, shared
+  config/credentials, SSO, ECS, IMDS, web identity, STS assume-role.
+  `aws-config`'s `DefaultCredentialsChain` is the only Rust equivalent;
+  hand-rolling would silently cover static keys only.
+* Bodies stay hand-written, so the adapter is the same *shape* as
+  `AnthropicAdapter` and reuses its structured-output repair loop, corrective
+  re-ask, truncation retry, tracing spans, and `LlmError` taxonomy verbatim. An
+  SDK-based adapter would need all of that re-expressed against smithy types.
+* Streaming — the one place the raw SDK genuinely earns its keep (eventstream
+  framing) — is out of scope (§1.6).
+
+Dep weight is roughly a wash; `aws-config` pulls the smithy runtime either way.
+Escape hatch is cheap: transport sits behind one internal trait (§2.2), so
+swapping in `aws-sdk-bedrockruntime` later touches one file.
+
+Workspace note: `hyper 1.10.1` is already in the graph via `reqwest 0.12`
+(`Cargo.lock:4281`), so adding a hyper-1 consumer is not new; no `aws-*` crate is
+in the lock today. (The closed `cognee-cloud-rust` workspace also carries a
+`hyper 0.14` qdrant fork under `[patch.crates-io]`; the two already coexist
+there, so this does not disturb the closed build either.)
+
+**MSRV ceiling — [R1].** The workspace pins rustc **1.91**
+(`rust-toolchain.toml:2`, `Cargo.toml:55` `rust-version = "1.91"`), but
+`aws-config` ≥ 1.9.0 and `aws-sigv4` 1.5.x require **1.94.1**. The newest
+compatible line is `aws-config 1.8.18` / `aws-sigv4 1.4.5` /
+`aws-credential-types 1.2.14` (MSRV 1.91.1). `resolver = "3"` selects these
+automatically, so the build works — but the adapter is **frozen on a mid-2026
+AWS release line until the toolchain moves**. Pin those versions explicitly with
+a comment pointing here, so the next `cargo update` doesn't produce a confusing
+MSRV failure.
+
+Also: the SigV4 fallback's SSO leg needs `aws-config`'s `sso` feature turned on
+explicitly — verify it is not in the default set before relying on §1.2's
+"full boto3-equivalent chain".
+
+---
+
+## 4. Work breakdown — Rust
+
+### R1 — `aws/` module: env, region, endpoint, credentials, signer, transport
+Testable standalone against `httpmock` plus SigV4 golden vectors. Decide the
+`cognee-llm` vs `cognee-utils` home for the shared module here. **The `bedrock`
+cargo feature and its optional deps must land with this step**, not at R6 — the
+module cannot compile without them (§2.3, §6.8). Pin the AWS crate versions per
+§3's MSRV note.
+
+Two credential-ladder subtleties that are easy to get subtly wrong, and are the
+reason R8 has a dedicated `credentials.rs`: the uppercase-env expansion loop
+(`base_aws_llm.py:222-247`) and "skip `AssumeRole` when already running as that
+role" (`base_aws_llm.py:1076+`).
+
+### R2 — `AwsInputs` on the context, populated at both lowering sites
+`crates/components/src/context.rs` (struct + `aws_inputs_from_env()`),
+`crates/lib/src/config.rs:850`, `crates/http-server/src/config.rs:700`.
+Additive in behaviour but **not** free to compile: `LlmInputs` /
+`EmbeddingInputs` have no `Default` and are exhaustive struct literals in eight
+places (§2.1) — expect `E0063` at each and fix them in this step. Adding
+`#[derive(Default)]` to both input structs is the cheaper alternative and worth
+taking.
+
+### R3 — `BedrockAdapter` (`impl Llm`)
+
+**This is the riskiest step in the plan** — it is where silent non-parity is
+easiest to ship, and the first draft of this section was wrong on two counts
+(§1.4.1, §1.4.3). Implement in this order:
+
+1. **Model-id normalisation and routing** (§1.4.1 / §1.4.2), `model_id.rs` +
+   `route.rs`. Strip a leading `bedrock/`; unwrap ARNs; strip the cross-region
+   prefix, throughput suffix and context suffix; honour the explicit route
+   prefixes (`converse/`, `invoke/`, `converse_like/`, `agent/`, `agentcore/`,
+   `async_invoke/`, `openai/`, `claude_platform/`, `mantle/`) and the
+   application-inference-profile-ARN → converse branch. **The normalised id
+   feeds routing only — the request URL keeps the original id.** Get this wrong
+   and all three shipped models break.
+2. **Capability table** (`caps.rs`) — `supports_native_structured_output`,
+   `supports_tool_choice`, and max output tokens, keyed on the *normalised* id.
+   This is the Rust stand-in for litellm's
+   `model_prices_and_context_window.json`; hand-maintain the entries cognee
+   ships plus a documented conservative default for unknown ids (no native
+   structured output, no forced tool choice). Note the existing Anthropic
+   `model_max_output_tokens` (`crates/llm/src/adapters/anthropic.rs:169`) keys
+   on `claude-*` names and will **not** match Bedrock ids — this table is the
+   cap source R3 needs, not that one.
+3. **`generate()`** → Converse; map `output.message.content[].text` →
+   `GenerationResponse`, `usage` → `TokenUsage`. System messages hoisted to the
+   top-level `system` block array (Converse has no system role).
+4. **`create_structured_output_with_messages_raw_validated()`** — **both**
+   §1.4.3 branches, selected from the capability table:
+   * native → `outputConfig.textFormat` with the schema,
+     `additionalProperties: false` forced onto every object node; unwrap the
+     text format;
+   * fallback → synthetic `json_tool_call` tool whose input schema is the
+     response schema, with `toolChoice` forced **only when**
+     `supports_tool_choice`; unwrap `toolUse.input`.
+
+   Re-implement the Anthropic repair loop's *behaviour* over Converse's JSON
+   (`stopReason`, `toolUse.input`): invalid / empty / validator-rejected output
+   triggers a corrective re-ask inside the same retry budget. See §6.7 — this is
+   a re-implementation, not a call into shared code.
+5. **Inference config** — `inferenceConfig.maxTokens` =
+   `min(ctx.llm.max_completion_tokens, model cap)` per §1.0, plus `temperature`
+   / `topP` / `stopSequences`.
+6. **`LLM_ARGS`** (`ctx.llm.llm_args`) merged into
+   `additionalModelRequestFields` — litellm's `{**self.llm_args, **kwargs}`,
+   explicit keys winning.
+7. **Error mapping** — Bedrock signals throttling as HTTP **400
+   `ThrottlingException`** as well as 429, unlike the 429-only mapping the
+   existing adapters use. Map both to `LlmError::RateLimitExceeded`
+   (`crates/llm/src/error.rs`) so the retry layer engages; also map
+   `ValidationException`, `AccessDeniedException`,
+   `ModelNotReadyException`/`ServiceUnavailableException`.
+8. `supports_streaming() = false`, `supports_function_calling() = true`.
+
+### R4 — `BedrockEmbeddingEngine` (`impl EmbeddingEngine`)
+InvokeModel per §1.5. Titan loops one text per request under bounded
+concurrency; Cohere batches. `dimension()` from `EmbeddingConfig.dimensions`.
+The OSS trait contract says embeddings are L2-normalised: Titan v2 normalises
+server-side with `normalize: true`; normalise client-side for the families that
+do not.
+
+Plumbing, per §2.2: `EmbeddingProvider::Bedrock`, the `create_engine` arm, a
+`"bedrock"` arm in **`parse_embedding_provider`** (without it the provider id is
+rejected before `create_engine` is ever reached), and an `aws` field on
+`EmbeddingConfig` carried across by `build_embedding_config`.
+
+### R5 — `BedrockLlmFactory` + registration
+`crates/components/src/builtins/llm.rs` alongside `AnthropicLlmFactory` /
+`AzureLlmFactory`; registered in `with_builtins()` under
+`#[cfg(feature = "bedrock")]`. `build_transcriber()` returns `Ok(None)` (§6.5),
+matching anthropic / ollama / gemini / mistral. **No API-key requirement** —
+Bedrock is absent from Python's `_API_KEY_REQUIRED_PROVIDERS`, so an empty
+`LLM_API_KEY` must fall through to SigV4 rather than erroring the way the
+Anthropic factory does.
+
+Also add the bedrock assertion to `builtins_register_documented_providers`
+(`registry.rs:318-374`), the drift guard over the registered provider set.
+
+### R6 — ~~Feature wiring~~ — folded into R1 and R5 (§6.8)
+Retained as a checklist item only: confirm §2.3's table matches what R1 and R5
+actually added, and that `default = [..., "bedrock"]` is present on `cognee`,
+`cognee-http-server` and `cognee-cli`.
+
+### R7 — HTTP `/settings` (see §5 for the parity ordering)
+`dto/settings.rs:62` gains `Bedrock`; `routers/settings.rs:~294` gains the
+match arm (the match is exhaustive, so this is a compile error until done);
+`routers/settings.rs:162` model list refreshed to Python's current three.
+
+### R8 — Tests
+* `model_id.rs` — §1.4.1 normalisation: ARN unwrap, each cross-region prefix,
+  throughput and `[1m]` suffixes. **Must include the three `eu.`-prefixed ids
+  cognee actually ships**, asserting they route to converse — that is the
+  regression this suite exists for.
+* `route_table.rs` — converse vs invoke selection, every explicit route prefix,
+  the application-inference-profile-ARN branch, and that the request URL keeps
+  the un-normalised id.
+* `structured_output.rs` — branch selection off the capability table: native
+  `outputConfig.textFormat` for the two Anthropic ids, `json_tool_call`
+  **without** forced `toolChoice` for nova-lite, forced `toolChoice` for a model
+  that advertises `supports_tool_choice`, and the conservative default for an
+  unknown id.
+* `converse_transform.rs` — system hoisting, `toolConfig`, `inferenceConfig`
+  clamping, `additionalModelRequestFields` merge precedence.
+* Error mapping — 400 `ThrottlingException` → `RateLimitExceeded`, not a
+  generic request error.
+* `sigv4_golden.rs` — signature vectors; bearer path asserts **no**
+  `Authorization: AWS4-HMAC-SHA256` and no credential lookup.
+* `credentials.rs` — the §1.2 ladder, including the uppercase-env fallbacks and
+  the `AWS_PROFILE_NAME` (not `AWS_PROFILE`) spelling.
+* `integration_bedrock.rs` — `httpmock`-backed, plus `#[ignore]`d live tests,
+  one per auth mode (bearer, static keys, profile).
+* Embedding: per-family request/response transforms, normalisation.
+
+---
+
+## 5. Work breakdown — Python parity
+
+Two-way parity is part of this plan, not a follow-up. Three of these are
+divergences that exist **today**, independent of the adapter work.
+
+### P1 — Python: accept `bedrock` on settings save
+`cognee/api/v1/settings/routers/get_settings_router.py:25-29` — add
+`Literal["bedrock"]` to `LLMConfigInputDTO.provider`. `save_llm_config.py`
+already takes `provider: str`, so this is the only gate. **Land this before
+R7**, or Rust starts accepting a payload Python rejects and the documented
+replication inverts.
+
+### P2 — Rust: refresh the bedrock model list (existing divergence)
+`routers/settings.rs:162` offers a single stale
+`anthropic.claude-3-5-sonnet-20240620-v1:0`. Python's `get_settings.py:165-178`
+now lists three: `eu.anthropic.claude-sonnet-4-5-20250929-v1:0`,
+`eu.anthropic.claude-haiku-4-5-20251001-v1:0`, `eu.amazon.nova-lite-v1:0`. The
+two GET responses have already drifted apart.
+
+### P3 — Rust: retire the replicated asymmetry from the spec
+`docs/http-server/routers/settings.md` — validation rule §2 ("we replicate this
+asymmetry; the frontend treats `bedrock` as read-only in v1"), the DTO doc
+comment at :163, open question §6.4, and the planned
+`POST provider: "bedrock" → 400` case in test plan §5.7.
+
+### P4 — Write the settings parity test the spec promised
+`e2e-cross-sdk/harness/test_http_settings.py` is referenced by
+`settings.md` §5.8 but **was never written**. Add it: GET byte-equality modulo
+the API-key mask, and `POST provider: "bedrock"` accepted on both SDKs. This is
+what keeps P1/P2/P3 from re-diverging.
+
+*(No CI gate blocks P1–P3 today: `test_http_openapi.py` compares path, method,
+security-scheme, and `components.schemas` **key sets** only — per-schema field
+diff is explicitly deferred there — so an enum-value change does not trip it.)*
+
+### P5 — Behavioural parity checklist for the adapter
+The acceptance criteria for R3/R4, each traceable to §1:
+
+| Behaviour | Source of truth |
+|---|---|
+| Bearer short-circuits before any credential resolution | §1.2 |
+| Credential ladder order, incl. STS and profile | §1.2 |
+| Uppercase env fallbacks, `AWS_PROFILE_NAME` spelling | §1.2 |
+| Region chain ending in `us-west-2` | §1.3 |
+| Endpoint chain incl. `AWS_BEDROCK_RUNTIME_ENDPOINT` | §1.3 |
+| Model-id normalisation before the route lookup (cross-region prefix, ARN, suffixes) | §1.4.1 |
+| converse/invoke routing + all explicit prefixes | §1.4.2 |
+| Structured output branch chosen by capability, not hard-coded | §1.4.3 |
+| `toolChoice` forced only when `supports_tool_choice` | §1.4.3 |
+| `max_completion_tokens` clamped to the model cap | §1.0 |
+| No API key required for bedrock | §1.1 |
+| Embeddings via InvokeModel, per-family bodies | §1.5 |
+
+Read these against §1.2/§1.4 rather than `get_s3_config()` — per §1.0 the
+default Python path never touches the latter.
+
+### P6 — Optional: raise Python to meet Rust on vision
+See §6.5. If strict two-way parity is wanted, implement `transcribe_image` in
+Python's `BedrockAdapter` using Converse image blocks rather than dropping it
+from the Rust side.
+
+---
+
+## 6. Decisions and caveats
+
+**6.1 Env-only AWS config is deliberate.** §2.1 — matches Python's `S3Config`
+and avoids the entire bindings/settings surface. If a future need arises to set
+region from the settings API, add the `Settings` fields then; the
+`BackendBuildContext` shape already accommodates it.
+
+**6.2 Default-on.** §2.3 — the shipped surfaces (`cognee`, `cognee-http-server`,
+`cognee-cli`) build with Bedrock available; slim targets drop it the same way
+they drop `lancedb`.
+
+**6.3 No streaming.** §1.6.
+
+**6.4 Audio transcription stays unsupported.** Bedrock has no Whisper
+equivalent; `build_transcriber()` returns `Ok(None)`, matching Python (which
+raises `NotImplementedError`) and the anthropic/ollama/gemini factories.
+
+**6.5 Vision exceeds Python parity — on purpose.** Python's
+`BedrockAdapter.transcribe_image` raises `NotImplementedError`. Converse *does*
+accept image content blocks, so implementing it in R3 costs ~40 lines (a base64
+`image` block plus the existing prompt). It ships, flagged in the crate docs as
+*exceeding* parity, with P6 as the optional path to closing the gap from the
+Python side instead.
+
+**6.6 `not-implemented.md` needs updating on landing.** Its provider-breadth
+entry (`docs/roadmap/not-implemented.md:52-55`) lists Bedrock as missing for
+both LLM and embeddings — remove both mentions when R3/R4 land, per this
+folder's conventions.
+
+**6.7 The Anthropic repair loop is a pattern, not shared code — and `/invoke`
+chat is out of scope.** `structured_output_impl` is a private method on
+`AnthropicAdapter`, coupled to `AnthropicResponse`, Anthropic `stop_reason`,
+`tool_use` blocks and `call_api` (`crates/llm/src/adapters/anthropic.rs:396-460`).
+Only `append_corrective_instruction` and `schema_required_validator`
+(`crates/llm/src/schema.rs:195,233`) are genuinely reusable. Converse's response
+JSON differs (`stopReason`, `toolUse.input`), so R3 re-implements the loop
+against Converse types. §3's "reuses its repair loop verbatim" overstated this;
+the *shape* argument for hand-written bodies still stands, the free-lunch
+framing does not — budget R3 accordingly.
+
+Relatedly, the first draft's `invoke.rs` carried legacy chat transforms for five
+model families. **No model cognee ships routes to invoke** (§1.4), and those
+transforms were the largest single lump of code in the plan. Scope is cut to:
+the InvokeModel *embedding* bodies (§1.5, genuinely required), and a clear
+`LlmError` for an invoke-route chat model. Reinstate if a user actually needs a
+pre-Converse chat model.
+
+**6.8 Feature wiring cannot be a late step.** `bedrock = ["dep:aws-config", …]`
+on `crates/llm` must exist at R1 or the `aws/` module has no deps to compile
+against; the `cognee-components` feature must exist at R5 for the `#[cfg]`'d
+registration. R6 as an independent late step was a paper step — intermediate
+commits would not build. Folded into R1/R5, kept as a verification checklist.
+
+**6.9 The AWS crate line is pinned by the toolchain.** §3 — 1.8.x/1.4.x until
+rustc moves past 1.91. Revisit on the next toolchain bump.
+
+---
+
+## 7. Ordering
+
+```
+R1 aws/ module (env, region, endpoint, credentials, signer, transport)
+     └─ carries the cognee-llm `bedrock` feature + pinned AWS deps  (§6.8, §3)
+R2 AwsInputs on BackendBuildContext + both lowering sites (+ 8 E0063 fixes)
+     ├─ R3 BedrockAdapter
+     │    model_id → route → caps → converse → structured output (both
+     │    branches) → error mapping → vision
+     └─ R4 BedrockEmbeddingEngine (+ parse_embedding_provider, EmbeddingConfig.aws)
+R5 factory + registry registration      ← first point LLM_PROVIDER=bedrock works
+     └─ carries the components/lib/http-server features            (§6.8)
+R6 feature-wiring verification checklist (no longer a standalone step)
+P1 Python Literal["bedrock"]            ← must precede R7
+R7 /settings DTO + match arm + P2 model list
+P3 spec doc cleanup · P4 parity test
+R8 tests · §8 docs
+```
+
+R3 and R4 are independent once R1+R2 land. P1 is independent of everything and
+can go first. R7's exhaustive match does work as a compile-time forcing function
+— the DTO variant will not build without the router arm — so that pairing is
+correctly sequenced.
+
+**Riskiest item: R3**, specifically steps 1 and 2 (normalisation + capability
+table). Both were wrong in the first draft, both fail *silently* into
+plausible-looking wrong behaviour, and both are exercised by the models cognee
+ships by default. Second riskiest: R1's credential ladder. Effort is materially
+heavier than the first draft's tone implied — comparable to the Anthropic Tier-2
+landing, **plus** an auth stack this workspace has never carried.
+
+---
+
+## 8. Docs to update
+
+* `docs/configuration.md:114` — replace "Native Bedrock adapters are tracked
+  separately in issue #17" with the real provider section: the env-var table,
+  the auth ladder of §1.2, the region/endpoint chains of §1.3, and the
+  converse/invoke note.
+* `docs/roadmap/not-implemented.md:52-55` — drop Bedrock from the LLM and
+  embedding provider-breadth entries.
+* `docs/http-server/routers/settings.md` — P3.
+* `crates/llm/README.md` / `crates/embedding/README.md` — adapter + engine rows.
+* This doc — delete on completion, per `docs/roadmap/README.md` conventions.
+
+---
+
+## 9. Verification
+
+* `cargo check --all-targets`, then `scripts/check_all.sh` (fmt, clippy
+  `-D warnings`, wrapper-binding gates).
+* `cargo check --no-default-features` on `cognee`, `cognee-http-server`, and
+  `cognee-llm` — confirms the feature gating is clean and the AWS stack is
+  genuinely droppable.
+* ~~`ci/assert-bindings-layout.sh` as the env-only tripwire~~ — **this does not
+  work.** That script guards the path contract between the `bindings/`
+  workspace and the prebuild workflows (`ci/assert-bindings-layout.sh:1-25`); it
+  would be a no-op even if `Settings` fields *were* added, so it cannot detect a
+  §2.1 violation. The real tripwires are the wrapper-gate scripts run by
+  `scripts/check_all.sh` (`python/scripts/check.sh`, `ts/scripts/check.sh`,
+  `java/scripts/check.sh`) — if any of them regenerates output, the env-only
+  decision has been violated somewhere.
+* The R8 test set, plus P4's cross-SDK settings test.
+* One `#[ignore]`d live test per auth mode, runnable by hand against a real
+  account.

--- a/docs/roadmap/bedrock-provider-plan.md
+++ b/docs/roadmap/bedrock-provider-plan.md
@@ -1,9 +1,35 @@
 # AWS Bedrock provider — implementation plan
 
-Status: proposed · Scope: **OSS `cognee-rs`**, plus a small set of Python-side
-edits for two-way parity · Tracking: issue **#17** (the remaining tier —
-`docs/configuration.md:114` "Native Bedrock adapters are tracked separately in
-issue #17"; Tier 2 = Anthropic, Tier 3 = Azure, both shipped).
+Status: **landed in this repository; one upstream item outstanding** · Scope:
+**OSS `cognee-rs`**, plus a small set of Python-side edits for two-way parity ·
+Tracking: issue **#17** (the remaining tier; Tier 2 = Anthropic, Tier 3 = Azure,
+both shipped earlier).
+
+| Item | State |
+|---|---|
+| R1 — `aws/` module (env, region, endpoint, credentials, signer, transport) + the `bedrock` feature and pinned AWS deps | ✅ `b8755114` |
+| R2 — `AwsInputs` on `BackendBuildContext`, both lowering sites | ✅ `c81a049f` |
+| R3 — `BedrockAdapter` over Converse | ✅ `950d9827` |
+| R4 — `BedrockEmbeddingEngine` + provider plumbing | ✅ `ea4d47f0` |
+| R5 — `BedrockLlmFactory` + registry registration and drift guard | ✅ `287208d0` |
+| R6 — feature-wiring verification | ✅ folded into R1/R5 (§6.8) |
+| R7 / P2 — `/settings` `Bedrock` DTO variant, router arm, refreshed model list | ✅ `b76a216d` |
+| R8 — test suites (`crates/llm/tests/bedrock_*.rs`, embedding + `caps`/`route` unit tests) | ✅ landed inside `b8755114` / `950d9827` |
+| P3 — `docs/http-server/routers/settings.md` asymmetry retired | ✅ `8a89ed43` |
+| P4 — `e2e-cross-sdk/harness/test_http_settings.py` | ✅ `28afb533` |
+| §8 — docs landing (`configuration.md`, `not-implemented.md`, crate READMEs, `architecture.md`) | ✅ this pass |
+| **P1 — Python `Literal["bedrock"]` on `LLMConfigInputDTO.provider`** | ⬜ **open — upstream `topoteretes/cognee`, cannot land from this repo** |
+| P6 — raise Python's `transcribe_image` to match Rust (§6.5) | ⬜ optional, not required for parity |
+
+**Why this doc stays in the roadmap folder.** P1 is still outstanding upstream,
+and it is the tracker that `docs/http-server/routers/settings.md` §6.4 and the
+`xfail(strict=True)` case `test_settings_post_bedrock_accepted_by_python` in
+`e2e-cross-sdk/harness/test_http_settings.py` both point at. Several source files
+also cite this path — including a user-visible `LlmError` message in
+`crates/llm/src/adapters/bedrock/mod.rs` (§6.7) — so §1 (the wire spec) and §6
+(decisions and caveats) are load-bearing references, not historical notes. Delete
+the doc only once P1 has landed upstream **and** those references have been
+re-pointed.
 
 Parity baseline: Python `cognee` and the `litellm` it depends on, read directly
 rather than assumed. §1 is the wire spec; everything after implements it.
@@ -469,7 +495,7 @@ explicitly — verify it is not in the default set before relying on §1.2's
 
 ## 4. Work breakdown — Rust
 
-### R1 — `aws/` module: env, region, endpoint, credentials, signer, transport
+### R1 — ✅ landed (`b8755114`) — `aws/` module: env, region, endpoint, credentials, signer, transport
 Testable standalone against `httpmock` plus SigV4 golden vectors. Decide the
 `cognee-llm` vs `cognee-utils` home for the shared module here. **The `bedrock`
 cargo feature and its optional deps must land with this step**, not at R6 — the
@@ -481,7 +507,7 @@ reason R8 has a dedicated `credentials.rs`: the uppercase-env expansion loop
 (`base_aws_llm.py:222-247`) and "skip `AssumeRole` when already running as that
 role" (`base_aws_llm.py:1076+`).
 
-### R2 — `AwsInputs` on the context, populated at both lowering sites
+### R2 — ✅ landed (`c81a049f`) — `AwsInputs` on the context, populated at both lowering sites
 `crates/components/src/context.rs` (struct + `aws_inputs_from_env()`),
 `crates/lib/src/config.rs:850`, `crates/http-server/src/config.rs:700`.
 Additive in behaviour but **not** free to compile: `LlmInputs` /
@@ -490,7 +516,7 @@ places (§2.1) — expect `E0063` at each and fix them in this step. Adding
 `#[derive(Default)]` to both input structs is the cheaper alternative and worth
 taking.
 
-### R3 — `BedrockAdapter` (`impl Llm`)
+### R3 — ✅ landed (`950d9827`) — `BedrockAdapter` (`impl Llm`)
 
 **This is the riskiest step in the plan** — it is where silent non-parity is
 easiest to ship, and the first draft of this section was wrong on two counts
@@ -543,7 +569,7 @@ easiest to ship, and the first draft of this section was wrong on two counts
    `ModelNotReadyException`/`ServiceUnavailableException`.
 8. `supports_streaming() = false`, `supports_function_calling() = true`.
 
-### R4 — `BedrockEmbeddingEngine` (`impl EmbeddingEngine`)
+### R4 — ✅ landed (`ea4d47f0`) — `BedrockEmbeddingEngine` (`impl EmbeddingEngine`)
 InvokeModel per §1.5. Titan loops one text per request under bounded
 concurrency; Cohere batches. `dimension()` from `EmbeddingConfig.dimensions`.
 The OSS trait contract says embeddings are L2-normalised: Titan v2 normalises
@@ -555,7 +581,7 @@ Plumbing, per §2.2: `EmbeddingProvider::Bedrock`, the `create_engine` arm, a
 rejected before `create_engine` is ever reached), and an `aws` field on
 `EmbeddingConfig` carried across by `build_embedding_config`.
 
-### R5 — `BedrockLlmFactory` + registration
+### R5 — ✅ landed (`287208d0`) — `BedrockLlmFactory` + registration
 `crates/components/src/builtins/llm.rs` alongside `AnthropicLlmFactory` /
 `AzureLlmFactory`; registered in `with_builtins()` under
 `#[cfg(feature = "bedrock")]`. `build_transcriber()` returns `Ok(None)` (§6.5),
@@ -567,17 +593,17 @@ Anthropic factory does.
 Also add the bedrock assertion to `builtins_register_documented_providers`
 (`registry.rs:318-374`), the drift guard over the registered provider set.
 
-### R6 — ~~Feature wiring~~ — folded into R1 and R5 (§6.8)
+### R6 — ✅ ~~Feature wiring~~ — folded into R1 and R5 (§6.8)
 Retained as a checklist item only: confirm §2.3's table matches what R1 and R5
 actually added, and that `default = [..., "bedrock"]` is present on `cognee`,
 `cognee-http-server` and `cognee-cli`.
 
-### R7 — HTTP `/settings` (see §5 for the parity ordering)
+### R7 — ✅ landed (`b76a216d`) — HTTP `/settings` (see §5 for the parity ordering)
 `dto/settings.rs:62` gains `Bedrock`; `routers/settings.rs:~294` gains the
 match arm (the match is exhaustive, so this is a compile error until done);
 `routers/settings.rs:162` model list refreshed to Python's current three.
 
-### R8 — Tests
+### R8 — ✅ landed (inside `b8755114` / `950d9827` / `ea4d47f0`) — Tests
 * `model_id.rs` — §1.4.1 normalisation: ARN unwrap, each cross-region prefix,
   throughput and `[1m]` suffixes. **Must include the three `eu.`-prefixed ids
   cognee actually ships**, asserting they route to converse — that is the
@@ -609,27 +635,27 @@ match arm (the match is exhaustive, so this is a compile error until done);
 Two-way parity is part of this plan, not a follow-up. Three of these are
 divergences that exist **today**, independent of the adapter work.
 
-### P1 — Python: accept `bedrock` on settings save
+### P1 — ⬜ **open, upstream** — Python: accept `bedrock` on settings save
 `cognee/api/v1/settings/routers/get_settings_router.py:25-29` — add
 `Literal["bedrock"]` to `LLMConfigInputDTO.provider`. `save_llm_config.py`
 already takes `provider: str`, so this is the only gate. **Land this before
 R7**, or Rust starts accepting a payload Python rejects and the documented
 replication inverts.
 
-### P2 — Rust: refresh the bedrock model list (existing divergence)
+### P2 — ✅ landed (`b76a216d`) — Rust: refresh the bedrock model list (existing divergence)
 `routers/settings.rs:162` offers a single stale
 `anthropic.claude-3-5-sonnet-20240620-v1:0`. Python's `get_settings.py:165-178`
 now lists three: `eu.anthropic.claude-sonnet-4-5-20250929-v1:0`,
 `eu.anthropic.claude-haiku-4-5-20251001-v1:0`, `eu.amazon.nova-lite-v1:0`. The
 two GET responses have already drifted apart.
 
-### P3 — Rust: retire the replicated asymmetry from the spec
+### P3 — ✅ landed (`8a89ed43`) — Rust: retire the replicated asymmetry from the spec
 `docs/http-server/routers/settings.md` — validation rule §2 ("we replicate this
 asymmetry; the frontend treats `bedrock` as read-only in v1"), the DTO doc
 comment at :163, open question §6.4, and the planned
 `POST provider: "bedrock" → 400` case in test plan §5.7.
 
-### P4 — Write the settings parity test the spec promised
+### P4 — ✅ landed (`28afb533`) — Write the settings parity test the spec promised
 `e2e-cross-sdk/harness/test_http_settings.py` is referenced by
 `settings.md` §5.8 but **was never written**. Add it: GET byte-equality modulo
 the API-key mask, and `POST provider: "bedrock"` accepted on both SDKs. This is
@@ -639,7 +665,7 @@ what keeps P1/P2/P3 from re-diverging.
 security-scheme, and `components.schemas` **key sets** only — per-schema field
 diff is explicitly deferred there — so an enum-value change does not trip it.)*
 
-### P5 — Behavioural parity checklist for the adapter
+### P5 — ✅ satisfied by R3/R4 — Behavioural parity checklist for the adapter
 The acceptance criteria for R3/R4, each traceable to §1:
 
 | Behaviour | Source of truth |
@@ -660,7 +686,7 @@ The acceptance criteria for R3/R4, each traceable to §1:
 Read these against §1.2/§1.4 rather than `get_s3_config()` — per §1.0 the
 default Python path never touches the latter.
 
-### P6 — Optional: raise Python to meet Rust on vision
+### P6 — ⬜ optional, open — raise Python to meet Rust on vision
 See §6.5. If strict two-way parity is wanted, implement `transcribe_image` in
 Python's `BedrockAdapter` using Converse image blocks rather than dropping it
 from the Rust side.
@@ -691,10 +717,9 @@ accept image content blocks, so implementing it in R3 costs ~40 lines (a base64
 *exceeding* parity, with P6 as the optional path to closing the gap from the
 Python side instead.
 
-**6.6 `not-implemented.md` needs updating on landing.** Its provider-breadth
-entry (`docs/roadmap/not-implemented.md:52-55`) lists Bedrock as missing for
-both LLM and embeddings — remove both mentions when R3/R4 land, per this
-folder's conventions.
+**6.6 `not-implemented.md` needed updating on landing — ✅ done.** Its
+provider-breadth entry listed Bedrock as missing for both LLM and embeddings;
+both mentions were removed in the §8 docs pass, per this folder's conventions.
 
 **6.7 The Anthropic repair loop is a pattern, not shared code — and `/invoke`
 chat is out of scope.** `structured_output_impl` is a private method on
@@ -749,6 +774,14 @@ can go first. R7's exhaustive match does work as a compile-time forcing function
 — the DTO variant will not build without the router arm — so that pairing is
 correctly sequenced.
 
+> **As executed**, P1 could not go first: it lives in `topoteretes/cognee` and is
+> not landable from this repository. R7 shipped ahead of it, which inverts the
+> documented replication in exactly the direction §5 P1 warned about — Rust now
+> accepts a payload Python rejects. That inversion is documented in
+> `docs/http-server/routers/settings.md` §6.4 and guarded by the
+> `xfail(strict=True)` case in P4's test, which turns red the moment upstream
+> accepts the value.
+
 **Riskiest item: R3**, specifically steps 1 and 2 (normalisation + capability
 table). Both were wrong in the first draft, both fail *silently* into
 plausible-looking wrong behaviour, and both are exercised by the models cognee
@@ -758,17 +791,31 @@ landing, **plus** an auth stack this workspace has never carried.
 
 ---
 
-## 8. Docs to update
+## 8. Docs to update — ✅ landed
 
-* `docs/configuration.md:114` — replace "Native Bedrock adapters are tracked
-  separately in issue #17" with the real provider section: the env-var table,
-  the auth ladder of §1.2, the region/endpoint chains of §1.3, and the
-  converse/invoke note.
-* `docs/roadmap/not-implemented.md:52-55` — drop Bedrock from the LLM and
-  embedding provider-breadth entries.
-* `docs/http-server/routers/settings.md` — P3.
-* `crates/llm/README.md` / `crates/embedding/README.md` — adapter + engine rows.
-* This doc — delete on completion, per `docs/roadmap/README.md` conventions.
+* ✅ `docs/configuration.md` — the "Native Bedrock adapters are tracked
+  separately in issue #17" line is gone, replaced by a
+  **Bedrock (`LLM_PROVIDER=bedrock`)** section carrying the env-var table, the
+  §1.2 auth ladder, the §1.3 region/endpoint chains, the converse/invoke note and
+  the capability/feature-gating notes. Three neighbouring claims were corrected
+  at the same time: the "`LLM_API_KEY` is required for every provider" sentence
+  now carries the Bedrock carve-out (§1.1), the audio-transcription note lists
+  `bedrock` under graceful no-audio (§6.4), and the Embedding section documents
+  `EMBEDDING_PROVIDER=bedrock` (§1.5).
+* ✅ `docs/roadmap/not-implemented.md` — Bedrock dropped from the LLM and
+  embedding provider-breadth entries (§6.6).
+* ✅ `docs/http-server/routers/settings.md` — P3.
+* ✅ `crates/llm/README.md` / `crates/embedding/README.md` — `BedrockAdapter` and
+  `BedrockEmbeddingEngine` bullets (and the stale "Planned: Anthropic adapter"
+  line retired).
+* ✅ `docs/architecture.md` — crate-tree comments, the `cognee-embedding` /
+  `cognee-llm` impl lists, the rustdoc entry-point table, and a key-dependency
+  row for the pinned AWS crate line.
+* **This doc — kept, not deleted.** The `docs/roadmap/README.md` convention says
+  a completed plan leaves the folder; this one has not completed (P1 is open
+  upstream), and a dozen in-repo references cite its path — source comments, two
+  Cargo manifests, `settings.md`, the cross-SDK parity test, and one runtime
+  `LlmError` message. See the note under the status table at the top.
 
 ---
 

--- a/docs/roadmap/bedrock-provider-plan.md
+++ b/docs/roadmap/bedrock-provider-plan.md
@@ -745,6 +745,20 @@ against; the `cognee-components` feature must exist at R5 for the `#[cfg]`'d
 registration. R6 as an independent late step was a paper step — intermediate
 commits would not build. Folded into R1/R5, kept as a verification checklist.
 
+**6.10 Credentials are refreshed, not snapshotted.** §1.2 specifies how a
+credential set is *resolved* and says nothing about how long it lives — an
+omission that shipped as a real defect: the ladder ran once at construction and
+every later request was signed with that snapshot. Every non-static rung yields
+temporary credentials (`AssumeRole` ~1h, the default chain over IMDS/ECS/SSO
+comparable), and because the built adapter is cached for the process lifetime, a
+long-running host started returning terminal 403 `ExpiredTokenException` and
+never recovered. Python does not have this problem: boto3 hands litellm
+`RefreshableCredentials`. `BedrockAuthProvider` closes it — it keeps the ladder
+inputs, re-runs the resolution when the cached credentials are within 60s of
+expiry, and is a no-op clone for bearer tokens and static keys. Re-running
+reaches the same rung, because the rung is chosen from `AwsSettings` and the
+ambient identity, neither of which changes over the process lifetime.
+
 **6.9 The AWS crate line is pinned by the toolchain.** §3 — 1.8.x/1.4.x until
 rustc moves past 1.91. Revisit on the next toolchain bump.
 

--- a/docs/roadmap/not-implemented.md
+++ b/docs/roadmap/not-implemented.md
@@ -49,10 +49,13 @@ from the docs is correct). The four memory-API CLI verbs (`remember` / `recall` 
   static artifact with no server behind it.
 - **LLM / embedding / backend provider breadth** — Python documents many more backends than Rust
   implements:
-  - LLM: Python adds Anthropic, Google Gemini, Mistral, Bedrock; Rust covers OpenAI-compatible
-    (OpenAI/Ollama/vLLM/llama.cpp) + `LiteRtAdapter` (Android).
-  - Embeddings: Python adds Gemini, Mistral, Bedrock, Fastembed; Rust covers ONNX, OpenAI-compatible,
-    Ollama, mock.
+  - LLM: Rust covers OpenAI-compatible (OpenAI/Ollama/Mistral/Gemini/vLLM/llama.cpp),
+    Anthropic (native Messages API), Azure, AWS Bedrock (Converse, `bedrock` feature)
+    + `LiteRtAdapter` (Android) — i.e. every provider Python names is now covered,
+    though Python reaches the wider LiteLLM catalogue that Rust does not.
+  - Embeddings: Python adds Gemini and Mistral; Rust covers ONNX (also reachable as
+    `fastembed`), OpenAI-compatible, Ollama, AWS Bedrock (InvokeModel, `bedrock`
+    feature), mock.
   - Vector stores: Python adds ChromaDB, Neptune Analytics, Redis, FalkorDB; Rust covers
     LanceDB (embedded, default on non-Android), pgvector, and an in-memory brute-force store
     (Android default + `vector_db_url = ":memory:"` escape hatch). The embedded Qdrant adapter

--- a/e2e-cross-sdk/harness/test_http_settings.py
+++ b/e2e-cross-sdk/harness/test_http_settings.py
@@ -1,0 +1,317 @@
+"""Phase-1a parity tests for /api/v1/settings (no LLM key required).
+
+This is the guard that `docs/http-server/routers/settings.md` §5 item 8 asks
+for and that `docs/roadmap/bedrock-provider-plan.md` §5 P4 tracks: it keeps the
+server-rendered provider/model lists and the save-side provider enum from
+re-diverging between the two SDKs.  `test_http_openapi.py` does not cover this
+— it compares path/method/security-scheme/``components.schemas`` **key sets**
+only, so an enum value or a model-list entry can drift without tripping it.
+
+Authentication is asymmetric here, and deliberately so.  The Rust server serves
+``/settings`` unauthenticated: ``require_authentication`` defaults to false
+(``crates/http-server/src/config.rs``) and ``bin/start_servers.sh`` does not set
+``REQUIRE_AUTHENTICATION``, so ``AuthenticatedUser`` resolves to the synthetic
+default user.  Upstream Python at the SHA pinned in
+``.github/workflows/http-parity.yml`` does **not**: its
+``get_authenticated_user`` computes
+
+    REQUIRE_AUTHENTICATION = (
+        os.getenv("REQUIRE_AUTHENTICATION", "true").lower() == "true"
+        or os.environ.get("ENABLE_BACKEND_ACCESS_CONTROL", "true").lower() == "true"
+    )
+
+which is **true when both variables are unset** — the harness sets neither — so
+an unauthenticated ``GET /api/v1/settings`` answers 401 rather than falling back
+to ``get_default_user()``.  The ``py_settings_client`` fixture below therefore
+logs the Python client in; see its docstring for why ``conftest.authed_clients``
+is the wrong tool.
+
+Ignore extension: the environment-dependent scalars.  ``llm.provider`` /
+``model`` / ``endpoint`` / ``apiVersion`` / ``apiKey`` and ``vectorDb``'s
+``provider`` / ``url`` / ``apiKey`` come from each server's own environment, and
+the two servers run out of the separate ``/py`` and ``/rs`` tmpfs workspaces, so
+``vectorDb.url`` in particular can never match (and ``start_servers.sh`` pins the
+Rust server to ``VECTOR_DB_PROVIDER=mock``).  Both sides mask keys identically
+(``key[:10] + "*" * (len(key) - 10)``), but the *configured* key is not
+guaranteed to be the same, so the masked value is ignored rather than normalised.
+
+Two notes on the ignore syntax, both load-bearing:
+
+* ``strip_paths`` understands ``$.key``, ``$..key`` and ``$.list[*].key`` only —
+  a two-level ``$.llm.api_key`` parses as an unknown pattern and is silently
+  dropped, i.e. it would *not* ignore anything.  The recursive ``$..`` form is
+  used instead, and it is exact for this endpoint: nothing nested inside the
+  response reuses these key names (the entries of ``providers`` / ``models``
+  carry ``value`` and ``label`` only).
+* The wire keys are **camelCase on both sides**, so the recursive patterns must
+  spell them that way.  Rust's DTOs carry ``#[serde(rename_all = "camelCase")]``
+  (enforced by ``crates/http-server/tests/test_openapi_camelcase.rs``) and
+  Python's ``OutDTO`` sets ``alias_generator=to_camel`` with FastAPI's default
+  ``response_model_by_alias=True``.  Both therefore emit ``apiKey`` /
+  ``apiVersion`` / ``vectorDb``.  The snake_case spellings are kept alongside so
+  the ignore set survives either side flipping its serialization convention.
+"""
+
+import pytest
+
+from http_helpers import DEFAULT_IGNORE, assert_responses_match
+
+SETTINGS_PATH = "/api/v1/settings"
+
+# Environment-dependent scalars — see the module docstring for why each one is
+# here, why the patterns are `$..` rather than `$.llm.…`, and why both casings
+# are listed.
+_SETTINGS_IGNORE = DEFAULT_IGNORE | {
+    # llm.apiKey + vectorDb.apiKey (masked, but the configured key may differ)
+    "$..apiKey",
+    "$..api_key",
+    # llm.apiVersion (env-configured)
+    "$..apiVersion",
+    "$..api_version",
+    "$..provider",  # llm.provider + vectorDb.provider (env-configured)
+    "$..model",  # llm.model (env-configured; the `models` map is NOT matched)
+    "$..endpoint",  # llm.endpoint (env-configured)
+    "$..url",  # vectorDb.url — /py vs /rs tmpfs workspaces
+}
+
+# Known, pre-existing, NON-bedrock list divergences.  Out of scope for the
+# bedrock plan (which only aligns the bedrock entries); enumerated here because
+# they are what keeps `test_settings_get_full_body_parity` xfailing.
+_KNOWN_LIST_DIVERGENCES = (
+    "llm.models.openai (py: gpt-5-mini/gpt-4o/gpt-4-turbo/gpt-3.5-turbo vs "
+    "rs: gpt-4o/gpt-4o-mini/gpt-4-turbo/gpt-4/gpt-3.5-turbo); "
+    "llm.models.anthropic (py: Claude 3 Opus/Sonnet/Haiku vs "
+    "rs: claude-3-5-sonnet-latest/claude-3-opus-latest); "
+    "llm.models.gemini (py: gemini-2.0-flash-exp labelled 'Gemini 2.0 Flash' vs "
+    "rs: gemini-2.0-flash/gemini-1.5-pro); "
+    "llm.models.mistral (py: four dated models vs "
+    "rs: mistral-large-latest/open-mistral-nemo); "
+    "vector_db.providers (py: [LanceDB, PGVector] vs "
+    "rs: [LanceDB, pgvector, brute-force] — extra entry and label case)"
+)
+
+# Credentials for the Python-side session.  Mirrors the pair
+# `conftest.authed_clients` uses; the email is module-specific so a failure here
+# is never confused with that fixture's user.
+_PY_CREDS = {"username": "settings-parity@example.com", "password": "test_password_123"}
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def py_settings_client(py_client):
+    """``py_client`` with a logged-in session cookie.
+
+    Upstream Python requires authentication on ``/api/v1/settings`` (see the
+    module docstring), so every Python-side call in this file goes through here.
+
+    ``conftest.authed_clients`` is deliberately **not** used: it calls
+    ``pytest.skip`` whenever the session-scoped ``auth_endpoints_available``
+    probe finds ``/api/v1/auth/*`` missing — which is always true for the *Rust*
+    OSS ``cognee-http-server``.  Skipping on that would silently void this gate
+    in CI, which is the whole failure mode P4 exists to prevent.  The Rust client
+    needs no session at all, so only the Python one is authenticated.
+
+    The login is asserted rather than skipped: Python's ``/api/v1/auth/*`` routes
+    are unconditionally mounted by ``cognee/api/client.py``, so a failure here is
+    a real regression in the harness, not an unsupported deployment.
+    """
+    # Bootstrap the user; a re-run answers 400 REGISTER_USER_ALREADY_EXISTS,
+    # which is fine — the login below is the actual gate.
+    py_client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": _PY_CREDS["username"],
+            "password": _PY_CREDS["password"],
+            "is_verified": True,
+        },
+    )
+    r = py_client.post("/api/v1/auth/login", data=_PY_CREDS)
+    assert r.status_code == 200, (
+        f"py: POST /api/v1/auth/login -> {r.status_code}: {r.text[:300]}. "
+        "The Python settings endpoints require authentication at the pinned SHA."
+    )
+    return py_client
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _get_settings(client, side: str) -> dict:
+    """GET /api/v1/settings, assert 200, return the parsed body."""
+    r = client.get(SETTINGS_PATH)
+    assert r.status_code == 200, f"{side}: GET {SETTINGS_PATH} -> {r.status_code}: {r.text[:300]}"
+    return r.json()
+
+
+def _provider_choice(body: dict, value: str, side: str) -> dict:
+    """Return the ``llm.providers`` entry whose ``value`` is *value*."""
+    providers = body["llm"]["providers"]
+    matches = [p for p in providers if p.get("value") == value]
+    assert matches, (
+        f"{side}: llm.providers does not advertise {value!r}; "
+        f"got {[p.get('value') for p in providers]}"
+    )
+    assert len(matches) == 1, f"{side}: llm.providers lists {value!r} {len(matches)} times"
+    return matches[0]
+
+
+# ── GET parity ───────────────────────────────────────────────────────────────
+
+
+def test_settings_bedrock_provider_choice_matches(py_settings_client, rs_client):
+    """The `bedrock` entry of llm.providers is identical (value AND label)."""
+    py_choice = _provider_choice(_get_settings(py_settings_client, "py"), "bedrock", "py")
+    rs_choice = _provider_choice(_get_settings(rs_client, "rs"), "bedrock", "rs")
+    assert py_choice == rs_choice, (
+        f"bedrock provider choice diverged: py={py_choice} rs={rs_choice}"
+    )
+
+
+def test_settings_bedrock_model_list_matches(py_settings_client, rs_client):
+    """llm.models["bedrock"] matches element-for-element and in order.
+
+    This is the drift guard for plan §5 P2: Rust carried a single stale
+    `anthropic.claude-3-5-sonnet-20240620-v1:0` while Python moved to three
+    `eu.*` models, and nothing caught it.
+    """
+    py_models = _get_settings(py_settings_client, "py")["llm"]["models"]
+    rs_models = _get_settings(rs_client, "rs")["llm"]["models"]
+
+    assert "bedrock" in py_models, f"py: llm.models has no bedrock key: {sorted(py_models)}"
+    assert "bedrock" in rs_models, f"rs: llm.models has no bedrock key: {sorted(rs_models)}"
+    assert py_models["bedrock"] == rs_models["bedrock"], (
+        f"bedrock model list diverged:\npy={py_models['bedrock']}\nrs={rs_models['bedrock']}"
+    )
+
+
+def test_settings_llm_provider_value_set_matches(py_settings_client, rs_client):
+    """llm.providers[*].value is the same list, in the same order, on both SDKs.
+
+    Catches any future one-sided provider addition (the failure mode P1/P2/P3
+    were all instances of).
+    """
+    py_values = [p.get("value") for p in _get_settings(py_settings_client, "py")["llm"]["providers"]]
+    rs_values = [p.get("value") for p in _get_settings(rs_client, "rs")["llm"]["providers"]]
+
+    assert set(py_values) == set(rs_values), (
+        f"llm provider value sets diverged: only in py={sorted(set(py_values) - set(rs_values))}, "
+        f"only in rs={sorted(set(rs_values) - set(py_values))}"
+    )
+    assert py_values == rs_values, (
+        f"llm provider order diverged: py={py_values} rs={rs_values}"
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Full-body GET parity is blocked by pre-existing, non-bedrock list "
+        "divergences that are out of scope for bedrock-provider-plan.md §5: "
+        + _KNOWN_LIST_DIVERGENCES
+        + ". The environment-dependent scalars are already ignored (see the "
+        "module docstring); everything left is a real list divergence. Delete "
+        "this marker once those lists are aligned — strict=False means the day "
+        "they converge this reports XPASS rather than turning CI red."
+    ),
+    strict=False,
+)
+def test_settings_get_full_body_parity(py_settings_client, rs_client):
+    """GET /api/v1/settings is byte-equal modulo the env-dependent scalars."""
+    py = py_settings_client.get(SETTINGS_PATH)
+    rs = rs_client.get(SETTINGS_PATH)
+    assert_responses_match(py, rs, ignore=_SETTINGS_IGNORE)
+
+
+# ── POST parity ──────────────────────────────────────────────────────────────
+
+# `api_key` is required by both input DTOs. The literal below deliberately
+# contains no "*****" substring: both SDKs treat a submitted key containing
+# that sentinel as the redacted echo from GET and refuse to persist it, so a
+# sentinel-free value is what actually exercises the save path.
+#
+# The snake_case spelling is accepted by both sides on *input* — Rust's
+# `LLMConfigInputDTO` carries `#[serde(alias = "api_key")]` and Python's `InDTO`
+# sets `populate_by_name=True` — so it does not need the camelCase treatment the
+# GET response does.
+_BEDROCK_POST = {
+    "llm": {
+        "provider": "bedrock",
+        "model": "eu.amazon.nova-lite-v1:0",
+        "api_key": "test-key-not-persisted",
+    }
+}
+
+# Restoring the previous provider/model afterwards uses this literal key: it
+# contains the "*****" sentinel, so neither SDK overwrites the real configured
+# key while the provider/model are put back.
+_ECHO_SENTINEL_KEY = "*****"
+
+
+def test_settings_post_bedrock_accepted_by_rust(rs_client):
+    """POST provider="bedrock" is accepted by Rust and reflected on the next GET.
+
+    The save mutates a process-singleton on the Rust server (Python does the
+    same — settings are in-process, never written to a relational table), so
+    this leaves `llm.provider`/`llm.model` changed for the rest of the session.
+    Those two fields are in `_SETTINGS_IGNORE` for exactly that reason; the
+    previous values are restored best-effort below anyway.
+    """
+    before = _get_settings(rs_client, "rs")["llm"]
+    try:
+        r = rs_client.post(SETTINGS_PATH, json=_BEDROCK_POST)
+        assert r.status_code == 200, (
+            f"rs: POST {SETTINGS_PATH} provider=bedrock -> {r.status_code}: {r.text[:300]}"
+        )
+
+        after = _get_settings(rs_client, "rs")["llm"]
+        assert after["provider"] == "bedrock", (
+            f"rs: provider did not persist as 'bedrock', got {after['provider']!r}"
+        )
+    finally:
+        # Best-effort restore — unasserted: if the environment configured a
+        # provider outside the input enum this POST is rejected, which is not
+        # this test's subject.
+        rs_client.post(
+            SETTINGS_PATH,
+            json={
+                "llm": {
+                    "provider": before["provider"],
+                    "model": before["model"],
+                    "api_key": _ECHO_SENTINEL_KEY,
+                }
+            },
+        )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Upstream gap, tracked as bedrock-provider-plan.md §5 P1: "
+        "cognee/api/v1/settings/routers/get_settings_router.py types "
+        "LLMConfigInputDTO.provider as a Literal union that omits 'bedrock', so "
+        "Python rejects the value it advertises on GET. "
+        ".github/workflows/http-parity.yml pins topoteretes/cognee at "
+        "b9014c16, which predates any fix, and P1 cannot be landed from this "
+        "repository. strict=True makes this XPASS loudly (a CI failure) the day "
+        "upstream adds Literal['bedrock'] and the pin is bumped — at which "
+        "point delete this marker rather than the test."
+    ),
+    strict=True,
+)
+def test_settings_post_bedrock_accepted_by_python(py_settings_client):
+    """POST provider="bedrock" is accepted by Python (xfail: upstream P1).
+
+    No specific rejection status is asserted: cognee/FastAPI's exact
+    400-vs-422 mapping for the Literal violation is not verifiable from this
+    repository. Asserting the *success* case under a strict xfail covers both
+    directions — it fails today and turns red the moment upstream lands P1.
+
+    Unlike the Rust case there is no restore leg: the POST cannot currently
+    succeed, and once P1 lands the mutation is confined to this pytest session
+    anyway (`start_servers.sh` is the compose entrypoint, so every phase step
+    boots its own server pair, and Phase-1a exercises no LLM call).
+    """
+    r = py_settings_client.post(SETTINGS_PATH, json=_BEDROCK_POST)
+    assert r.status_code == 200, (
+        f"py: POST {SETTINGS_PATH} provider=bedrock -> {r.status_code}: {r.text[:300]}"
+    )

--- a/e2e-cross-sdk/harness/test_http_settings.py
+++ b/e2e-cross-sdk/harness/test_http_settings.py
@@ -7,6 +7,21 @@ re-diverging between the two SDKs.  `test_http_openapi.py` does not cover this
 — it compares path/method/security-scheme/``components.schemas`` **key sets**
 only, so an enum value or a model-list entry can drift without tripping it.
 
+A **non-empty ``LLM_API_KEY`` is required** to run this file, which is why
+``http-parity.yml`` gives it its own step rather than folding it into the main
+keyless Phase-1a.  No test here calls an LLM — the requirement is entirely an
+upstream defect at the pinned SHA: ``LLMConfig.api_key`` is a required ``str``
+while ``get_settings`` renders ``None`` for a falsy key, so
+``SettingsDict.model_validate`` raises and ``GET /api/v1/settings`` answers 500
+before any comparison can happen::
+
+    pydantic_core.ValidationError: 1 validation error for SettingsDict
+    llm.api_key  Input should be a valid string [input_value=None]
+
+Upstream ``dev`` has since widened the field to ``Optional[str]``, so the
+dedicated step can fold back into Phase-1a once the SHA in
+``.github/workflows/http-parity.yml`` is bumped past that fix.
+
 Authentication is asymmetric here, and deliberately so.  The Rust server serves
 ``/settings`` unauthenticated: ``require_authentication`` defaults to false
 (``crates/http-server/src/config.rs``) and ``bin/start_servers.sh`` does not set
@@ -141,7 +156,12 @@ def py_settings_client(py_client):
 def _get_settings(client, side: str) -> dict:
     """GET /api/v1/settings, assert 200, return the parsed body."""
     r = client.get(SETTINGS_PATH)
-    assert r.status_code == 200, f"{side}: GET {SETTINGS_PATH} -> {r.status_code}: {r.text[:300]}"
+    assert r.status_code == 200, (
+        f"{side}: GET {SETTINGS_PATH} -> {r.status_code}: {r.text[:300]}. "
+        "A 500 from the Python side with a `llm.api_key` validation error means "
+        "LLM_API_KEY is empty — see the module docstring; this file needs a "
+        "non-empty (not necessarily valid) key."
+    )
     return r.json()
 
 

--- a/java/cognee-java-jni/Cargo.toml
+++ b/java/cognee-java-jni/Cargo.toml
@@ -24,6 +24,7 @@ default = [
     "ladybug",
     "lancedb",
     "onnx",
+    "bedrock",
     "hf-tokenizer",
     "tiktoken",
     "sqlite",
@@ -36,6 +37,7 @@ visualization = ["cognee/visualization", "cognee-bindings-common/visualization"]
 ladybug       = ["cognee/ladybug",       "cognee-bindings-common/ladybug"]
 lancedb       = ["cognee/lancedb",       "cognee-bindings-common/lancedb"]
 onnx          = ["cognee/onnx",          "cognee-bindings-common/onnx"]
+bedrock       = ["cognee/bedrock",       "cognee-bindings-common/bedrock"]
 hf-tokenizer  = ["cognee/hf-tokenizer",  "cognee-bindings-common/hf-tokenizer"]
 tiktoken      = ["cognee/tiktoken",      "cognee-bindings-common/tiktoken"]
 sqlite        = ["cognee/sqlite",        "cognee-bindings-common/sqlite"]

--- a/java/cognee-java-jni/Cargo.toml
+++ b/java/cognee-java-jni/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cognee-java-jni"
 version = "0.2.0"
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.91.1"
 license = "MIT OR Apache-2.0"
 description = "JNI (jni-rs) native binding for the cognee Rust SDK (Java)."
 repository = "https://github.com/topoteretes/cognee-rs"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -48,6 +48,7 @@ default = [
     "ladybug",
     "lancedb",
     "onnx",
+    "bedrock",
     "hf-tokenizer",
     "tiktoken",
     "sqlite",
@@ -65,6 +66,7 @@ visualization = ["cognee/visualization", "cognee-bindings-common/visualization"]
 ladybug       = ["cognee/ladybug",       "cognee-bindings-common/ladybug"]
 lancedb       = ["cognee/lancedb",       "cognee-bindings-common/lancedb"]
 onnx          = ["cognee/onnx",          "cognee-bindings-common/onnx"]
+bedrock       = ["cognee/bedrock",       "cognee-bindings-common/bedrock"]
 hf-tokenizer  = ["cognee/hf-tokenizer",  "cognee-bindings-common/hf-tokenizer"]
 tiktoken      = ["cognee/tiktoken",      "cognee-bindings-common/tiktoken"]
 sqlite        = ["cognee/sqlite",        "cognee-bindings-common/sqlite"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91"
+channel = "1.91.1"
 components = ["rustfmt", "clippy"]

--- a/ts/cognee-ts-neon/Cargo.toml
+++ b/ts/cognee-ts-neon/Cargo.toml
@@ -27,6 +27,7 @@ default = [
     "ladybug",
     "lancedb",
     "onnx",
+    "bedrock",
     "hf-tokenizer",
     "tiktoken",
     "sqlite",
@@ -51,6 +52,7 @@ visualization = ["cognee/visualization", "cognee-bindings-common/visualization"]
 ladybug       = ["cognee/ladybug",       "cognee-bindings-common/ladybug"]
 lancedb       = ["cognee/lancedb",       "cognee-bindings-common/lancedb"]
 onnx          = ["cognee/onnx",          "cognee-bindings-common/onnx"]
+bedrock       = ["cognee/bedrock",       "cognee-bindings-common/bedrock"]
 hf-tokenizer  = ["cognee/hf-tokenizer",  "cognee-bindings-common/hf-tokenizer"]
 tiktoken      = ["cognee/tiktoken",      "cognee-bindings-common/tiktoken"]
 sqlite        = ["cognee/sqlite",        "cognee-bindings-common/sqlite"]

--- a/ts/cognee-ts-neon/Cargo.toml
+++ b/ts/cognee-ts-neon/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cognee-ts-neon"
 version = "0.2.0"
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.91.1"
 license = "MIT OR Apache-2.0"
 description = "Neon (Node.js) native binding for the cognee Rust SDK."
 repository = "https://github.com/topoteretes/cognee-rs"


### PR DESCRIPTION
Implements `docs/roadmap/bedrock-provider-plan.md` — a native AWS Bedrock LLM adapter and embedding engine, ported for parity with Python `cognee` and the `litellm` it delegates to. Closes the remaining tier of #17 (Tier 2 Anthropic and Tier 3 Azure shipped earlier).

`LLM_PROVIDER=bedrock` and `EMBEDDING_PROVIDER=bedrock` now resolve, over Converse and InvokeModel respectively, with the full §1.2 auth ladder (bearer → static keys → profile → STS AssumeRole / web identity → the default chain over SSO/ECS/IMDS).

## What landed

| | |
|---|---|
| `crates/llm/src/adapters/bedrock/` | adapter, model-id normalisation, routing, capability table, Converse transforms, and the shared `aws/` module (env, region, endpoint, credentials, SigV4 signer, transport seam) |
| `crates/embedding/src/bedrock/` | Titan (g1/v2/multimodal) and Cohere engines over InvokeModel |
| `crates/components/` | `BedrockLlmFactory`, registry registration, `AwsInputs` on `BackendBuildContext` |
| `crates/http-server/` | `bedrock` on the `/settings` LLM provider list, model list refreshed to match Python |
| `e2e-cross-sdk/harness/test_http_settings.py` | the cross-SDK settings parity test the spec promised but never had |

**No `Settings` fields were added.** Python resolves AWS config from the environment and never threads it through its LLM config, so `AwsInputs` follows the existing `anthropic_base_url_from_env()` precedent. That keeps the entire bindings surface untouched — no setters, no `to_dict`/`from_map` entries, no wrapper-gate regeneration.

## Design decisions worth review

- **Transport is `aws-config` + `aws-sigv4` + the existing `reqwest` client**, not `aws-sdk-bedrockruntime`. The bearer path must send a plain header with no SigV4 and no credential lookup at all — a two-line branch here, a fight with the SDK's auth-scheme resolver there. Bodies stay hand-written so the adapter mirrors `AnthropicAdapter`'s shape. Transport sits behind one internal trait, so swapping later touches one file.
- **Pinned to `aws-config` 1.8.x / `aws-sigv4` 1.4.x** — newer lines require rustc 1.94 against this workspace's pinned 1.91.
- **No streaming.** `converse-stream` uses binary eventstream framing and no OSS Rust adapter streams today; `supports_streaming()` returns `false`.
- **Vision exceeds Python parity on purpose** — Python's `BedrockAdapter.transcribe_image` raises `NotImplementedError`; Converse accepts image blocks, so it ships. Flagged in the crate docs.

## Two things that fail silently if ported naively

Both were caught by review and both have regression tests:

1. **Model-id normalisation happens before the converse-table lookup.** litellm strips cross-region prefixes, ARNs and throughput/context suffixes first. Every model cognee ships by default is `eu.`-prefixed, and the table stores bare ids — so a port that looks the raw id up routes 3 of 3 shipped models to `invoke`.
2. **Structured output is capability-gated.** The forced `json_tool_call` tool is the *fallback*; both Anthropic models cognee ships take the native `outputConfig.textFormat` branch, and `eu.amazon.nova-lite-v1:0` gets the tool *without* a forced `toolChoice` (it lacks `supports_tool_choice`, and Nova is documented to reject a specific one).

## Fixes on top of the initial implementation

The last five commits are review findings, each with a test that fails against the unfixed code:

- **Converse table was 38 ids short.** litellm doesn't stop at its static constant — it extends the set at import with every `bedrock_converse` entry in `model_prices_and_context_window.json`. Two of the missing ids already had capability rows and were rejected at construction with a message claiming they weren't Converse-capable. Added as a separately-derived table with the derivation rule documented, plus a drift guard asserting every capability row routes to Converse.
- **Routing tokens leaked into the request URL.** `bedrock/…`, the spelling Python cognee configs commonly carry, constructed fine then 400ed on every request. A follow-up commit corrects the first attempt, which wrongly kept the `nova/` spec prefix — `converse_handler.py` strips that too.
- **Temporary credentials never refreshed.** The ladder ran once at construction and the snapshot signed every later request. Every non-static rung yields short-lived credentials, and since the built adapter is cached for the process lifetime, the HTTP server would fail permanently with a terminal 403 about an hour in. Python is unaffected — boto3 hands litellm refreshable credentials — so this was a parity regression. `BedrockAuthProvider` re-resolves within 60s of expiry; bearer tokens and static keys never trigger a lookup.
- **Embedding dimension lookup missed cross-region prefixes**, falling back to 384 where Titan v2 accepts only 1024/512/256.

## Verification

`cargo check --all-targets`, clippy `-D warnings`, and the Rust half of `scripts/check_all.sh` are clean; C API, TypeScript and Python binding gates pass. Bedrock-specific coverage is 7 suites (model-id normalisation, structured output, converse transforms, SigV4 golden vectors, credential ladder, region/endpoint, httpmock integration) plus embedding and transport unit tests.

Java's gate was skipped locally (no JDK); CI installs one.

> **Heads-up on the local gate:** `scripts/check_all.sh` exits 0 without completing — it stops at `pytest: command not found` because it calls bare `pytest` rather than activating `python/.venv`, and never reaches the TS or Java gates. Unrelated to this PR, but its exit code shouldn't be trusted until fixed.

## Outstanding

**P1 is upstream work.** Python's `LLMConfigInputDTO.provider` needs `Literal["bedrock"]` added in `topoteretes/cognee` before it accepts a bedrock settings save. It's tracked by an `xfail(strict=True)` in the new parity test and cited from `docs/http-server/routers/settings.md` §6.4 and a user-visible `LlmError` message — which is why `docs/roadmap/bedrock-provider-plan.md` stays in the roadmap folder rather than being deleted on landing.

Two known gaps, both pre-existing and out of scope: the main pipeline sends the Settings default dimension for Bedrock embedding models unless `EMBEDDING_DIMENSIONS` is set, and 7 bare model ids route to Converse here where litellm routes them to invoke (permissive direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5dYEVN57KcHDXChHgrRbo
