### PR TITLE
fix(cognify): let a dataset be cognified more than once (TOP-7)

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -35,8 +35,9 @@ use crate::error::CliError;
 ///   rows only, which for the benchmark would turn a populated-dataset delete
 ///   into a metadata-row delete;
 /// - the pipeline-runs repository — without it a deletion writes no fresh
-///   `INITIATED` row, so a later re-cognify is short-circuited by
-///   `check_pipeline_run_qualification`.
+///   `INITIATED` row. That only changes behaviour for a caller that enabled
+///   `CognifyConfig::use_pipeline_cache`: since the cache became opt-in, a
+///   `COMPLETED` row no longer short-circuits the default re-cognify path.
 pub(crate) async fn build_delete_service(
     cm: &Arc<ComponentManager>,
 ) -> Result<DeleteService, CliError> {

--- a/crates/cognify/src/memify/config.rs
+++ b/crates/cognify/src/memify/config.rs
@@ -72,6 +72,17 @@ pub struct MemifyConfig {
     /// Python: memify(data=...)
     #[serde(skip)]
     pub custom_data: Option<Vec<serde_json::Value>>,
+
+    /// Opt in to the pipeline-run cache: when `true`, a memify run whose
+    /// dataset already has a COMPLETED `memify_pipeline` row short-circuits
+    /// instead of re-running.
+    ///
+    /// Default `false`, matching Python — `memify()` hard-codes
+    /// `use_pipeline_cache=False`, and `run_pipeline_per_dataset` only consults
+    /// `check_pipeline_run_qualification` when the flag is set. Mirrors
+    /// [`crate::CognifyConfig::use_pipeline_cache`].
+    #[serde(default)]
+    pub use_pipeline_cache: bool,
 }
 
 impl Default for MemifyConfig {
@@ -84,6 +95,7 @@ impl Default for MemifyConfig {
             extraction_tasks: None,
             enrichment_tasks: None,
             custom_data: None,
+            use_pipeline_cache: false,
         }
     }
 }
@@ -91,6 +103,13 @@ impl Default for MemifyConfig {
 impl MemifyConfig {
     pub fn with_triplet_batch_size(mut self, size: usize) -> Self {
         self.triplet_batch_size = size;
+        self
+    }
+
+    /// Opt in to the pipeline-run cache (see
+    /// [`use_pipeline_cache`](Self::use_pipeline_cache)). Off by default.
+    pub fn with_pipeline_cache(mut self, enable: bool) -> Self {
+        self.use_pipeline_cache = enable;
         self
     }
 

--- a/crates/cognify/src/memify/pipeline.rs
+++ b/crates/cognify/src/memify/pipeline.rs
@@ -16,7 +16,7 @@ use cognee_embedding::EmbeddingEngine;
 use cognee_graph::GraphDBTrait;
 use cognee_models::{Entity, Triplet};
 use cognee_vector::VectorDB;
-use tracing::info;
+use tracing::{info, warn};
 use uuid::Uuid;
 
 use super::config::MemifyConfig;
@@ -24,6 +24,7 @@ use super::error::MemifyError;
 use super::extract_triplets::extract_triplets_from_graph_db;
 use super::index_triplets::{IndexResult, index_triplets};
 use crate::qualification::{Qualification, check_pipeline_run_qualification};
+use crate::tasks::CLAIM_STALE_AFTER;
 
 /// Pipeline name for memify runs, matching Python's
 /// `pipeline_name="memify_pipeline"` argument to `run_tasks`
@@ -196,9 +197,8 @@ pub async fn memify(
     // `run_pipeline_per_dataset` (`memify()` passes `use_pipeline_cache=False`).
     // Short-circuiting unconditionally made every memify after the first a
     // silent no-op. `AlreadyRunning` still rejects either way — see the longer
-    // note in `tasks::cognify` for why, including the residual race it does
-    // *not* close (the qualification read and the `Started` write are separate
-    // operations, so two callers entering within that window both proceed).
+    // note in `tasks::cognify` for why, including why this check alone is not
+    // serialization (the exclusive-run claim below is what provides that).
     //
     // Skipped entirely when `dataset_id` is `None` — Python's gate only applies
     // per dataset, and ad-hoc memify runs without a dataset cannot be looked
@@ -232,118 +232,164 @@ pub async fn memify(
         }
     }
 
-    // 2. Pre-flight: extract triplets from the graph database (or use custom data).
-    let triplets = if let Some(ref custom_data) = config.custom_data {
-        // When custom data is provided, convert JSON values to Triplet objects.
-        // Each value should be a JSON object with "source_node", "relationship_name",
-        // and "target_node" fields. UUIDs are generated deterministically from the
-        // text values.
-        let mut custom_triplets = Vec::new();
-        for value in custom_data {
-            let source = value
-                .get("source_node")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown")
-                .to_string();
-            let relationship = value
-                .get("relationship_name")
-                .and_then(|v| v.as_str())
-                .unwrap_or("related_to")
-                .to_string();
-            let target = value
-                .get("target_node")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown")
-                .to_string();
-            // Custom-triplet endpoints use the same `Entity::id_for` scheme as
-            // graph entities, so a custom node connects to an existing entity
-            // when its name matches that entity's LLM node id (which
-            // `Entity::from_node` hashes). When the graph entity's node id
-            // differs from its display name, the ids won't coincide — but this
-            // is still strictly better than the previous bare `to_lowercase`
-            // hash, which shared no id space with entities at all.
-            let source_id = Entity::id_for(&source);
-            let target_id = Entity::id_for(&target);
-            let text = format!("{source}-\u{203A}{relationship}-\u{203A}{target}");
-            custom_triplets.push(
-                Triplet::new(source_id, target_id, relationship, text).with_names(source, target),
-            );
+    // ── Exclusive-run claim ─────────────────────────────────────────────────
+    // Same reasoning as `tasks::cognify`: the `AlreadyRunning` verdict above
+    // only catches a run that already wrote its `Started` row, so the claim is
+    // what actually serializes concurrent runs. Scoped to a known dataset for
+    // the same reason the gate is — an ad-hoc run without one has nothing to
+    // claim, and cannot collide on `(dataset_id, pipeline_name)`.
+    let claim_repo = Arc::clone(&pipeline_run_repo);
+    let claim = if let Some(ds_id) = dataset_id {
+        let claim_id = Uuid::new_v4();
+        if !claim_repo
+            .try_claim_pipeline_run(ds_id, pipeline_name, claim_id, CLAIM_STALE_AFTER)
+            .await
+            .map_err(|e| MemifyError::Database(e.to_string()))?
+        {
+            return Err(MemifyError::PipelineAlreadyRunning {
+                pipeline_name: pipeline_name.to_string(),
+                dataset_id: Some(ds_id),
+            });
         }
-        info!(
-            "Using {} custom triplets instead of graph extraction",
-            custom_triplets.len()
-        );
-        custom_triplets
+        Some((ds_id, claim_id))
     } else {
-        extract_triplets_from_graph_db(&*graph_db, config).await?
+        None
     };
 
-    let triplet_count = triplets.len();
+    // Wrapped so the release below is reached on every exit path, `?`
+    // included. `Drop` cannot await, so an RAII guard is not an option.
+    let outcome: Result<MemifyResult, MemifyError> = async {
+        // 2. Pre-flight: extract triplets from the graph database (or use custom data).
+        let triplets = if let Some(ref custom_data) = config.custom_data {
+            // When custom data is provided, convert JSON values to Triplet objects.
+            // Each value should be a JSON object with "source_node", "relationship_name",
+            // and "target_node" fields. UUIDs are generated deterministically from the
+            // text values.
+            let mut custom_triplets = Vec::new();
+            for value in custom_data {
+                let source = value
+                    .get("source_node")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                let relationship = value
+                    .get("relationship_name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("related_to")
+                    .to_string();
+                let target = value
+                    .get("target_node")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                // Custom-triplet endpoints use the same `Entity::id_for` scheme as
+                // graph entities, so a custom node connects to an existing entity
+                // when its name matches that entity's LLM node id (which
+                // `Entity::from_node` hashes). When the graph entity's node id
+                // differs from its display name, the ids won't coincide — but this
+                // is still strictly better than the previous bare `to_lowercase`
+                // hash, which shared no id space with entities at all.
+                let source_id = Entity::id_for(&source);
+                let target_id = Entity::id_for(&target);
+                let text = format!("{source}-\u{203A}{relationship}-\u{203A}{target}");
+                custom_triplets.push(
+                    Triplet::new(source_id, target_id, relationship, text)
+                        .with_names(source, target),
+                );
+            }
+            info!(
+                "Using {} custom triplets instead of graph extraction",
+                custom_triplets.len()
+            );
+            custom_triplets
+        } else {
+            extract_triplets_from_graph_db(&*graph_db, config).await?
+        };
 
-    // 3. If empty, return early with zeros — skip the executor entirely.
-    if triplets.is_empty() {
-        info!("No triplets extracted from graph; nothing to index");
-        return Ok(MemifyResult::empty());
+        let triplet_count = triplets.len();
+
+        // 3. If empty, return early with zeros — skip the executor entirely.
+        if triplets.is_empty() {
+            info!("No triplets extracted from graph; nothing to index");
+            return Ok(MemifyResult::empty());
+        }
+
+        // 4. Build the one-task index-only pipeline and run it through
+        //    `pipeline::execute` (Decision 8 / 11).
+        let pipeline = build_memify_index_only_pipeline(
+            Arc::clone(&vector_db),
+            Arc::clone(&embedding_engine),
+            dataset_id,
+            user_id,
+            tenant_id,
+        );
+
+        // The executor re-derives `PipelineRunInfo.pipeline_id` from
+        // `(pipeline.name, user_id, dataset_id)`; we still carry `pipeline.id`
+        // through `PipelineContext` as the placeholder.
+        let pipeline_ctx = PipelineContext {
+            pipeline_id: pipeline.id,
+            pipeline_name: pipeline.name.clone().unwrap_or_default(),
+            user_id,
+            tenant_id,
+            dataset_id,
+            current_data: None,
+            run_id: None,
+            user_email: None,
+            provenance_visited: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+        };
+
+        let (_cancel_handle, ctx) = TaskContextBuilder::new()
+            .thread_pool(thread_pool)
+            .database(database)
+            .graph_db(Arc::clone(&graph_db))
+            .vector_db(Arc::clone(&vector_db))
+            .pipeline_context(pipeline_ctx)
+            .build()
+            .map_err(|e| MemifyError::Context(e.to_string()))?;
+        let ctx = Arc::new(ctx);
+
+        let inputs: Vec<Arc<dyn Value>> = vec![Arc::new(triplets) as Arc<dyn Value>];
+
+        // Decision 11 (gap 08-07): persist the four-state `pipeline_runs` trail
+        // through the caller-supplied repository.
+        let watcher = DbPipelineWatcher::new(pipeline_run_repo);
+        let outputs = cognee_core::pipeline::execute(&pipeline, inputs, ctx, &watcher)
+            .await
+            .map_err(|e| MemifyError::Execute(e.to_string()))?;
+
+        let index_result = extract_memify_outputs(outputs)?;
+
+        // 5. Log summary and return.
+        info!(
+            "Memify complete: {} triplets extracted, {} indexed",
+            triplet_count, index_result.indexed_count
+        );
+
+        Ok(MemifyResult {
+            triplet_count,
+            index_result,
+            already_completed: false,
+            prior_pipeline_run_id: None,
+        })
+    }
+    .await;
+
+    if let Some((ds_id, claim_id)) = claim
+        && let Err(e) = claim_repo
+            .release_pipeline_run_claim(ds_id, pipeline_name, claim_id)
+            .await
+    {
+        // The run is over either way, and an unreleased claim ages out rather
+        // than being lost, so this must not mask the outcome.
+        warn!(
+            dataset_id = %ds_id,
+            pipeline_name = %pipeline_name,
+            "failed to release the pipeline-run claim (it will age out): {e}"
+        );
     }
 
-    // 4. Build the one-task index-only pipeline and run it through
-    //    `pipeline::execute` (Decision 8 / 11).
-    let pipeline = build_memify_index_only_pipeline(
-        Arc::clone(&vector_db),
-        Arc::clone(&embedding_engine),
-        dataset_id,
-        user_id,
-        tenant_id,
-    );
-
-    // The executor re-derives `PipelineRunInfo.pipeline_id` from
-    // `(pipeline.name, user_id, dataset_id)`; we still carry `pipeline.id`
-    // through `PipelineContext` as the placeholder.
-    let pipeline_ctx = PipelineContext {
-        pipeline_id: pipeline.id,
-        pipeline_name: pipeline.name.clone().unwrap_or_default(),
-        user_id,
-        tenant_id,
-        dataset_id,
-        current_data: None,
-        run_id: None,
-        user_email: None,
-        provenance_visited: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
-    };
-
-    let (_cancel_handle, ctx) = TaskContextBuilder::new()
-        .thread_pool(thread_pool)
-        .database(database)
-        .graph_db(Arc::clone(&graph_db))
-        .vector_db(Arc::clone(&vector_db))
-        .pipeline_context(pipeline_ctx)
-        .build()
-        .map_err(|e| MemifyError::Context(e.to_string()))?;
-    let ctx = Arc::new(ctx);
-
-    let inputs: Vec<Arc<dyn Value>> = vec![Arc::new(triplets) as Arc<dyn Value>];
-
-    // Decision 11 (gap 08-07): persist the four-state `pipeline_runs` trail
-    // through the caller-supplied repository.
-    let watcher = DbPipelineWatcher::new(pipeline_run_repo);
-    let outputs = cognee_core::pipeline::execute(&pipeline, inputs, ctx, &watcher)
-        .await
-        .map_err(|e| MemifyError::Execute(e.to_string()))?;
-
-    let index_result = extract_memify_outputs(outputs)?;
-
-    // 5. Log summary and return.
-    info!(
-        "Memify complete: {} triplets extracted, {} indexed",
-        triplet_count, index_result.indexed_count
-    );
-
-    Ok(MemifyResult {
-        triplet_count,
-        index_result,
-        already_completed: false,
-        prior_pipeline_run_id: None,
-    })
+    outcome
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/cognify/src/memify/pipeline.rs
+++ b/crates/cognify/src/memify/pipeline.rs
@@ -191,10 +191,18 @@ pub async fn memify(
     config.validate()?;
 
     // 1b. Qualification gate (gap 08-08, locked decision 3) ────────────────
-    // Skip when `dataset_id` is `None` — Python's gate only applies per
-    // dataset, and ad-hoc memify runs without a dataset cannot be looked up
-    // via `get_pipeline_run_by_dataset`. The pipeline name used here matches
-    // what the executor-routed pipeline persists
+    // `AlreadyCompleted` short-circuits ONLY when the caller opted into the
+    // pipeline cache, mirroring Python's `if use_pipeline_cache:` guard in
+    // `run_pipeline_per_dataset` (`memify()` passes `use_pipeline_cache=False`).
+    // Short-circuiting unconditionally made every memify after the first a
+    // silent no-op. `AlreadyRunning` still rejects either way — see the longer
+    // note in `tasks::cognify`: Python relies on a per-dataset lock Rust does
+    // not have, so this row check is our only run serialization.
+    //
+    // Skipped entirely when `dataset_id` is `None` — Python's gate only applies
+    // per dataset, and ad-hoc memify runs without a dataset cannot be looked
+    // up via `get_pipeline_run_by_dataset`. The pipeline name used here
+    // matches what the executor-routed pipeline persists
     // (`build_memify_index_only_pipeline` sets
     // `with_name(MEMIFY_PIPELINE_STAMP_NAME)`).
     let pipeline_name = MEMIFY_PIPELINE_STAMP_NAME;
@@ -203,14 +211,16 @@ pub async fn memify(
             .await
             .map_err(|e| MemifyError::Database(e.to_string()))?
         {
-            Qualification::AlreadyCompleted(prior) => {
+            Qualification::AlreadyCompleted(prior) if config.use_pipeline_cache => {
                 info!(
                     dataset_id = %ds_id,
                     pipeline_run_id = %prior.pipeline_run_id,
-                    "memify: dataset already completed; short-circuiting (Python parity)"
+                    "memify: dataset already completed; short-circuiting (pipeline cache hit)"
                 );
                 return Ok(MemifyResult::already_completed(prior.pipeline_run_id));
             }
+            // Cache off (the default): a completed prior run does not stop this one.
+            Qualification::AlreadyCompleted(_) => {}
             Qualification::AlreadyRunning(_prior) => {
                 return Err(MemifyError::PipelineAlreadyRunning {
                     pipeline_name: pipeline_name.to_string(),

--- a/crates/cognify/src/memify/pipeline.rs
+++ b/crates/cognify/src/memify/pipeline.rs
@@ -196,8 +196,9 @@ pub async fn memify(
     // `run_pipeline_per_dataset` (`memify()` passes `use_pipeline_cache=False`).
     // Short-circuiting unconditionally made every memify after the first a
     // silent no-op. `AlreadyRunning` still rejects either way — see the longer
-    // note in `tasks::cognify`: Python relies on a per-dataset lock Rust does
-    // not have, so this row check is our only run serialization.
+    // note in `tasks::cognify` for why, including the residual race it does
+    // *not* close (the qualification read and the `Started` write are separate
+    // operations, so two callers entering within that window both proceed).
     //
     // Skipped entirely when `dataset_id` is `None` — Python's gate only applies
     // per dataset, and ad-hoc memify runs without a dataset cannot be looked

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -2181,11 +2181,28 @@ pub async fn cognify(
 
     // ── Qualification gate (gap 08-08, locked decision 3) ───────────────────
     // Python-parity `check_pipeline_run_qualification`: read the latest
-    // `pipeline_runs` row for `(dataset_id, pipeline_name)` and decide
-    // whether to proceed, short-circuit, or reject. The pipeline name used
-    // here MUST match what `DbPipelineWatcher` will persist on the next
-    // `pipeline::execute` call — that is the `Pipeline.name` set below
-    // ([`COGNIFY_PIPELINE_STAMP_NAME`] or `"temporal-cognify"`).
+    // `pipeline_runs` row for `(dataset_id, pipeline_name)` and decide whether
+    // to proceed, short-circuit, or reject.
+    //
+    // The two verdicts are gated differently, on purpose:
+    //
+    // * `AlreadyCompleted` short-circuits ONLY when the caller opted into the
+    //   pipeline cache. Python guards this layer behind `if use_pipeline_cache:`
+    //   in `run_pipeline_per_dataset` (`modules/pipelines/operations/pipeline.py`)
+    //   and every public entry point passes `use_pipeline_cache=False`, so
+    //   upstream a repeat cognify always re-runs. Short-circuiting
+    //   unconditionally made every cognify after the first a silent no-op, so a
+    //   dataset could never take a second wave of data. `dataset_resolver`
+    //   already gates its own dataset-level skip on this same flag.
+    //
+    // * `AlreadyRunning` still rejects regardless of the flag. Python can put
+    //   this behind the flag because `run_pipeline_per_dataset` serializes on
+    //   `get_dataset_lock(dataset.id)` — its own comment reads "concurrent runs
+    //   are kept safe by the per-dataset lock, not by this check". Rust has no
+    //   such lock, so this row check is the only thing keeping two concurrent
+    //   cognify runs off one dataset (double LLM spend, interleaved graph and
+    //   `pipeline_runs` writes). Deliberate deviation from Python's structure in
+    //   order to preserve Python's actual guarantee.
     let pipeline_name: &str = if effective_config.temporal_cognify {
         "temporal-cognify"
     } else {
@@ -2195,14 +2212,16 @@ pub async fn cognify(
         .await
         .map_err(|e| CognifyError::DatabaseError(e.to_string()))?
     {
-        Qualification::AlreadyCompleted(prior) => {
+        Qualification::AlreadyCompleted(prior) if effective_config.use_pipeline_cache => {
             info!(
                 dataset_id = %dataset_id,
                 pipeline_run_id = %prior.pipeline_run_id,
-                "cognify: dataset already completed; short-circuiting (Python parity)"
+                "cognify: dataset already completed; short-circuiting (pipeline cache hit)"
             );
             return Ok(CognifyResult::already_completed(prior.pipeline_run_id));
         }
+        // Cache off (the default): a completed prior run does not stop this one.
+        Qualification::AlreadyCompleted(_) => {}
         Qualification::AlreadyRunning(_prior) => {
             return Err(CognifyError::PipelineAlreadyRunning {
                 pipeline_name: pipeline_name.to_string(),

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -2199,10 +2199,23 @@ pub async fn cognify(
     //   this behind the flag because `run_pipeline_per_dataset` serializes on
     //   `get_dataset_lock(dataset.id)` — its own comment reads "concurrent runs
     //   are kept safe by the per-dataset lock, not by this check". Rust has no
-    //   such lock, so this row check is the only thing keeping two concurrent
-    //   cognify runs off one dataset (double LLM spend, interleaved graph and
-    //   `pipeline_runs` writes). Deliberate deviation from Python's structure in
-    //   order to preserve Python's actual guarantee.
+    //   such lock, so this row check is the closest equivalent available: it
+    //   rejects a run that has already reached `Started`, which covers the
+    //   common case of re-invoking cognify while a long run is in flight, and
+    //   keeps a stale `Started` row from being silently ignored.
+    //
+    //   It is NOT full serialization and must not be mistaken for it. The read
+    //   here and the `Started` write in `pipeline::execute`
+    //   (`crates/core/src/pipeline.rs:916-923`) are separate operations, so two
+    //   callers entering within that window both observe the pre-run state and
+    //   both proceed — duplicate LLM work and interleaved graph/`pipeline_runs`
+    //   writes. Closing it needs an atomic claim on
+    //   `(dataset_id, pipeline_name)`, or an in-process per-dataset lock
+    //   mirroring Python's; tracked separately. For calibration: Python's lock
+    //   is an `asyncio.Lock` held in a module-level dict
+    //   (`infrastructure/locks/dataset_lock.py`), so it serializes within a
+    //   single process only — neither implementation serializes across
+    //   processes.
     let pipeline_name: &str = if effective_config.temporal_cognify {
         "temporal-cognify"
     } else {

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -2204,18 +2204,20 @@ pub async fn cognify(
     //   common case of re-invoking cognify while a long run is in flight, and
     //   keeps a stale `Started` row from being silently ignored.
     //
-    //   It is NOT full serialization and must not be mistaken for it. The read
-    //   here and the `Started` write in `pipeline::execute`
-    //   (`crates/core/src/pipeline.rs:916-923`) are separate operations, so two
-    //   callers entering within that window both observe the pre-run state and
-    //   both proceed — duplicate LLM work and interleaved graph/`pipeline_runs`
-    //   writes. Closing it needs an atomic claim on
-    //   `(dataset_id, pipeline_name)`, or an in-process per-dataset lock
-    //   mirroring Python's; tracked separately. For calibration: Python's lock
-    //   is an `asyncio.Lock` held in a module-level dict
+    //   By itself this row check is NOT serialization: it and the `Started`
+    //   write in `pipeline::execute` (`crates/core/src/pipeline.rs:916-923`)
+    //   are separate operations, so two callers entering between them would
+    //   both observe the pre-run state and both proceed. What actually
+    //   serializes runs is the exclusive-run claim taken below; this check
+    //   stays because it is the cheaper path (no write) for the common case of
+    //   a run already visibly in flight, and because it is what reports a
+    //   stale `Started` row rather than silently ignoring it.
+    //
+    //   For calibration against the reference: Python's lock is an
+    //   `asyncio.Lock` held in a module-level dict
     //   (`infrastructure/locks/dataset_lock.py`), so it serializes within a
-    //   single process only — neither implementation serializes across
-    //   processes.
+    //   single process only. The claim below is a database row, so it also
+    //   excludes concurrent runs across processes.
     let pipeline_name: &str = if effective_config.temporal_cognify {
         "temporal-cognify"
     } else {
@@ -2244,112 +2246,160 @@ pub async fn cognify(
         Qualification::Proceed => {}
     }
 
-    // ── Empty-document short-circuit ────────────────────────────────────────
-    // Preserved from the pre-executor path: a caller passing zero documents
-    // gets back an empty result without paying for pipeline / context
-    // construction or a no-op LLM round-trip.
-    if data_items.is_empty() {
-        return Ok(CognifyResult::empty());
-    }
-
-    // ── Branch: temporal vs. standard pipeline ──────────────────────────────
-    // LIB-06-04: both branches now route through `pipeline::execute`. The
-    // selection happens *before* `execute()` per locked Decision 2 — temporal
-    // is a distinct `Pipeline` with its own task DAG. Per locked option (a)
-    // (user decision 2026-05-15), the shared tasks
-    // (`make_classify_documents_task`, `make_extract_chunks_task`) stamp
-    // `Document` / `DocumentChunk` DataPoints with
-    // `source_pipeline = COGNIFY_PIPELINE_STAMP_NAME` on both
-    // branches; the temporal pipeline keeps its distinct identity at the
-    // `pipeline_runs` row level via `build_temporal_cognify_pipeline`'s
-    // `with_name("temporal-cognify")`.
-    let is_temporal = effective_config.temporal_cognify;
-    let pipeline = if is_temporal {
-        build_temporal_cognify_pipeline(
-            Arc::clone(&storage),
-            Arc::clone(&graph_db),
-            Arc::clone(&vector_db),
-            Arc::clone(&embedding_engine),
-            Arc::clone(&llm),
-            Some(Arc::clone(&database)),
-            effective_config.clone(),
-        )
-    } else {
-        build_cognify_pipeline(
-            Arc::clone(&storage),
-            Arc::clone(&graph_db),
-            Arc::clone(&vector_db),
-            Arc::clone(&embedding_engine),
-            Arc::clone(&llm),
-            Some(Arc::clone(&database)),
-            Arc::clone(&ontology_resolver),
-            effective_config.clone(),
-        )
-    };
-
-    // The executor re-derives `PipelineRunInfo.pipeline_id` from
-    // `(pipeline.name, user_id, dataset_id)`; we still carry `pipeline.id`
-    // through `PipelineContext` as the placeholder.
-    let pipeline_ctx = PipelineContext {
-        pipeline_id: pipeline.id,
-        pipeline_name: pipeline.name.clone().unwrap_or_default(),
-        user_id,
-        tenant_id,
-        dataset_id: Some(dataset_id),
-        current_data: None,
-        run_id: None,
-        user_email: user_email.clone(),
-        provenance_visited: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
-    };
-
-    let (_cancel_handle, ctx) = TaskContextBuilder::new()
-        .thread_pool(thread_pool)
-        .database(Arc::clone(&database))
-        .graph_db(Arc::clone(&graph_db))
-        .vector_db(Arc::clone(&vector_db))
-        .pipeline_context(pipeline_ctx)
-        .build()
-        .map_err(|e| CognifyError::ContextBuild(e.to_string()))?;
-    let ctx = Arc::new(ctx);
-
-    let input = CognifyInput {
-        data_items,
-        dataset_id,
-        user_id,
-        tenant_id,
-    };
-    let inputs: Vec<Arc<dyn Value>> = vec![Arc::new(input) as Arc<dyn Value>];
-
-    // Decision 11 (gap 08-07): `DbPipelineWatcher` persists the four-state
-    // `pipeline_runs` trail through the caller-supplied repository.
-    // Embedded callers pass `NoopPipelineRunRepository`; CLI / HTTP callers
-    // pass a `SeaOrmPipelineRunRepository` to surface rows in the
-    // `/api/v1/activity/pipeline-runs` endpoint.
-    let watcher = DbPipelineWatcher::new(pipeline_run_repo);
-    let outputs = cognee_core::pipeline::execute(&pipeline, inputs, ctx, &watcher)
-        .await
-        .map_err(|e| CognifyError::Execute(e.to_string()))?;
-
-    let result = extract_cognify_outputs(outputs)?;
-
-    // Decision 5: post-pipeline teardown — `extract_dlt_fk_edges` stays
-    // outside the executor. The pipeline_runs row is already marked
-    // COMPLETED by the watcher at this point; teardown failure surfaces as
-    // `Err(...)` to the caller but does not roll back the run state.
+    // ── Exclusive-run claim ─────────────────────────────────────────────────
+    // The `AlreadyRunning` verdict above only catches a run that already wrote
+    // its `Started` row; that write and the read above are separate
+    // operations, so two callers entering within the window between them would
+    // both observe the pre-run state and both proceed. This claim closes the
+    // window — the insert *is* the contended operation, so exactly one caller
+    // holds `(dataset_id, pipeline_name)` at a time. It also excludes
+    // concurrent runs across processes, which Python's in-process
+    // `asyncio.Lock` (`infrastructure/locks/dataset_lock.py`) does not.
     //
-    // LIB-06-04: skip DLT FK extraction on the temporal branch — temporal
-    // does not propagate `documents_for_dlt` (and Python's temporal cognify
-    // does not run DLT teardown either).
-    if !is_temporal {
-        extract_dlt_fk_edges(
-            &result.chunks,
-            &result.documents_for_dlt,
-            Arc::clone(&graph_db),
-        )
-        .await?;
+    // Deliberately NOT cleared by the server's startup orphan sweep: claims
+    // are cross-process, so one instance restarting must not drop another
+    // live instance's claim. A claim a killed process left behind is recovered
+    // by the staleness window below, or by an explicit reset.
+    let claim_repo = Arc::clone(&pipeline_run_repo);
+    let claim_id = Uuid::new_v4();
+    if !claim_repo
+        .try_claim_pipeline_run(dataset_id, pipeline_name, claim_id, CLAIM_STALE_AFTER)
+        .await
+        .map_err(|e| CognifyError::DatabaseError(e.to_string()))?
+    {
+        return Err(CognifyError::PipelineAlreadyRunning {
+            pipeline_name: pipeline_name.to_string(),
+            dataset_id,
+        });
     }
 
-    Ok(result)
+    // Everything past the claim runs inside this block so the release below is
+    // reached on every exit path, `?` included. `Drop` cannot await, so an RAII
+    // guard is not an option.
+    let outcome: Result<CognifyResult, CognifyError> = async {
+        // ── Empty-document short-circuit ────────────────────────────────────────
+        // Preserved from the pre-executor path: a caller passing zero documents
+        // gets back an empty result without paying for pipeline / context
+        // construction or a no-op LLM round-trip.
+        if data_items.is_empty() {
+            return Ok(CognifyResult::empty());
+        }
+
+        // ── Branch: temporal vs. standard pipeline ──────────────────────────────
+        // LIB-06-04: both branches now route through `pipeline::execute`. The
+        // selection happens *before* `execute()` per locked Decision 2 — temporal
+        // is a distinct `Pipeline` with its own task DAG. Per locked option (a)
+        // (user decision 2026-05-15), the shared tasks
+        // (`make_classify_documents_task`, `make_extract_chunks_task`) stamp
+        // `Document` / `DocumentChunk` DataPoints with
+        // `source_pipeline = COGNIFY_PIPELINE_STAMP_NAME` on both
+        // branches; the temporal pipeline keeps its distinct identity at the
+        // `pipeline_runs` row level via `build_temporal_cognify_pipeline`'s
+        // `with_name("temporal-cognify")`.
+        let is_temporal = effective_config.temporal_cognify;
+        let pipeline = if is_temporal {
+            build_temporal_cognify_pipeline(
+                Arc::clone(&storage),
+                Arc::clone(&graph_db),
+                Arc::clone(&vector_db),
+                Arc::clone(&embedding_engine),
+                Arc::clone(&llm),
+                Some(Arc::clone(&database)),
+                effective_config.clone(),
+            )
+        } else {
+            build_cognify_pipeline(
+                Arc::clone(&storage),
+                Arc::clone(&graph_db),
+                Arc::clone(&vector_db),
+                Arc::clone(&embedding_engine),
+                Arc::clone(&llm),
+                Some(Arc::clone(&database)),
+                Arc::clone(&ontology_resolver),
+                effective_config.clone(),
+            )
+        };
+
+        // The executor re-derives `PipelineRunInfo.pipeline_id` from
+        // `(pipeline.name, user_id, dataset_id)`; we still carry `pipeline.id`
+        // through `PipelineContext` as the placeholder.
+        let pipeline_ctx = PipelineContext {
+            pipeline_id: pipeline.id,
+            pipeline_name: pipeline.name.clone().unwrap_or_default(),
+            user_id,
+            tenant_id,
+            dataset_id: Some(dataset_id),
+            current_data: None,
+            run_id: None,
+            user_email: user_email.clone(),
+            provenance_visited: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+        };
+
+        let (_cancel_handle, ctx) = TaskContextBuilder::new()
+            .thread_pool(thread_pool)
+            .database(Arc::clone(&database))
+            .graph_db(Arc::clone(&graph_db))
+            .vector_db(Arc::clone(&vector_db))
+            .pipeline_context(pipeline_ctx)
+            .build()
+            .map_err(|e| CognifyError::ContextBuild(e.to_string()))?;
+        let ctx = Arc::new(ctx);
+
+        let input = CognifyInput {
+            data_items,
+            dataset_id,
+            user_id,
+            tenant_id,
+        };
+        let inputs: Vec<Arc<dyn Value>> = vec![Arc::new(input) as Arc<dyn Value>];
+
+        // Decision 11 (gap 08-07): `DbPipelineWatcher` persists the four-state
+        // `pipeline_runs` trail through the caller-supplied repository.
+        // Embedded callers pass `NoopPipelineRunRepository`; CLI / HTTP callers
+        // pass a `SeaOrmPipelineRunRepository` to surface rows in the
+        // `/api/v1/activity/pipeline-runs` endpoint.
+        let watcher = DbPipelineWatcher::new(pipeline_run_repo);
+        let outputs = cognee_core::pipeline::execute(&pipeline, inputs, ctx, &watcher)
+            .await
+            .map_err(|e| CognifyError::Execute(e.to_string()))?;
+
+        let result = extract_cognify_outputs(outputs)?;
+
+        // Decision 5: post-pipeline teardown — `extract_dlt_fk_edges` stays
+        // outside the executor. The pipeline_runs row is already marked
+        // COMPLETED by the watcher at this point; teardown failure surfaces as
+        // `Err(...)` to the caller but does not roll back the run state.
+        //
+        // LIB-06-04: skip DLT FK extraction on the temporal branch — temporal
+        // does not propagate `documents_for_dlt` (and Python's temporal cognify
+        // does not run DLT teardown either).
+        if !is_temporal {
+            extract_dlt_fk_edges(
+                &result.chunks,
+                &result.documents_for_dlt,
+                Arc::clone(&graph_db),
+            )
+            .await?;
+        }
+
+        Ok(result)
+    }
+    .await;
+
+    if let Err(e) = claim_repo
+        .release_pipeline_run_claim(dataset_id, pipeline_name, claim_id)
+        .await
+    {
+        // The run is over either way, and an unreleased claim is reclaimed as
+        // stale rather than lost, so this must not mask the outcome.
+        warn!(
+            dataset_id = %dataset_id,
+            pipeline_name = %pipeline_name,
+            "failed to release the pipeline-run claim (it will age out): {e}"
+        );
+    }
+
+    outcome
 }
 
 // ---------------------------------------------------------------------------
@@ -3417,6 +3467,19 @@ pub const ADD_DATA_POINTS_TASK_RANK: i32 = 4;
 /// by [`build_cognify_pipeline`], and the value the visualization's
 /// operations catalog matches on to mark a stage as observed.
 pub const COGNIFY_PIPELINE_STAMP_NAME: &str = "cognify_pipeline";
+
+/// How long an exclusive-run claim stays valid without being released, after
+/// which another run may reclaim it — see
+/// [`PipelineRunRepository::try_claim_pipeline_run`].
+///
+/// Deliberately generous. Reclaiming too eagerly is the worse failure: it
+/// re-admits a concurrent run into a legitimately long one (a multi-gigabyte
+/// cognify runs for hours), which is exactly what the claim exists to prevent.
+/// The cost of being generous is that a claim left by a killed process blocks
+/// that dataset until it ages out — recoverable by resetting the dataset's
+/// pipeline-run state, and no worse than the stale `Started` row such a crash
+/// already leaves behind.
+pub const CLAIM_STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
 
 /// Resolve the user label for in-body stamping from a [`TaskContext`].
 ///

--- a/crates/cognify/tests/integration_repeat_cognify.rs
+++ b/crates/cognify/tests/integration_repeat_cognify.rs
@@ -25,6 +25,7 @@
 
 use std::sync::Arc;
 
+use cognee_cognify::tasks::CLAIM_STALE_AFTER;
 use cognee_cognify::{CognifyConfig, CognifyError, CognifyResult, cognify};
 use cognee_database::{
     DatabaseConnection, IngestDb, PipelineRunRepository, PipelineRunStatus,
@@ -404,5 +405,83 @@ async fn a_started_run_still_rejects_a_concurrent_run_with_the_cache_off() {
     assert!(
         matches!(err, CognifyError::PipelineAlreadyRunning { .. }),
         "expected PipelineAlreadyRunning, got {err:?}"
+    );
+}
+
+/// A claim held by someone else blocks a run, and the run succeeds again once
+/// that claim is released.
+///
+/// This is the "two simultaneous starts" case in deterministic form. The state
+/// that matters is *a claim being held while a second caller enters the run*,
+/// and pre-taking the claim reproduces exactly that without depending on task
+/// interleaving — a timing-based race would be flaky in both directions (both
+/// callers could serialize in time and legitimately succeed). The atomicity of
+/// the claim itself is covered by `concurrent_claims_grant_exactly_one` in
+/// `cognee-database`, which contends on the real primary key.
+#[tokio::test]
+async fn a_claim_held_elsewhere_blocks_the_run() {
+    let h = Harness::new().await;
+    let dataset_name = "repeat_cognify_claimed";
+    let config = base_config();
+
+    let items = h.add(dataset_name, WAVE_1_TEXT).await;
+    let dataset_id = h.dataset_id(dataset_name).await;
+
+    // Stand in for a run already in flight elsewhere — in another process, or
+    // in the window before it has written its `Started` row.
+    let elsewhere = Uuid::new_v4();
+    assert!(
+        h.pipeline_run_repo
+            .try_claim_pipeline_run(dataset_id, COGNIFY_PIPELINE, elsewhere, CLAIM_STALE_AFTER)
+            .await
+            .expect("foreign claim"),
+        "the foreign claim must be granted first"
+    );
+
+    let err = h
+        .try_cognify(dataset_id, items.clone(), &config)
+        .await
+        .expect_err("a claimed dataset must not be cognified concurrently");
+    assert!(
+        matches!(err, CognifyError::PipelineAlreadyRunning { .. }),
+        "expected PipelineAlreadyRunning, got {err:?}"
+    );
+
+    h.pipeline_run_repo
+        .release_pipeline_run_claim(dataset_id, COGNIFY_PIPELINE, elsewhere)
+        .await
+        .expect("release foreign claim");
+
+    let result = h.cognify(dataset_id, items, &config).await;
+    assert!(
+        !result.already_completed && !result.entities.is_empty(),
+        "the run must proceed once the claim is free"
+    );
+}
+
+/// A completed run must not leave its claim behind — otherwise the very next
+/// wave would be rejected instead of processed.
+#[tokio::test]
+async fn a_finished_run_releases_its_claim() {
+    let h = Harness::new().await;
+    let dataset_name = "repeat_cognify_release";
+    let config = base_config();
+
+    let items = h.add(dataset_name, WAVE_1_TEXT).await;
+    let dataset_id = h.dataset_id(dataset_name).await;
+    h.cognify(dataset_id, items, &config).await;
+
+    // If the run leaked its claim, this could not be granted.
+    assert!(
+        h.pipeline_run_repo
+            .try_claim_pipeline_run(
+                dataset_id,
+                COGNIFY_PIPELINE,
+                Uuid::new_v4(),
+                CLAIM_STALE_AFTER
+            )
+            .await
+            .expect("claim after run"),
+        "the claim must be free once the run has finished"
     );
 }

--- a/crates/cognify/tests/integration_repeat_cognify.rs
+++ b/crates/cognify/tests/integration_repeat_cognify.rs
@@ -1,0 +1,408 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression test: a dataset must be cognifiable more than once, so data can
+//! be loaded in waves (`add` → `cognify` → `add` → `cognify`).
+//!
+//! Before the fix, `cognify()` consulted `check_pipeline_run_qualification`
+//! unconditionally, so the COMPLETED `pipeline_runs` row left by the first run
+//! made every later run a silent no-op — new data added to the dataset was
+//! never extracted. Python only consults that layer behind
+//! `if use_pipeline_cache:` (`modules/pipelines/operations/pipeline.py`), and
+//! both public entry points pass `use_pipeline_cache=False`, so upstream a
+//! repeat cognify always re-runs.
+//!
+//! **These tests must use a real [`SeaOrmPipelineRunRepository`].** The rest of
+//! the crate's tests pass `NoopPipelineRunRepository`, whose
+//! `get_pipeline_run_by_dataset` returns `Ok(None)` → `Qualification::Proceed`,
+//! which is precisely why the bug shipped with a green suite. The first test
+//! asserts the COMPLETED row actually exists before re-running, so it cannot
+//! silently degrade into a vacuous pass.
+//!
+//! Runs fully offline (mock LLM / embeddings / graph / vector) — a real CI gate.
+
+use std::sync::Arc;
+
+use cognee_cognify::{CognifyConfig, CognifyError, CognifyResult, cognify};
+use cognee_database::{
+    DatabaseConnection, IngestDb, PipelineRunRepository, PipelineRunStatus,
+    SeaOrmPipelineRunRepository, connect, initialize, ops,
+};
+use cognee_embedding::{EmbeddingEngine, MockEmbeddingEngine};
+use cognee_graph::{GraphDBTrait, MockGraphDB};
+use cognee_ingestion::AddPipeline;
+use cognee_llm::{GenerationOptions, GenerationResponse, Llm, Message};
+use cognee_models::{Data, DataInput};
+use cognee_ontology::{NoOpOntologyResolver, OntologyResolver};
+use cognee_storage::{LocalStorage, StorageTrait};
+use cognee_test_utils::MockVectorDB;
+use cognee_vector::VectorDB;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+const WAVE_1_TEXT: &str = "\
+Alice is a senior software engineer at TechCorp, a technology company. \
+She has worked on the cloud platform for three years.";
+
+const WAVE_2_TEXT: &str = "\
+Bob is a data scientist at DataCorp, an analytics company. \
+He joined the research team last spring.";
+
+/// The `Pipeline.name` the cognify DAG stamps, and therefore the
+/// `pipeline_runs.pipeline_name` the gate reads. Mirrors
+/// `tasks::COGNIFY_PIPELINE_STAMP_NAME` (not re-exported from the crate root).
+const COGNIFY_PIPELINE: &str = "cognify_pipeline";
+
+/// LLM stub that extracts one fixed entity pair regardless of input. The
+/// content does not matter here — only whether extraction ran at all.
+#[derive(Clone)]
+struct FixedGraphLlm;
+
+#[async_trait::async_trait]
+impl Llm for FixedGraphLlm {
+    async fn generate(
+        &self,
+        _messages: Vec<Message>,
+        _options: Option<GenerationOptions>,
+    ) -> cognee_llm::LlmResult<GenerationResponse> {
+        Ok(GenerationResponse {
+            content: String::new(),
+            model: self.model().to_string(),
+            usage: None,
+            finish_reason: Some("stop".to_string()),
+        })
+    }
+
+    async fn create_structured_output_with_messages_raw(
+        &self,
+        _messages: Vec<Message>,
+        _json_schema: &serde_json::Value,
+        _options: Option<GenerationOptions>,
+    ) -> cognee_llm::LlmResult<serde_json::Value> {
+        Ok(serde_json::json!({
+            "nodes": [
+                { "id": "alice", "name": "Alice", "type": "Person",
+                  "description": "A software engineer." },
+                { "id": "techcorp", "name": "TechCorp", "type": "Organization",
+                  "description": "A technology company." }
+            ],
+            "edges": [
+                { "source_node_id": "alice", "target_node_id": "techcorp",
+                  "relationship_name": "works_at" }
+            ]
+        }))
+    }
+
+    fn model(&self) -> &str {
+        "fixed-graph-fixture"
+    }
+}
+
+/// Everything a cognify run needs, built once per test over one temp dir so the
+/// relational DB (and therefore the `pipeline_runs` trail) persists across runs.
+struct Harness {
+    _temp_dir: TempDir,
+    storage: Arc<dyn StorageTrait>,
+    database: Arc<DatabaseConnection>,
+    graph_db: Arc<dyn GraphDBTrait>,
+    vector_db: Arc<dyn VectorDB>,
+    embedding_engine: Arc<dyn EmbeddingEngine>,
+    llm: Arc<dyn Llm>,
+    ontology: Arc<dyn OntologyResolver>,
+    // The real repository — see the module docs on why a no-op one would make
+    // these tests vacuous.
+    pipeline_run_repo: Arc<dyn PipelineRunRepository>,
+    ingest: AddPipeline,
+    owner_id: Uuid,
+}
+
+impl Harness {
+    async fn new() -> Self {
+        let temp_dir = TempDir::new().expect("temp dir");
+
+        let storage: Arc<dyn StorageTrait> =
+            Arc::new(LocalStorage::new(temp_dir.path().join("storage")));
+        storage.initialize().await.expect("storage.initialize");
+
+        let db_path = temp_dir.path().join("cognee.db");
+        std::fs::File::create(&db_path).expect("create sqlite db file");
+        let db_url = format!("sqlite://{}", db_path.display());
+        let db = connect(&db_url).await.expect("connect");
+        initialize(&db).await.expect("initialize");
+        let database: Arc<DatabaseConnection> = Arc::new(db);
+
+        let graph_db: Arc<dyn GraphDBTrait> = Arc::new(MockGraphDB::new());
+        graph_db.initialize().await.expect("graph_db.initialize");
+
+        let vector_db: Arc<dyn VectorDB> = Arc::new(MockVectorDB::new());
+        let embedding_engine: Arc<dyn EmbeddingEngine> = Arc::new(MockEmbeddingEngine::new(8));
+        let llm: Arc<dyn Llm> = Arc::new(FixedGraphLlm);
+        let ontology: Arc<dyn OntologyResolver> = Arc::new(NoOpOntologyResolver::new());
+        let pipeline_run_repo: Arc<dyn PipelineRunRepository> =
+            Arc::new(SeaOrmPipelineRunRepository::new(Arc::clone(&database)));
+
+        let ingest = AddPipeline::new(Arc::clone(&storage), database.clone() as Arc<dyn IngestDb>)
+            .with_thread_pool(Arc::new(
+                cognee_core::RayonThreadPool::with_default_threads().unwrap(),
+            ))
+            .with_graph_db(Arc::clone(&graph_db))
+            .with_vector_db(Arc::clone(&vector_db))
+            .with_database(Arc::clone(&database));
+
+        Self {
+            _temp_dir: temp_dir,
+            storage,
+            database,
+            graph_db,
+            vector_db,
+            embedding_engine,
+            llm,
+            ontology,
+            pipeline_run_repo,
+            ingest,
+            owner_id: Uuid::nil(),
+        }
+    }
+
+    async fn add(&self, dataset_name: &str, text: &str) -> Vec<Data> {
+        self.ingest
+            .add(
+                vec![DataInput::Text(text.to_string())],
+                dataset_name,
+                self.owner_id,
+                None,
+            )
+            .await
+            .expect("ingest")
+    }
+
+    async fn dataset_id(&self, dataset_name: &str) -> Uuid {
+        ops::datasets::get_dataset_by_name(&self.database, dataset_name, self.owner_id, None)
+            .await
+            .expect("get_dataset_by_name")
+            .expect("dataset exists")
+            .id
+    }
+
+    async fn cognify(
+        &self,
+        dataset_id: Uuid,
+        items: Vec<Data>,
+        config: &CognifyConfig,
+    ) -> CognifyResult {
+        cognify(
+            items,
+            dataset_id,
+            Some(self.owner_id),
+            None,
+            None,
+            Arc::clone(&self.llm),
+            Arc::clone(&self.storage),
+            Arc::clone(&self.graph_db),
+            Arc::clone(&self.vector_db),
+            Arc::clone(&self.embedding_engine),
+            Arc::clone(&self.database),
+            Arc::clone(&self.pipeline_run_repo),
+            Arc::new(cognee_core::RayonThreadPool::with_default_threads().unwrap())
+                as Arc<dyn cognee_core::CpuPool>,
+            Arc::clone(&self.ontology),
+            config,
+        )
+        .await
+        .expect("cognify")
+    }
+
+    /// Like [`Self::cognify`] but surfaces the error instead of panicking.
+    async fn try_cognify(
+        &self,
+        dataset_id: Uuid,
+        items: Vec<Data>,
+        config: &CognifyConfig,
+    ) -> Result<CognifyResult, CognifyError> {
+        cognify(
+            items,
+            dataset_id,
+            Some(self.owner_id),
+            None,
+            None,
+            Arc::clone(&self.llm),
+            Arc::clone(&self.storage),
+            Arc::clone(&self.graph_db),
+            Arc::clone(&self.vector_db),
+            Arc::clone(&self.embedding_engine),
+            Arc::clone(&self.database),
+            Arc::clone(&self.pipeline_run_repo),
+            Arc::new(cognee_core::RayonThreadPool::with_default_threads().unwrap())
+                as Arc<dyn cognee_core::CpuPool>,
+            Arc::clone(&self.ontology),
+            config,
+        )
+        .await
+    }
+
+    /// Write a bare `Started` row for the cognify pipeline, standing in for a
+    /// run that is still in flight (or was killed mid-run).
+    async fn seed_started_row(&self, dataset_id: Uuid) {
+        self.pipeline_run_repo
+            .log_pipeline_run(
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                COGNIFY_PIPELINE,
+                Some(dataset_id),
+                PipelineRunStatus::Started,
+                None,
+            )
+            .await
+            .expect("log_pipeline_run");
+    }
+
+    /// Latest `pipeline_runs` status for the cognify pipeline on this dataset.
+    async fn latest_cognify_status(&self, dataset_id: Uuid) -> Option<PipelineRunStatus> {
+        self.pipeline_run_repo
+            .get_pipeline_run_by_dataset(dataset_id, COGNIFY_PIPELINE)
+            .await
+            .expect("get_pipeline_run_by_dataset")
+            .map(|run| run.status)
+    }
+}
+
+/// Keep the graph focused and the run cheap — no summaries or triplet embeddings.
+fn base_config() -> CognifyConfig {
+    CognifyConfig::default()
+        .with_summarization(false)
+        .with_triplet_embeddings(false)
+}
+
+/// The regression test for this issue: a second wave of data added to an
+/// already-cognified dataset must actually be extracted.
+#[tokio::test]
+async fn second_cognify_wave_is_processed_not_skipped() {
+    let h = Harness::new().await;
+    let dataset_name = "repeat_cognify_waves";
+    let config = base_config();
+
+    // ── Wave 1 ──────────────────────────────────────────────────────────────
+    let items_1 = h.add(dataset_name, WAVE_1_TEXT).await;
+    let dataset_id = h.dataset_id(dataset_name).await;
+
+    let result_1 = h.cognify(dataset_id, items_1.clone(), &config).await;
+    assert!(!result_1.already_completed, "wave 1 must extract, not skip");
+    assert!(
+        !result_1.entities.is_empty(),
+        "wave 1 must produce entities"
+    );
+
+    // Guard against a vacuous pass: the trail must really carry a COMPLETED
+    // row, i.e. the repository is live and the gate has something to find.
+    assert_eq!(
+        h.latest_cognify_status(dataset_id).await,
+        Some(PipelineRunStatus::Completed),
+        "wave 1 must leave a COMPLETED pipeline_runs row — without it this test \
+         would pass even with the bug present"
+    );
+
+    // ── Wave 2: more data into the same dataset ─────────────────────────────
+    let items_2 = h.add(dataset_name, WAVE_2_TEXT).await;
+    assert_eq!(
+        h.dataset_id(dataset_name).await,
+        dataset_id,
+        "wave 2 must land in the same dataset"
+    );
+
+    let all_items: Vec<Data> = items_1.iter().chain(items_2.iter()).cloned().collect();
+    assert!(
+        all_items.len() > items_1.len(),
+        "wave 2 must add a new data item"
+    );
+
+    let result_2 = h.cognify(dataset_id, all_items, &config).await;
+    assert!(
+        !result_2.already_completed,
+        "wave 2 must extract: a COMPLETED row from wave 1 must not skip the run \
+         when the pipeline cache is off (the default)"
+    );
+    assert!(
+        !result_2.entities.is_empty(),
+        "wave 2 must produce entities"
+    );
+    assert!(
+        !result_2.chunks.is_empty(),
+        "wave 2 must produce chunks from the newly added data"
+    );
+}
+
+/// The cache still works when a caller explicitly opts in — the flag is what
+/// selects the behaviour, matching Python's `use_pipeline_cache` parameter.
+#[tokio::test]
+async fn pipeline_cache_opt_in_short_circuits_the_second_run() {
+    let h = Harness::new().await;
+    let dataset_name = "repeat_cognify_cache_on";
+    let config = base_config().with_pipeline_cache(true);
+
+    let items = h.add(dataset_name, WAVE_1_TEXT).await;
+    let dataset_id = h.dataset_id(dataset_name).await;
+
+    let result_1 = h.cognify(dataset_id, items.clone(), &config).await;
+    assert!(
+        !result_1.already_completed,
+        "the first run has no prior row to hit"
+    );
+    assert_eq!(
+        h.latest_cognify_status(dataset_id).await,
+        Some(PipelineRunStatus::Completed),
+    );
+
+    let result_2 = h.cognify(dataset_id, items, &config).await;
+    assert!(
+        result_2.already_completed,
+        "with the cache on, a COMPLETED dataset must short-circuit"
+    );
+    assert!(
+        result_2.prior_pipeline_run_id.is_some(),
+        "the short-circuit must report the prior run id"
+    );
+    assert!(
+        result_2.entities.is_empty(),
+        "a short-circuited run does no extraction"
+    );
+}
+
+/// The concurrency guard must survive the fix: a run still in flight (a
+/// `Started` row) rejects a second run *regardless* of the cache flag.
+///
+/// Python can gate this verdict on `use_pipeline_cache` because
+/// `run_pipeline_per_dataset` serializes on `get_dataset_lock(dataset.id)`
+/// ("concurrent runs are kept safe by the per-dataset lock, not by this
+/// check"). Rust has no such lock, so this row check is the only thing keeping
+/// two concurrent cognify runs off one dataset — gating it on the cache flag
+/// would have silently removed that protection.
+#[tokio::test]
+async fn a_started_run_still_rejects_a_concurrent_run_with_the_cache_off() {
+    let h = Harness::new().await;
+    let dataset_name = "repeat_cognify_concurrent";
+    let config = base_config();
+    assert!(
+        !config.use_pipeline_cache,
+        "this test is about the cache being OFF"
+    );
+
+    let items = h.add(dataset_name, WAVE_1_TEXT).await;
+    let dataset_id = h.dataset_id(dataset_name).await;
+
+    h.seed_started_row(dataset_id).await;
+    assert_eq!(
+        h.latest_cognify_status(dataset_id).await,
+        Some(PipelineRunStatus::Started),
+    );
+
+    let err = h
+        .try_cognify(dataset_id, items, &config)
+        .await
+        .expect_err("a run already in flight must be rejected");
+    assert!(
+        matches!(err, CognifyError::PipelineAlreadyRunning { .. }),
+        "expected PipelineAlreadyRunning, got {err:?}"
+    );
+}

--- a/crates/database/src/entities/mod.rs
+++ b/crates/database/src/entities/mod.rs
@@ -12,6 +12,7 @@ pub mod edge;
 pub mod graph_metrics;
 pub mod node;
 pub mod pipeline_run;
+pub mod pipeline_run_claim;
 pub mod pipeline_run_payload_field;
 pub mod task_run;
 

--- a/crates/database/src/entities/pipeline_run_claim.rs
+++ b/crates/database/src/entities/pipeline_run_claim.rs
@@ -1,0 +1,41 @@
+//! Exclusive-run claim for a `(dataset_id, pipeline_name)` pair.
+//!
+//! The composite primary key is what makes the claim atomic: concurrent
+//! `INSERT`s for the same pair race in the database and exactly one wins, so a
+//! caller that inserts successfully knows no other caller is running that
+//! pipeline on that dataset. This closes the window the `pipeline_runs` status
+//! read cannot: that read and the later `Started` write are separate
+//! operations, so two callers can both observe the pre-run state.
+//!
+//! Rust-only table — Python cognee serializes with an in-process
+//! `asyncio.Lock` (`infrastructure/locks/dataset_lock.py`) instead, so it
+//! neither writes nor reads this table. Extra tables are invisible to the
+//! Python SDK, and unlike an in-process lock this also excludes concurrent
+//! runs across processes.
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "pipeline_run_claims")]
+pub struct Model {
+    /// Claimed dataset, as 32-char un-hyphenated hex (`uuid_hex::to_hex`),
+    /// matching every other `dataset_id` column in this schema.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub dataset_id: String,
+    /// Claimed pipeline name (`cognify_pipeline`, `temporal-cognify`,
+    /// `memify_pipeline`), so cognify and memify on one dataset do not
+    /// exclude each other.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub pipeline_name: String,
+    /// Identifies the holder, so a release only ever removes its own claim and
+    /// can never drop a claim a later run took over.
+    pub claim_id: String,
+    /// When the claim was taken — the basis for reclaiming one a killed
+    /// process left behind.
+    pub claimed_at: DateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/database/src/migrator/m20260915_000001_pipeline_run_claims.rs
+++ b/crates/database/src/migrator/m20260915_000001_pipeline_run_claims.rs
@@ -1,0 +1,65 @@
+//! Adds `pipeline_run_claims` — the atomic exclusive-run claim behind
+//! `PipelineRunRepository::try_claim_pipeline_run`.
+//!
+//! Dated one day after the baseline so it sorts (and therefore applies) after
+//! it; the table is independent, so the ordering only matters for determinism.
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // The composite primary key IS the mutual exclusion: two concurrent
+        // inserts for the same `(dataset_id, pipeline_name)` race in the
+        // database and exactly one commits.
+        manager
+            .create_table(
+                Table::create()
+                    .table(PipelineRunClaims::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(PipelineRunClaims::DatasetId)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(PipelineRunClaims::PipelineName)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(PipelineRunClaims::ClaimId).text().not_null())
+                    .col(
+                        ColumnDef::new(PipelineRunClaims::ClaimedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .col(PipelineRunClaims::DatasetId)
+                            .col(PipelineRunClaims::PipelineName),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(PipelineRunClaims::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum PipelineRunClaims {
+    Table,
+    DatasetId,
+    PipelineName,
+    ClaimId,
+    ClaimedAt,
+}

--- a/crates/database/src/migrator/mod.rs
+++ b/crates/database/src/migrator/mod.rs
@@ -1,6 +1,7 @@
 use sea_orm_migration::prelude::*;
 
 mod m20260914_000001_baseline;
+mod m20260915_000001_pipeline_run_claims;
 
 pub struct Migrator;
 
@@ -11,7 +12,10 @@ pub struct Migrator;
 /// The OSS [`Migrator`] simply delegates to this accessor so behaviour is
 /// unchanged for OSS-only builds.
 pub fn core_migrations() -> Vec<Box<dyn MigrationTrait>> {
-    vec![Box::new(m20260914_000001_baseline::Migration)]
+    vec![
+        Box::new(m20260914_000001_baseline::Migration),
+        Box::new(m20260915_000001_pipeline_run_claims::Migration),
+    ]
 }
 
 #[async_trait::async_trait]

--- a/crates/database/src/pipelines/repository.rs
+++ b/crates/database/src/pipelines/repository.rs
@@ -163,4 +163,51 @@ pub trait PipelineRunRepository: Send + Sync {
         &self,
         dataset_id: Uuid,
     ) -> Result<Vec<PipelineRun>, DbError>;
+
+    /// Atomically claim exclusive-run rights for `(dataset_id,
+    /// pipeline_name)`, returning `true` iff the claim was taken.
+    ///
+    /// This exists because reading the latest `pipeline_runs` status is *not*
+    /// mutual exclusion: that read and the `Started` row the executor writes
+    /// later are separate operations, so two callers entering within that
+    /// window both observe the pre-run state and both proceed. A claim closes
+    /// the window because the insert itself is the contended operation.
+    ///
+    /// A claim whose `claimed_at` is older than `stale_after` is reclaimed —
+    /// otherwise a killed process would wedge the pair forever, since a
+    /// release can only come from the holder. Pick `stale_after` above the
+    /// longest run you expect; too low re-admits a concurrent run into a
+    /// legitimately long one.
+    ///
+    /// Callers MUST pair a `true` with [`Self::release_pipeline_run_claim`] on
+    /// every exit path, including errors.
+    ///
+    /// The default implementation always grants the claim, so repositories
+    /// with no durable storage (and existing external implementors) keep
+    /// compiling and behaving as before — with **no** serialization. Only
+    /// override it where the insert can actually contend.
+    async fn try_claim_pipeline_run(
+        &self,
+        _dataset_id: Uuid,
+        _pipeline_name: &str,
+        _claim_id: Uuid,
+        _stale_after: std::time::Duration,
+    ) -> Result<bool, DbError> {
+        Ok(true)
+    }
+
+    /// Release a claim taken with `claim_id`. Idempotent, and scoped to
+    /// `claim_id` so it can never drop a claim another run has since taken
+    /// over (e.g. after this one was reclaimed as stale).
+    ///
+    /// The default implementation does nothing — see
+    /// [`Self::try_claim_pipeline_run`].
+    async fn release_pipeline_run_claim(
+        &self,
+        _dataset_id: Uuid,
+        _pipeline_name: &str,
+        _claim_id: Uuid,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
 }

--- a/crates/database/src/pipelines/sea_orm_impl.rs
+++ b/crates/database/src/pipelines/sea_orm_impl.rs
@@ -3,15 +3,16 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
+use sea_orm::sea_query::OnConflict;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, DbErr, EntityTrait, QueryFilter, QueryOrder,
     QuerySelect, RelationTrait,
 };
 use serde_json::json;
 use uuid::Uuid;
 
 use crate::conversions::{domain_status_to_entity, entity_status_to_domain};
-use crate::entities::{dataset, pipeline_run, pipeline_run_payload_field};
+use crate::entities::{dataset, pipeline_run, pipeline_run_claim, pipeline_run_payload_field};
 use crate::types::{DatabaseError, PipelineRun, PipelineRunStatus};
 use crate::uuid_hex;
 
@@ -28,6 +29,45 @@ pub struct SeaOrmPipelineRunRepository {
 }
 
 impl SeaOrmPipelineRunRepository {
+    /// `INSERT ... ON CONFLICT DO NOTHING`, returning whether the row was
+    /// written. `false` means a claim already exists for the pair.
+    ///
+    /// SeaORM signals a do-nothing conflict either as `Ok(0)` rows affected or
+    /// as `DbErr::RecordNotInserted` depending on backend and version; both
+    /// mean the same thing here.
+    async fn insert_claim(
+        &self,
+        dataset_hex: &str,
+        pipeline_name: &str,
+        claim_id: Uuid,
+    ) -> Result<bool, DatabaseError> {
+        let row = pipeline_run_claim::ActiveModel {
+            dataset_id: sea_orm::ActiveValue::Set(dataset_hex.to_string()),
+            pipeline_name: sea_orm::ActiveValue::Set(pipeline_name.to_string()),
+            claim_id: sea_orm::ActiveValue::Set(uuid_hex::to_hex(claim_id)),
+            claimed_at: sea_orm::ActiveValue::Set(Utc::now()),
+        };
+
+        match pipeline_run_claim::Entity::insert(row)
+            .on_conflict(
+                OnConflict::columns([
+                    pipeline_run_claim::Column::DatasetId,
+                    pipeline_run_claim::Column::PipelineName,
+                ])
+                .do_nothing()
+                .to_owned(),
+            )
+            .exec_without_returning(self.db.as_ref())
+            .await
+        {
+            Ok(rows) => Ok(rows > 0),
+            Err(DbErr::RecordNotInserted) => Ok(false),
+            Err(e) => Err(DatabaseError::QueryError(format!(
+                "insert pipeline_run_claim failed: {e}"
+            ))),
+        }
+    }
+
     /// Create a new repository backed by the given database connection.
     pub fn new(db: Arc<DatabaseConnection>) -> Self {
         Self { db }
@@ -415,5 +455,94 @@ impl PipelineRunRepository for SeaOrmPipelineRunRepository {
             }
         }
         Ok(out)
+    }
+
+    /// Take the claim by inserting the `(dataset_id, pipeline_name)` row. The
+    /// composite primary key is the mutual exclusion: concurrent inserts race
+    /// in the database and exactly one commits, so `ON CONFLICT DO NOTHING`
+    /// reporting zero rows written *is* the "someone else holds it" signal.
+    /// Portable across SQLite and Postgres.
+    async fn try_claim_pipeline_run(
+        &self,
+        dataset_id: Uuid,
+        pipeline_name: &str,
+        claim_id: Uuid,
+        stale_after: std::time::Duration,
+    ) -> Result<bool, DatabaseError> {
+        let dataset_hex = uuid_hex::to_hex(dataset_id);
+
+        if self
+            .insert_claim(&dataset_hex, pipeline_name, claim_id)
+            .await?
+        {
+            return Ok(true);
+        }
+
+        // Someone holds it. Reclaim only if their claim has aged out — a
+        // killed process cannot release, and a release is scoped to its own
+        // `claim_id`, so without this the pair would wedge permanently.
+        let Some(existing) = pipeline_run_claim::Entity::find_by_id((
+            dataset_hex.clone(),
+            pipeline_name.to_string(),
+        ))
+        .one(self.db.as_ref())
+        .await
+        .map_err(|e| DatabaseError::QueryError(format!("find pipeline_run_claim failed: {e}")))?
+        else {
+            // Released between our insert and this read — retry once.
+            return self
+                .insert_claim(&dataset_hex, pipeline_name, claim_id)
+                .await;
+        };
+
+        let age = Utc::now().signed_duration_since(existing.claimed_at);
+        let stale_after = chrono::Duration::from_std(stale_after)
+            .map_err(|e| DatabaseError::QueryError(format!("stale_after out of range: {e}")))?;
+        if age < stale_after {
+            return Ok(false);
+        }
+
+        // Delete scoped to the `claim_id` we observed, so we lose the race
+        // rather than stomping a claim taken since the read.
+        let deleted = pipeline_run_claim::Entity::delete_many()
+            .filter(pipeline_run_claim::Column::DatasetId.eq(dataset_hex.clone()))
+            .filter(pipeline_run_claim::Column::PipelineName.eq(pipeline_name.to_string()))
+            .filter(pipeline_run_claim::Column::ClaimId.eq(existing.claim_id.clone()))
+            .exec(self.db.as_ref())
+            .await
+            .map_err(|e| {
+                DatabaseError::QueryError(format!("delete stale pipeline_run_claim failed: {e}"))
+            })?;
+        if deleted.rows_affected == 0 {
+            return Ok(false);
+        }
+
+        tracing::warn!(
+            dataset_id = %dataset_id,
+            pipeline_name = %pipeline_name,
+            stale_claim_id = %existing.claim_id,
+            age_seconds = age.num_seconds(),
+            "reclaimed a stale pipeline-run claim; the previous holder never released it"
+        );
+        self.insert_claim(&dataset_hex, pipeline_name, claim_id)
+            .await
+    }
+
+    async fn release_pipeline_run_claim(
+        &self,
+        dataset_id: Uuid,
+        pipeline_name: &str,
+        claim_id: Uuid,
+    ) -> Result<(), DatabaseError> {
+        pipeline_run_claim::Entity::delete_many()
+            .filter(pipeline_run_claim::Column::DatasetId.eq(uuid_hex::to_hex(dataset_id)))
+            .filter(pipeline_run_claim::Column::PipelineName.eq(pipeline_name.to_string()))
+            .filter(pipeline_run_claim::Column::ClaimId.eq(uuid_hex::to_hex(claim_id)))
+            .exec(self.db.as_ref())
+            .await
+            .map_err(|e| {
+                DatabaseError::QueryError(format!("release pipeline_run_claim failed: {e}"))
+            })?;
+        Ok(())
     }
 }

--- a/crates/database/tests/migration_compat.rs
+++ b/crates/database/tests/migration_compat.rs
@@ -253,15 +253,36 @@ async fn baseline_creates_full_table_set_sqlite() {
 }
 
 // ---------------------------------------------------------------------------
-// D1.5 — Single-migration invariant
+// D1.5 — Migration-chain shape
 // ---------------------------------------------------------------------------
 
+/// The chain is one squashed baseline followed by additive migrations, and this
+/// pins the count so re-splitting the baseline — or adding a migration without
+/// meaning to — fails loudly.
+///
+/// D1.5 originally required *exactly* one migration, because the baseline
+/// squashed 14 predecessors for 0.1.0 when "there is no deployed schema to
+/// upgrade from" (see the baseline's module docs). That premise expired once
+/// 0.2.0 databases existed: editing the baseline to add a table leaves every
+/// already-migrated database without it, and the first query against that
+/// table then fails at runtime. Additive migrations after the baseline are the
+/// only way to change the schema without breaking existing deployments.
+///
+/// Bump this deliberately, with the same reasoning, when a migration is added.
 #[test]
-fn relational_chain_has_one_migration() {
+fn relational_chain_is_baseline_plus_additive_migrations() {
     use sea_orm_migration::MigratorTrait;
+    let names: Vec<String> = Migrator::migrations()
+        .iter()
+        .map(|m| m.name().to_string())
+        .collect();
     assert_eq!(
-        Migrator::migrations().len(),
-        1,
-        "relational chain must have exactly one baseline migration"
+        names.len(),
+        2,
+        "unexpected migration-chain length — chain: {names:?}"
+    );
+    assert!(
+        names[0].contains("baseline"),
+        "the squashed baseline must stay first in the chain — chain: {names:?}"
     );
 }

--- a/crates/database/tests/pipeline_run_repository.rs
+++ b/crates/database/tests/pipeline_run_repository.rs
@@ -909,3 +909,161 @@ async fn run_info_initiated_shape_is_empty_object() {
 // are part of the `cognee` public API and adding `cognee` as a
 // dev-dependency of `cognee-database` would create a build cycle.
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Exclusive-run claims (`try_claim_pipeline_run` / `release_pipeline_run_claim`)
+//
+// These cover the atomicity the `pipeline_runs` status read cannot provide:
+// that read and the executor's later `Started` write are separate operations,
+// so two callers entering between them both see the pre-run state. The claim
+// insert is the contended operation instead.
+// ---------------------------------------------------------------------------
+
+/// A staleness window no real claim can exceed during a test.
+const NEVER_STALE: std::time::Duration = std::time::Duration::from_secs(3600);
+
+#[tokio::test]
+async fn claim_is_granted_once_and_blocks_the_second_caller() {
+    let db = make_db().await;
+    let repo = make_repo(Arc::clone(&db));
+    let dataset_id = Uuid::new_v4();
+    create_dataset(&db, dataset_id).await;
+
+    let first = Uuid::new_v4();
+    let second = Uuid::new_v4();
+
+    assert!(
+        repo.try_claim_pipeline_run(dataset_id, "cognify_pipeline", first, NEVER_STALE)
+            .await
+            .expect("first claim"),
+        "the first caller must take the claim"
+    );
+    assert!(
+        !repo
+            .try_claim_pipeline_run(dataset_id, "cognify_pipeline", second, NEVER_STALE)
+            .await
+            .expect("second claim"),
+        "a second caller must be refused while the claim is held"
+    );
+
+    repo.release_pipeline_run_claim(dataset_id, "cognify_pipeline", first)
+        .await
+        .expect("release");
+
+    assert!(
+        repo.try_claim_pipeline_run(dataset_id, "cognify_pipeline", second, NEVER_STALE)
+            .await
+            .expect("claim after release"),
+        "the claim must be available again once released"
+    );
+}
+
+#[tokio::test]
+async fn claims_are_scoped_per_pipeline_name() {
+    let db = make_db().await;
+    let repo = make_repo(Arc::clone(&db));
+    let dataset_id = Uuid::new_v4();
+    create_dataset(&db, dataset_id).await;
+
+    assert!(
+        repo.try_claim_pipeline_run(dataset_id, "cognify_pipeline", Uuid::new_v4(), NEVER_STALE)
+            .await
+            .expect("cognify claim")
+    );
+    assert!(
+        repo.try_claim_pipeline_run(dataset_id, "memify_pipeline", Uuid::new_v4(), NEVER_STALE)
+            .await
+            .expect("memify claim"),
+        "cognify and memify on one dataset must not exclude each other"
+    );
+}
+
+#[tokio::test]
+async fn release_only_removes_the_holders_own_claim() {
+    let db = make_db().await;
+    let repo = make_repo(Arc::clone(&db));
+    let dataset_id = Uuid::new_v4();
+    create_dataset(&db, dataset_id).await;
+
+    let holder = Uuid::new_v4();
+    assert!(
+        repo.try_claim_pipeline_run(dataset_id, "cognify_pipeline", holder, NEVER_STALE)
+            .await
+            .expect("claim")
+    );
+
+    // A release from someone else must not free the holder's claim — otherwise
+    // a run reclaimed as stale could later drop its successor's claim.
+    repo.release_pipeline_run_claim(dataset_id, "cognify_pipeline", Uuid::new_v4())
+        .await
+        .expect("foreign release is a no-op, not an error");
+
+    assert!(
+        !repo
+            .try_claim_pipeline_run(dataset_id, "cognify_pipeline", Uuid::new_v4(), NEVER_STALE)
+            .await
+            .expect("claim attempt"),
+        "the holder's claim must survive a foreign release"
+    );
+}
+
+#[tokio::test]
+async fn a_stale_claim_is_reclaimed() {
+    let db = make_db().await;
+    let repo = make_repo(Arc::clone(&db));
+    let dataset_id = Uuid::new_v4();
+    create_dataset(&db, dataset_id).await;
+
+    // Stands in for a claim left behind by a killed process: nothing will ever
+    // release it, so without reclamation the dataset would wedge forever.
+    let abandoned = Uuid::new_v4();
+    assert!(
+        repo.try_claim_pipeline_run(dataset_id, "cognify_pipeline", abandoned, NEVER_STALE)
+            .await
+            .expect("abandoned claim")
+    );
+
+    // A zero window makes any existing claim stale immediately.
+    assert!(
+        repo.try_claim_pipeline_run(
+            dataset_id,
+            "cognify_pipeline",
+            Uuid::new_v4(),
+            std::time::Duration::ZERO
+        )
+        .await
+        .expect("reclaim"),
+        "a claim older than the staleness window must be reclaimable"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_claims_grant_exactly_one() {
+    let db = make_db().await;
+    let dataset_id = Uuid::new_v4();
+    create_dataset(&db, dataset_id).await;
+
+    // Eight tasks contend for the same pair at once. Whatever the interleaving,
+    // the composite primary key admits exactly one — this is the property the
+    // status read could not provide.
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let repo = make_repo(Arc::clone(&db));
+        handles.push(tokio::spawn(async move {
+            repo.try_claim_pipeline_run(dataset_id, "cognify_pipeline", Uuid::new_v4(), NEVER_STALE)
+                .await
+                .expect("claim attempt")
+        }));
+    }
+
+    let mut granted = 0;
+    for h in handles {
+        if h.await.expect("task join") {
+            granted += 1;
+        }
+    }
+    assert_eq!(
+        granted, 1,
+        "exactly one concurrent caller may hold the claim"
+    );
+}

--- a/crates/delete/src/lib.rs
+++ b/crates/delete/src/lib.rs
@@ -199,6 +199,10 @@ impl DeleteService {
     /// re-cognify is not short-circuited by
     /// `check_pipeline_run_qualification` (task 08-08).
     ///
+    /// Since the pipeline cache became opt-in, that short-circuit only applies
+    /// to callers that set `CognifyConfig::use_pipeline_cache`; the fresh row
+    /// is still written for parity and for those callers.
+    ///
     /// When unset (default for back-compat / mock paths) the reset is a
     /// no-op.
     pub fn with_pipeline_run_repo(mut self, repo: Arc<dyn PipelineRunRepository>) -> Self {
@@ -334,7 +338,9 @@ impl DeleteService {
             // Python parity: writing a fresh `INITIATED` row for every
             // pipeline registered against this dataset invalidates any prior
             // `COMPLETED` row so a future re-cognify is not short-circuited
-            // by `check_pipeline_run_qualification` (task 08-08). The rows
+            // by `check_pipeline_run_qualification` (task 08-08) — which since
+            // the cache became opt-in only affects callers that set
+            // `CognifyConfig::use_pipeline_cache`. The rows
             // outlive the dataset itself — once the FK is dropped (gap 08-01)
             // the orphans are harmless and surface in
             // `list_recent_with_attribution` with `dataset_name = None`.

--- a/docs/http-server/pipelines.md
+++ b/docs/http-server/pipelines.md
@@ -436,7 +436,8 @@ The library function (the `work` future) does not see the flag. It just runs aga
 ```
 Pending ──► Running ──► Completed
                     └─► Errored
-        └─► AlreadyCompleted    (idempotent re-cognify; no work performed)
+        └─► AlreadyCompleted    (opt-in pipeline cache only; no work performed —
+                                 no production caller emits this today)
         └─► Aborted (shutdown)  (writes Errored to durable + channel; matches "shutdown_grace" error)
 ```
 

--- a/docs/http-server/routers/cognify.md
+++ b/docs/http-server/routers/cognify.md
@@ -243,10 +243,12 @@ When `run_in_background=true` and one dataset's dispatch errors during *startup*
 
 The POST handler returns the deterministic `pipeline_run_id` for each dataset; clients use it directly in the WS path. There is no opaque session token — `pipeline_run_id` is itself the subscription handle. Because the id is deterministic in `(user, dataset, pipeline_name)`, two clients running cognify on the same dataset see the same id and either:
 
-1. The first run is still in flight — the second client's POST handler observes the existing handle, does *not* spawn a new run, and emits `PipelineRunAlreadyCompleted` once the first finishes.
-2. The first run already completed — the second POST emits `PipelineRunAlreadyCompleted` immediately.
+1. The first run is still in flight — the second client's POST handler observes the existing handle and does *not* spawn a new run.
+2. The first run already completed — the second POST **runs the pipeline again**, and the response reports `PipelineRunCompleted`.
 
-Both cases match Python's idempotent-re-cognify semantics. The WS subscription protocol works identically: any client with the id can attach.
+Case 2 is not a cache hit: `run_real_cognify` hands `cognify()` a `NoopPipelineRunRepository` (`routers/cognify.rs`), so the `check_pipeline_run_qualification` gate reads nothing on this path, and that gate now short-circuits only for callers that set `CognifyConfig::use_pipeline_cache` — which the cognify payload DTO does not expose. This matches Python, where `use_pipeline_cache=False` means a repeat cognify always re-runs. Note that `PipelineRunAlreadyCompleted` has no production emitter at all (`publish_already_completed` is uncalled), so no client observes that status today.
+
+The WS subscription protocol works identically: any client with the id can attach.
 
 ## 4. DTO definitions
 

--- a/docs/http-server/routers/cognify.md
+++ b/docs/http-server/routers/cognify.md
@@ -243,10 +243,12 @@ When `run_in_background=true` and one dataset's dispatch errors during *startup*
 
 The POST handler returns the deterministic `pipeline_run_id` for each dataset; clients use it directly in the WS path. There is no opaque session token — `pipeline_run_id` is itself the subscription handle. Because the id is deterministic in `(user, dataset, pipeline_name)`, two clients running cognify on the same dataset see the same id and either:
 
-1. The first run is still in flight — the second client's POST handler observes the existing handle and does *not* spawn a new run.
-2. The first run already completed — the second POST **runs the pipeline again**, and the response reports `PipelineRunCompleted`.
+1. The first run is still in flight — the second POST **spawns another run anyway**. `dispatch_pipeline` always calls `register_*` with the deterministic id, and `DefaultPipelineRunRegistry::create_slot` does not de-duplicate: on a hit it only reuses the existing slot's channels (so early subscribers keep their events), updates the metadata and resets the phase to `Pending`. Dispatch is *not* idempotent.
+2. The first run already completed — the second POST **runs the pipeline again**.
 
-Case 2 is not a cache hit: `run_real_cognify` hands `cognify()` a `NoopPipelineRunRepository` (`routers/cognify.rs`), so the `check_pipeline_run_qualification` gate reads nothing on this path, and that gate now short-circuits only for callers that set `CognifyConfig::use_pipeline_cache` — which the cognify payload DTO does not expose. This matches Python, where `use_pipeline_cache=False` means a repeat cognify always re-runs. Note that `PipelineRunAlreadyCompleted` has no production emitter at all (`publish_already_completed` is uncalled), so no client observes that status today.
+The status the response carries in both cases depends on the dispatch mode, not on any prior run: blocking mode maps `RunPhase::Completed | Pending` to `PipelineRunCompleted`, while `run_in_background=true` returns `PipelineRunStarted` immediately.
+
+Neither case is a cache hit. `run_real_cognify` hands `cognify()` a `NoopPipelineRunRepository` (`routers/cognify.rs`), so the `check_pipeline_run_qualification` gate reads nothing on this path, and that gate short-circuits only for callers that set `CognifyConfig::use_pipeline_cache` — which the cognify payload DTO does not expose. This matches Python, where `use_pipeline_cache=False` means a repeat cognify always re-runs. `PipelineRunAlreadyCompleted` has no production emitter at all (`publish_already_completed` is uncalled), so no client observes that status today.
 
 The WS subscription protocol works identically: any client with the id can attach.
 


### PR DESCRIPTION
Fixes the first half of [TOP-7](https://linear.app/topoteretes/issue/TOP-7/cognify-silently-skips-every-run-after-the-first-for-a-dataset). Reported by n.zivkovic while porting a 10 GB load test to the Rust binary:

> I can cognify dataset once. I wanted to upload data in waves but I will have to do it once, making it easy failure point.

## The bug

`cognify()` consulted `check_pipeline_run_qualification` **unconditionally**, so the COMPLETED `pipeline_runs` row left by the first run turned every later run into a silent no-op. Data added to an already-cognified dataset was never extracted, and loading in waves was impossible.

Python only consults that layer behind `if use_pipeline_cache:` in `run_pipeline_per_dataset` (`modules/pipelines/operations/pipeline.py:132`), and every public entry point passes `use_pipeline_cache=False` (`api/v1/cognify/cognify.py:330`, `api/v1/add/add.py:307`), so upstream a repeat cognify always re-runs. Python's gate uses no content hash, so there is no equivalence check we were missing. `memify` had the same unconditional gate.

`dataset_resolver.rs:136/:270` already gated its own dataset-level skip on `config.use_pipeline_cache`, so the two layers contradicted each other and the flag was meaningless for repeat-run behaviour.

### Which surfaces this actually affected

The gate only fires where a **real** `SeaOrmPipelineRunRepository` reaches `cognify()`:

| Caller | Repo | Affected |
|---|---|---|
| CLI `cognify` / `add-and-cognify` (`crates/cli/src/commands/cognify.rs:163`) | real | **yes** |
| SDK bindings — Python/TS/Java (`crates/bindings-common/src/services.rs:114`) | real | **yes** |
| embedded `api::remember` (`crates/lib/src/api/remember.rs:381`), `api::update` (`update.rs:141`) | real | **yes** |
| HTTP `POST /api/v1/cognify` (`routers/cognify.rs:448`) | Noop | no |
| HTTP `POST /api/v1/remember` (`routers/remember.rs:486,523`) | Noop | no |

## The fix — the two verdicts are gated differently, on purpose

- **`AlreadyCompleted`** short-circuits only when the caller opted into the pipeline cache.
- **`AlreadyRunning`** still rejects regardless of the flag.

That asymmetry is deliberate. Python can gate the `Started` check too because `run_pipeline_per_dataset` serializes on `get_dataset_lock(dataset.id)` (`pipeline.py:173`), whose own comment reads *"When caching is disabled the run always proceeds — concurrent runs are kept safe by the per-dataset lock, not by this check."* **Rust has no per-dataset lock** — no `get_dataset_lock`/`held_datasets` equivalent anywhere in `crates/`, and `DefaultPipelineRunRegistry::create_slot` *reuses* a slot for a duplicate `run_id` rather than rejecting it. So this row check is Rust's only run serialization; gating it would silently allow two concurrent cognify runs on one dataset (double LLM spend, interleaved graph/vector writes, an interleaved `pipeline_runs` trail). A deviation from Python's structure that preserves Python's actual guarantee.

**Known trade-off:** keeping the `Started` rejection also keeps the stale-`Started` wedge for embedded/CLI callers, which have no orphan sweep (the HTTP server recovers via `reset_orphans` at startup, `state.rs:157`). That makes the reset escape hatch — a later PR in this series — load-bearing rather than a nice-to-have.

### Serialization: an atomic claim, not the status read

Copilot review caught that the status read is not mutual exclusion, and it was right — my original justification for keeping the `AlreadyRunning` arm ungated overstated what it buys. That read and the `Started` row the executor writes later (`crates/core/src/pipeline.rs:916-923`) are separate operations, so two callers entering between them both saw the pre-run state and both proceeded.

Runs are now serialized by a new `pipeline_run_claims` table whose composite primary key `(dataset_id, pipeline_name)` *is* the mutual exclusion: concurrent inserts race in the database and exactly one commits, so `ON CONFLICT DO NOTHING` writing zero rows is the "someone else holds it" signal. Portable across SQLite and Postgres. `cognify()`/`memify()` claim after the gate and release on every exit path (the body is wrapped in an async block — `Drop` cannot await).

This goes *beyond* Python rather than matching it: `get_dataset_lock` is an in-process `asyncio.Lock` over a module-level dict (`infrastructure/locks/dataset_lock.py`), so Python serializes within one process only and two Python workers race exactly as Rust did. A database row also excludes concurrent runs across processes — which is what the CLI, the SDK bindings and a multi-instance server need.

Details worth reviewing:

- Claims are keyed per pipeline name, so cognify and memify on one dataset do not exclude each other.
- A claim left by a killed process is reclaimed after `CLAIM_STALE_AFTER` (24h). Deliberately generous: reclaiming early re-admits a concurrent run into a legitimately long one, which is the failure the claim exists to prevent. A multi-gigabyte cognify runs for hours.
- Claims are **not** cleared by the server's startup orphan sweep, unlike stale `Started` rows: claims are cross-process, so one instance restarting must not drop another live instance's claim.
- The status check stays, ungated — it is the cheaper path (no write) for a run already visibly in flight, and it is what reports a stale `Started` row rather than silently ignoring it.

**Schema change:** this is a second migration, not an edit to the squashed baseline. The baseline justifies its squash with "there is no deployed schema to upgrade from", which stopped being true once 0.2.0 databases existed — editing it would leave every already-migrated database (including the reporter's) without the table, failing at the first claim insert. The D1.5 single-migration invariant test is therefore updated to "baseline plus additive migrations", with that reasoning recorded in the test. **Flagging it explicitly since it reverses a stated repo policy.**

`MemifyConfig` gains the `use_pipeline_cache` field it never had (default `false`, matching Python's hard-coded `use_pipeline_cache=False`; `#[serde(default)]` so stored configs still deserialize).

## Why CI was green

Every crate-level test wires `NoopPipelineRunRepository`, whose `get_pipeline_run_by_dataset` returns `Ok(None)` → `Qualification::Proceed` (`crates/database/src/pipelines/noop.rs:113`). `entity_id_determinism.rs:179` even asserts `!already_completed` and passes, for exactly that reason.

So the new `crates/cognify/tests/integration_repeat_cognify.rs` uses a **real** `SeaOrmPipelineRunRepository`, and asserts the COMPLETED row exists before re-running so it cannot decay into a vacuous pass. Three cases, all offline (mock LLM/embeddings/graph/vector), no env gating:

1. `second_cognify_wave_is_processed_not_skipped` — the regression test. **Verified to fail with the gate change reverted.**
2. `pipeline_cache_opt_in_short_circuits_the_second_run` — the cache still works when requested.
3. `a_started_run_still_rejects_a_concurrent_run_with_the_cache_off` — the concurrency guard survives.
4. `a_claim_held_elsewhere_blocks_the_run` — a claim held by another process rejects the run, and it succeeds once released.
5. `a_finished_run_releases_its_claim` — no leaked claim, so the next wave is processed rather than rejected.

Plus five in `crates/database/tests/pipeline_run_repository.rs` covering the claim itself: grant/refuse/release, per-pipeline scoping, release scoped to the holder's own `claim_id`, stale reclamation, and `concurrent_claims_grant_exactly_one` — eight tasks contending on the real primary key, of which exactly one may win.

On the timing-based race test Copilot asked for: the cognify-level test pre-takes the claim instead of racing two `cognify()` calls. The state that matters is *a claim held while a second caller enters*, and pre-taking it reproduces that deterministically; two racing calls could legitimately serialize in time and both succeed, making the test flaky in both directions. The atomicity itself is covered by the contended-insert test above.

## Also corrected

Invariants this change invalidates, plus one that was never true:

- `docs/http-server/routers/cognify.md` §3.2 and `docs/http-server/pipelines.md` §8 documented an "idempotent re-cognify" HTTP contract that **no client has ever observed** — the HTTP path passes a no-op repo, and `publish_already_completed` has zero production callers.
- `crates/cli/src/commands/mod.rs` and two comments in `crates/delete/src/lib.rs` claimed omitting the pipeline-runs repo would let a later re-cognify be short-circuited; that now only holds for cache-on callers.

## Not in this PR

Tracked in TOP-7: reset-on-`add` (Python `add.py:290`), the CLI/HTTP reset escape hatch, and real `incremental_loading` (so wave *N* doesn't re-pay wave *N-1*'s LLM cost — `CognifyConfig.incremental_loading` is currently a dead field).

## Verification

`cargo test -p cognee-cognify` — 259 passed, 5 ignored; `cargo test -p cognee-database --features sqlite` — 107 passed; `cargo test -p cognee-core` — 141 passed. `cargo fmt --all -- --check` and workspace `cargo clippy --all-targets -- -D warnings` — clean. The Python/TS/Java binding stages of `scripts/check_all.sh` were not run locally; leaving those to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187bXSk3PJzrfUoz1Mg2C4J

