### PR TITLE
fix(e2e): repair the parity harness's oracles

### DIFF
--- a/e2e-cross-sdk/Dockerfile
+++ b/e2e-cross-sdk/Dockerfile
@@ -57,9 +57,17 @@ RUN uv venv --relocatable /build/.venv
 # Copy dependency files first for layer caching
 COPY cognee/pyproject.toml cognee/uv.lock cognee/README.md ./
 
-# Install deps without the project itself
+# Install deps without the project itself.
+#
+# `--extra dlt` matters for parity, not just coverage: cognee registers
+# `dlt_csv_loader` only when the optional `dlt` extra is installed
+# (pyproject.toml:176). Without it, Python falls back to the same
+# `csv_loader` Rust uses, the two sides agree, and a real routing
+# divergence — Python routes CSV through the DLT_SOURCE cognify route,
+# Rust has no route concept at all — is masked by the harness's own
+# environment rather than by the code under test.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-install-project --no-dev --no-editable
+    uv sync --frozen --no-install-project --no-dev --no-editable --extra dlt
 
 # Copy project source and install. At the pinned SHA cognee declares
 # `[tool.hatch.build.targets.wheel] packages = ["cognee", "cognee_db_workers", "kuzu"]`
@@ -77,7 +85,7 @@ COPY cognee/cognee /build/cognee
 COPY cognee/cognee_db_workers /build/cognee_db_workers
 COPY cognee/distributed /build/distributed
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-editable
+    uv sync --frozen --no-dev --no-editable --extra dlt
 
 # kuzu is an optional cognee backend not pulled in by the default `uv sync`,
 # but cognee's alembic migration `b9274c27a25a_kuzu_11_migration.py` does a

--- a/e2e-cross-sdk/README.md
+++ b/e2e-cross-sdk/README.md
@@ -30,6 +30,53 @@ docker compose -f docker-compose.yml run --rm e2e-http-tests \
   pytest -vs /harness/ -k "test_http_(cognify|remember|recall|memify|improve|llm|hybrid)" --tb=short
 ```
 
+## What this harness does and does not prove
+
+Read this before citing a green run as evidence of parity.
+
+**Two lanes, different strengths.** The HTTP lane (`test_http_*`) compares
+responses through `assert_responses_match`, which strips a tolerance set
+(`http_helpers.py:DEFAULT_IGNORE`) that includes **every `id` field**. The CLI/DB
+lane (`test_*_parity`, `test_cross_*`, `test_readd_*`) shells out to both CLIs and
+compares SQLite state directly with exact equality on content hashes, UUIDs and
+row counts — no ignore list in the path. The CLI/DB lane is the stronger evidence
+and, until recently, no CI filter selected it.
+
+**Known limits, in rough order of how much they weaken a green run:**
+
+- **Auth-gated tests skip by default.** The OSS `cognee-http-server` ships no auth
+  router, and `bin/start_servers.sh` launches that binary, so `authed_clients`
+  skips — currently ~20 of 46 files. The run now prints a summary saying so; set
+  `COGNEE_PARITY_REQUIRE_AUTH=1` to turn those skips into failures, or boot a
+  closed `cognee-http-cloud` binary.
+- **The two sides do not run the same vector backend.** `start_servers.sh` sets
+  `VECTOR_DB_PROVIDER=mock` for Rust (the OSS server's only non-pgvector option,
+  and the harness has no Postgres) while Python falls through to its `lancedb`
+  default. **Any vector-specific result from this harness is therefore not a
+  parity result.** Graph (`ladybug`), relational (`sqlite`) and embedding provider
+  (`openai`) *are* matched. Fixing this needs either Postgres in the compose file
+  so both sides can use pgvector, or a Python-side mock vector provider.
+- **Per-test ignore sets can remove the thing under test.** `test_http_llm.py`
+  ignores `$..output` and `$..response`; `test_http_v2_recall.py` ignores `$..text`,
+  `$..answer` and `$..score`; `test_http_errors.py` ignores error messages. When
+  adding a case, check its ignore set actually leaves your oracle visible.
+- **"Both absent" scores as agreement.** Tests that accept 404-on-both convert
+  *neither side implements this* into a pass. Prefer `xfail(strict=True)` keyed to
+  a tracked gap.
+- **Rust's identity is seeded from Python's database.** `conftest.py` reads
+  `owner_id`/`tenant_id` out of Python's SQLite and passes them to the Rust CLI,
+  so UUID5 agreement proves the hash function agrees on identical inputs — not
+  that both sides derive the same inputs.
+- **No OpenAPI comparison exists.** `harness/golden/openapi.python.json` is a
+  placeholder with empty `paths`, and `test_http_openapi.py` is skipped.
+- **LLM determinism is unwired.** Rust has `MOCK_LLM`, `crates/llm/src/mock/` and
+  cassette replay (`COGNEE_RECORD_LLM` / `COGNEE_TEST_REPLAY`); nothing under
+  `e2e-cross-sdk/` uses any of it. Python has no general LLM mock, and a shared
+  fake cannot key on prompt text because the two SDKs' prompts differ.
+
+A fuller accounting, with the divergences these limits were hiding, is in
+[`docs/roadmap/python-parity-audit.md`](../docs/roadmap/python-parity-audit.md).
+
 ## COGX golden archive
 
 `harness/golden/cogx_archive/` is a COGX archive written by the Rust exporter

--- a/e2e-cross-sdk/bin/start_servers.sh
+++ b/e2e-cross-sdk/bin/start_servers.sh
@@ -108,10 +108,20 @@ echo "[start_servers] Starting Python uvicorn on :8000..."
 PY_PID=$!
 
 # ── Start Rust HTTP server on :8001 ──────────────────────────────────────────
-# The Rust server gets its OWN roots under $RS_WORKSPACE (/rs) — otherwise it
-# inherits the Python SYSTEM_ROOT_DIRECTORY (/py/...) exported above and both
-# servers would share one workspace, defeating the isolation the harness relies
-# on. VECTOR_DB_PROVIDER=mock selects the in-memory vector store (the binary is
+# The Rust server gets its OWN roots under $RS_WORKSPACE (/rs), so the two
+# servers never share a workspace.
+#
+# Note the env-var asymmetry, which is easy to get wrong: the Rust config reads
+# COGNEE_SYSTEM_ROOT_DIRECTORY and COGNEE_DATA_ROOT_DIRECTORY (prefixed —
+# crates/lib/src/config.rs:589,592) but CACHE_ROOT_DIRECTORY *unprefixed*
+# (:667). Python reads all three unprefixed. Both spellings are therefore set
+# below for the two that differ.
+#
+# Until this was fixed, only the `cd "$RS_WORKSPACE"` below kept the servers
+# apart: the two bare *_ROOT_DIRECTORY exports were silently ignored by the Rust
+# binary, which fell back to its relative defaults, which happened to resolve
+# under the workspace we had just cd'd into. Any absolute-path override would
+# have gone nowhere. VECTOR_DB_PROVIDER=mock selects the in-memory vector store (the binary is
 # built with --features dev-mock): the harness has no Postgres, and the OSS
 # server's only other option is pgvector. Without this the server derives the
 # pgvector connection string from SYSTEM_ROOT_DIRECTORY (a filesystem path),
@@ -125,6 +135,8 @@ echo "[start_servers] Starting Rust cognee-http-server on :8001..."
  HTTP_API_HOST=127.0.0.1 \
  HTTP_API_PORT=8001 \
  ENV=test \
+ COGNEE_SYSTEM_ROOT_DIRECTORY="$RS_WORKSPACE/.cognee_system" \
+ COGNEE_DATA_ROOT_DIRECTORY="$RS_WORKSPACE/.data_storage" \
  SYSTEM_ROOT_DIRECTORY="$RS_WORKSPACE/.cognee_system" \
  DATA_ROOT_DIRECTORY="$RS_WORKSPACE/.data_storage" \
  CACHE_ROOT_DIRECTORY="$RS_WORKSPACE/.cognee_cache" \

--- a/e2e-cross-sdk/bin/start_servers.sh
+++ b/e2e-cross-sdk/bin/start_servers.sh
@@ -112,16 +112,18 @@ PY_PID=$!
 # servers never share a workspace.
 #
 # Note the env-var asymmetry, which is easy to get wrong: the Rust config reads
-# COGNEE_SYSTEM_ROOT_DIRECTORY and COGNEE_DATA_ROOT_DIRECTORY (prefixed —
-# crates/lib/src/config.rs:589,592) but CACHE_ROOT_DIRECTORY *unprefixed*
-# (:667). Python reads all three unprefixed. Both spellings are therefore set
-# below for the two that differ.
+# COGNEE_SYSTEM_ROOT_DIRECTORY and COGNEE_DATA_ROOT_DIRECTORY (prefixed) but
+# CACHE_ROOT_DIRECTORY *unprefixed* — grep those names in
+# crates/lib/src/config.rs. Python reads all three unprefixed. Both spellings
+# are therefore set below for the two that differ.
 #
 # Until this was fixed, only the `cd "$RS_WORKSPACE"` below kept the servers
 # apart: the two bare *_ROOT_DIRECTORY exports were silently ignored by the Rust
 # binary, which fell back to its relative defaults, which happened to resolve
 # under the workspace we had just cd'd into. Any absolute-path override would
-# have gone nowhere. VECTOR_DB_PROVIDER=mock selects the in-memory vector store (the binary is
+# have gone nowhere.
+#
+# VECTOR_DB_PROVIDER=mock selects the in-memory vector store (the binary is
 # built with --features dev-mock): the harness has no Postgres, and the OSS
 # server's only other option is pgvector. Without this the server derives the
 # pgvector connection string from SYSTEM_ROOT_DIRECTORY (a filesystem path),

--- a/e2e-cross-sdk/harness/conftest.py
+++ b/e2e-cross-sdk/harness/conftest.py
@@ -240,6 +240,33 @@ def both_clients(py_client, rs_client):
     return {"py": py_client, "rs": rs_client}
 
 
+# Tests skipped because a server exposes no /api/v1/auth/* surface. Collected so
+# the run can state the count instead of burying it in per-test skip reasons: a
+# suite reporting "120 passed, 40 skipped" reads as healthy, and the reason those
+# 40 did not run is the single most important fact about the run.
+_AUTH_SKIPPED: list[str] = []
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """State the auth-skip count prominently at the end of the run."""
+    if not _AUTH_SKIPPED:
+        return
+    terminalreporter.write_sep("=", "cross-SDK parity: auth-gated tests skipped")
+    terminalreporter.write_line(
+        f"{len(_AUTH_SKIPPED)} test(s) did not execute because a server exposes "
+        "no /api/v1/auth/* routes."
+    )
+    terminalreporter.write_line(
+        "The OSS cognee-http-server ships no auth router (only the "
+        "AuthenticatedUser extractor), and bin/start_servers.sh launches exactly "
+        "that binary — so these tests never run in the default configuration."
+    )
+    terminalreporter.write_line(
+        "To make them count: boot a closed cognee-http-cloud binary, or set "
+        "COGNEE_PARITY_REQUIRE_AUTH=1 to turn these skips into failures."
+    )
+
+
 @pytest.fixture(scope="session")
 def auth_endpoints_available() -> dict:
     """Probe each server for the closed-cloud ``/api/v1/auth/*`` surface.
@@ -282,12 +309,27 @@ def authed_clients(both_clients, auth_endpoints_available):
     """
     missing = [name for name, ok in auth_endpoints_available.items() if not ok]
     if missing:
-        pytest.skip(
+        _AUTH_SKIPPED.append(", ".join(missing))
+        message = (
             "Cognee server(s) do not expose /api/v1/auth/* "
             f"(missing on: {', '.join(missing)}) — likely an OSS build. "
             "These tests cover the closed cognee-http-cloud auth surface; run them "
             "against a closed cognee-cloud-rust deployment (plan §6.1)."
         )
+        # Opt-in strictness. The default remains a skip, because the OSS server
+        # genuinely has no auth router and failing every one of these on an OSS
+        # build would be noise rather than signal. But a skip is invisible, and
+        # this fixture gates ~20 of the harness's files — the whole of CI phases
+        # 1, 2 and 2b — so a run that believes it is checking auth-gated parity
+        # needs a way to insist. Set COGNEE_PARITY_REQUIRE_AUTH=1 (e.g. in a job
+        # that boots a closed cognee-http-cloud binary) to turn the skip into a
+        # failure.
+        if os.environ.get("COGNEE_PARITY_REQUIRE_AUTH", "").lower() in {"1", "true", "yes"}:
+            pytest.fail(
+                "COGNEE_PARITY_REQUIRE_AUTH is set, but " + message,
+                pytrace=False,
+            )
+        pytest.skip(message)
     creds = {"username": "test@example.com", "password": "test_password_123"}
     for name, c in both_clients.items():
         # Bootstrap user — ignore 409 / 422 "already exists" on re-runs.

--- a/e2e-cross-sdk/harness/helpers.py
+++ b/e2e-cross-sdk/harness/helpers.py
@@ -433,6 +433,19 @@ def write_rust_config(
     return config_path
 
 
+# Maximum accepted relative divergence between the two SDKs' counts, as
+# |py - rust| / mean. Used by the structural parity tests (cognify + hybrid).
+# Overridable so a genuinely noisy signal can be widened deliberately, in one
+# place, with the new value visible in CI config.
+#
+# These bounds used to be enforced by `warnings.warn`, which meant the checks
+# could only fail if a side produced literally zero. If real-LLM runs prove
+# this too tight — edge counts are the likeliest, the two SDKs phrase and merge
+# relationships differently — raise it here or via the env var, or mock the LLM
+# (crates/llm/src/mock/ + COGNEE_TEST_REPLAY). Do not return to warning.
+COUNT_TOLERANCE = float(os.environ.get("COGNEE_PARITY_COUNT_TOLERANCE", "0.5"))
+
+
 # ── SQLite helpers ───────────────────────────────────────────────────────────
 
 
@@ -494,6 +507,12 @@ def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
     return row is not None
 
 
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    if not _table_exists(conn, table):
+        return False
+    return any(r[1] == column for r in conn.execute(f"PRAGMA table_info({table})"))
+
+
 def query_dataset_membership(conn: sqlite3.Connection) -> list[dict]:
     """Dataset membership as ``[{"dataset_id": ..., "data_id": ...}]``.
 
@@ -511,8 +530,16 @@ def query_dataset_membership(conn: sqlite3.Connection) -> list[dict]:
     against any current Python database. Its three callers therefore errored out
     before reaching an assertion, and reported no parity verdict at all.
 
-    Detecting the schema rather than the SDK keeps this correct for the
-    cross-read tests, where one SDK opens a database the other one wrote.
+    Detecting the schema rather than the SDK is what keeps this correct for
+    the cross-read tests, where one SDK opens a database the other one wrote —
+    but detection alone is not enough, because the two shapes are not mutually
+    exclusive. Rust's baseline migration creates ``dataset_data`` with
+    ``.if_not_exists()`` and Rust's ``data`` entity has no ``dataset_id``
+    column, so a Python-written database that Rust has since opened carries
+    **both**: Python's rows in ``data.dataset_id`` and an empty (or partial)
+    ``dataset_data``. Preferring the junction table there would report ``[]``
+    and silently drop Python's membership. Both shapes are therefore read and
+    unioned whenever both are present.
 
     Note that the row *counts* legitimately differ once the same bytes are added
     to two datasets: Python yields two ``data`` rows and Rust one row with two
@@ -520,12 +547,18 @@ def query_dataset_membership(conn: sqlite3.Connection) -> list[dict]:
     ``docs/roadmap/python-parity-audit.md`` §1.1); this helper only makes it
     observable instead of masking it behind an error.
     """
+    rows: list[dict] = []
     if _table_exists(conn, "dataset_data"):
-        return query_rows(conn, "SELECT dataset_id, data_id FROM dataset_data")
-    return query_rows(
-        conn,
-        "SELECT dataset_id, id AS data_id FROM data WHERE dataset_id IS NOT NULL",
-    )
+        rows += query_rows(conn, "SELECT dataset_id, data_id FROM dataset_data")
+    if _column_exists(conn, "data", "dataset_id"):
+        rows += query_rows(
+            conn,
+            "SELECT dataset_id, id AS data_id FROM data WHERE dataset_id IS NOT NULL",
+        )
+    # De-duplicate: a row recorded in both shapes is one membership fact, not
+    # two. Dict insertion order is preserved, so output stays stable.
+    seen = {(r["dataset_id"], r["data_id"]): r for r in rows}
+    return list(seen.values())
 
 
 # Retained so the existing call sites keep working; prefer the explicit name.

--- a/e2e-cross-sdk/harness/helpers.py
+++ b/e2e-cross-sdk/harness/helpers.py
@@ -487,8 +487,49 @@ def query_datasets(conn: sqlite3.Connection) -> list[dict]:
     return query_rows(conn, "SELECT * FROM datasets ORDER BY name")
 
 
-def query_dataset_data(conn: sqlite3.Connection) -> list[dict]:
-    return query_rows(conn, "SELECT * FROM dataset_data")
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def query_dataset_membership(conn: sqlite3.Connection) -> list[dict]:
+    """Dataset membership as ``[{"dataset_id": ..., "data_id": ...}]``.
+
+    The two SDKs model membership differently, so this cannot be one query:
+
+    * **Rust** keeps the ``dataset_data`` junction table, so a ``data`` row is
+      dataset-agnostic and may be linked to several datasets.
+    * **Python** retired that table (alembic
+      ``d6e8f0a2b4c6_backfill_dataset_scoped_data_drop_dataset_data``) and moved
+      membership onto a ``data.dataset_id`` column, so a ``data`` row belongs to
+      exactly one dataset.
+
+    Selecting from ``dataset_data`` unconditionally — which is what this helper
+    did — raises ``sqlite3.OperationalError: no such table: dataset_data``
+    against any current Python database. Its three callers therefore errored out
+    before reaching an assertion, and reported no parity verdict at all.
+
+    Detecting the schema rather than the SDK keeps this correct for the
+    cross-read tests, where one SDK opens a database the other one wrote.
+
+    Note that the row *counts* legitimately differ once the same bytes are added
+    to two datasets: Python yields two ``data`` rows and Rust one row with two
+    junction links. That divergence is real (see
+    ``docs/roadmap/python-parity-audit.md`` §1.1); this helper only makes it
+    observable instead of masking it behind an error.
+    """
+    if _table_exists(conn, "dataset_data"):
+        return query_rows(conn, "SELECT dataset_id, data_id FROM dataset_data")
+    return query_rows(
+        conn,
+        "SELECT dataset_id, id AS data_id FROM data WHERE dataset_id IS NOT NULL",
+    )
+
+
+# Retained so the existing call sites keep working; prefer the explicit name.
+query_dataset_data = query_dataset_membership
 
 
 def query_nodes(conn: sqlite3.Connection) -> list[dict]:

--- a/e2e-cross-sdk/harness/seed.py
+++ b/e2e-cross-sdk/harness/seed.py
@@ -90,6 +90,23 @@ def seed_cognify(
     return r.json()
 
 
+def extract_content_hash(resp: dict) -> str | None:
+    """Pull ``content_hash`` out of an /add response, whichever shape it uses.
+
+    Rust nests it in ``data_ingestion_info[].content_hash``; a top-level field
+    is accepted too so this keeps working if either SDK flattens the envelope.
+    Returns ``None`` when no hash is present in either position, which is the
+    pinned Python build's behaviour.
+    """
+    top = resp.get("content_hash")
+    if top is not None:
+        return top
+    items = resp.get("data_ingestion_info") or []
+    if isinstance(items, list) and items and isinstance(items[0], dict):
+        return items[0].get("content_hash")
+    return None
+
+
 def seed_both(
     both_clients: dict,
     *,
@@ -117,24 +134,26 @@ def seed_both(
     # content_hash is deterministic (MD5 of content), so where both sides
     # present it they must agree.
     #
-    # The `is not None` guard this check used to carry made it a no-op in
-    # practice: the pinned Python build returns a nested
-    # `{run_info: PipelineRunInfo}` with no content_hash at all (documented at
-    # test_http_add.py:22-29), so py_hash was always None and the only
-    # content-addressed equality assertion in the HTTP lane never executed.
+    # This lives one level down, not at the top level. Rust's /add returns a
+    # PipelineRunInfoDTO — {status, pipeline_run_id, dataset_id, dataset_name,
+    # data_ingestion_info: [...]} (crates/http-server/src/dto/pipeline_run.rs)
+    # — and the hash is a field of each data_ingestion_info item, never of the
+    # envelope. An earlier version of this check read results["rs"]["content_hash"]
+    # and so could only ever see None; it had misread the note in
+    # test_http_add.py, which describes the shape of the *items* inside
+    # data_ingestion_info, as a description of the response body.
     #
-    # Rust's flat `{content_hash, name, extension, mime_type}` IS a documented
-    # contract, so that half is asserted unconditionally — losing it would be a
-    # real regression, and silently skipping is how the original check died.
-    # The Python-side absence is tracked by a strict xfail in
-    # test_http_add.py::test_python_add_omits_content_hash, which flips to a
-    # failure the moment Python starts returning the field, at which point the
-    # comparison below can be made unconditional.
-    py_hash = results["py"].get("content_hash")
-    rs_hash = results["rs"].get("content_hash")
+    # Rust's half is asserted unconditionally: the nested content_hash is a
+    # documented part of DataIngestionInfoDTO, and silently skipping is how the
+    # original check died. The pinned Python build returns a nested
+    # {run_info: PipelineRunInfo} carrying no content_hash in either position,
+    # so its half stays conditional and is tracked by the strict xfail in
+    # test_http_add.py::test_python_add_omits_content_hash.
+    py_hash = extract_content_hash(results["py"])
+    rs_hash = extract_content_hash(results["rs"])
     assert rs_hash is not None, (
-        "seed_both: Rust /add did not return content_hash, which is its "
-        f"documented response contract. rs response: {results['rs']}"
+        "seed_both: Rust /add returned no content_hash at the top level or in "
+        f"data_ingestion_info[]. rs response: {results['rs']}"
     )
     if py_hash is not None:
         assert py_hash == rs_hash, (

--- a/e2e-cross-sdk/harness/seed.py
+++ b/e2e-cross-sdk/harness/seed.py
@@ -114,10 +114,29 @@ def seed_both(
     for side, client in both_clients.items():
         results[side] = seed_dataset_with_text(client, name=name, text=text)
 
-    # content_hash is deterministic (MD5 of content); both sides must agree.
+    # content_hash is deterministic (MD5 of content), so where both sides
+    # present it they must agree.
+    #
+    # The `is not None` guard this check used to carry made it a no-op in
+    # practice: the pinned Python build returns a nested
+    # `{run_info: PipelineRunInfo}` with no content_hash at all (documented at
+    # test_http_add.py:22-29), so py_hash was always None and the only
+    # content-addressed equality assertion in the HTTP lane never executed.
+    #
+    # Rust's flat `{content_hash, name, extension, mime_type}` IS a documented
+    # contract, so that half is asserted unconditionally — losing it would be a
+    # real regression, and silently skipping is how the original check died.
+    # The Python-side absence is tracked by a strict xfail in
+    # test_http_add.py::test_python_add_omits_content_hash, which flips to a
+    # failure the moment Python starts returning the field, at which point the
+    # comparison below can be made unconditional.
     py_hash = results["py"].get("content_hash")
     rs_hash = results["rs"].get("content_hash")
-    if py_hash is not None and rs_hash is not None:
+    assert rs_hash is not None, (
+        "seed_both: Rust /add did not return content_hash, which is its "
+        f"documented response contract. rs response: {results['rs']}"
+    )
+    if py_hash is not None:
         assert py_hash == rs_hash, (
             f"seed_both: content_hash mismatch — py={py_hash!r} rs={rs_hash!r}\n"
             f"py response: {results['py']}\n"

--- a/e2e-cross-sdk/harness/test_cognify_structural.py
+++ b/e2e-cross-sdk/harness/test_cognify_structural.py
@@ -5,6 +5,7 @@ LLM-based graph extraction is non-deterministic, so we compare structural
 properties (counts, type sets) rather than exact values.
 """
 
+import os
 import pytest
 
 from helpers import (
@@ -19,6 +20,18 @@ from conftest import requires_openai
 
 
 # ── Tests ────────────────────────────────────────────────────────────────────
+
+
+# Maximum accepted relative divergence in node/edge counts between the two SDKs,
+# as |py - rust| / mean. Overridable so a genuinely noisy signal can be widened
+# deliberately, in one place, with the new value visible in CI config.
+#
+# This used to be enforced by `warnings.warn`, which meant the two
+# "within_tolerance" tests below could only fail if a side produced literally
+# zero — they asserted nothing about tolerance despite their names. If real-LLM
+# runs prove this bound too tight, raise it here or mock the LLM
+# (crates/llm/src/mock/ + COGNEE_TEST_REPLAY); do not return to warning.
+COUNT_TOLERANCE = float(os.environ.get("COGNEE_PARITY_COUNT_TOLERANCE", "0.5"))
 
 
 @requires_openai
@@ -65,12 +78,10 @@ def test_cognify_node_count_within_tolerance(both_cognified):
 
     assert py_count > 0, "Python produced zero nodes"
     assert rust_count > 0, "Rust produced zero nodes"
-    if ratio > 0.5:
-        import warnings
-        warnings.warn(
-            f"Node count divergence is large ({ratio:.0%}): "
-            f"Python={py_count}, Rust={rust_count}"
-        )
+    assert ratio <= COUNT_TOLERANCE, (
+        f"Node count divergence {ratio:.0%} exceeds the "
+        f"{COUNT_TOLERANCE:.0%} tolerance: Python={py_count}, Rust={rust_count}"
+    )
 
 
 @requires_openai
@@ -86,17 +97,15 @@ def test_cognify_edge_count_within_tolerance(both_cognified):
     diff = abs(py_count - rust_count)
     ratio = diff / avg if avg > 0 else 0
 
-    # LLM extraction is highly non-deterministic for edges (different
-    # relationship phrasing, merging, etc.).  Only assert both produced
-    # some edges; log the ratio for monitoring.
+    # LLM extraction is more non-deterministic for edges than for nodes
+    # (relationship phrasing, merging). If COUNT_TOLERANCE proves too tight
+    # here specifically, widen it there rather than dropping the assertion.
     assert py_count > 0, "Python produced zero edges"
     assert rust_count > 0, "Rust produced zero edges"
-    if ratio > 0.5:
-        import warnings
-        warnings.warn(
-            f"Edge count divergence is large ({ratio:.0%}): "
-            f"Python={py_count}, Rust={rust_count}"
-        )
+    assert ratio <= COUNT_TOLERANCE, (
+        f"Edge count divergence {ratio:.0%} exceeds the "
+        f"{COUNT_TOLERANCE:.0%} tolerance: Python={py_count}, Rust={rust_count}"
+    )
 
 
 @requires_openai

--- a/e2e-cross-sdk/harness/test_cognify_structural.py
+++ b/e2e-cross-sdk/harness/test_cognify_structural.py
@@ -5,10 +5,10 @@ LLM-based graph extraction is non-deterministic, so we compare structural
 properties (counts, type sets) rather than exact values.
 """
 
-import os
 import pytest
 
 from helpers import (
+    COUNT_TOLERANCE,
     open_db,
     query_data,
     query_nodes,
@@ -20,18 +20,6 @@ from conftest import requires_openai
 
 
 # ── Tests ────────────────────────────────────────────────────────────────────
-
-
-# Maximum accepted relative divergence in node/edge counts between the two SDKs,
-# as |py - rust| / mean. Overridable so a genuinely noisy signal can be widened
-# deliberately, in one place, with the new value visible in CI config.
-#
-# This used to be enforced by `warnings.warn`, which meant the two
-# "within_tolerance" tests below could only fail if a side produced literally
-# zero — they asserted nothing about tolerance despite their names. If real-LLM
-# runs prove this bound too tight, raise it here or mock the LLM
-# (crates/llm/src/mock/ + COGNEE_TEST_REPLAY); do not return to warning.
-COUNT_TOLERANCE = float(os.environ.get("COGNEE_PARITY_COUNT_TOLERANCE", "0.5"))
 
 
 @requires_openai

--- a/e2e-cross-sdk/harness/test_http_add.py
+++ b/e2e-cross-sdk/harness/test_http_add.py
@@ -81,6 +81,28 @@ def local_url_fixture():
         server.server_close()
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "The pinned Python build returns a nested {run_info: PipelineRunInfo} "
+        "from /add with no content_hash, while Rust returns it flat. This test "
+        "is expected to fail. When it XPASSes, Python has started returning "
+        "content_hash: drop this test and make the comparison in "
+        "seed.py::seed_both unconditional, since that is the HTTP lane's only "
+        "content-addressed equality oracle."
+    ),
+)
+def test_python_add_omits_content_hash(authed_clients, unique_dataset_name):
+    """Tripwire for the asymmetry that disabled seed_both's hash comparison."""
+    from seed import seed_dataset_with_text
+
+    py = seed_dataset_with_text(
+        authed_clients["py"], name=unique_dataset_name, text="content hash probe"
+    )
+    assert py.get("content_hash") is not None
+
+
+
 def test_add_text_upload(authed_clients, unique_dataset_name):
     """POST /api/v1/add with a single text/plain file returns 200 on both servers."""
     py = authed_clients["py"].post(

--- a/e2e-cross-sdk/harness/test_http_add.py
+++ b/e2e-cross-sdk/harness/test_http_add.py
@@ -179,7 +179,9 @@ def test_add_deduplication(authed_clients, unique_dataset_name):
         "side. (Python's lenient behaviour is also what makes its dataset count "
         "higher in forget_everything.)"
     ),
-    strict=False,
+    # Deterministic divergence, so an XPASS means one side changed its
+    # validation behaviour — worth a CI failure rather than a silent pass.
+    strict=True,
 )
 def test_add_validation_error_on_missing_file(authed_clients, unique_dataset_name):
     """POST /api/v1/add with no file and no URL returns a 4xx error on both."""

--- a/e2e-cross-sdk/harness/test_http_add.py
+++ b/e2e-cross-sdk/harness/test_http_add.py
@@ -5,7 +5,9 @@ validation error on missing file.
 
 Ignore extension: ``{"$..tenant_id", "$..data_id", "$..dataset_id",
 "$..raw_data_location"}`` — file paths under /py vs /rs differ.
-The ``content_hash`` field is NOT ignored — it must match.
+Note that ``content_hash`` lives only inside ``data_ingestion_info``,
+which ``_ADD_IGNORE`` strips — so the response-diff tests here do NOT
+compare it. ``test_add_content_hash_matches_across_sdks`` is what pins it.
 """
 
 from contextlib import contextmanager
@@ -85,7 +87,8 @@ def local_url_fixture():
     strict=True,
     reason=(
         "The pinned Python build returns a nested {run_info: PipelineRunInfo} "
-        "from /add with no content_hash, while Rust returns it flat. This test "
+        "from /add carrying no content_hash in any position, while Rust returns "
+        "one per item in data_ingestion_info[]. This test "
         "is expected to fail. When it XPASSes, Python has started returning "
         "content_hash: drop this test and make the comparison in "
         "seed.py::seed_both unconditional, since that is the HTTP lane's only "
@@ -94,13 +97,33 @@ def local_url_fixture():
 )
 def test_python_add_omits_content_hash(authed_clients, unique_dataset_name):
     """Tripwire for the asymmetry that disabled seed_both's hash comparison."""
-    from seed import seed_dataset_with_text
+    from seed import extract_content_hash, seed_dataset_with_text
 
     py = seed_dataset_with_text(
         authed_clients["py"], name=unique_dataset_name, text="content hash probe"
     )
-    assert py.get("content_hash") is not None
+    assert extract_content_hash(py) is not None
 
+
+def test_add_content_hash_matches_across_sdks(authed_clients, unique_dataset_name):
+    """Same bytes in, same content_hash out of both SDKs.
+
+    This is the HTTP lane's only content-addressed equality oracle: every other
+    add test runs through ``assert_responses_match`` with ``_ADD_IGNORE``, which
+    strips ``data_ingestion_info`` and with it the hash. ``seed_both`` carries
+    the assertion; calling it here is what makes it run.
+
+    Like the rest of this module it is auth-gated, so it skips on an OSS build
+    (see the run's auth-skip summary). That gating is a known harness limit, not
+    a property of this check.
+    """
+    from seed import seed_both
+
+    seed_both(
+        authed_clients,
+        name=unique_dataset_name,
+        text="cross-SDK content-addressed identity probe",
+    )
 
 
 def test_add_text_upload(authed_clients, unique_dataset_name):

--- a/e2e-cross-sdk/harness/test_http_auth.py
+++ b/e2e-cross-sdk/harness/test_http_auth.py
@@ -143,7 +143,10 @@ def test_me_after_logout(py_client, rs_client):
         "Making this pass needs a shared relational DB across both servers, which "
         "is a harness architecture change, not an SDK bug."
     ),
-    strict=False,
+    # Deterministic under the harness's isolated-DB architecture. An XPASS
+    # means that architecture changed, which should be noticed. (Moot in the
+    # default config, where the auth fixture skips this module anyway.)
+    strict=True,
 )
 def test_jwt_cross_compat(py_client, rs_client):
     """Issue a JWT on Python, present it to Rust's /me — must return 200.

--- a/e2e-cross-sdk/harness/test_http_auth.py
+++ b/e2e-cross-sdk/harness/test_http_auth.py
@@ -144,8 +144,9 @@ def test_me_after_logout(py_client, rs_client):
         "is a harness architecture change, not an SDK bug."
     ),
     # Deterministic under the harness's isolated-DB architecture. An XPASS
-    # means that architecture changed, which should be noticed. (Moot in the
-    # default config, where the auth fixture skips this module anyway.)
+    # means that architecture changed, which should be noticed. Note this test
+    # takes py_client/rs_client, not authed_clients, so it really does run in
+    # the default config — it xfails because the OSS server has no /auth/login.
     strict=True,
 )
 def test_jwt_cross_compat(py_client, rs_client):

--- a/e2e-cross-sdk/harness/test_http_datasets.py
+++ b/e2e-cross-sdk/harness/test_http_datasets.py
@@ -81,7 +81,8 @@ def test_datasets_get_by_id(authed_clients, unique_dataset_name):
         "correctly reject the bad input, but the error envelopes are not "
         "byte-comparable and matching Pydantic's exact JSON shape is out of scope."
     ),
-    strict=False,
+    # Deterministic envelope-shape divergence; convergence is a real event.
+    strict=True,
 )
 def test_datasets_status_by_name(authed_clients, unique_dataset_name):
     """GET /api/v1/datasets/status?dataset=<name> returns processing status."""
@@ -123,7 +124,8 @@ def test_datasets_delete(authed_clients, unique_dataset_name):
         "correct here — matching would mean removing Rust's route. Tracked as a "
         "known divergence rather than a regression."
     ),
-    strict=False,
+    # Convergence here means someone added or removed a route. Fail loudly.
+    strict=True,
 )
 def test_datasets_get_deleted_returns_404(authed_clients, unique_dataset_name):
     """GET /api/v1/datasets/{id} returns 404 after deletion on both servers."""

--- a/e2e-cross-sdk/harness/test_http_hybrid_structural.py
+++ b/e2e-cross-sdk/harness/test_http_hybrid_structural.py
@@ -23,13 +23,12 @@ are what get compared across SDKs — with cognify-style tolerances, since
 LLM extraction is non-deterministic.
 """
 
-import os
 import json
 import re
 
 import pytest
 
-from helpers import NLP_TEXT_FILE
+from helpers import COUNT_TOLERANCE, NLP_TEXT_FILE
 from seed import seed_cognify, seed_dataset_with_text
 from conftest import requires_openai
 
@@ -245,11 +244,6 @@ def test_hybrid_context_structural_parity(authed_clients, hybrid_seeded_dataset)
     assert py_facts > 0, "Python produced zero facts"
     assert rs_facts > 0, "Rust produced zero facts"
     _assert_within_tolerance("Fact", py_facts, rs_facts)
-
-
-# Maximum accepted relative divergence, as |py - rust| / mean. Overridable so a
-# genuinely noisy signal can be widened deliberately rather than silently.
-COUNT_TOLERANCE = float(os.environ.get("COGNEE_PARITY_COUNT_TOLERANCE", "0.5"))
 
 
 def _assert_within_tolerance(label: str, py_count: int, rust_count: int) -> None:

--- a/e2e-cross-sdk/harness/test_http_hybrid_structural.py
+++ b/e2e-cross-sdk/harness/test_http_hybrid_structural.py
@@ -23,9 +23,9 @@ are what get compared across SDKs — with cognify-style tolerances, since
 LLM extraction is non-deterministic.
 """
 
+import os
 import json
 import re
-import warnings
 
 import pytest
 
@@ -236,26 +236,33 @@ def test_hybrid_context_structural_parity(authed_clients, hybrid_seeded_dataset)
         f"  Overlap:         {sorted(intersection)}"
     )
 
-    # Passage-count tolerance: both > 0, warn (not fail) on >50% divergence.
+    # Passage-count tolerance: both > 0, and within COUNT_TOLERANCE.
     assert py_passages > 0, "Python produced zero passages"
     assert rs_passages > 0, "Rust produced zero passages"
-    _warn_if_divergent("Passage", py_passages, rs_passages)
+    _assert_within_tolerance("Passage", py_passages, rs_passages)
 
-    # Fact-count tolerance: both > 0, warn (not fail) on >50% divergence.
+    # Fact-count tolerance: both > 0, and within COUNT_TOLERANCE.
     assert py_facts > 0, "Python produced zero facts"
     assert rs_facts > 0, "Rust produced zero facts"
-    _warn_if_divergent("Fact", py_facts, rs_facts)
+    _assert_within_tolerance("Fact", py_facts, rs_facts)
 
 
-def _warn_if_divergent(label: str, py_count: int, rust_count: int) -> None:
-    """Warn (do not fail) if the two counts diverge by more than 50%.
+# Maximum accepted relative divergence, as |py - rust| / mean. Overridable so a
+# genuinely noisy signal can be widened deliberately rather than silently.
+COUNT_TOLERANCE = float(os.environ.get("COGNEE_PARITY_COUNT_TOLERANCE", "0.5"))
 
-    Matches the warn-only pattern in test_cognify_structural.py.
+
+def _assert_within_tolerance(label: str, py_count: int, rust_count: int) -> None:
+    """Fail if the two counts diverge by more than COUNT_TOLERANCE.
+
+    This previously warned instead of asserting, which made the surrounding
+    checks unfailable except on a literal zero. If the bound proves too tight
+    under real-LLM runs, raise COGNEE_PARITY_COUNT_TOLERANCE or mock the LLM;
+    do not return to warning.
     """
     avg = (py_count + rust_count) / 2
     ratio = abs(py_count - rust_count) / avg if avg > 0 else 0
-    if ratio > 0.5:
-        warnings.warn(
-            f"{label} count divergence is large ({ratio:.0%}): "
-            f"Python={py_count}, Rust={rust_count}"
-        )
+    assert ratio <= COUNT_TOLERANCE, (
+        f"{label} count divergence {ratio:.0%} exceeds the "
+        f"{COUNT_TOLERANCE:.0%} tolerance: Python={py_count}, Rust={rust_count}"
+    )


### PR DESCRIPTION
## Why

The cross-SDK harness is how we claim the two SDKs agree. Auditing it against Python
`v1.5.3` found that a large share of its green is not load-bearing: assertions that
cannot fail, oracles disabled by a guard, a helper that errors against Python's current
schema, and an environment that hides a real divergence.

None of that is fixed by adding tests. It is fixed by repairing the instrument. That is
all this PR does — it changes no product code and adds no new parity cases.

## What each commit does

| Commit | Problem | Fix |
|---|---|---|
| `382bf7f` | The Rust launch exported `SYSTEM_ROOT_DIRECTORY` / `DATA_ROOT_DIRECTORY`, which the Rust config does not read — it reads the `COGNEE_`-prefixed forms (`crates/lib/src/config.rs:589,592`). Isolation held only because of the `cd "$RS_WORKSPACE"` before `exec`; an absolute-path override would have gone nowhere. The comment claimed the opposite. | Set both spellings, and record the asymmetry (`CACHE_ROOT_DIRECTORY` really is unprefixed, `:667`). |
| `4cb48ac` | `query_dataset_data` ran `SELECT * FROM dataset_data` unconditionally. Python retired that table (alembic `d6e8f0a2b4c6`) for a `data.dataset_id` column, so it raises `no such table` against any current Python DB. Its three callers errored before asserting. | `query_dataset_membership`, which detects the schema and returns the same `{dataset_id, data_id}` shape either way. Old name kept as an alias. |
| `df65794` | Neither `uv sync` passed `--extra dlt`, so `dlt_csv_loader` never registered and Python fell back to the same `csv_loader` Rust uses. The sides agreed because of the harness's environment, not the code. | Add the extra to both sync steps. |
| `243d842` | Four "within tolerance" checks computed a ratio then called `warnings.warn`, so they could only fail on a literal zero — while their names promised a bound. | Assert against a named `COUNT_TOLERANCE` (default `0.5`, the value the docstrings already claimed), overridable via `COGNEE_PARITY_COUNT_TOLERANCE`. |
| `fda6b87` | `seed_both`'s `content_hash` comparison was guarded `is not None` on both sides. The pinned Python returns no `content_hash`, so the HTTP lane's only content-addressed equality assertion never ran. | Assert Rust's half unconditionally (it is a documented contract) and add a `strict=True` xfail tripwire that fails the day Python starts returning the field. |
| `8d7801e` | An XPASS under `strict=False` is accepted silently, so a divergence that converges tells nobody. | Four deterministic ones made strict. **Two deliberately left alone** — see below. |
| `1c1f32e` | `authed_clients` skips against the OSS binary the harness itself starts, gating ~20 of 46 files including all of CI phases 1, 2 and 2b — invisibly. | `COGNEE_PARITY_REQUIRE_AUTH=1` turns the skip into a failure; a terminal-summary hook states the count and cause on every run. |
| `020e1d9` | The README explained how to run the suite but not how far to trust it. | A "what this does and does not prove" section, limits ordered by severity. |

## Two things I deliberately did not change

**The ~20 auth-gated files.** Most are not about auth and could use an unauthenticated
client against an OSS build, but that is a semantic change across 20 files. Docker was
unavailable in my environment, so I could not run the suite — doing it blind would be
worse than leaving the problem visible. `1c1f32e` makes it visible and enforceable
instead; the conversion is follow-up work.

**Two `xfail`s stay non-strict.** `test_http_search.py:53` is parametrized and its own
reason documents per-type variation (Rust already returns 200 for `CHUNKS_LEXICAL` where
the others are 422), so strict would fire on whichever parameter happens to agree.
`test_http_settings.py:227` explicitly chose `strict=False` and said why — I disagree, but
reversing a documented decision from another plan's scope is not this PR's business.

**The vector-backend asymmetry is documented, not fixed.** `start_servers.sh` runs Rust on
`VECTOR_DB_PROVIDER=mock` and Python on its `lancedb` default, so no vector-specific result
from this harness is a parity result. A fix needs Postgres in the compose file (so both can
use pgvector) or a Python-side mock provider. Neither is worth attempting without being
able to run the suite.

## Verification

Docker was unavailable, so **none of this was validated by a harness run.** What I did
check:

- `bash -n` on `start_servers.sh`; `ast.parse` on every touched Python file.
- `query_dataset_membership` exercised against both schema shapes built in memory,
  confirming identical output and that a `NULL dataset_id` row is excluded.
- The `pytest_terminal_summary` hook exercised against a stub reporter, including the
  empty-list early return.

Expect the first real run to surface failures. That is the intent of the companion
branch, not a regression from this one.

## Relationship to the other branches

- `harness/enable-dead-parity-lanes` adds the CI selectors for the 22 files no `-k`
  expression reached. **These two are independent but complementary**: that branch makes
  the CLI/DB lane run, this branch makes it correct. Landing that one first without this
  one means `test_add_parity`, `test_delete_parity` and `test_cross_delete` fail with
  `no such table: dataset_data` rather than with a parity verdict.
- `docs/python-parity-audit` carries the full audit that motivated both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hAERAfFc43murUQCkdcGe
