### PR TITLE
perf(search): scope the graph load to the query's neighbourhood

### DIFF
--- a/crates/graph/src/mock.rs
+++ b/crates/graph/src/mock.rs
@@ -546,55 +546,35 @@ impl GraphDBTrait for MockGraphDB {
         let nodes_guard = self.nodes.lock().unwrap(); // lock poison is unrecoverable
         let edges_guard = self.edges.lock().unwrap(); // lock poison is unrecoverable
 
-        // Hand-rolled BFS directly against the internal edge store. We must NOT
-        // delegate to `get_connections`, which drops `relationship_name`. Edges
-        // are pushed as their unmodified `(src, tgt, rel, props)` tuples, so the
-        // true stored direction is preserved by construction.
-        let mut nodes_by_id: HashMap<String, NodeData> = HashMap::new();
-        let mut visited: HashSet<String> = HashSet::new();
-        let mut frontier: Vec<String> = Vec::new();
-
-        for id in node_ids {
-            if visited.insert(id.clone()) {
-                frontier.push(id.clone());
-                // Seed lookup so isolated seeds still appear in the output.
-                if let Some(data) = nodes_guard.get(id) {
-                    nodes_by_id.insert(id.clone(), data.clone());
-                }
-            }
-        }
-
-        let mut edges: Vec<EdgeData> = Vec::new();
-        let mut edge_keys: HashSet<(String, String, String)> = HashSet::new();
+        // Two phases, mirroring the real adapters (`PgGraphAdapter`'s recursive
+        // CTE and `LadybugAdapter`'s traversal): first resolve the id set by
+        // undirected BFS out to `depth`, then return the **induced subgraph** over
+        // it — every edge with both endpoints resolved, per the contract on
+        // `GraphDBTrait::get_neighborhood`.
+        //
+        // Collecting edges during the walk instead (only those incident to the
+        // current frontier) silently omits edges between two nodes discovered at
+        // the same depth, so a caller that partitions the result itself — graph
+        // search keeps edges with at least one *seed* endpoint — would see a
+        // different set here than in production.
+        //
+        // Read straight from the internal edge store rather than delegating to
+        // `get_connections`, which drops `relationship_name`. Edge tuples are
+        // cloned unmodified, so the true stored direction is preserved.
+        let mut resolved: HashSet<String> = node_ids.iter().cloned().collect();
+        let mut frontier: Vec<String> = resolved.iter().cloned().collect();
 
         for _ in 0..depth {
             let frontier_set: HashSet<&String> = frontier.iter().collect();
             let mut next_frontier: Vec<String> = Vec::new();
 
-            for (src, tgt, rel, props) in edges_guard.iter() {
+            for (src, tgt, _, _) in edges_guard.iter() {
                 let src_in = frontier_set.contains(src);
                 let tgt_in = frontier_set.contains(tgt);
-                if !src_in && !tgt_in {
-                    continue;
-                }
-
-                let key = (src.clone(), tgt.clone(), rel.clone());
-                if edge_keys.insert(key) {
-                    edges.push((src.clone(), tgt.clone(), rel.clone(), props.clone()));
-                }
-
-                if let Some(data) = nodes_guard.get(src) {
-                    nodes_by_id.insert(src.clone(), data.clone());
-                }
-                if let Some(data) = nodes_guard.get(tgt) {
-                    nodes_by_id.insert(tgt.clone(), data.clone());
-                }
-
-                // Enqueue the endpoint that isn't in the current frontier.
-                if src_in && visited.insert(tgt.clone()) {
+                if src_in && resolved.insert(tgt.clone()) {
                     next_frontier.push(tgt.clone());
                 }
-                if tgt_in && visited.insert(src.clone()) {
+                if tgt_in && resolved.insert(src.clone()) {
                     next_frontier.push(src.clone());
                 }
             }
@@ -605,7 +585,22 @@ impl GraphDBTrait for MockGraphDB {
             frontier = next_frontier;
         }
 
-        Ok((nodes_by_id.into_iter().collect(), edges))
+        // Seeds are included even when isolated or absent from the node store,
+        // matching the previous behaviour.
+        let nodes: Vec<(String, NodeData)> = resolved
+            .iter()
+            .filter_map(|id| nodes_guard.get(id).map(|data| (id.clone(), data.clone())))
+            .collect();
+
+        let mut edge_keys: HashSet<(String, String, String)> = HashSet::new();
+        let edges: Vec<EdgeData> = edges_guard
+            .iter()
+            .filter(|(src, tgt, _, _)| resolved.contains(src) && resolved.contains(tgt))
+            .filter(|(src, tgt, rel, _)| edge_keys.insert((src.clone(), tgt.clone(), rel.clone())))
+            .cloned()
+            .collect();
+
+        Ok((nodes, edges))
     }
 
     async fn get_node_truth_state(

--- a/crates/graph/src/mock.rs
+++ b/crates/graph/src/mock.rs
@@ -585,8 +585,10 @@ impl GraphDBTrait for MockGraphDB {
             frontier = next_frontier;
         }
 
-        // Seeds are included even when isolated or absent from the node store,
-        // matching the previous behaviour.
+        // An isolated seed still appears, because it is in `resolved`. A seed with
+        // no row in the node store is dropped here — same as the previous
+        // behaviour, and same as the real adapters, whose node halves select from
+        // `graph_node`/`(n:Node)` and so cannot invent a row either.
         let nodes: Vec<(String, NodeData)> = resolved
             .iter()
             .filter_map(|id| nodes_guard.get(id).map(|data| (id.clone(), data.clone())))

--- a/crates/search/src/graph_retrieval/brute_force_triplet_search.rs
+++ b/crates/search/src/graph_retrieval/brute_force_triplet_search.rs
@@ -269,13 +269,13 @@ pub async fn brute_force_triplet_search(
         // Neo4j implementation uses OR semantics, which `get_neighborhood`
         // reproduces.
         // Sorted, not just collected: `candidate_node_ids` is a `HashSet`, so its
-        // iteration order varies per process. Backends whose output order tracks
-        // the seed order (the trait's default BFS walks the frontier in order;
-        // Ladybug inlines the list into the query text) would then return edges
-        // in a different order each run, and `sort_by` below is a *stable* sort
-        // over scores that tie constantly — every non-seed endpoint takes the
-        // same penalty — so `take(top_k)` could hand the LLM a different context
-        // for the same query. `get_graph_data()` had a stable backend order.
+        // iteration order varies per process, and the trait's default BFS walks
+        // the frontier in seed order — so an unsorted seed list makes that
+        // backend's edge order vary run to run. Cheap insurance; the ranking
+        // sort's tie-break below is what actually guarantees a stable top-k,
+        // since neither real adapter's row order tracks the seed order (Ladybug
+        // re-collects into its own `HashSet` and returns storage order; the
+        // Postgres CTE has no ORDER BY).
         let mut seed_ids: Vec<String> = candidate_node_ids.iter().cloned().collect();
         seed_ids.sort_unstable();
         graph_db
@@ -391,11 +391,25 @@ pub async fn brute_force_triplet_search(
         })
         .collect::<Vec<_>>();
 
-    // Sort ascending: lowest total distance = best match (matches Python heapq.nsmallest)
+    // Sort ascending: lowest total distance = best match (matches Python heapq.nsmallest).
+    //
+    // Ties break on the edge triple, not on arrival order. `sort_by` is stable, so
+    // without an explicit tie-break the winners of a tie are decided by whatever
+    // order the graph backend returned its rows in — which no backend guarantees
+    // (the Postgres neighborhood CTE has no ORDER BY; Ladybug is storage-ordered)
+    // and which `take(top_k)` below then makes user-visible. Ties are the common
+    // case rather than a rarity: every endpoint absent from the vector results
+    // takes the same `triplet_distance_penalty`, so an `is_a` fan-out around one
+    // EntityType hub yields hundreds of exactly-equal scores. Comparing the ids
+    // makes the top-k context handed to the LLM identical across runs and across
+    // backends.
     ranked_edges.sort_by(|left, right| {
         left.score
             .partial_cmp(&right.score)
             .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| left.source_id.cmp(&right.source_id))
+            .then_with(|| left.target_id.cmp(&right.target_id))
+            .then_with(|| left.relationship_name.cmp(&right.relationship_name))
     });
 
     let ranked_edges: Vec<_> = ranked_edges.into_iter().take(config.top_k).collect();

--- a/crates/search/src/graph_retrieval/brute_force_triplet_search.rs
+++ b/crates/search/src/graph_retrieval/brute_force_triplet_search.rs
@@ -10,6 +10,23 @@ use crate::types::SearchError;
 
 const DEFAULT_WIDE_SEARCH_TOP_K: usize = 100;
 
+/// Hop radius used to scope the graph load around the vector-search seed set.
+///
+/// Must stay at 1 for the scoped load to be **result-identical** to loading the
+/// whole graph. The edge ranking below keeps an edge when *at least one*
+/// endpoint is a seed. `get_neighborhood(seeds, 1)` returns every edge whose
+/// endpoints both lie in `seeds ∪ N(seeds)`, which is a superset of that set:
+/// if `src` is a seed then `tgt ∈ N(seeds)` by adjacency, so the edge is
+/// returned; extra edges between two non-seed neighbors are then dropped by the
+/// same filter that already ran against the full graph. Node property lookups
+/// are unaffected because every endpoint of a kept edge is in the resolved set.
+///
+/// Raising this would pull in edges the filter discards anyway — more IO for
+/// identical output. Lowering it to 0 is backend-dependent (the trait's default
+/// BFS returns no edges at depth 0, while the Postgres and Ladybug overrides
+/// return seed-to-seed edges) and would drop edges with one non-seed endpoint.
+const NEIGHBORHOOD_DEPTH: usize = 1;
+
 /// Default cosine distance assigned to graph elements (nodes or edges) that have no
 /// vector match for the current query. Matches Python's `triplet_distance_penalty`
 /// default of 6.5 in
@@ -58,7 +75,7 @@ pub struct GraphRetrievalConfig {
     pub feedback_influence: f32,
     /// Filter graph to nodes of this type before scoring.
     /// When combined with `node_name`, calls `get_nodeset_subgraph` instead of
-    /// `get_graph_data`.
+    /// the seed-scoped `get_neighborhood` load.
     pub node_type: Option<String>,
     /// Filter graph to nodes with these names (paired with `node_type`).
     pub node_name: Option<Vec<String>>,
@@ -234,7 +251,27 @@ pub async fn brute_force_triplet_search(
             .get_nodeset_subgraph(node_type, node_names, &config.node_name_filter_operator)
             .await?
     } else {
-        graph_db.get_graph_data().await?
+        // Scope the load to the seed set's neighborhood instead of pulling the
+        // whole graph. This is result-identical to `get_graph_data()`, not merely
+        // narrower — see `NEIGHBORHOOD_DEPTH` for the argument.
+        //
+        // Python scopes here unconditionally: its `relevant_node_ids` is only
+        // `None` when `wide_search_limit is None`, but `wide_search_top_k`
+        // defaults to 100, so the id filter is always populated and
+        // `CogneeGraph._get_full_or_id_filtered_graph` always takes the scoped
+        // branch (brute_force_triplet_search.py:156-160, CogneeGraph.py:123-151).
+        // The full-graph branch is dead code there.
+        //
+        // Deliberately NOT `get_id_filtered_graph_data`, despite the name match
+        // with Python's method: this trait's version keeps an edge only when
+        // *both* endpoints are in the id set (traits.rs), which would silently
+        // drop every edge with one non-seed endpoint and change ranking. Python's
+        // Neo4j implementation uses OR semantics, which `get_neighborhood`
+        // reproduces.
+        let seed_ids: Vec<String> = candidate_node_ids.iter().cloned().collect();
+        graph_db
+            .get_neighborhood(&seed_ids, NEIGHBORHOOD_DEPTH)
+            .await?
     };
 
     // Extract name, text, description, and (optionally) feedback_weight from each node.

--- a/crates/search/src/graph_retrieval/brute_force_triplet_search.rs
+++ b/crates/search/src/graph_retrieval/brute_force_triplet_search.rs
@@ -268,7 +268,16 @@ pub async fn brute_force_triplet_search(
         // drop every edge with one non-seed endpoint and change ranking. Python's
         // Neo4j implementation uses OR semantics, which `get_neighborhood`
         // reproduces.
-        let seed_ids: Vec<String> = candidate_node_ids.iter().cloned().collect();
+        // Sorted, not just collected: `candidate_node_ids` is a `HashSet`, so its
+        // iteration order varies per process. Backends whose output order tracks
+        // the seed order (the trait's default BFS walks the frontier in order;
+        // Ladybug inlines the list into the query text) would then return edges
+        // in a different order each run, and `sort_by` below is a *stable* sort
+        // over scores that tie constantly — every non-seed endpoint takes the
+        // same penalty — so `take(top_k)` could hand the LLM a different context
+        // for the same query. `get_graph_data()` had a stable backend order.
+        let mut seed_ids: Vec<String> = candidate_node_ids.iter().cloned().collect();
+        seed_ids.sort_unstable();
         graph_db
             .get_neighborhood(&seed_ids, NEIGHBORHOOD_DEPTH)
             .await?

--- a/crates/search/src/lib.rs
+++ b/crates/search/src/lib.rs
@@ -14,6 +14,8 @@ pub mod query_router_stats;
 pub mod recall_scope;
 /// Individual retriever implementations for each `SearchType`.
 pub mod retrievers;
+#[cfg(test)]
+mod test_support;
 /// Core search types: `SearchType`, `SearchParams`, `SearchResult`, etc.
 pub mod types;
 /// Shared search utilities (completion helpers, etc.).

--- a/crates/search/src/retrievers/graph_completion_retriever.rs
+++ b/crates/search/src/retrievers/graph_completion_retriever.rs
@@ -217,6 +217,8 @@ mod tests {
     use cognee_llm::{
         GenerationOptions, GenerationResponse, Llm, LlmError, LlmResult, Message, TokenUsage,
     };
+
+    use crate::test_support::neighborhood_of;
     use cognee_vector::{SearchResult, VectorDB, VectorDBResult, VectorPoint};
 
     use serde_json::json;
@@ -489,6 +491,18 @@ mod tests {
 
         async fn get_graph_data(&self) -> GraphDBResult<(Vec<GraphNode>, Vec<EdgeData>)> {
             Ok((self.nodes.clone(), self.edges.clone()))
+        }
+
+        /// Mirrors the real adapters' scoped load, which graph search uses instead
+        /// of `get_graph_data`. The trait's default implementation walks
+        /// `get_connections`, which this stub returns empty, so without this
+        /// override every graph search here would see an empty graph.
+        async fn get_neighborhood(
+            &self,
+            node_ids: &[String],
+            depth: usize,
+        ) -> GraphDBResult<(Vec<GraphNode>, Vec<EdgeData>)> {
+            Ok(neighborhood_of(&self.nodes, &self.edges, node_ids, depth))
         }
 
         async fn get_graph_metrics(

--- a/crates/search/src/retrievers/temporal_retriever.rs
+++ b/crates/search/src/retrievers/temporal_retriever.rs
@@ -562,6 +562,8 @@ mod tests {
     };
     use cognee_vector::{SearchResult, VectorDB, VectorDBResult, VectorPoint};
 
+    use crate::test_support::neighborhood_of;
+
     use chrono::{TimeZone, Utc};
     use serde_json::{Value, json};
     use uuid::Uuid;
@@ -796,6 +798,18 @@ mod tests {
 
         async fn get_graph_data(&self) -> GraphDBResult<(Vec<GraphNode>, Vec<EdgeData>)> {
             Ok((self.nodes.clone(), self.edges.clone()))
+        }
+
+        /// Mirrors the real adapters' scoped load, which the graph-context
+        /// fallback uses instead of `get_graph_data`. Without it the trait's
+        /// default BFS would walk this stub's empty `get_connections` and the
+        /// fallback would find no triplets.
+        async fn get_neighborhood(
+            &self,
+            node_ids: &[String],
+            depth: usize,
+        ) -> GraphDBResult<(Vec<GraphNode>, Vec<EdgeData>)> {
+            Ok(neighborhood_of(&self.nodes, &self.edges, node_ids, depth))
         }
 
         async fn get_graph_metrics(

--- a/crates/search/src/test_support.rs
+++ b/crates/search/src/test_support.rs
@@ -1,0 +1,54 @@
+//! Shared helpers for the crate's inline `#[cfg(test)]` modules.
+
+use cognee_graph::{EdgeData, GraphNode};
+use std::collections::HashSet;
+
+/// Reference implementation of `GraphDBTrait::get_neighborhood` over an
+/// in-memory `(nodes, edges)` pair, for the test doubles in this crate.
+///
+/// Matches what the real adapters return: the resolved id set is the seeds plus
+/// every node within `depth` undirected hops, and the returned edges are those
+/// with **both** endpoints in that resolved set (`pg_graph_adapter.rs` and
+/// `ladybug.rs` both express exactly this). Test doubles that only stub
+/// `get_connections` cannot rely on the trait's default BFS, which would walk
+/// that stub and see an empty graph.
+pub(crate) fn neighborhood_of(
+    nodes: &[GraphNode],
+    edges: &[EdgeData],
+    seed_ids: &[String],
+    depth: usize,
+) -> (Vec<GraphNode>, Vec<EdgeData>) {
+    if seed_ids.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+
+    let mut resolved: HashSet<&str> = seed_ids.iter().map(String::as_str).collect();
+    for _ in 0..depth {
+        let mut next: HashSet<&str> = HashSet::new();
+        for (src, tgt, _, _) in edges {
+            if resolved.contains(src.as_str()) {
+                next.insert(tgt.as_str());
+            }
+            if resolved.contains(tgt.as_str()) {
+                next.insert(src.as_str());
+            }
+        }
+        resolved.extend(next);
+    }
+
+    let out_nodes: Vec<GraphNode> = nodes
+        .iter()
+        .filter(|(id, _)| resolved.contains(id.as_str()))
+        .cloned()
+        .collect();
+
+    let out_edges: Vec<EdgeData> = edges
+        .iter()
+        .filter(|(src, tgt, _, _)| {
+            resolved.contains(src.as_str()) && resolved.contains(tgt.as_str())
+        })
+        .cloned()
+        .collect();
+
+    (out_nodes, out_edges)
+}

--- a/crates/search/tests/graph_load_scoping.rs
+++ b/crates/search/tests/graph_load_scoping.rs
@@ -1,0 +1,336 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Tests that `brute_force_triplet_search` scopes its graph load to the
+//! neighborhood of the vector-search seed set instead of pulling the whole
+//! graph, **without changing which edges come back**.
+//!
+//! The unfiltered path used to call `get_graph_data()`, materialising every
+//! node and edge row on every graph query, and then discarded every edge with
+//! no seed endpoint a few lines later. These tests pin both halves of the fix:
+//!
+//! - the scoped adapter method is the one actually called, and
+//! - the ranked output is byte-identical to what the full-graph load produced,
+//!   including the discriminating case of an edge between two *non-seed*
+//!   neighbours, which `get_neighborhood(seeds, 1)` returns but the edge filter
+//!   must still drop.
+//!
+//! Run with:
+//!   cargo test --package cognee-search --test graph_load_scoping -- --nocapture
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cognee_embedding::{EmbeddingEngine, EmbeddingResult};
+use cognee_graph::{GraphDBTrait, MockGraphDB};
+use cognee_search::graph_retrieval::{GraphRetrievalConfig, brute_force_triplet_search};
+use cognee_vector::{MockVectorDB, VectorDB, VectorPoint};
+use serde_json::json;
+use uuid::Uuid;
+
+/// Maps every input to the same 2-D unit vector, so every seeded point is an
+/// exact nearest neighbour and retrieval is deterministic with no model.
+struct AlignedEmbedding;
+
+#[async_trait]
+impl EmbeddingEngine for AlignedEmbedding {
+    async fn embed(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|_| vec![1.0, 0.0]).collect())
+    }
+    fn dimension(&self) -> usize {
+        2
+    }
+    fn batch_size(&self) -> usize {
+        8
+    }
+    fn max_sequence_length(&self) -> usize {
+        128
+    }
+}
+
+/// Node ids for the fixture graph. `a`/`b` are seeds (indexed as `Entity`
+/// vectors); `c`/`d` are one hop out; `e`/`f` are a disconnected component that
+/// no query should ever touch.
+struct Fixture {
+    a: Uuid,
+    b: Uuid,
+    c: Uuid,
+    d: Uuid,
+    e: Uuid,
+    f: Uuid,
+}
+
+/// Build the fixture:
+///
+/// ```text
+///   a --a_to_b--> b        (both seeds)
+///   a --a_to_c--> c        (one seed endpoint)
+///   b --b_to_d--> d        (one seed endpoint)
+///   c --c_to_d--> d        (NO seed endpoint — in the depth-1 neighborhood,
+///                           but must be filtered out)
+///   e --e_to_f--> f        (disconnected — never loaded, never returned)
+/// ```
+///
+/// Only `a` and `b` are indexed as vectors, so only they become seeds.
+async fn seed() -> (Arc<dyn VectorDB>, Arc<MockGraphDB>, Fixture) {
+    let fx = Fixture {
+        a: Uuid::new_v4(),
+        b: Uuid::new_v4(),
+        c: Uuid::new_v4(),
+        d: Uuid::new_v4(),
+        e: Uuid::new_v4(),
+        f: Uuid::new_v4(),
+    };
+
+    let vector_db = MockVectorDB::new();
+    vector_db
+        .create_collection("Entity", "name", 2)
+        .await
+        .unwrap();
+    vector_db
+        .index_points(
+            "Entity",
+            "name",
+            &[
+                VectorPoint::new(fx.a, vec![1.0, 0.0])
+                    .with_metadata("id", json!(fx.a.to_string()))
+                    .with_metadata("name", json!("A")),
+                VectorPoint::new(fx.b, vec![1.0, 0.0])
+                    .with_metadata("id", json!(fx.b.to_string()))
+                    .with_metadata("name", json!("B")),
+            ],
+        )
+        .await
+        .unwrap();
+
+    let graph = MockGraphDB::new();
+    for (id, name) in [
+        (fx.a, "A"),
+        (fx.b, "B"),
+        (fx.c, "C"),
+        (fx.d, "D"),
+        (fx.e, "E"),
+        (fx.f, "F"),
+    ] {
+        graph
+            .add_node_raw(json!({ "id": id.to_string(), "name": name }))
+            .await
+            .unwrap();
+    }
+
+    for (src, tgt, rel) in [
+        (fx.a, fx.b, "a_to_b"),
+        (fx.a, fx.c, "a_to_c"),
+        (fx.b, fx.d, "b_to_d"),
+        (fx.c, fx.d, "c_to_d"),
+        (fx.e, fx.f, "e_to_f"),
+    ] {
+        graph
+            .add_edge(&src.to_string(), &tgt.to_string(), rel, None)
+            .await
+            .unwrap();
+    }
+
+    (Arc::new(vector_db), Arc::new(graph), fx)
+}
+
+fn config() -> GraphRetrievalConfig {
+    GraphRetrievalConfig {
+        top_k: 100,
+        ..Default::default()
+    }
+}
+
+/// The scoped adapter method is the one called — the full-graph scan is gone.
+#[tokio::test]
+async fn unfiltered_path_loads_the_neighborhood_not_the_whole_graph() {
+    let (vector_db, graph, _fx) = seed().await;
+
+    brute_force_triplet_search(
+        "any query",
+        vector_db.as_ref(),
+        &AlignedEmbedding,
+        graph.as_ref(),
+        &config(),
+    )
+    .await
+    .unwrap();
+
+    let calls = graph.get_call_log();
+    assert!(
+        calls.contains(&"get_neighborhood".to_string()),
+        "expected the seed-scoped load; call log was {calls:?}"
+    );
+    assert!(
+        !calls.contains(&"get_graph_data".to_string()),
+        "get_graph_data materialises every node and edge row — it must not be \
+         called on the unfiltered search path; call log was {calls:?}"
+    );
+}
+
+/// The discriminating case: scoping must not change the result set.
+///
+/// `get_neighborhood(seeds, 1)` returns `c --c_to_d--> d` because both endpoints
+/// are one hop from a seed, so this asserts the edge filter still drops it —
+/// exactly as it did when the full graph was loaded. It also pins that no edge
+/// with a seed endpoint was lost, which is the failure mode of scoping via
+/// `get_id_filtered_graph_data` (which requires *both* endpoints in the seed set).
+#[tokio::test]
+async fn scoped_load_returns_exactly_the_edges_the_full_scan_did() {
+    let (vector_db, graph, _fx) = seed().await;
+
+    let ranked = brute_force_triplet_search(
+        "any query",
+        vector_db.as_ref(),
+        &AlignedEmbedding,
+        graph.as_ref(),
+        &config(),
+    )
+    .await
+    .unwrap();
+
+    let mut rels: Vec<String> = ranked
+        .iter()
+        .map(|edge| edge.relationship_name.clone())
+        .collect();
+    rels.sort();
+
+    assert_eq!(
+        rels,
+        vec![
+            "a_to_b".to_string(),
+            "a_to_c".to_string(),
+            "b_to_d".to_string()
+        ],
+        "expected exactly the edges with at least one seed endpoint: a_to_b \
+         (both seeds), a_to_c and b_to_d (one seed each). c_to_d has no seed \
+         endpoint and e_to_f is disconnected — both must be absent."
+    );
+}
+
+/// Node property lookups still resolve for non-seed endpoints. The scoped load
+/// returns `seeds ∪ N(seeds)`, so `c` and `d` are present and their `name`
+/// resolves; a regression here would surface raw uuids as node names.
+#[tokio::test]
+async fn non_seed_endpoints_keep_their_names() {
+    let (vector_db, graph, fx) = seed().await;
+
+    let ranked = brute_force_triplet_search(
+        "any query",
+        vector_db.as_ref(),
+        &AlignedEmbedding,
+        graph.as_ref(),
+        &config(),
+    )
+    .await
+    .unwrap();
+
+    let a_to_c = ranked
+        .iter()
+        .find(|edge| edge.relationship_name == "a_to_c")
+        .expect("a_to_c has a seed endpoint and must be returned");
+
+    assert_eq!(a_to_c.source_name, "A");
+    assert_eq!(
+        a_to_c.target_name, "C",
+        "C is one hop from a seed, so the scoped load must include its row; \
+         falling back to the raw id ({}) means the node half was dropped",
+        fx.c
+    );
+}
+
+/// A graph with no edges touching the seed set yields nothing, and still does
+/// not fall back to a full scan.
+#[tokio::test]
+async fn seeds_with_no_incident_edges_return_empty_without_a_full_scan() {
+    let vector_db = MockVectorDB::new();
+    vector_db
+        .create_collection("Entity", "name", 2)
+        .await
+        .unwrap();
+    let orphan = Uuid::new_v4();
+    vector_db
+        .index_points(
+            "Entity",
+            "name",
+            &[VectorPoint::new(orphan, vec![1.0, 0.0])
+                .with_metadata("id", json!(orphan.to_string()))
+                .with_metadata("name", json!("Orphan"))],
+        )
+        .await
+        .unwrap();
+
+    let graph = MockGraphDB::new();
+    graph
+        .add_node_raw(json!({ "id": orphan.to_string(), "name": "Orphan" }))
+        .await
+        .unwrap();
+    let far_src = Uuid::new_v4();
+    let far_tgt = Uuid::new_v4();
+    for (id, name) in [(far_src, "Far1"), (far_tgt, "Far2")] {
+        graph
+            .add_node_raw(json!({ "id": id.to_string(), "name": name }))
+            .await
+            .unwrap();
+    }
+    graph
+        .add_edge(&far_src.to_string(), &far_tgt.to_string(), "far", None)
+        .await
+        .unwrap();
+
+    let ranked = brute_force_triplet_search(
+        "any query",
+        &vector_db,
+        &AlignedEmbedding,
+        &graph,
+        &config(),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        ranked.is_empty(),
+        "no edge touches the seed set, so nothing should rank; got {ranked:?}"
+    );
+    assert!(
+        !graph.get_call_log().contains(&"get_graph_data".to_string()),
+        "an empty result must not come from a full graph scan"
+    );
+}
+
+/// The nodeset-filtered branch is untouched: when `node_type` and `node_name`
+/// are both set, the subgraph query is still the one used.
+#[tokio::test]
+async fn node_filter_path_still_uses_nodeset_subgraph() {
+    let (vector_db, graph, _fx) = seed().await;
+
+    let cfg = GraphRetrievalConfig {
+        top_k: 100,
+        node_type: Some("Entity".to_string()),
+        node_name: Some(vec!["A".to_string()]),
+        ..Default::default()
+    };
+
+    brute_force_triplet_search(
+        "any query",
+        vector_db.as_ref(),
+        &AlignedEmbedding,
+        graph.as_ref(),
+        &cfg,
+    )
+    .await
+    .unwrap();
+
+    let calls = graph.get_call_log();
+    assert!(
+        calls.contains(&"get_nodeset_subgraph".to_string()),
+        "the node-filtered path must keep using get_nodeset_subgraph; call log \
+         was {calls:?}"
+    );
+    assert!(
+        !calls.contains(&"get_graph_data".to_string()),
+        "call log was {calls:?}"
+    );
+}

--- a/crates/search/tests/graph_load_scoping.rs
+++ b/crates/search/tests/graph_load_scoping.rs
@@ -179,7 +179,28 @@ async fn unfiltered_path_loads_the_neighborhood_not_the_whole_graph() {
 /// `get_id_filtered_graph_data` (which requires *both* endpoints in the seed set).
 #[tokio::test]
 async fn scoped_load_returns_exactly_the_edges_the_full_scan_did() {
-    let (vector_db, graph, _fx) = seed().await;
+    let (vector_db, graph, fx) = seed().await;
+
+    // Pin the precondition this test depends on: the scoped load really does
+    // hand back c_to_d, whose endpoints are both non-seed. Without this the
+    // assertion below would pass even if the load had never produced the edge,
+    // and the filter — the thing that makes the swap result-identical — would
+    // go untested.
+    let (_, loaded) = graph
+        .get_neighborhood(&[fx.a.to_string(), fx.b.to_string()], 1)
+        .await
+        .unwrap();
+    let loaded_rels: Vec<&str> = loaded.iter().map(|(_, _, rel, _)| rel.as_str()).collect();
+    assert!(
+        loaded_rels.contains(&"c_to_d"),
+        "precondition: the depth-1 neighborhood of {{a, b}} must include the \
+         neighbor-to-neighbor edge c_to_d, so that the ranking filter is what \
+         removes it. Loaded: {loaded_rels:?}"
+    );
+    assert!(
+        !loaded_rels.contains(&"e_to_f"),
+        "the disconnected component must not be loaded at all. Loaded: {loaded_rels:?}"
+    );
 
     let ranked = brute_force_triplet_search(
         "any query",

--- a/crates/search/tests/graph_load_scoping.rs
+++ b/crates/search/tests/graph_load_scoping.rs
@@ -143,6 +143,86 @@ fn config() -> GraphRetrievalConfig {
     }
 }
 
+/// Exactly-tied edges rank by their `(source, target, relationship)` triple, not
+/// by the order the backend happened to return rows in.
+///
+/// This is what makes the top-k context stable across runs and across backends.
+/// No backend guarantees row order — the Postgres neighborhood CTE has no
+/// `ORDER BY` and Ladybug returns storage order — and `sort_by` is a stable sort,
+/// so before the tie-break the surviving members of a tie were whatever arrived
+/// first. Ties are routine here, not a corner case: every endpoint missing from
+/// the vector results takes the same `triplet_distance_penalty`, so all three
+/// edges below score identically (0 for the seed + 6.5 + 6.5).
+#[tokio::test]
+async fn exactly_tied_edges_rank_by_id_not_by_arrival_order() {
+    // Fixed, ordered uuids so the expected order is exact. Edges are inserted in
+    // an order that does not match the sorted one, so passing means the tie-break
+    // reordered them rather than the store happening to agree.
+    let hub = Uuid::from_u128(0xF0);
+    let n1 = Uuid::from_u128(0x01);
+    let n2 = Uuid::from_u128(0x02);
+    let n3 = Uuid::from_u128(0x03);
+
+    let vector_db = MockVectorDB::new();
+    vector_db
+        .create_collection("Entity", "name", 2)
+        .await
+        .unwrap();
+    // Only the hub is a seed, so each spoke endpoint takes the penalty and all
+    // three edges tie exactly.
+    vector_db
+        .index_points(
+            "Entity",
+            "name",
+            &[VectorPoint::new(hub, vec![1.0, 0.0])
+                .with_metadata("id", json!(hub.to_string()))
+                .with_metadata("name", json!("Hub"))],
+        )
+        .await
+        .unwrap();
+
+    let graph = MockGraphDB::new();
+    for (id, name) in [(hub, "Hub"), (n1, "N1"), (n2, "N2"), (n3, "N3")] {
+        graph
+            .add_node_raw(json!({ "id": id.to_string(), "name": name }))
+            .await
+            .unwrap();
+    }
+    for target in [n3, n1, n2] {
+        graph
+            .add_edge(&hub.to_string(), &target.to_string(), "spoke", None)
+            .await
+            .unwrap();
+    }
+
+    let ranked = brute_force_triplet_search(
+        "any query",
+        &vector_db,
+        &AlignedEmbedding,
+        &graph,
+        &config(),
+    )
+    .await
+    .unwrap();
+
+    let scores: Vec<f32> = ranked.iter().map(|edge| edge.score).collect();
+    assert_eq!(scores.len(), 3, "all three spokes have a seed endpoint");
+    assert!(
+        scores.windows(2).all(|pair| pair[0] == pair[1]),
+        "precondition: the three edges must tie exactly, otherwise the score \
+         comparison decides the order and the tie-break goes untested. Scores: \
+         {scores:?}"
+    );
+
+    let targets: Vec<String> = ranked.iter().map(|edge| edge.target_id.clone()).collect();
+    assert_eq!(
+        targets,
+        vec![n1.to_string(), n2.to_string(), n3.to_string()],
+        "tied edges must come back ordered by target id, not in insertion order \
+         (which was n3, n1, n2)"
+    );
+}
+
 /// The scoped adapter method is the one called — the full-graph scan is gone.
 #[tokio::test]
 async fn unfiltered_path_loads_the_neighborhood_not_the_whole_graph() {


### PR DESCRIPTION
## Problem

`brute_force_triplet_search` fell back to `get_graph_data()` whenever `node_type`/`node_name` were absent — the default — materialising **every** `graph_node` and `graph_edge` row on every graph query.

On the 171,888-paper corpus that is 187,419 + 333,980 rows per query, every JSONB blob parsed, to keep a few hundred edges. `GRAPH_COMPLETION_COT` and `GRAPH_COMPLETION_CONTEXT_EXTENSION` call `get_context` in a loop, so a 3-round query issued **four** full loads. Nothing on the path caches.

The scoped seed set was **already computed** — `candidate_node_ids` comes from the wide vector search directly above, bounded by `wide_search_top_k` (default 100) — and then thrown away.

## Fix

Pass the seeds to `get_neighborhood(seeds, 1)`, which every real adapter implements as one scoped query (a recursive CTE on Postgres, a bounded traversal on Ladybug). It was added for the hybrid retriever and wired nowhere else.

The kept-edge **set** is identical, not merely narrower. The ranking filter keeps an edge when *at least one* endpoint is a seed; `get_neighborhood` at depth 1 returns every edge inside `seeds ∪ N(seeds)` — a superset — and the same filter drops the extras. Node property lookups are unaffected because every endpoint of a kept edge is in the resolved set.

**Caveat, corrected after review:** identical *set*, but the final `take(top_k)` slice was not. `sort_by` is stable, so tie winners were decided by backend row order, which the swap changed. Ties are routine — every endpoint absent from the vector results takes the same `triplet_distance_penalty`, so one EntityType hub's `is_a` fan-out yields hundreds of exactly-equal scores. Addressed below.

## Parity

Python scopes here unconditionally: `relevant_node_ids` is `None` only when `wide_search_limit is None`, but `wide_search_top_k` defaults to 100, so `CogneeGraph._get_full_or_id_filtered_graph` always takes the scoped branch. **Rust's `else` branch is Python's dead code.**

Deliberately **not** `get_id_filtered_graph_data`, despite matching the name of Python's method: this trait's version keeps an edge only when *both* endpoints are in the id set, which would silently drop every edge with one non-seed endpoint. Python's Neo4j implementation uses OR semantics, which `get_neighborhood` reproduces.

## Scope

Reaches `brute_force_triplet_search`: **`GRAPH_COMPLETION`, `GRAPH_SUMMARY_COMPLETION`, `GRAPH_COMPLETION_CONTEXT_EXTENSION`, `GRAPH_COMPLETION_COT`, `TEMPORAL`** — plus `FEELING_LUCKY` when it routes to one of those. `TEMPORAL` benefits on its main event-ranking path (`temporal_retriever.rs:430`), not only the fallback.

⚠️ **`FEEDBACK` and `CODING_RULES` are _not_ fixed.** `recent_interaction_ids` (`lucky_feedback_rules_retrievers.rs:342`) and `load_rules` (`:493`) call `get_graph_data()` directly. An earlier revision of this description claimed 8 types including these; that was wrong.

## Mock contract fix (found by review)

`MockGraphDB::get_neighborhood` collected edges incident to the current *frontier*, so at depth 1 it omitted edges between two nodes discovered at the same depth — violating the contract on `GraphDBTrait::get_neighborhood` and disagreeing with both real adapters.

That mattered: the new test's discriminating case was never exercised, and the whole original suite passed with the ranking filter deleted. Rewrote the mock into the two phases the real adapters use — resolve the id set by BFS, then return the induced subgraph — and the test now **pins the precondition** rather than assuming it. Verified: reverting the mock makes that assertion fail with `Loaded: ["a_to_b", "a_to_c", "b_to_d"]`.

Side effect, intentional: the mock now returns seed-to-seed edges at depth 0, matching the real backends instead of the trait default. Nothing in the workspace calls depth 0.

The trait's own default impl still has the same contract gap — left alone, since no production adapter uses it. Noted as a follow-up.

## Determinism fix (found by review, then corrected)

First attempt sorted `seed_ids` off the `HashSet`. Validation showed that was incomplete and partly misjustified: **Ladybug's row order is storage-ordered and does not track the seed list** (measured across reversed seed orders and three processes), and its adapter re-collects into its own `HashSet` anyway; **the Postgres CTE has no `ORDER BY`**, so it too is unaffected by seed order. Sorting seeds is correct only for the trait's default BFS, which does walk the frontier in order.

The fix that works sits one level up: an explicit tie-break in the ranking sort on `(source_id, target_id, relationship_name)`. That determinizes the top-k context on **all** backends and closes the tie-boundary divergence noted in the Fix section — a stronger guarantee than either path had before. Seed sort kept as cheap insurance for default-BFS backends, no longer load-bearing.

## Known limitation, not addressed here

The depth-1 neighborhood is **unbounded**. `EntityType` is a seed collection, `EntityType` nodes *are* written to the graph (unlike `EdgeType`), and every `Entity` carries an `is_a` edge to its type — so those nodes are hubs and one such seed resolves to every entity of that type.

Benign on Postgres (parameterized `$1::text[]` CTE, covering indexes) — the backend the motivating corpus ran on. Worse on Ladybug, which cannot use parameterized queries at all (`ladybug.rs:781`) and inlines the resolved id set into query text three times; a large resolved set there plausibly costs more than the full scan it replaces.

Not fixed here, but the shape of the fix is clearer than I first stated: capping the *seed* set would break the identical-set property, but an **identity-preserving** bound does exist — when the resolved set exceeds a threshold, have the Ladybug adapter scan and filter in Rust, so the worst case merely equals the old full scan. Correcting one more thing: the "pre-existing via `HYBRID_COMPLETION`" mitigation understated the change in exposure. Hybrid passes ≤ 15 Entity seeds and never an EntityType; this path passes up to ~400 including up to 100 hubs. Mechanism pre-existing, magnitude materially increased.

## Tests

`crates/search/tests/graph_load_scoping.rs` (6 cases):

- the scoped method is called and `get_graph_data` is **not**
- output unchanged, precondition pinned so the *filter* is demonstrably what drops the extra neighbour↔neighbour edge
- non-seed endpoints keep their resolved names
- seeds with no incident edges return empty without a full scan
- the `node_type`/`node_name` branch still uses `get_nodeset_subgraph`
- exactly-tied edges rank by id, not arrival order

**Each guard was verified to fail when its fix is reverted.** The equivalence assertion passes either way, by design.

`cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings` clean. `cognee-graph`, `cognee-search`, `cognee-cognify`, `cognee-delete`, `cognee-visualization`, `cognee-core`, `cognee-components`, `cognee-ingestion`, `cognee-test-utils`, `test_recall_scope` and the http-server search suites pass.

⚠️ Pre-existing, unrelated: `temporal_retriever_single_month_query` fails identically at baseline `89efd24`, same output (non-deterministic LLM interval extraction).

## Follow-ups (separate items)

- `FEEDBACK` / `CODING_RULES` still full-scan via direct `get_graph_data()` calls
- Identity-preserving bound in `LadybugAdapter::get_neighborhood` (see known limitation)
- `GraphDBTrait`'s default `get_neighborhood` still violates the documented contract at depth ≥ 1
- `SearchParams.neighborhood_depth` / `neighborhood_seed_top_k` are plumbed through CLI, HTTP and bindings and **read by nothing**
- Ladybug has no `get_id_filtered_graph_data` override and falls back to a full scan
- `MockGraphDB::get_neighborhood` dedupes duplicate `(src,tgt,rel)` edges where `get_graph_data` does not (pre-existing; impossible on Postgres, which has that triple as its PK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2KsXSUu7FfnJdqMF3jppu