### PR TITLE
fix(persistence): strip NUL bytes before they reach Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -784,7 +784,7 @@ jobs:
       - name: Assert the suite really executed
         run: |
           bash scripts/ci/assert_pg_suite_ran.sh --label PgVector \
-            --log pgvector-integration.log --min-tests 20 \
+            --log pgvector-integration.log --min-tests 21 \
             --log pgvector-lib.log         --min-tests 1 \
             --log pgvector-spans.log       --min-tests 1 \
             --log pgvector-close.log --min-tests 2 \
@@ -1083,7 +1083,7 @@ jobs:
       - name: Assert the suite really executed
         run: |
           bash scripts/ci/assert_pg_suite_ran.sh --label PgGraph \
-            --log pggraph-integration.log --min-tests 30 \
+            --log pggraph-integration.log --min-tests 31 \
             --log pggraph-lib.log         --min-tests 1 \
             --log pggraph-close.log --min-tests 3 \
             --require-test pggraph_coexists_with_relational_migrator_in_shared_db \

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -288,7 +288,7 @@ jobs:
       - name: Assert the suite really executed
         run: |
           bash scripts/ci/assert_pg_suite_ran.sh --label PgGraph \
-            --log pggraph-integration.log --min-tests 30 \
+            --log pggraph-integration.log --min-tests 31 \
             --log pggraph-lib.log         --min-tests 1 \
             --log pggraph-close.log --min-tests 3 \
             --require-test pggraph_coexists_with_relational_migrator_in_shared_db \
@@ -404,7 +404,7 @@ jobs:
       - name: Assert the suite really executed
         run: |
           bash scripts/ci/assert_pg_suite_ran.sh --label PgVector \
-            --log pgvector-integration.log --min-tests 20 \
+            --log pgvector-integration.log --min-tests 21 \
             --log pgvector-lib.log         --min-tests 1 \
             --log pgvector-spans.log       --min-tests 1 \
             --log pgvector-close.log --min-tests 2 \

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -46,6 +46,7 @@ use cognee_models::{
 };
 use cognee_ontology::OntologyResolver;
 use cognee_storage::StorageTrait;
+use cognee_utils::sanitize::sanitize_string;
 use cognee_vector::{VectorDB, VectorPoint};
 use serde::Serialize;
 use serde_json::json;
@@ -2695,6 +2696,14 @@ async fn upsert_provenance(
         } else {
             edge_pair.relationship_name.clone()
         };
+        // Strip NUL bytes *before* deriving the id and slug, not after. Python's
+        // `upsert_edges` (`cognee/modules/graph/methods/upsert_edges.py:41-66`)
+        // feeds `sanitized_edge_text` into both its uuid5 and `generate_edge_id`,
+        // so deriving from the raw text here would hand a NUL-bearing edge a
+        // different deterministic id than the Python SDK produces for the same
+        // input. The relational conversion sanitizes again on the way out; this
+        // is about what the hash sees.
+        let edge_text = sanitize_string(edge_text);
 
         let source_data_id = entity_data_map.get(&edge_pair.source_entity_id).copied();
         let target_data_id = entity_data_map.get(&edge_pair.target_entity_id).copied();
@@ -4083,6 +4092,62 @@ mod tests {
     use super::*;
     use cognee_models::DataPoint;
     use cognee_storage::MockStorage;
+
+    /// Provenance edge ids must be derived from *sanitized* edge text.
+    ///
+    /// Python's `upsert_edges`
+    /// (`cognee/modules/graph/methods/upsert_edges.py:41-66`) derives its uuid5
+    /// id from `sanitized_edge_text`. If the Rust side hashed the raw text
+    /// instead, a `contains` edge whose `edge_text` carried a NUL would land in
+    /// Postgres with a *different* deterministic id than the Python SDK
+    /// produces for the same input — a silent cross-SDK divergence that only
+    /// shows up on NUL-bearing corpora.
+    ///
+    /// The slug is a weaker claim and is asserted as such. Rust uses
+    /// `triplet_slug(source, edge_text, target)` while Python uses
+    /// `generate_edge_id(sanitized_edge_text)`, which takes no node ids at all —
+    /// a pre-existing formula divergence this change neither introduces nor
+    /// fixes. All that is pinned below is that Rust's slug reads the same
+    /// sanitized text as Rust's id, so the two cannot disagree with each other.
+    ///
+    /// The second assertion is the load-bearing one: it proves the strip
+    /// actually changes the hash, so removing the `sanitize_string` call in
+    /// `upsert_provenance` cannot be a no-op that slips through review.
+    #[test]
+    fn provenance_edge_ids_derive_from_sanitized_text() {
+        let tenant = Some(Uuid::new_v4());
+        let user = Uuid::new_v4();
+        let dataset = Uuid::new_v4();
+        let source = Uuid::new_v4();
+        let target = Uuid::new_v4();
+
+        let dirty = "Document chunk mentions Ali\u{0}ce";
+        let clean = "Document chunk mentions Alice";
+
+        assert_eq!(
+            provenance_edge_id(
+                tenant,
+                user,
+                dataset,
+                source,
+                &sanitize_string(dirty.to_string()),
+                target
+            ),
+            provenance_edge_id(tenant, user, dataset, source, clean, target),
+            "sanitizing before hashing must reproduce the id Python derives"
+        );
+        assert_eq!(
+            triplet_slug(source, &sanitize_string(dirty.to_string()), target),
+            triplet_slug(source, clean, target),
+            "Rust's slug must read the same sanitized text as its id"
+        );
+
+        assert_ne!(
+            provenance_edge_id(tenant, user, dataset, source, dirty, target),
+            provenance_edge_id(tenant, user, dataset, source, clean, target),
+            "hashing raw text must differ — otherwise this guard proves nothing"
+        );
+    }
 
     #[test]
     fn test_classify_documents_empty() {

--- a/crates/database/src/conversions.rs
+++ b/crates/database/src/conversions.rs
@@ -17,6 +17,7 @@ use crate::uuid_hex;
 /// Shared SeaORM ↔ domain-type conversions and error helpers used across ops modules.
 use chrono::Utc;
 use cognee_models::{Data, Dataset};
+use cognee_utils::sanitize::{sanitize_json, sanitize_str, sanitize_string};
 use sea_orm::ActiveValue::Set;
 
 // ---------------------------------------------------------------------------
@@ -223,16 +224,20 @@ impl From<node::Model> for GraphNode {
 
 impl From<&GraphNode> for node::ActiveModel {
     fn from(n: &GraphNode) -> Self {
+        // `attributes` carries the serialized DataPoint, chunk text included, so
+        // NUL bytes must be stripped before this reaches Postgres — the whole
+        // provenance batch shares one transaction, so a single bad chunk would
+        // abort every row in it. See `cognee_utils::sanitize`.
         Self {
             id: Set(uuid_hex::to_hex(n.id)),
             slug: Set(uuid_hex::to_hex(n.slug)),
             user_id: Set(uuid_hex::to_hex(n.user_id)),
             data_id: Set(uuid_hex::to_hex(n.data_id)),
             dataset_id: Set(uuid_hex::to_hex(n.dataset_id)),
-            label: Set(n.label.clone()),
-            node_type: Set(n.node_type.clone()),
-            indexed_fields: Set(n.indexed_fields.clone()),
-            attributes: Set(n.attributes.clone()),
+            label: Set(n.label.clone().map(sanitize_string)),
+            node_type: Set(sanitize_str(&n.node_type).into_owned()),
+            indexed_fields: Set(sanitize_json(n.indexed_fields.clone())),
+            attributes: Set(n.attributes.clone().map(sanitize_json)),
             created_at: Set(n.created_at),
         }
     }
@@ -266,9 +271,9 @@ impl From<&GraphEdge> for edge::ActiveModel {
             dataset_id: Set(uuid_hex::to_hex(e.dataset_id)),
             source_node_id: Set(uuid_hex::to_hex(e.source_node_id)),
             destination_node_id: Set(uuid_hex::to_hex(e.destination_node_id)),
-            relationship_name: Set(e.relationship_name.clone()),
-            label: Set(e.label.clone()),
-            attributes: Set(e.attributes.clone()),
+            relationship_name: Set(sanitize_str(&e.relationship_name).into_owned()),
+            label: Set(e.label.clone().map(sanitize_string)),
+            attributes: Set(e.attributes.clone().map(sanitize_json)),
             created_at: Set(e.created_at),
         }
     }
@@ -321,7 +326,11 @@ impl From<&PipelineRun> for pipeline_run::ActiveModel {
             pipeline_name: Set(r.pipeline_name.clone()),
             pipeline_id: Set(uuid_hex::to_hex(r.pipeline_id)),
             dataset_id: Set(uuid_hex::to_hex_opt(r.dataset_id)),
-            run_info: Set(r.run_info.clone()),
+            // `run_info_for_errored` embeds an arbitrary error string, which can
+            // quote offending source text. A NUL here fails the Errored-status
+            // write, and that failure is logged-and-ignored by the run watcher —
+            // leaving the run recorded as `Started` with the error never stored.
+            run_info: Set(r.run_info.clone().map(sanitize_json)),
         }
     }
 }
@@ -349,7 +358,11 @@ impl From<&TaskRun> for task_run::ActiveModel {
             task_name: Set(r.task_name.clone()),
             created_at: Set(r.created_at),
             status: Set(r.status.clone()),
-            run_info: Set(r.run_info.clone()),
+            // `run_info_for_errored` embeds an arbitrary error string, which can
+            // quote offending source text. A NUL here fails the Errored-status
+            // write, and that failure is logged-and-ignored by the run watcher —
+            // leaving the run recorded as `Started` with the error never stored.
+            run_info: Set(r.run_info.clone().map(sanitize_json)),
         }
     }
 }
@@ -397,5 +410,132 @@ impl From<&GraphMetrics> for graph_metrics::ActiveModel {
             created_at: Set(gm.created_at),
             updated_at: Set(gm.updated_at),
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NUL-byte sanitization (no database required)
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod sanitize_tests {
+    use super::*;
+    use chrono::Utc;
+    use sea_orm::ActiveValue;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    fn unwrap_set<T>(v: ActiveValue<T>) -> T
+    where
+        T: Into<sea_orm::Value>,
+    {
+        match v {
+            ActiveValue::Set(inner) => inner,
+            _ => panic!("conversion must produce ActiveValue::Set"),
+        }
+    }
+
+    /// Provenance rows carry the serialized DataPoint — chunk text included —
+    /// and the whole batch shares one transaction, so a single NUL would abort
+    /// every row in it, not just its own.
+    #[test]
+    fn graph_node_active_model_strips_nul_bytes() {
+        let node = GraphNode {
+            id: Uuid::new_v4(),
+            slug: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            data_id: Uuid::new_v4(),
+            dataset_id: Uuid::new_v4(),
+            label: Some("Nikola\u{0} Tesla".to_string()),
+            node_type: "Doc\u{0}Chunk".to_string(),
+            indexed_fields: json!(["te\u{0}xt"]),
+            // Mirrors Python's `test_upsert_nodes_sanitizes_strings_before_insert`
+            // (`cognee/tests/unit/modules/graph/test_relational_upserts.py:65`),
+            // whose `details` carries both a dirty nested key and a nested list.
+            attributes: Some(json!({
+                "text": "page 1\u{0}page 2",
+                "details": {"summa\u{0}ry": "Nested\u{0} value", "items": ["A\u{0}", "B"]},
+                "count": 7,
+            })),
+            created_at: Utc::now(),
+        };
+
+        let model: node::ActiveModel = (&node).into();
+
+        assert_eq!(unwrap_set(model.label), Some("Nikola Tesla".to_string()));
+        assert_eq!(unwrap_set(model.node_type), "DocChunk");
+        assert_eq!(unwrap_set(model.indexed_fields), json!(["text"]));
+        assert_eq!(
+            unwrap_set(model.attributes),
+            Some(json!({
+                "text": "page 1page 2",
+                "details": {"summary": "Nested value", "items": ["A", "B"]},
+                "count": 7,
+            }))
+        );
+    }
+
+    #[test]
+    fn graph_edge_active_model_strips_nul_bytes() {
+        let edge = GraphEdge {
+            id: Uuid::new_v4(),
+            slug: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            data_id: Uuid::new_v4(),
+            dataset_id: Uuid::new_v4(),
+            source_node_id: Uuid::new_v4(),
+            destination_node_id: Uuid::new_v4(),
+            relationship_name: "is\u{0}_a".to_string(),
+            label: Some("la\u{0}bel".to_string()),
+            // Mirrors Python's `test_upsert_edges_sanitizes_strings_before_insert`
+            // (`test_relational_upserts.py:100`), which pins that dirty keys
+            // nested inside `attributes` are rewritten too, not just values.
+            attributes: Some(json!({
+                "edge_text": "described\u{0}relationship",
+                "no\u{0}te": "nul\u{0} byte",
+                "nested": {"va\u{0}lue": "still\u{0} here"},
+            })),
+            created_at: Utc::now(),
+        };
+
+        let model: edge::ActiveModel = (&edge).into();
+
+        assert_eq!(unwrap_set(model.relationship_name), "is_a");
+        assert_eq!(unwrap_set(model.label), Some("label".to_string()));
+        assert_eq!(
+            unwrap_set(model.attributes),
+            Some(json!({
+                "edge_text": "describedrelationship",
+                "note": "nul byte",
+                "nested": {"value": "still here"},
+            }))
+        );
+    }
+
+    #[test]
+    fn clean_provenance_rows_are_unchanged() {
+        let attrs = json!({"text": "no nulls — just an em dash", "n": 1});
+        let node = GraphNode {
+            id: Uuid::new_v4(),
+            slug: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            data_id: Uuid::new_v4(),
+            dataset_id: Uuid::new_v4(),
+            label: Some("Ada Lovelace".to_string()),
+            node_type: "Person".to_string(),
+            indexed_fields: json!(["text"]),
+            attributes: Some(attrs.clone()),
+            created_at: Utc::now(),
+        };
+
+        let model: node::ActiveModel = (&node).into();
+
+        assert_eq!(unwrap_set(model.label), Some("Ada Lovelace".to_string()));
+        assert_eq!(unwrap_set(model.node_type), "Person");
+        assert_eq!(unwrap_set(model.attributes), Some(attrs));
     }
 }

--- a/crates/database/src/ops/search_history.rs
+++ b/crates/database/src/ops/search_history.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use cognee_utils::sanitize::sanitize_str;
 use cognee_utils::tracing_keys::{COGNEE_DB_ROW_COUNT, COGNEE_DB_SYSTEM};
 use sea_orm::PaginatorTrait;
 use sea_orm::{
@@ -30,7 +31,10 @@ pub async fn log_query(
     let id = Uuid::new_v4();
     let model = query::ActiveModel {
         id: Set(uuid_hex::to_hex(id)),
-        query_text: Set(query_text.to_string()),
+        // The caller discards a `log_query` error (`search_orchestrator.rs`
+        // pattern-matches `if let Ok(..)`), so an unsanitized NUL here drops the
+        // query *and* its result from search history with no diagnostic.
+        query_text: Set(sanitize_str(query_text).into_owned()),
         query_type: Set(query_type.to_string()),
         user_id: Set(uuid_hex::to_hex_opt(user_id)),
         created_at: Set(Utc::now()),
@@ -57,7 +61,10 @@ pub async fn log_result(
     let model = result_log::ActiveModel {
         id: Set(uuid_hex::to_hex(id)),
         query_id: Set(uuid_hex::to_hex(query_id)),
-        serialized_result: Set(serialized_result.to_string()),
+        // Search results echo back chunk text, so a NUL that survived into the
+        // graph or vector store reaches this `text` column too. See
+        // `cognee_utils::sanitize`.
+        serialized_result: Set(sanitize_str(serialized_result).into_owned()),
         user_id: Set(uuid_hex::to_hex_opt(user_id)),
         created_at: Set(Utc::now()),
     };

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -25,6 +25,8 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use tracing::debug;
 
+use cognee_utils::sanitize::{sanitize_json, sanitize_str, sanitize_string};
+
 use crate::error::{GraphDBError, GraphDBResult};
 use crate::traits::GraphDBTrait;
 use crate::types::{EdgeData, GraphNode, NodeData, parse_audit_timestamp};
@@ -337,11 +339,25 @@ impl PgGraphAdapter {
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
 
+        // Strip NUL bytes before they reach `varchar` columns and the `jsonb`
+        // blob. PDF-extracted chunk text routinely carries literal `0x00`, which
+        // Postgres rejects outright — see `cognee_utils::sanitize`. This is the
+        // single choke point for every node write on this adapter.
+        //
+        // `id` is sanitized here but *not* on the read and delete paths
+        // (`get_node`, `has_node`, `get_nodes`, `delete_node`, `delete_nodes`),
+        // so a node written under a NUL-bearing id is not retrievable by that
+        // raw id. That asymmetry is deliberate: Python does exactly the same
+        // thing — `postgres_demo/adapter.py:56` sanitizes the id on write while
+        // every read there passes `node_id` through untouched — and diverging
+        // would make the two SDKs disagree about whether such a lookup hits.
+        // Node ids are UUIDs or normalized identifiers in practice, so the
+        // corner is unreachable from the real pipeline.
         Ok(NodeRow {
-            id,
-            name,
-            node_type,
-            properties: Value::Object(extra),
+            id: sanitize_string(id),
+            name: sanitize_string(name),
+            node_type: sanitize_string(node_type),
+            properties: sanitize_json(Value::Object(extra)),
             created_at,
             updated_at,
         })
@@ -800,12 +816,28 @@ impl GraphDBTrait for PgGraphAdapter {
 
         let now = Utc::now();
 
-        // Deduplicate by composite key (last wins).
-        let mut seen: HashMap<(String, String, String), &EdgeData> = HashMap::new();
+        // Sanitize *before* deduplicating, not after. The `ON CONFLICT` target
+        // below is the sanitized triple, so two edges differing only by an
+        // embedded NUL must collapse into one entry here. Keying the dedup map
+        // on the raw triple would let both survive into a single
+        // `INSERT ... ON CONFLICT DO UPDATE`, which Postgres rejects with
+        // `21000: ON CONFLICT DO UPDATE command cannot affect row a second
+        // time` — aborting the whole chunk. `add_nodes_raw` gets this right by
+        // construction because it dedups on the already-sanitized `row.id`.
+        let mut seen: HashMap<(String, String, String), Value> = HashMap::new();
         for edge in edges {
-            seen.insert((edge.0.clone(), edge.1.clone(), edge.2.clone()), edge);
+            let props_json =
+                serde_json::to_value(&edge.3).map_err(GraphDBError::SerializationError)?;
+            let key = (
+                sanitize_str(&edge.0).into_owned(),
+                sanitize_str(&edge.1).into_owned(),
+                sanitize_str(&edge.2).into_owned(),
+            );
+            // Edge properties carry LLM-authored descriptions and, through
+            // them, source text — same NUL exposure as node properties.
+            seen.insert(key, sanitize_json(props_json));
         }
-        let deduped: Vec<&EdgeData> = seen.into_values().collect();
+        let deduped: Vec<((String, String, String), Value)> = seen.into_iter().collect();
 
         for chunk in deduped.chunks(BATCH_SIZE) {
             let mut insert = Query::insert()
@@ -820,14 +852,12 @@ impl GraphDBTrait for PgGraphAdapter {
                 ])
                 .to_owned();
 
-            for edge in chunk {
-                let props_json =
-                    serde_json::to_value(&edge.3).map_err(GraphDBError::SerializationError)?;
+            for ((source, target, relationship_name), props_json) in chunk {
                 insert.values_panic([
-                    edge.0.clone().into(),
-                    edge.1.clone().into(),
-                    edge.2.clone().into(),
-                    props_json.into(),
+                    source.clone().into(),
+                    target.clone().into(),
+                    relationship_name.clone().into(),
+                    props_json.clone().into(),
                     now.into(),
                     now.into(),
                 ]);
@@ -1810,5 +1840,73 @@ mod shared_db_migration_tests {
                 .expect("core migrator must not choke after legacy row is purged");
         })
         .await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NUL-byte sanitization (no database required)
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod sanitize_tests {
+    use super::PgGraphAdapter;
+    use serde_json::json;
+
+    /// `serialize_node_to_row` is the single choke point for every node write on
+    /// this adapter, so the strip has to happen there or not at all.
+    ///
+    /// Before this, a chunk carrying a literal `0x00` — 42.5% of one real corpus
+    /// of PDF-extracted papers — made Postgres reject the first `add_nodes` of
+    /// the run with `unsupported Unicode escape sequence`, discarding every
+    /// chunk, summary and embedding the two LLM stages had just produced.
+    #[test]
+    fn serialize_node_to_row_strips_nul_bytes() {
+        let node = json!({
+            "id": "chunk\u{0}1",
+            "name": "Nikola\u{0} Tesla",
+            "type": "Doc\u{0}Chunk",
+            "text": "page 1\u{0}page 2",
+            "nested": {"inner": ["a\u{0}b"]},
+            "count": 7,
+        });
+
+        let row = PgGraphAdapter::serialize_node_to_row(&node).unwrap();
+
+        assert_eq!(row.id, "chunk1");
+        assert_eq!(row.name, "Nikola Tesla");
+        assert_eq!(row.node_type, "DocChunk");
+
+        let props = serde_json::to_string(&row.properties).unwrap();
+        assert!(
+            !props.contains("\\u0000"),
+            "properties must carry no NUL escape, got: {props}"
+        );
+        assert_eq!(row.properties["text"], json!("page 1page 2"));
+        assert_eq!(row.properties["nested"]["inner"][0], json!("ab"));
+        // Non-string values are untouched.
+        assert_eq!(row.properties["count"], json!(7));
+    }
+
+    #[test]
+    fn serialize_node_to_row_leaves_clean_text_alone() {
+        let node = json!({
+            "id": "n1",
+            "name": "Ada Lovelace",
+            "type": "Person",
+            "text": "no nulls — just an em dash and 日本語",
+        });
+
+        let row = PgGraphAdapter::serialize_node_to_row(&node).unwrap();
+
+        assert_eq!(row.id, "n1");
+        assert_eq!(row.name, "Ada Lovelace");
+        assert_eq!(
+            row.properties["text"],
+            json!("no nulls — just an em dash and 日本語")
+        );
     }
 }

--- a/crates/graph/tests/common/mod.rs
+++ b/crates/graph/tests/common/mod.rs
@@ -888,3 +888,88 @@ pub async fn test_get_neighborhood_empty_seeds(db: &dyn GraphDBTrait) {
     assert!(nodes.is_empty());
     assert!(edges.is_empty());
 }
+
+// -- NUL bytes ---------------------------------------------------------------
+
+/// A NUL byte in node or edge text must never break persistence.
+///
+/// PDF-extracted chunk text routinely contains a literal `0x00`. Postgres
+/// cannot store it in `varchar` and its `jsonb` parser rejects the escape
+/// `serde_json` emits for it, so before `cognee_utils::sanitize` the very first
+/// `add_nodes` of a cognify run died — after both LLM stages had been paid for.
+///
+/// Backends differ in what they *store*: the Postgres adapters strip the NUL,
+/// Ladybug keeps it. Both are acceptable, so this asserts the contract they do
+/// share — the write succeeds, the row is retrievable, and every non-NUL
+/// character survives in order.
+pub async fn test_nul_bytes_in_text_are_persistable(db: &dyn GraphDBTrait) {
+    db.delete_graph().await.unwrap();
+
+    let dirty_name = "Nikola\0 Tesla";
+    let dirty_body = "page 1\0page 2";
+    let node = json!({
+        "id": "nul1",
+        "name": dirty_name,
+        "type": "Person",
+        "text": dirty_body,
+        "nested": {"inner": ["a\0b"]},
+    });
+    db.add_node_raw(node).await.unwrap();
+
+    let other = json!({"id": "nul2", "name": "Clean", "type": "Person"});
+    db.add_node_raw(other).await.unwrap();
+
+    let edge: EdgeData = (
+        "nul1".to_string(),
+        "nul2".to_string(),
+        "knows".to_string(),
+        HashMap::from([(Cow::Borrowed("edge_text"), json!("described\0relationship"))]),
+    );
+    db.add_edges(&[edge]).await.unwrap();
+
+    let fetched = db
+        .get_node("nul1")
+        .await
+        .unwrap()
+        .expect("the node must be retrievable after a write carrying NUL bytes");
+
+    let strip = |s: &str| s.replace('\0', "");
+    assert_eq!(
+        strip(fetched.get("name").unwrap().as_str().unwrap()),
+        strip(dirty_name),
+        "every non-NUL character of `name` must survive"
+    );
+    assert_eq!(
+        strip(fetched.get("text").unwrap().as_str().unwrap()),
+        strip(dirty_body),
+        "every non-NUL character of a JSON property must survive"
+    );
+
+    assert!(
+        db.has_edge("nul1", "nul2", "knows").await.unwrap(),
+        "an edge whose properties carry NUL bytes must still be written"
+    );
+
+    // Two edges whose relationship names differ *only* by an embedded NUL
+    // collapse to one row once sanitized. They must be deduplicated before the
+    // insert is built: on Postgres both would otherwise reach a single
+    // `INSERT ... ON CONFLICT DO UPDATE`, which fails with `21000: ON CONFLICT
+    // DO UPDATE command cannot affect row a second time` and aborts the batch.
+    let colliding: Vec<EdgeData> = vec![
+        (
+            "nul1".to_string(),
+            "nul2".to_string(),
+            "cite\0s".to_string(),
+            HashMap::from([(Cow::Borrowed("edge_text"), json!("first"))]),
+        ),
+        (
+            "nul1".to_string(),
+            "nul2".to_string(),
+            "cites".to_string(),
+            HashMap::from([(Cow::Borrowed("edge_text"), json!("second"))]),
+        ),
+    ];
+    db.add_edges(&colliding)
+        .await
+        .expect("edges colliding only after NUL removal must not abort the batch");
+}

--- a/crates/graph/tests/ladybug_integration.rs
+++ b/crates/graph/tests/ladybug_integration.rs
@@ -72,3 +72,4 @@ ladybug_test!(test_get_neighborhood_empty_seeds);
 ladybug_test!(test_node_truth_state_round_trip);
 ladybug_test!(test_node_truth_state_missing_and_invalid);
 ladybug_test!(test_node_truth_state_preserves_other_properties);
+ladybug_test!(test_nul_bytes_in_text_are_persistable);

--- a/crates/graph/tests/pg_graph_integration.rs
+++ b/crates/graph/tests/pg_graph_integration.rs
@@ -146,3 +146,4 @@ pggraph_test!(test_get_neighborhood_empty_seeds);
 pggraph_test!(test_node_truth_state_round_trip);
 pggraph_test!(test_node_truth_state_missing_and_invalid);
 pggraph_test!(test_node_truth_state_preserves_other_properties);
+pggraph_test!(test_nul_bytes_in_text_are_persistable);

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -34,8 +34,15 @@ uuid = { workspace = true, features = ["v4", "v5"] }
 # Secret redaction (cognee_utils::redact)
 regex = { workspace = true }
 
-# JSON payload walking (cognee_utils::sanitize)
-serde_json = { workspace = true }
+# JSON payload walking (cognee_utils::sanitize). `preserve_order` keeps
+# `serde_json::Map` insertion-ordered, which is what makes the sanitizer's
+# key-collision rule ("last one wins") actually match Python's dict
+# comprehension. Without it `Map` is a `BTreeMap` and the surviving value is
+# decided by raw-key sort order instead — a divergence that only shows up when
+# this crate is built in isolation (`cargo test -p cognee-utils`, the wasm32
+# lane), because `cognee-database` and `cognee-visualization` already turn the
+# feature on for every build that includes them.
+serde_json = { workspace = true, features = ["preserve_order"] }
 
 # WebAssembly (browser) spike — Config 1. The only getrandom in our wasm tree is
 # 0.2, pulled transitively by rand 0.8 (the jitter in retry.rs). On wasm32 it has

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -34,6 +34,9 @@ uuid = { workspace = true, features = ["v4", "v5"] }
 # Secret redaction (cognee_utils::redact)
 regex = { workspace = true }
 
+# JSON payload walking (cognee_utils::sanitize)
+serde_json = { workspace = true }
+
 # WebAssembly (browser) spike — Config 1. The only getrandom in our wasm tree is
 # 0.2, pulled transitively by rand 0.8 (the jitter in retry.rs). On wasm32 it has
 # no default backend, so the `js` feature routes it through the browser crypto

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -12,6 +12,7 @@ pub mod id_generation;
 pub mod pacing;
 pub mod redact;
 pub mod retry;
+pub mod sanitize;
 pub mod tracing_keys;
 
 pub use env::parse_env_bool;
@@ -21,3 +22,4 @@ pub use id_generation::{
 };
 pub use redact::redact;
 pub use retry::{RetryConfig, RetryDecision, retry_with_backoff};
+pub use sanitize::{sanitize_json, sanitize_json_in_place, sanitize_str, sanitize_string};

--- a/crates/utils/src/sanitize.rs
+++ b/crates/utils/src/sanitize.rs
@@ -66,6 +66,12 @@ pub fn sanitize_string(mut value: String) -> String {
 /// Walks strings, arrays and object values, and rewrites object *keys* too. Two
 /// keys that collapse to the same text after stripping merge, last one wins —
 /// the same outcome as Python's dict comprehension.
+///
+/// "Last" means last in `serde_json::Map` iteration order, so that parity claim
+/// holds only because this crate enables serde_json's `preserve_order`, which
+/// backs `Map` with an insertion-ordered `IndexMap`. Under the default
+/// `BTreeMap` the winner would instead be whichever raw key sorts last, which
+/// is not Python's rule. See the dependency comment in `Cargo.toml`.
 pub fn sanitize_json_in_place(value: &mut Value) {
     match value {
         Value::String(s) => {
@@ -205,6 +211,28 @@ mod tests {
     fn python_parity_replacement_char_is_not_a_nul() {
         assert_eq!(sanitize_str("\u{fffd}"), "\u{fffd}");
         assert_eq!(sanitize_str("a\u{fffd}\u{0}b"), "a\u{fffd}b");
+    }
+
+    /// Pins the collision rule the module doc claims, which is only meaningful
+    /// with `preserve_order` enabled: `"ab"` is inserted first and `"a\u{0}b"`
+    /// second, so the *second* insertion wins the collapse — matching Python,
+    /// where the dict comprehension iterates in insertion order. Under a default
+    /// `BTreeMap` build the raw keys iterate sorted (`"a\u{0}b"` before `"ab"`,
+    /// since 0x00 < 0x62) and the other value would survive instead.
+    #[test]
+    fn colliding_keys_resolve_in_insertion_order() {
+        let mut input = Map::new();
+        input.insert("ab".to_string(), json!("inserted_first"));
+        input.insert("a\u{0}b".to_string(), json!("inserted_second"));
+        assert_eq!(
+            input.keys().collect::<Vec<_>>(),
+            vec!["ab", "a\u{0}b"],
+            "preserve_order must keep the map insertion-ordered"
+        );
+
+        let out = sanitize_json(Value::Object(input));
+
+        assert_eq!(out, json!({"ab": "inserted_second"}));
     }
 
     #[test]

--- a/crates/utils/src/sanitize.rs
+++ b/crates/utils/src/sanitize.rs
@@ -1,0 +1,228 @@
+//! NUL-byte stripping for values on their way into Postgres.
+//!
+//! Postgres cannot store `0x00` in `text`/`varchar`, and its JSON(B) parser
+//! rejects the `\u0000` escape that `serde_json` emits for an embedded NUL —
+//! `unsupported Unicode escape sequence`. Text extracted from real-world PDFs
+//! routinely contains literal NULs, so any write that carries such text into a
+//! `text` column or a `jsonb` blob fails the whole statement.
+//!
+//! Mirrors Python's `sanitize_relational_payload`
+//! (`cognee/modules/graph/methods/sanitize_relational_payload.py`): strip NUL
+//! from strings and recurse through arrays and objects, sanitizing object keys
+//! as well as values. Python's `bytes` arm has no Rust equivalent — a Rust
+//! `String` is already valid UTF-8, and `serde_json` has no byte-string
+//! variant.
+//!
+//! # Where to apply this
+//!
+//! **At the database adapter boundary, never at ingestion or chunking.** The
+//! extracted text is hashed into `raw_content_hash`, and that hash is asserted
+//! byte-equal against the Python SDK in the cross-SDK parity suite. Python
+//! deliberately sanitizes only when writing, keeping the stored bytes and the
+//! hash intact. Stripping earlier would change chunk boundaries, token counts
+//! and content-addressed IDs, and break parity.
+//!
+//! Non-Postgres backends do not need this: SQLite tolerates an embedded NUL in
+//! `TEXT`, and neither Ladybug nor LanceDB round-trips through a Postgres JSON
+//! parser. Applying it unconditionally in shared conversion code is still
+//! correct — a NUL byte carries no meaning in any of these payloads.
+
+use std::borrow::Cow;
+
+use serde_json::{Map, Value};
+
+/// Strip NUL bytes from a string slice.
+///
+/// Returns `Cow::Borrowed` when there is nothing to strip. Callers that need an
+/// owned `String` still pay one allocation via `into_owned`; the borrow only
+/// pays off where the result can stay borrowed, so prefer [`sanitize_string`]
+/// when the input is already owned.
+///
+/// ```
+/// # use cognee_utils::sanitize::sanitize_str;
+/// # use std::borrow::Cow;
+/// assert!(matches!(sanitize_str("clean"), Cow::Borrowed("clean")));
+/// assert_eq!(sanitize_str("a\0b"), "ab");
+/// ```
+pub fn sanitize_str(value: &str) -> Cow<'_, str> {
+    if value.contains('\0') {
+        Cow::Owned(value.replace('\0', ""))
+    } else {
+        Cow::Borrowed(value)
+    }
+}
+
+/// Strip NUL bytes from an owned string, reusing the allocation when it is
+/// already clean.
+pub fn sanitize_string(mut value: String) -> String {
+    if value.contains('\0') {
+        value.retain(|c| c != '\0');
+    }
+    value
+}
+
+/// Recursively strip NUL bytes from a JSON value, in place.
+///
+/// Walks strings, arrays and object values, and rewrites object *keys* too. Two
+/// keys that collapse to the same text after stripping merge, last one wins —
+/// the same outcome as Python's dict comprehension.
+pub fn sanitize_json_in_place(value: &mut Value) {
+    match value {
+        Value::String(s) => {
+            if s.contains('\0') {
+                s.retain(|c| c != '\0');
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                sanitize_json_in_place(item);
+            }
+        }
+        Value::Object(map) => {
+            for (_, v) in map.iter_mut() {
+                sanitize_json_in_place(v);
+            }
+            if map.keys().any(|k| k.contains('\0')) {
+                let mut rebuilt = Map::with_capacity(map.len());
+                for (k, v) in std::mem::take(map) {
+                    rebuilt.insert(sanitize_string(k), v);
+                }
+                *map = rebuilt;
+            }
+        }
+        // Numbers, booleans and null cannot carry a NUL byte.
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+/// Owned convenience wrapper around [`sanitize_json_in_place`].
+///
+/// ```
+/// # use cognee_utils::sanitize::sanitize_json;
+/// # use serde_json::json;
+/// assert_eq!(sanitize_json(json!({"text": "a\0b"})), json!({"text": "ab"}));
+/// ```
+pub fn sanitize_json(mut value: Value) -> Value {
+    sanitize_json_in_place(&mut value);
+    value
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn clean_str_is_borrowed() {
+        assert!(matches!(sanitize_str("no nulls here"), Cow::Borrowed(_)));
+        assert!(matches!(sanitize_str(""), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn dirty_str_is_stripped() {
+        assert_eq!(sanitize_str("a\0b\0c"), "abc");
+        assert_eq!(sanitize_str("\0"), "");
+        assert_eq!(sanitize_str("\0lead"), "lead");
+        assert_eq!(sanitize_str("trail\0"), "trail");
+    }
+
+    #[test]
+    fn sanitize_string_matches_str_variant() {
+        assert_eq!(sanitize_string("a\0b".to_string()), "ab");
+        assert_eq!(sanitize_string("clean".to_string()), "clean");
+    }
+
+    #[test]
+    fn non_ascii_is_preserved() {
+        // The NUL scan must not disturb multi-byte UTF-8 around it.
+        assert_eq!(sanitize_str("é\0日本語\0—"), "é日本語—");
+    }
+
+    #[test]
+    fn nested_json_is_sanitized() {
+        let input = json!({
+            "text": "pdf\0text",
+            "nested": {"inner": ["a\0", {"deep": "b\0c"}]},
+            "count": 42,
+            "flag": true,
+            "nothing": null,
+        });
+        let expected = json!({
+            "text": "pdftext",
+            "nested": {"inner": ["a", {"deep": "bc"}]},
+            "count": 42,
+            "flag": true,
+            "nothing": null,
+        });
+        assert_eq!(sanitize_json(input), expected);
+    }
+
+    #[test]
+    fn object_keys_are_sanitized() {
+        let mut input = Map::new();
+        input.insert("ke\0y".to_string(), json!("value"));
+        let out = sanitize_json(Value::Object(input));
+        assert_eq!(out, json!({"key": "value"}));
+    }
+
+    /// Direct port of Python's
+    /// `test_sanitize_relational_payload_strips_null_bytes_recursively`
+    /// (`cognee/tests/unit/modules/graph/test_relational_upserts.py:37`), with
+    /// its tuple entry expressed as a JSON array — JSON has no tuple type, and
+    /// `serde_json` serializes a Rust tuple as an array anyway.
+    #[test]
+    fn python_parity_strips_null_bytes_recursively() {
+        let payload = json!({
+            "ti\u{0}tle": "hel\u{0}lo",
+            "nested": ["wo\u{0}rld", {"ke\u{0}y": "va\u{0}lue"}],
+            "tupled": ["a\u{0}", 1],
+        });
+
+        assert_eq!(
+            sanitize_json(payload),
+            json!({
+                "title": "hello",
+                "nested": ["world", {"key": "value"}],
+                "tupled": ["a", 1],
+            })
+        );
+    }
+
+    /// Python's companion case,
+    /// `test_sanitize_relational_payload_decodes_bytes_and_bytearray`, has no
+    /// Rust analogue and deliberately gets no port: it exists because a Python
+    /// payload can hold raw `bytes` that are not valid UTF-8, which Python
+    /// decodes with `errors="replace"`. A Rust `String` is UTF-8 by
+    /// construction and `serde_json::Value` has no byte-string variant, so the
+    /// failure it guards against is unrepresentable here. This test pins the
+    /// one part that *is* representable — a lone replacement character is
+    /// ordinary text and must survive untouched.
+    #[test]
+    fn python_parity_replacement_char_is_not_a_nul() {
+        assert_eq!(sanitize_str("\u{fffd}"), "\u{fffd}");
+        assert_eq!(sanitize_str("a\u{fffd}\u{0}b"), "a\u{fffd}b");
+    }
+
+    #[test]
+    fn clean_json_round_trips_unchanged() {
+        let input = json!({"a": [1, "two", {"b": null}]});
+        assert_eq!(sanitize_json(input.clone()), input);
+    }
+
+    #[test]
+    fn sanitized_json_survives_serialization() {
+        // The failure this guards: `serde_json` renders an embedded NUL as the
+        // `\u0000` escape, which Postgres' jsonb parser rejects outright.
+        let dirty = serde_json::to_string(&json!({"text": "a\0b"}))
+            .expect("json object with a string value always serializes");
+        assert!(dirty.contains("\\u0000"));
+
+        let clean = serde_json::to_string(&sanitize_json(json!({"text": "a\0b"})))
+            .expect("json object with a string value always serializes");
+        assert!(!clean.contains("\\u0000"));
+    }
+}

--- a/crates/vector/src/pgvector_adapter.rs
+++ b/crates/vector/src/pgvector_adapter.rs
@@ -15,6 +15,7 @@ use std::fmt;
 use tracing::{Span, debug, instrument};
 use uuid::Uuid;
 
+use cognee_utils::sanitize::sanitize_json;
 use cognee_utils::tracing_keys::{
     COGNEE_DB_ROW_COUNT, COGNEE_VECTOR_COLLECTION, COGNEE_VECTOR_RESULT_COUNT,
 };
@@ -556,13 +557,16 @@ impl VectorDB for PgVectorAdapter {
 
                 values.push(pt.id.into());
                 values.push(Self::format_vector(&pt.vector).into());
-                let metadata_obj: serde_json::Value = serde_json::Value::Object(
+                // Chunk and summary text is injected into point metadata, so
+                // this `jsonb` cast has the same NUL exposure as the graph
+                // tables — see `cognee_utils::sanitize`.
+                let metadata_obj: serde_json::Value = sanitize_json(serde_json::Value::Object(
                     merged
                         .metadata
                         .iter()
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect(),
-                );
+                ));
                 values.push(metadata_obj.into());
             }
 
@@ -651,12 +655,12 @@ impl VectorDB for PgVectorAdapter {
 
                 values.push(pt.id.into());
                 values.push(Self::format_vector(&pt.vector).into());
-                let metadata_obj: serde_json::Value = serde_json::Value::Object(
+                let metadata_obj: serde_json::Value = sanitize_json(serde_json::Value::Object(
                     pt.metadata
                         .iter()
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect(),
-                );
+                ));
                 values.push(metadata_obj.into());
             }
 

--- a/crates/vector/tests/brute_force_integration.rs
+++ b/crates/vector/tests/brute_force_integration.rs
@@ -172,3 +172,8 @@ async fn brute_force_upsert_raw_vectors_round_trip() {
 async fn brute_force_upsert_raw_vectors_empty_noop() {
     common::test_upsert_raw_vectors_empty_noop(&BruteForceVectorDB::new()).await;
 }
+
+#[tokio::test]
+async fn brute_force_nul_bytes_in_metadata_are_persistable() {
+    common::test_nul_bytes_in_metadata_are_persistable(&BruteForceVectorDB::new()).await;
+}

--- a/crates/vector/tests/common/mod.rs
+++ b/crates/vector/tests/common/mod.rs
@@ -585,3 +585,41 @@ pub async fn test_batch_search(db: &dyn VectorDB) {
         "query 1 should rank its exact-match point first"
     );
 }
+
+// -- NUL bytes ---------------------------------------------------------------
+
+/// A NUL byte in point metadata must never break persistence.
+///
+/// Cognify injects the full chunk and summary text into point metadata, so the
+/// `::jsonb` cast in the pgvector upsert has the same exposure to PDF-extracted
+/// `0x00` as the graph tables do. See `cognee_utils::sanitize`.
+///
+/// Backends differ in what they store — pgvector strips the NUL, the in-memory
+/// and LanceDB adapters keep it — so this asserts the shared contract: the
+/// upsert succeeds, the point comes back, and every non-NUL character survives.
+pub async fn test_nul_bytes_in_metadata_are_persistable(db: &dyn VectorDB) {
+    db.create_collection("NulChunk", "text", 3).await.unwrap();
+
+    let dirty = "page 1\0page 2";
+    let id = Uuid::new_v4();
+    let point = VectorPoint::new(id, vec![1.0, 0.0, 0.0])
+        .with_metadata("text", json!(dirty))
+        .with_metadata("nested", json!({"inner": ["a\0b"]}));
+
+    db.index_points("NulChunk", "text", &[point]).await.unwrap();
+
+    let fetched = db.retrieve("NulChunk", "text", &[id]).await.unwrap();
+    assert_eq!(fetched.len(), 1, "the point must be retrievable");
+
+    let strip = |s: &str| s.replace('\0', "");
+    let text = fetched[0]
+        .metadata
+        .get("text")
+        .and_then(|v| v.as_str())
+        .expect("the `text` metadata key must survive the round trip");
+    assert_eq!(
+        strip(text),
+        strip(dirty),
+        "every non-NUL character of the chunk text must survive"
+    );
+}

--- a/crates/vector/tests/pgvector_integration.rs
+++ b/crates/vector/tests/pgvector_integration.rs
@@ -91,3 +91,4 @@ pgvector_test!(test_search_similar_filtered_filter_then_limit);
 pgvector_test!(test_search_similar_filtered_semantics);
 pgvector_test!(test_search_similar_filtered_and_vs_or);
 pgvector_test!(test_search_similar_filtered_none_matches_all);
+pgvector_test!(test_nul_bytes_in_metadata_are_persistable);


### PR DESCRIPTION
## Problem

Text extracted from real-world PDFs routinely contains a literal `0x00`. Postgres cannot store it in `varchar`, and its JSONB parser rejects the six-character unicode escape `serde_json` emits for it. So the first `add_nodes` of a cognify run died — **after both LLM stages had already been paid for.**

On one 171,888-paper corpus this hit **42.5% of documents** and killed two calibration runs after 103 minutes and $86 of LLM work. The chunks, summaries, documents, structural edges, embeddings and the entire vector index were lost, leaving an entity-only graph that could not be searched.

Python has had a fix since `sanitize_relational_payload`. The Rust port never picked it up — and fails *harder* than Python, because Python's pgvector payload column is `JSON` where ours is `JSONB`.

## Approach

New `cognee_utils::sanitize`: a `Cow`-returning string stripper plus a recursive JSON walker that rewrites object **keys** as well as values, matching Python's dict comprehension including its last-wins key merge.

Applied at the write sites — ten Postgres sinks take user text, not one:

| Sink | Where |
|---|---|
| Graph nodes (`id`, `name`, `type`, `properties`) | `serialize_node_to_row` — the single choke point for every node write |
| Graph edges (3 key columns + `properties`) | `add_edges` |
| pgvector `metadata` | both `index_points` and `upsert_raw_vectors`, which carry full chunk and summary text |
| Relational provenance | the `GraphNode`/`GraphEdge` ActiveModel conversions, whose batch shares one transaction — so one bad chunk aborted every row in it |
| Search history | `log_query` and `log_result`, both of whose errors callers swallow |
| Pipeline/task `run_info` | so an Errored write cannot itself fail and leave the run stuck as `Started` with the error never persisted |

**Sanitization happens at the adapter boundary, never at ingestion or chunking.** The extracted bytes are hashed into `raw_content_hash`, which the cross-SDK suite asserts byte-equal against Python (`test_add_parity.py:268`). Python sanitizes only on write for exactly this reason; stripping earlier would change chunk boundaries, token counts and content-addressed IDs.

## Two ordering details that matter

Both are pinned by tests, and both are bugs an earlier draft of this change actually had:

**1. Hash before or after the strip.** `upsert_provenance` derives an edge's uuid5 id from `edge_text`. Python feeds `sanitized_edge_text` into its uuid5, so hashing raw text here would have given NUL-bearing `contains` edges a *different deterministic id* than the Python SDK produces for identical input — a silent cross-SDK divergence visible only on NUL-bearing corpora.

**2. Dedup before or after the strip.** `add_edges` deduplicated on the raw `(source, target, relationship_name)` triple while inserting sanitized values. Two edges differing only by an embedded NUL survived dedup, then collided on the same `ON CONFLICT` target inside one statement:

```
ON CONFLICT DO UPDATE command cannot affect row a second time
```

...aborting the whole chunk. The dedup key is now the inserted value, so the two cannot diverge again.

## One deliberate non-fix

Node ids are sanitized on write but **not** on the read and delete paths, so a NUL-bearing id is not retrievable by that raw id — a silent miss where the old behaviour was a loud failure.

This asymmetry is kept on purpose and documented inline. Python does exactly the same thing (`postgres_demo/adapter.py:56` sanitizes on write; every read at `:306-326` passes `node_id` through untouched), and diverging would make the two SDKs disagree about whether such a lookup hits. Node ids are UUIDs or normalized identifiers in practice, so the corner is unreachable from the real pipeline. **Happy to change this if reviewers prefer correctness over parity here.**

## Tests

- 12 unit tests on the helper, **two ported from Python's `test_relational_upserts.py`**. The `bytes`/`bytearray` case has no Rust analogue — a `String` is UTF-8 by construction and `serde_json::Value` has no byte variant — and the file says so rather than silently omitting it.
- DB-free unit tests on `serialize_node_to_row`, the relational conversions, and edge-id determinism. The edge-id test's load-bearing assertion is that hashing raw vs. clean text *differs*, so deleting the strip cannot slip through as a no-op.
- Shared-harness contract cases registered across the **pggraph, ladybug, pgvector and brute-force** suites. These assert the backend-agnostic contract — the write succeeds and every non-NUL character survives in order — because Ladybug and brute-force legitimately *keep* the NUL while the Postgres adapters strip it. The strict "it was stripped" assertions live in the unit tests.

**Every new integration case was confirmed to fail against the pre-fix code with the exact production error before being kept:**

```
pggraph:  invalid byte sequence for encoding "UTF8": 0x00
pgvector: unsupported Unicode escape sequence
add_edges: ON CONFLICT DO UPDATE command cannot affect row a second time
```

CI floors bumped to match the added cases (`pgvector-integration` 20→21, `pggraph-integration` 30→31, in both `ci.yml` and `community.yml`).

## Verification

Against a live Postgres: **33/33 pggraph, 25/25 pgvector, 3/3 provenance_batch, 33/33 ladybug, 12/12 brute-force.** Plus `cargo clippy -D warnings`, `cargo fmt --check`, and the wasm32 logic-crate lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDwDofYtFLnJx6yPXNXMXS
