### PR TITLE
fix(cli): give the CLI a real feature facade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,10 +238,53 @@ jobs:
           cargo check -p cognee-http-server --no-default-features \
             --features telemetry,html-loader,pgvector,pggraph
 
-      # crates/vector declares no default features, so `cargo test -p cognee-vector`
-      # runs none of the inline LanceDB adapter tests; only the workspace-wide
-      # nextest run reaches them, via unification from `cognee`. Spell the lane out
-      # so the adapter keeps its own coverage.
+      # crates/cli reaches `cognee` with `default-features = false`, so its own
+      # feature list can actually subtract. Guard both ends of that seam: the
+      # bare slim build, and `android-default` -- the composite that
+      # deliberately drops pdfium, postgres, tiktoken and lancedb, and which
+      # silently built the full desktop stack for as long as the CLI manifest
+      # was missing the flag. Mirrors the slim-CLI lane in scripts/check_all.sh.
+      - name: Compilation check (slim CLI facade)
+        env:
+          CARGO_TARGET_DIR: target/no-default
+        run: |
+          cargo check -p cognee-cli --no-default-features
+          cargo check -p cognee-cli --no-default-features \
+            --features cognee-cli/android-default
+
+      # A compile check alone cannot tell a slim tree from a fat one, so assert
+      # the profile's actual contract: android-default excludes pdfium,
+      # postgres, tiktoken and lancedb. Marker crates beat a package-count
+      # ceiling -- a count is host-dependent: the pre-fix fat tree measured 690
+      # packages on the Linux runner but only 523 for aarch64-linux-android,
+      # where lancedb is already target-gated away. A ceiling loose enough for
+      # one is blind for the other -- 520 would have missed the real Android
+      # regression by 3 packages. `lbug` and `ort` are sentinels: android-default
+      # genuinely pulls both, so their absence means the measurement broke
+      # rather than the profile being clean. Mirrors scripts/check_all.sh.
+      - name: Feature-subtraction contract (android-default CLI profile)
+        env:
+          CARGO_TARGET_DIR: target/no-default
+        shell: bash
+        run: |
+          set -euo pipefail
+          tree=$(cargo tree -p cognee-cli --no-default-features \
+              --features cognee-cli/android-default -e normal --prefix none \
+              --format '{p}' | sed 's/ (\*)//' | awk '{print $1}' | sort -u)
+          for sentinel in lbug ort; do
+            if ! grep -qx "$sentinel" <<<"$tree"; then
+              echo "::error::'$sentinel' missing from the android-default tree. Expected it to be present, so this measurement is broken -- not a clean profile."
+              exit 1
+            fi
+          done
+          for forbidden in lancedb pdfium-render tiktoken-rs aws-config; do
+            if grep -qx "$forbidden" <<<"$tree"; then
+              echo "::error::'$forbidden' leaked into cognee-cli/android-default, which is defined to exclude it. A feature forward has stopped subtracting -- check that crates/cli/Cargo.toml still declares 'default-features = false' on the cognee dependency."
+              exit 1
+            fi
+          done
+          echo "android-default excludes lancedb/pdfium/tiktoken/aws (sentinels lbug, ort present)"
+
       - name: Test (cognee-vector lancedb lane)
         run: cargo test -p cognee-vector --features lancedb
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,6 +25,10 @@ path = "src/main.rs"
 default = [
     "onnx",
     "ladybug",
+    # Default-on because the runtime default `vector_db_provider` is "lancedb"
+    # (crates/lib/src/config.rs). Dropping it from `default` would turn a
+    # compile-time choice into a runtime failure on a stock build.
+    "lancedb",
     "pgvector",
     "pggraph",
     "sqlite",
@@ -62,6 +66,7 @@ ort-cuda      = ["cognee/ort-cuda"]
 ort-tensorrt  = ["cognee/ort-tensorrt"]
 onnx-dynamic  = ["cognee/onnx-dynamic"]
 ladybug       = ["cognee/ladybug"]
+lancedb       = ["cognee/lancedb"]
 pgvector      = ["cognee/pgvector"]
 pggraph       = ["cognee/pggraph"]
 sqlite        = ["cognee/sqlite"]
@@ -96,7 +101,12 @@ android-default = ["cognee/android-default"]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
-cognee = { path = "../lib", version = "0.2.0" }
+# `default-features = false` is load-bearing: without it the feature list below
+# is purely additive (it can add but never subtract) and `--no-default-features`
+# is inert for the whole backend stack. Every other consumer of `cognee` in this
+# repo already does this; the CLI was missed when the lancedb/onnx/ladybug gates
+# landed. Guarded by the slim-CLI lanes in scripts/check_all.sh and ci.yml.
+cognee = { path = "../lib", version = "0.2.0", default-features = false }
 cognee-logging = { path = "../logging", version = "0.2.0" }
 dirs.workspace = true
 serde.workspace = true

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -76,7 +76,14 @@ default = [
 mock-llm       = ["cognee-llm/mock", "cognee-components/mock-llm"]
 visualization  = ["dep:cognee-visualization"]
 onnx           = ["cognee-embedding/onnx", "cognee-components/onnx"]
-onnx-dynamic   = ["cognee-embedding/onnx-dynamic", "cognee-components/onnx-dynamic"]
+# Self-implies `onnx`, matching cognee-components and cognee-embedding, whose
+# `onnx-dynamic` both do the same. Without it, a consumer that reaches this
+# crate with `default-features = false` and enables only `onnx-dynamic` (e.g.
+# via `android-default`) flips ort into dlopen mode but compiles out the
+# `#[cfg(feature = "onnx")]` re-exports below. The docs.rs metadata blocks here
+# and in crates/cognee-lib still list `onnx` alongside `onnx-dynamic`; that is
+# now redundant rather than load-bearing, and harmless to leave in place.
+onnx-dynamic   = ["onnx", "cognee-embedding/onnx-dynamic", "cognee-components/onnx-dynamic"]
 ort-cuda       = ["cognee-embedding/ort-cuda", "cognee-components/ort-cuda"]
 ort-tensorrt   = ["cognee-embedding/ort-tensorrt", "cognee-components/ort-tensorrt"]
 ladybug        = ["cognee-graph/ladybug", "cognee-components/ladybug"]

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1183,6 +1183,19 @@ impl Default for Settings {
             // `cognee-http-server` and every binding). A consumer that drops that
             // feature MUST set `vector_db_provider` explicitly; the registry's
             // unsupported-provider error names the feature to rebuild with.
+            //
+            // Android is the one first-party profile that does drop it:
+            // `cognee/android-default` omits `lancedb` because the Arrow + lance
+            // native stack does not cross-compile. Its effective backend has
+            // always been in-memory brute-force anyway — when the feature IS
+            // present, `LanceDbFactory::build` falls back to brute-force on
+            // Android rather than opening a store. Naming brute-force directly
+            // there keeps that behaviour and stops a stock Android build from
+            // erroring on a provider whose factory was never registered. Every
+            // other slim consumer keeps the loud failure described above.
+            #[cfg(all(target_os = "android", not(feature = "lancedb")))]
+            vector_db_provider: "brute-force".to_string(),
+            #[cfg(not(all(target_os = "android", not(feature = "lancedb"))))]
             vector_db_provider: "lancedb".to_string(),
             vector_db_url: String::new(),
             vector_db_port: 1234,

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -91,6 +91,54 @@ cargo check -p cognee-http-server --no-default-features \
 
 echo ""
 echo "================================================================"
+echo "=== Rust: Compilation check (slim CLI facade) ==="
+echo "================================================================"
+# crates/cli reaches `cognee` with `default-features = false`, so its own
+# feature list can actually subtract. Guard both ends of that seam:
+#   1. the bare slim build (no backend at all), and
+#   2. `android-default`, the composite that deliberately drops pdfium,
+#      postgres, tiktoken and lancedb — and which silently built the full
+#      desktop stack for as long as the CLI manifest was missing the flag.
+# A plain compile check is not enough on its own: it passes just as happily
+# with the fat tree as with the slim one, which is how the original break went
+# unnoticed. So the android lane also asserts a package-count ceiling.
+cargo check -p cognee-cli --no-default-features
+cargo check -p cognee-cli --no-default-features --features cognee-cli/android-default
+
+# A compile check alone cannot tell a slim tree from a fat one, so assert the
+# profile's actual contract: android-default excludes pdfium, postgres, tiktoken
+# and lancedb. Marker crates beat a package-count ceiling here -- a count is
+# host-dependent: the pre-fix fat tree measured 690 packages on this host but
+# only 523 for aarch64-linux-android, where lancedb is already target-gated
+# away. A ceiling loose enough for one is blind for the other -- 520 would have
+# missed the real Android regression by 3 packages. `lbug` and `ort` are
+# sentinels: android-default genuinely pulls both, so their absence means the
+# measurement itself broke rather than the profile being clean.
+android_tree=$(cargo tree -p cognee-cli --no-default-features \
+    --features cognee-cli/android-default -e normal --prefix none --format '{p}' \
+    | sed 's/ (\*)//' | awk '{print $1}' | sort -u)
+
+for sentinel in lbug ort; do
+    if ! grep -qx "${sentinel}" <<<"${android_tree}"; then
+        echo "ERROR: '${sentinel}' missing from the android-default tree. Expected it to" >&2
+        echo "       be present, so this measurement is broken -- not a clean profile." >&2
+        exit 1
+    fi
+done
+
+for forbidden in lancedb pdfium-render tiktoken-rs aws-config; do
+    if grep -qx "${forbidden}" <<<"${android_tree}"; then
+        echo "ERROR: '${forbidden}' leaked into cognee-cli/android-default, which is" >&2
+        echo "       defined to exclude it. A feature forward has stopped subtracting --" >&2
+        echo "       check that crates/cli/Cargo.toml still declares" >&2
+        echo "       'default-features = false' on the cognee dependency." >&2
+        exit 1
+    fi
+done
+echo "android-default excludes lancedb/pdfium/tiktoken/aws (sentinels lbug, ort present)"
+
+echo ""
+echo "================================================================"
 echo "=== Rust: wasm32 Config-1 (logic crates + wasm test drift guard) ==="
 echo "================================================================"
 # The wasm smoke-test files are #![cfg(target_arch = "wasm32")], so the native

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -99,15 +99,14 @@ echo "================================================================"
 #   2. `android-default`, the composite that deliberately drops pdfium,
 #      postgres, tiktoken and lancedb — and which silently built the full
 #      desktop stack for as long as the CLI manifest was missing the flag.
-# A plain compile check is not enough on its own: it passes just as happily
-# with the fat tree as with the slim one, which is how the original break went
-# unnoticed. So the android lane also asserts a package-count ceiling.
+# A compile check alone cannot tell a slim tree from a fat one -- it passes just
+# as happily with either, which is how the original break went unnoticed -- so
+# the contract check below asserts the android profile's exclusions directly.
 cargo check -p cognee-cli --no-default-features
 cargo check -p cognee-cli --no-default-features --features cognee-cli/android-default
 
-# A compile check alone cannot tell a slim tree from a fat one, so assert the
-# profile's actual contract: android-default excludes pdfium, postgres, tiktoken
-# and lancedb. Marker crates beat a package-count ceiling here -- a count is
+# Assert the profile's actual contract: android-default excludes pdfium,
+# postgres, tiktoken and lancedb. Marker crates beat a package count -- a count is
 # host-dependent: the pre-fix fat tree measured 690 packages on this host but
 # only 523 for aarch64-linux-android, where lancedb is already target-gated
 # away. A ceiling loose enough for one is blind for the other -- 520 would have


### PR DESCRIPTION
## What's true

`crates/cli/Cargo.toml` depended on `cognee` without `default-features = false`, so the CLI's own feature list was purely **additive** — it could add but never subtract, and `--no-default-features` was inert for the entire backend stack. Verified with `cargo tree`: `lbug`, `lancedb`, `ort`, `lance-*` and `aws-config` all survived it.

## Why it happened

Commit `644480d` introduced the lancedb/onnx/ladybug gates and updated every downstream consumer — capi, bindings-common, cognee-lib, http-server, java, python, ts — plus CI and the check script. It did not touch the CLI manifest. The CLI was the only offender left; all six binding manifests were already correct.

## Second victim

`scripts/android-build-and-deploy.sh` builds with `--no-default-features --features cognee-cli/android-default`, a profile that deliberately excludes pdfium, postgres, tiktoken and lancedb. It got all of them anyway — the Android lane has been silently building the full desktop stack.

## Measured

`cargo tree -e normal`, deduplicated:

| Profile | Before | After |
|---|---|---|
| default build | 672 | **672** (exact parity) |
| `--no-default-features` | 672 | **328** |
| `android-default`, host | 690 | **440** |
| `android-default`, `aarch64-linux-android` | 523 | **441** |

Default parity is exact, so nothing that builds with defaults changes. `lancedb` is added to the CLI's own `default` set because the runtime default `vector_db_provider` is lancedb; it is the only difference between the CLI's default list and `cognee`'s, which is why the default tree is unchanged.

Every other `cognee-cli` invocation in the repo (`http-parity.yml`, `record-perf-cassette.yml`) builds with defaults, so only the Android script's behaviour changes.

## Two things the seam exposed once it started subtracting

Both were masked by the leak and would have shipped as regressions if only the three-line manifest fix had landed:

1. **`cognee`'s `onnx-dynamic` did not self-imply `onnx`**, unlike the identically-named features in `cognee-components` and `cognee-embedding`. `android-default` lists `onnx-dynamic` and not `onnx`, so the `#[cfg(feature = "onnx")]` re-exports in `crates/lib/src/lib.rs` would have compiled out of the Android profile.

2. **The Android build would have lost its vector backend.** `Settings::default().vector_db_provider` is the literal `"lancedb"`, and `android-default` drops that feature, so `LanceDbFactory` is never registered and a stock Android build would fail at run time with `unsupported vector_db_provider: lancedb`. The effective Android backend has always been in-memory brute-force anyway — `LanceDbFactory::build` falls back to it on Android when the feature *is* present — so it is now named directly there. Every other slim consumer keeps the documented loud failure.

## Guard it

A slim-CLI lane in `scripts/check_all.sh` and `ci.yml` compiles both `--no-default-features` and `--features cognee-cli/android-default`. CI had **no Android build lane at all** before this.

The lane asserts the profile's contract **by marker crate rather than by package count**. A count is host-dependent — the pre-fix fat tree was 690 packages on the host but 523 on `aarch64-linux-android`, where `lancedb` is already target-gated away — so no single threshold catches the regression in both places. (A 520 ceiling, the first thing I tried, would have missed the real Android regression by three packages while looking authoritative.) `lbug` and `ort` are sentinels: `android-default` genuinely pulls both, so their absence means the measurement broke rather than the profile being clean.

## Verification

- Full `scripts/check_all.sh` green (`=== All checks passed! ===`).
- `cargo check -p cognee-cli --no-default-features` and `--features cognee-cli/android-default` both compile clean.
- `cargo check -p cognee --target aarch64-linux-android --no-default-features --features android-default` compiles clean (target installed locally to verify the new `cfg` branch).
- The new guard was tested in both directions: passes on the fixed tree; reintroducing the missing `default-features = false` produces `ERROR: 'lancedb' leaked into cognee-cli/android-default` and exit 1.

**Not covered locally:** the Java Maven/JVM half skipped (`mvn`/`java` not installed — its Rust shim ran and passed), and the credential-gated Python/TS example smoke tests skipped. CI covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019i3unYvzNqyKqMGK92gTBU
