### PR TITLE
perf(search,graph): stop FEEDBACK/CODING_RULES full scans, fix the neighborhood default

### DIFF
--- a/crates/graph/src/ladybug.rs
+++ b/crates/graph/src/ladybug.rs
@@ -1302,6 +1302,48 @@ impl GraphDBTrait for LadybugAdapter {
         Ok(metrics)
     }
 
+    /// Read only the node half of the store and apply
+    /// [`node_label_contains`](crate::node_label_contains) in Rust.
+    ///
+    /// Ladybug keeps a node's extra properties as a serialised JSON *string*
+    /// column, so the four non-`type` label keys are not addressable from
+    /// Cypher here the way they are from Postgres' jsonb. The win over the
+    /// default is therefore narrower but still real: `MATCH (a:Node)-[r:EDGE]->(b:Node)`
+    /// is never run, so the whole edge table stays unread. Because the filter
+    /// runs on fully parsed rows it is the exact predicate, not a superset —
+    /// callers re-applying it is harmless either way.
+    async fn get_candidate_nodes_by_label(&self, needle: &str) -> GraphDBResult<Vec<GraphNode>> {
+        let nodes_query = "MATCH (n:Node) RETURN n.id AS id, n.name AS name, n.type AS type, n.properties AS properties";
+        let node_results = self.execute_query(nodes_query)?;
+
+        let mut nodes = Vec::new();
+        for row in node_results {
+            if row.len() >= Self::NODE_QUERY_COLUMN_COUNT {
+                let mut node_data = NodeData::new();
+                if let Some(id_str) = row[0].as_str() {
+                    node_data.insert(Cow::Borrowed("id"), json!(id_str));
+                }
+                if let Some(name_str) = row[1].as_str() {
+                    node_data.insert(Cow::Borrowed("name"), json!(name_str));
+                }
+                if let Some(type_str) = row[2].as_str() {
+                    node_data.insert(Cow::Borrowed("type"), json!(type_str));
+                }
+                if let Some(props_str) = row[3].as_str() {
+                    node_data.insert(Cow::Borrowed("properties"), json!(props_str));
+                }
+                let parsed_node = self.parse_node_data(node_data)?;
+                if !crate::node_label_contains(&parsed_node, needle) {
+                    continue;
+                }
+                if let Some(id_str) = parsed_node.get("id").and_then(|v| v.as_str()) {
+                    nodes.push((id_str.to_string(), parsed_node));
+                }
+            }
+        }
+        Ok(nodes)
+    }
+
     async fn get_filtered_graph_data(
         &self,
         attribute_filters: &HashMap<Cow<'static, str>, Vec<serde_json::Value>>,

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -38,7 +38,9 @@ pub mod mock;
 
 pub use error::{GraphDBError, GraphDBResult};
 pub use formatted::get_formatted_graph_data;
-pub use traits::{EdgeKey, GraphDBTrait, GraphDBTraitExt, NodeTruthState};
+pub use traits::{
+    EdgeKey, GraphDBTrait, GraphDBTraitExt, NODE_LABEL_KEYS, NodeTruthState, node_label_contains,
+};
 pub use types::{EdgeData, GraphEdge, GraphNode, NodeData};
 
 #[cfg(feature = "ladybug")]

--- a/crates/graph/src/mock.rs
+++ b/crates/graph/src/mock.rs
@@ -87,7 +87,8 @@ impl MockGraphDB {
     /// Get a snapshot of the call log — the names of methods invoked on
     /// this mock in invocation order.
     ///
-    /// Currently records `"get_graph_data"`, `"get_nodeset_subgraph"`,
+    /// Currently records `"get_graph_data"`, `"get_filtered_graph_data"`,
+    /// `"get_candidate_nodes_by_label"`, `"get_nodeset_subgraph"`,
     /// `"get_neighborhood"`, `"get_node_truth_state"`, and
     /// `"set_node_truth_state"`.
     pub fn get_call_log(&self) -> Vec<String> {
@@ -421,10 +422,37 @@ impl GraphDBTrait for MockGraphDB {
             .collect())
     }
 
+    /// Stands in for the best case a real backend can manage: the exact
+    /// predicate, node rows only, no edge scan. Recorded in the call log so a
+    /// test can assert a caller stopped reaching for `get_graph_data`.
+    async fn get_candidate_nodes_by_label(
+        &self,
+        needle: &str,
+    ) -> GraphDBResult<Vec<(String, NodeData)>> {
+        self.call_log
+            .lock()
+            .unwrap() // lock poison is unrecoverable
+            .push("get_candidate_nodes_by_label".to_string());
+
+        let nodes = self.nodes.lock().unwrap(); // lock poison is unrecoverable
+        Ok(nodes
+            .iter()
+            .filter(|(_, data)| crate::node_label_contains(data, needle))
+            .map(|(id, data)| (id.clone(), data.clone()))
+            .collect())
+    }
+
+    /// Ignores the filters entirely and returns the whole graph, so a caller
+    /// that pushes a predicate down here is NOT narrowed by the mock — the
+    /// call is logged under its own name to make that visible.
     async fn get_filtered_graph_data(
         &self,
         _attribute_filters: &HashMap<Cow<'static, str>, Vec<serde_json::Value>>,
     ) -> GraphDBResult<(Vec<(String, NodeData)>, Vec<EdgeData>)> {
+        self.call_log
+            .lock()
+            .unwrap() // lock poison is unrecoverable
+            .push("get_filtered_graph_data".to_string());
         self.get_graph_data().await
     }
 

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -1256,6 +1256,52 @@ impl GraphDBTrait for PgGraphAdapter {
         Ok((nodes, edges))
     }
 
+    /// Narrow the node scan to rows that could carry `needle` as a type-ish
+    /// label, and read no edge rows at all.
+    ///
+    /// The SQL predicate is a deliberate **superset** of
+    /// [`node_label_contains`](crate::node_label_contains): `type` is a real
+    /// column, while `node_type`/`kind`/`label`/`labels` live inside the
+    /// `properties` jsonb, so the second clause matches the whole serialised
+    /// blob — keys and values alike. A JSON string value that contains
+    /// `needle` survives verbatim in `properties::text` (jsonb only escapes
+    /// quotes, backslashes and control characters, none of which appear in the
+    /// needles callers pass), so nothing that satisfies the exact predicate is
+    /// filtered out here; false positives are the caller's post-filter to
+    /// remove. Postgres' `lower()` is Unicode-aware where Rust's
+    /// `to_ascii_lowercase` is not, which again only widens the match.
+    ///
+    /// This is a sequential scan — there is no index on `lower(properties::text)`
+    /// — but it returns a handful of rows instead of the whole `graph_node`
+    /// table plus the whole `graph_edge` table.
+    async fn get_candidate_nodes_by_label(&self, needle: &str) -> GraphDBResult<Vec<GraphNode>> {
+        let sql = "SELECT id, name, type, properties FROM graph_node \
+                   WHERE position($1 IN lower(type)) > 0 \
+                      OR position($1 IN lower(coalesce(properties::text, ''))) > 0";
+
+        let rows = self
+            .db
+            .query_all(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                sql,
+                [sea_orm::Value::from(needle.to_lowercase())],
+            ))
+            .await
+            .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
+
+        let mut nodes = Vec::with_capacity(rows.len());
+        for row in &rows {
+            let data = Self::parse_node_row(row)?;
+            let id = data
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            nodes.push((id, data));
+        }
+        Ok(nodes)
+    }
+
     async fn get_nodeset_subgraph(
         &self,
         node_type: &str,

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -1260,30 +1260,54 @@ impl GraphDBTrait for PgGraphAdapter {
     /// label, and read no edge rows at all.
     ///
     /// The SQL predicate is a deliberate **superset** of
-    /// [`node_label_contains`](crate::node_label_contains): `type` is a real
-    /// column, while `node_type`/`kind`/`label`/`labels` live inside the
-    /// `properties` jsonb, so the second clause matches the whole serialised
-    /// blob — keys and values alike. A JSON string value that contains
-    /// `needle` survives verbatim in `properties::text` (jsonb only escapes
-    /// quotes, backslashes and control characters, none of which appear in the
-    /// needles callers pass), so nothing that satisfies the exact predicate is
-    /// filtered out here; false positives are the caller's post-filter to
-    /// remove. Postgres' `lower()` is Unicode-aware where Rust's
+    /// [`node_label_contains`](crate::node_label_contains), but a *narrow* one:
+    /// it tests exactly the [`NODE_LABEL_KEYS`](crate::NODE_LABEL_KEYS), never
+    /// the whole serialised blob.
+    ///
+    /// Matching `properties::text` wholesale would also be a superset, and it
+    /// was the first version of this, but it is a bad one: the needles callers
+    /// pass are ordinary English words. `"rule"` matches every `DocumentChunk`
+    /// whose `text` property mentions "rule" or "rules", so on a large corpus
+    /// the query drags thousands of full-text rows over the wire for
+    /// `is_rule_node` to throw away — the opposite of the point. Testing the
+    /// five label keys is orders of magnitude tighter and still cannot lose a
+    /// row that satisfies the exact predicate.
+    ///
+    /// Both `type` the column and `type` the JSON key are tested because
+    /// [`Self::parse_node_row`] merges `properties` *over* the columns, so a
+    /// writer that put `type` in the blob is what the Rust predicate will see.
+    /// For the other four keys the blob is the only home. `->>` renders an
+    /// array-valued `labels` as its serialised text, which contains each
+    /// element verbatim — jsonb escapes only quotes, backslashes and control
+    /// characters, none of which appear in a label — so the array case survives
+    /// too. Postgres' `lower()` is Unicode-aware where Rust's
     /// `to_ascii_lowercase` is not, which again only widens the match.
     ///
-    /// This is a sequential scan — there is no index on `lower(properties::text)`
-    /// — but it returns a handful of rows instead of the whole `graph_node`
-    /// table plus the whole `graph_edge` table.
+    /// This is still a sequential scan — there is no index on the extracted
+    /// label keys — but it returns a handful of rows instead of the whole
+    /// `graph_node` table plus the whole `graph_edge` table.
     async fn get_candidate_nodes_by_label(&self, needle: &str) -> GraphDBResult<Vec<GraphNode>> {
-        let sql = "SELECT id, name, type, properties FROM graph_node \
-                   WHERE position($1 IN lower(type)) > 0 \
-                      OR position($1 IN lower(coalesce(properties::text, ''))) > 0";
+        // Built from `NODE_LABEL_KEYS` rather than spelled out, so the
+        // pushed-down predicate cannot drift from the Rust one. These are
+        // compile-time constants from this crate, not caller input, so the
+        // interpolation needs no `ALLOWED_FILTER_ATTRS`-style whitelist — and
+        // they land in a jsonb key literal, not an identifier position.
+        let mut clauses = vec!["position($1 IN lower(type)) > 0".to_string()];
+        clauses.extend(
+            crate::NODE_LABEL_KEYS.iter().map(|key| {
+                format!("position($1 IN lower(coalesce(properties->>'{key}', ''))) > 0")
+            }),
+        );
+        let sql = format!(
+            "SELECT id, name, type, properties FROM graph_node WHERE {}",
+            clauses.join(" OR ")
+        );
 
         let rows = self
             .db
             .query_all(Statement::from_sql_and_values(
                 DatabaseBackend::Postgres,
-                sql,
+                &sql,
                 [sea_orm::Value::from(needle.to_lowercase())],
             ))
             .await

--- a/crates/graph/src/traits.rs
+++ b/crates/graph/src/traits.rs
@@ -77,14 +77,23 @@ pub const NODE_LABEL_KEYS: [&str; 5] = ["type", "node_type", "kind", "label", "l
 /// compared ASCII-case-insensitively.
 ///
 /// A key holding a JSON string matches on substring; a key holding a JSON array
-/// matches if any string element does (Neo4j-style multi-`labels`). `needle`
-/// must already be lowercase — the constants callers pass are.
+/// matches if any string element does (Neo4j-style multi-`labels`).
+///
+/// `needle` is normalised here rather than required to arrive lowercase. The
+/// precondition version of this was a footgun: `PgGraphAdapter` lowercases the
+/// needle for its own SQL, so an uppercase `"Rule"` would return candidate rows
+/// from Postgres and then lose every one of them to this post-filter, while
+/// Ladybug returned an empty vec outright — a silent empty result rather than a
+/// failure. The one extra `to_ascii_lowercase` per call is noise next to the one
+/// already paid per candidate *value*.
 ///
 /// This is the exact predicate that
 /// [`GraphDBTrait::get_candidate_nodes_by_label`] narrows towards, factored out
 /// so that the needle a caller pushes into the query cannot drift from the one
 /// it re-applies to the rows that come back.
 pub fn node_label_contains(node_data: &NodeData, needle: &str) -> bool {
+    let needle = needle.to_ascii_lowercase();
+    let needle = needle.as_str();
     NODE_LABEL_KEYS.iter().any(|key| {
         node_data
             .get(*key)
@@ -700,13 +709,16 @@ pub trait GraphDBTrait: Send + Sync {
     /// So this method is deliberately specified as a *narrowing* read:
     /// implementations may return a **superset** of the exact predicate, and
     /// callers MUST re-apply [`node_label_contains`] to the rows that come
-    /// back. What every implementation does guarantee is that no node matching
-    /// the exact predicate is missing, and that no edge row is read at all.
+    /// back. The one guarantee every implementation owes is that no node
+    /// matching the exact predicate is missing from the result.
     ///
-    /// Default implementation falls back to the full graph load and returns its
-    /// node half — no worse than what a caller would have done by hand, and it
-    /// keeps out-of-tree backends compiling. `PgGraphAdapter` and
-    /// `LadybugAdapter` override it.
+    /// Avoiding the edge half is the *point* of the method, but it is a property
+    /// of the overrides, not of the trait: the default below falls back to
+    /// [`get_graph_data`](GraphDBTrait::get_graph_data) and takes its node half,
+    /// so a backend that does not override this still reads every edge row —
+    /// no worse than what the callers did by hand before, and it keeps
+    /// out-of-tree backends compiling. `PgGraphAdapter` and `LadybugAdapter`
+    /// override it and read nodes only.
     async fn get_candidate_nodes_by_label(&self, needle: &str) -> GraphDBResult<Vec<GraphNode>> {
         let _ = needle;
         Ok(self.get_graph_data().await?.0)
@@ -735,20 +747,28 @@ pub trait GraphDBTrait: Send + Sync {
     ///
     /// Backends should still override this with a single batched query: the
     /// default costs one `get_edges` round trip per resolved node plus one
-    /// batched [`get_nodes`](GraphDBTrait::get_nodes), and Ladybug must
-    /// override to return direction-correct edges (its
-    /// `get_connections`/`get_edges` report the queried node as the source
-    /// regardless of the stored direction, so the induced-subgraph filter here
-    /// would still select the right edges but the emitted direction would be
-    /// wrong).
+    /// batched [`get_nodes`](GraphDBTrait::get_nodes).
+    ///
+    /// **A backend whose `get_edges` reports the queried node as the source
+    /// regardless of the stored direction MUST override this method.** Ladybug
+    /// is such a backend, and does. Phase 2 reads the incident edges of *both*
+    /// endpoints of every internal edge, so on such a backend one stored edge
+    /// arrives twice with opposite directions — `(a, b, rel)` from `a` and
+    /// `(b, a, rel)` from `b` — and the `EdgeKey` dedup cannot collapse them,
+    /// because for a well-behaved backend those two tuples are two genuinely
+    /// different edges that both have to survive. The frontier-only walk this
+    /// replaced emitted such an edge once, with one arbitrary direction; the
+    /// failure is now a duplicate *and* a fabricated reverse, which a consumer
+    /// like graph search would double-count. That is a louder version of the
+    /// same underlying defect, not a new one, and it is not repairable here:
+    /// direction is information only the backend has.
     ///
     /// What the default guarantees, given a `get_edges` that reports edges
     /// verbatim: the node set, the edge set, `relationship_name` and edge
     /// properties all match the overrides, including seed-to-seed edges at
     /// `depth == 0` (the previous frontier-only version returned no edges at
-    /// all for that case). What it cannot repair is a backend whose
-    /// `get_edges` itself rewrites direction — the tuples are passed through
-    /// untouched.
+    /// all for that case). Edge tuples are passed through untouched, which is
+    /// both why that holds and why the direction caveat above does.
     async fn get_neighborhood(
         &self,
         node_ids: &[String],
@@ -1164,6 +1184,32 @@ mod tests {
         let mut other = NodeData::new();
         other.insert(Cow::Borrowed("text"), json!("a rule about rules"));
         assert!(!node_label_contains(&other, "rule"));
+    }
+
+    /// The needle's case is normalised by the function, not demanded of the
+    /// caller. When it was a precondition, `PgGraphAdapter` (which lowercases
+    /// the needle for its own SQL) returned candidate rows that this post-filter
+    /// then discarded every one of — a silently empty result on a public method.
+    #[test]
+    fn node_label_contains_normalises_the_needles_own_case() {
+        use serde_json::json;
+
+        let mut data = NodeData::new();
+        data.insert(Cow::Borrowed("kind"), json!("UserInteraction"));
+        for needle in ["interaction", "Interaction", "INTERACTION", "InterAction"] {
+            assert!(
+                node_label_contains(&data, needle),
+                "needle {needle:?} must match regardless of case"
+            );
+        }
+
+        let mut arr = NodeData::new();
+        arr.insert(Cow::Borrowed("labels"), json!(["Node", "CodingRule"]));
+        assert!(node_label_contains(&arr, "RULE"));
+
+        // Normalising the needle must not start matching things that do not
+        // contain it at all.
+        assert!(!node_label_contains(&arr, "INTERACTION"));
     }
 
     /// The default `get_candidate_nodes_by_label` is a documented fallback to

--- a/crates/graph/src/traits.rs
+++ b/crates/graph/src/traits.rs
@@ -63,6 +63,43 @@ pub(crate) fn extract_truth_epoch(value: Option<&Value>) -> i64 {
     }
 }
 
+/// The node properties that can carry a node's type-ish label.
+///
+/// cognee's graph rows reach Rust from several writers — the Rust pipeline, the
+/// Python SDK, and hand-written imports — which disagree on where they put a
+/// node's kind. Postgres and ladybug both have a first-class `type` column, but
+/// anything the writer put under `node_type`, `kind`, `label` or `labels` lands
+/// in the JSON `properties` blob and is merged back into the flat [`NodeData`]
+/// map on read, so a reader that only looks at `type` misses those rows.
+pub const NODE_LABEL_KEYS: [&str; 5] = ["type", "node_type", "kind", "label", "labels"];
+
+/// Whether any of [`NODE_LABEL_KEYS`] on `node_data` contains `needle`,
+/// compared ASCII-case-insensitively.
+///
+/// A key holding a JSON string matches on substring; a key holding a JSON array
+/// matches if any string element does (Neo4j-style multi-`labels`). `needle`
+/// must already be lowercase — the constants callers pass are.
+///
+/// This is the exact predicate that
+/// [`GraphDBTrait::get_candidate_nodes_by_label`] narrows towards, factored out
+/// so that the needle a caller pushes into the query cannot drift from the one
+/// it re-applies to the rows that come back.
+pub fn node_label_contains(node_data: &NodeData, needle: &str) -> bool {
+    NODE_LABEL_KEYS.iter().any(|key| {
+        node_data
+            .get(*key)
+            .map(|value| match value {
+                Value::String(text) => text.to_ascii_lowercase().contains(needle),
+                Value::Array(values) => values.iter().any(|item| {
+                    item.as_str()
+                        .is_some_and(|text| text.to_ascii_lowercase().contains(needle))
+                }),
+                _ => false,
+            })
+            .unwrap_or(false)
+    })
+}
+
 /// Graph database interface trait.
 ///
 /// This trait defines the complete set of operations for graph database interaction,
@@ -100,6 +137,7 @@ pub(crate) fn extract_truth_epoch(value: Option<&Value>) -> i64 {
 /// - `get_filtered_graph_data()` - Get filtered subgraph
 /// - `get_nodeset_subgraph()` - Get subgraph for specific nodes
 /// - `get_neighborhood()` - Get k-hop subgraph around a set of seed nodes
+/// - `get_candidate_nodes_by_label()` - Get nodes-only candidates by type-ish label
 #[async_trait]
 pub trait GraphDBTrait: Send + Sync {
     /// Initialize the database schema.
@@ -647,24 +685,70 @@ pub trait GraphDBTrait: Send + Sync {
         Ok((filtered_nodes, filtered_edges))
     }
 
+    /// Fetch **candidate** nodes whose type-ish label contains `needle`,
+    /// without materialising the edge half of the graph.
+    ///
+    /// The predicate callers actually want is [`node_label_contains`]: any of
+    /// [`NODE_LABEL_KEYS`] containing `needle` ASCII-case-insensitively, over
+    /// both string and string-array values. That is a substring test across
+    /// five keys, four of which live inside the JSON `properties` blob, so it
+    /// is **not** expressible through
+    /// [`get_filtered_graph_data`](GraphDBTrait::get_filtered_graph_data), whose
+    /// contract is an exact `IN (…)` match on the `id`/`name`/`type` columns
+    /// (`PgGraphAdapter` even rejects any other attribute name outright).
+    ///
+    /// So this method is deliberately specified as a *narrowing* read:
+    /// implementations may return a **superset** of the exact predicate, and
+    /// callers MUST re-apply [`node_label_contains`] to the rows that come
+    /// back. What every implementation does guarantee is that no node matching
+    /// the exact predicate is missing, and that no edge row is read at all.
+    ///
+    /// Default implementation falls back to the full graph load and returns its
+    /// node half — no worse than what a caller would have done by hand, and it
+    /// keeps out-of-tree backends compiling. `PgGraphAdapter` and
+    /// `LadybugAdapter` override it.
+    async fn get_candidate_nodes_by_label(&self, needle: &str) -> GraphDBResult<Vec<GraphNode>> {
+        let _ = needle;
+        Ok(self.get_graph_data().await?.0)
+    }
+
     /// Fetch the raw k-hop neighborhood subgraph around a set of seed node ids.
     ///
     /// Returns every node reachable within `depth` hops of any seed, together
     /// with every edge whose endpoints are both in that resolved set, in the
-    /// same `(nodes, edges)` shape as [`get_graph_data`]. Edges preserve their
+    /// same `(nodes, edges)` shape as
+    /// [`get_graph_data`](GraphDBTrait::get_graph_data). Edges preserve their
     /// **true stored** `(source_id, target_id)` direction; the caller is
     /// responsible for any partitioning (e.g. keeping only edges incident to a
     /// seed).
     ///
-    /// Default implementation performs a layered BFS over [`get_connections`].
-    /// Backends should override with a single batched query for efficiency and,
-    /// in Ladybug's case, to return direction-correct edges (its
-    /// `get_connections`/`get_edges` report the queried node as the source
-    /// regardless of the stored direction).
+    /// Default implementation runs the same two phases as the real adapters
+    /// (`PgGraphAdapter`'s recursive CTE, `LadybugAdapter`'s traversal), only
+    /// through the per-node trait surface: an undirected BFS over
+    /// [`get_edges`](GraphDBTrait::get_edges) resolves the id set out to
+    /// `depth`, then a second pass re-reads the edges incident to every
+    /// resolved node and keeps the ones whose **both** endpoints are resolved —
+    /// the induced subgraph the contract above promises. Collecting edges
+    /// during the walk instead (only the ones incident to the current frontier)
+    /// silently omits edges between two nodes discovered at the same depth,
+    /// which is exactly the outermost layer of every result.
     ///
-    /// Note: at `depth == 0` this default path returns only the seed nodes with
-    /// no edges, whereas the real-backend overrides include seed-to-seed edges.
-    /// Phase 1 only ever calls with `depth == 1`.
+    /// Backends should still override this with a single batched query: the
+    /// default costs one `get_edges` round trip per resolved node plus one
+    /// batched [`get_nodes`](GraphDBTrait::get_nodes), and Ladybug must
+    /// override to return direction-correct edges (its
+    /// `get_connections`/`get_edges` report the queried node as the source
+    /// regardless of the stored direction, so the induced-subgraph filter here
+    /// would still select the right edges but the emitted direction would be
+    /// wrong).
+    ///
+    /// What the default guarantees, given a `get_edges` that reports edges
+    /// verbatim: the node set, the edge set, `relationship_name` and edge
+    /// properties all match the overrides, including seed-to-seed edges at
+    /// `depth == 0` (the previous frontier-only version returned no edges at
+    /// all for that case). What it cannot repair is a backend whose
+    /// `get_edges` itself rewrites direction — the tuples are passed through
+    /// untouched.
     async fn get_neighborhood(
         &self,
         node_ids: &[String],
@@ -674,70 +758,35 @@ pub trait GraphDBTrait: Send + Sync {
             return Ok((vec![], vec![]));
         }
 
-        let mut nodes_by_id: HashMap<String, NodeData> = HashMap::new();
-        let mut visited: HashSet<String> = HashSet::new();
+        // Phase 1: resolve the id set by undirected BFS out to `depth`. The
+        // edges read here only serve to find the next layer; keeping *them* as
+        // the result is what dropped the same-depth edges.
+        let mut resolved: HashSet<String> = HashSet::new();
         let mut frontier: Vec<String> = Vec::new();
-
         for id in node_ids {
-            if visited.insert(id.clone()) {
+            if resolved.insert(id.clone()) {
                 frontier.push(id.clone());
-                // Seed node lookup so isolated seeds still appear in the output.
-                if let Some(node) = self.get_node(id).await? {
-                    nodes_by_id.insert(id.clone(), node);
-                }
             }
         }
 
-        let mut edges: Vec<EdgeData> = Vec::new();
-        let mut edge_keys: HashSet<EdgeKey> = HashSet::new();
+        // Edges already fetched, keyed by the node they were fetched for, so
+        // phase 2 only pays for the layer the BFS never expanded.
+        let mut fetched: HashMap<String, Vec<EdgeData>> = HashMap::new();
 
         for _ in 0..depth {
             let mut next_frontier: Vec<String> = Vec::new();
             for id in &frontier {
-                for (source_node, edge_props, target_node) in self.get_connections(id).await? {
-                    let source_id = source_node
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or_default()
-                        .to_string();
-                    let target_id = target_node
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or_default()
-                        .to_string();
-                    let relationship_name = edge_props
-                        .get("relationship_name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or_default()
-                        .to_string();
-
-                    let key: EdgeKey = (
-                        source_id.clone(),
-                        target_id.clone(),
-                        relationship_name.clone(),
-                    );
-                    if edge_keys.insert(key) {
-                        edges.push((
-                            source_id.clone(),
-                            target_id.clone(),
-                            relationship_name,
-                            edge_props,
-                        ));
-                    }
-
-                    // The endpoint that isn't the queried node is a candidate
-                    // neighbor for the next layer.
-                    let neighbor_id = if source_id == *id {
-                        target_id.clone()
-                    } else {
-                        source_id.clone()
-                    };
-                    nodes_by_id.insert(source_id, source_node);
-                    nodes_by_id.insert(target_id, target_node);
-                    if visited.insert(neighbor_id.clone()) {
-                        next_frontier.push(neighbor_id);
+                let incident = self.get_edges(id).await?;
+                for (src, tgt, _, _) in &incident {
+                    // Undirected step: whichever endpoint is not the queried
+                    // node is a candidate for the next layer. A self-loop
+                    // yields `id` itself, which is already resolved.
+                    let neighbor = if src == id { tgt } else { src };
+                    if resolved.insert(neighbor.clone()) {
+                        next_frontier.push(neighbor.clone());
                     }
                 }
+                fetched.insert(id.clone(), incident);
             }
             if next_frontier.is_empty() {
                 break;
@@ -745,7 +794,50 @@ pub trait GraphDBTrait: Send + Sync {
             frontier = next_frontier;
         }
 
-        Ok((nodes_by_id.into_iter().collect(), edges))
+        // Phase 2: the induced subgraph over `resolved`. Every edge of that set
+        // is incident to at least one of its nodes, so reading the incident
+        // edges of all of them and dropping the ones with an unresolved
+        // endpoint yields exactly the induced edge set. Each surviving edge is
+        // seen twice (once per endpoint), hence the `EdgeKey` dedup.
+        //
+        // Sorted ids keep the output order deterministic across runs, which a
+        // `HashSet` iteration would not.
+        let mut resolved_ids: Vec<String> = resolved.iter().cloned().collect();
+        resolved_ids.sort();
+
+        let mut edges: Vec<EdgeData> = Vec::new();
+        let mut edge_keys: HashSet<EdgeKey> = HashSet::new();
+
+        for id in &resolved_ids {
+            let incident = match fetched.remove(id) {
+                Some(incident) => incident,
+                None => self.get_edges(id).await?,
+            };
+            for edge in incident {
+                let (src, tgt, rel, _) = &edge;
+                if !resolved.contains(src.as_str()) || !resolved.contains(tgt.as_str()) {
+                    continue;
+                }
+                if edge_keys.insert((src.clone(), tgt.clone(), rel.clone())) {
+                    edges.push(edge);
+                }
+            }
+        }
+
+        // One batched read for the node half. A resolved id with no row in the
+        // node store is dropped, matching the overrides — their node halves
+        // select from `graph_node`/`(n:Node)` and cannot invent a row either.
+        let nodes: Vec<GraphNode> = self
+            .get_nodes(&resolved_ids)
+            .await?
+            .into_iter()
+            .filter_map(|data| {
+                let id = data.get("id").and_then(|v| v.as_str())?.to_string();
+                Some((id, data))
+            })
+            .collect();
+
+        Ok((nodes, edges))
     }
 }
 
@@ -898,6 +990,195 @@ mod tests {
                 .get_nodeset_subgraph(node_type, node_names, node_name_filter_operator)
                 .await
         }
+    }
+
+    /// Seed a small graph on `db`: nodes `ids`, edges `edges`.
+    async fn seed(db: &DefaultImplDb, ids: &[&str], edges: &[(&str, &str, &str)]) {
+        for id in ids {
+            db.add_node_raw(serde_json::json!({"id": *id, "name": *id, "type": "T"}))
+                .await
+                .unwrap();
+        }
+        for (src, tgt, rel) in edges {
+            db.add_edge(src, tgt, rel, None).await.unwrap();
+        }
+    }
+
+    fn edge_keys(edges: &[EdgeData]) -> Vec<EdgeKey> {
+        let mut keys: Vec<EdgeKey> = edges
+            .iter()
+            .map(|(s, t, r, _)| (s.clone(), t.clone(), r.clone()))
+            .collect();
+        keys.sort();
+        keys
+    }
+
+    fn node_ids(nodes: &[GraphNode]) -> Vec<String> {
+        let mut ids: Vec<String> = nodes.iter().map(|(id, _)| id.clone()).collect();
+        ids.sort();
+        ids
+    }
+
+    /// The contract says "every edge whose endpoints are both in that resolved
+    /// set". The frontier-only walk this replaced never queried the outermost
+    /// layer, so `b -> c` — both ends at depth 1 — went missing.
+    #[tokio::test]
+    async fn default_neighborhood_returns_the_induced_subgraph() {
+        let db = DefaultImplDb::default();
+        seed(
+            &db,
+            &["a", "b", "c"],
+            &[("a", "b", "r1"), ("a", "c", "r2"), ("b", "c", "r3")],
+        )
+        .await;
+
+        let (nodes, edges) = db
+            .get_neighborhood(&["a".to_string()], 1)
+            .await
+            .expect("neighborhood");
+
+        assert_eq!(node_ids(&nodes), vec!["a", "b", "c"]);
+        assert_eq!(
+            edge_keys(&edges),
+            vec![
+                ("a".to_string(), "b".to_string(), "r1".to_string()),
+                ("a".to_string(), "c".to_string(), "r2".to_string()),
+                ("b".to_string(), "c".to_string(), "r3".to_string()),
+            ],
+            "the edge between the two depth-1 nodes must be included"
+        );
+    }
+
+    /// `depth == 0` used to return the seeds with no edges at all, which is not
+    /// what `PgGraphAdapter`/`LadybugAdapter`/`MockGraphDB` do — they return the
+    /// seed-to-seed edges. The default now agrees with them.
+    #[tokio::test]
+    async fn default_neighborhood_includes_seed_to_seed_edges_at_depth_zero() {
+        let db = DefaultImplDb::default();
+        seed(&db, &["a", "b", "c"], &[("a", "b", "r1"), ("b", "c", "r2")]).await;
+
+        let (nodes, edges) = db
+            .get_neighborhood(&["a".to_string(), "b".to_string()], 0)
+            .await
+            .expect("neighborhood");
+
+        assert_eq!(node_ids(&nodes), vec!["a", "b"]);
+        assert_eq!(
+            edge_keys(&edges),
+            vec![("a".to_string(), "b".to_string(), "r1".to_string())],
+        );
+    }
+
+    /// Edges are read through `get_edges`, which carries the relationship name;
+    /// the previous walk read them through `get_connections`, which does not, so
+    /// every edge came back with an empty `relationship_name` and two parallel
+    /// edges collapsed into one.
+    #[tokio::test]
+    async fn default_neighborhood_preserves_relationship_names_and_direction() {
+        let db = DefaultImplDb::default();
+        seed(
+            &db,
+            &["a", "b"],
+            &[("b", "a", "authored"), ("b", "a", "reviewed")],
+        )
+        .await;
+
+        let (_, edges) = db
+            .get_neighborhood(&["a".to_string()], 1)
+            .await
+            .expect("neighborhood");
+
+        assert_eq!(
+            edge_keys(&edges),
+            vec![
+                ("b".to_string(), "a".to_string(), "authored".to_string()),
+                ("b".to_string(), "a".to_string(), "reviewed".to_string()),
+            ],
+            "both parallel edges survive, with the stored b -> a direction"
+        );
+    }
+
+    /// The depth boundary itself is an equivalence pin — the frontier-only walk
+    /// stopped at `depth` too, and dropped the edge leaving the set rather than
+    /// dragging its far endpoint in. The `relationship_name` in the expectation
+    /// is not: that half fails before the fix.
+    #[tokio::test]
+    async fn default_neighborhood_stops_at_depth_and_drops_dangling_edges() {
+        let db = DefaultImplDb::default();
+        seed(&db, &["a", "b", "c"], &[("a", "b", "r1"), ("b", "c", "r2")]).await;
+
+        let (nodes, edges) = db
+            .get_neighborhood(&["a".to_string()], 1)
+            .await
+            .expect("neighborhood");
+
+        assert_eq!(node_ids(&nodes), vec!["a", "b"]);
+        assert_eq!(
+            edge_keys(&edges),
+            vec![("a".to_string(), "b".to_string(), "r1".to_string())],
+        );
+    }
+
+    /// Equivalence pin (passes before and after the fix): an isolated seed still
+    /// appears as a node, and a seed with no row in the store is still dropped,
+    /// matching every override. The seed half moved from a per-seed `get_node`
+    /// to one batched `get_nodes`, so it is worth holding in place.
+    #[tokio::test]
+    async fn default_neighborhood_keeps_isolated_seeds_and_drops_unknown_ids() {
+        let db = DefaultImplDb::default();
+        seed(&db, &["lonely"], &[]).await;
+
+        let (nodes, edges) = db
+            .get_neighborhood(&["lonely".to_string(), "ghost".to_string()], 1)
+            .await
+            .expect("neighborhood");
+
+        assert_eq!(node_ids(&nodes), vec!["lonely"]);
+        assert!(edges.is_empty());
+    }
+
+    #[test]
+    fn node_label_contains_scans_every_label_key_case_insensitively() {
+        use serde_json::json;
+
+        let mut data = NodeData::new();
+        data.insert(Cow::Borrowed("type"), json!("DocumentChunk"));
+        assert!(!node_label_contains(&data, "interaction"));
+
+        // A key that only exists inside the JSON properties blob still counts.
+        data.insert(Cow::Borrowed("kind"), json!("UserINTERACTION"));
+        assert!(node_label_contains(&data, "interaction"));
+
+        // Array-valued labels (Neo4j-style multi-label) match element-wise.
+        let mut arr = NodeData::new();
+        arr.insert(Cow::Borrowed("labels"), json!(["Node", "CodingRule"]));
+        assert!(node_label_contains(&arr, "rule"));
+        assert!(!node_label_contains(&arr, "interaction"));
+
+        // Non-string values are ignored rather than stringified.
+        let mut num = NodeData::new();
+        num.insert(Cow::Borrowed("kind"), json!(42));
+        assert!(!node_label_contains(&num, "4"));
+
+        // Keys outside NODE_LABEL_KEYS are not consulted.
+        let mut other = NodeData::new();
+        other.insert(Cow::Borrowed("text"), json!("a rule about rules"));
+        assert!(!node_label_contains(&other, "rule"));
+    }
+
+    /// The default `get_candidate_nodes_by_label` is a documented fallback to
+    /// the full graph load, so it must return the node half *unfiltered* — the
+    /// caller's own predicate is what narrows it.
+    #[tokio::test]
+    async fn default_candidate_nodes_by_label_returns_the_whole_node_half() {
+        let db = DefaultImplDb::default();
+        seed(&db, &["a", "b"], &[("a", "b", "r1")]).await;
+
+        let nodes = db
+            .get_candidate_nodes_by_label("interaction")
+            .await
+            .expect("candidates");
+        assert_eq!(node_ids(&nodes), vec!["a", "b"]);
     }
 
     /// The defaulted `close()` must be a no-op *and* idempotent for a backend

--- a/crates/graph/tests/common/mod.rs
+++ b/crates/graph/tests/common/mod.rs
@@ -480,6 +480,68 @@ pub async fn test_get_filtered_graph_data(db: &dyn GraphDBTrait) {
     assert_eq!(edges.len(), 1);
 }
 
+/// Node whose type-ish label sits in a *property* (`kind`) rather than in the
+/// backend's `type` column — the case `get_filtered_graph_data` cannot express
+/// and `get_candidate_nodes_by_label` exists for.
+#[derive(Debug, Clone, Serialize)]
+struct LabelledTestNode {
+    id: String,
+    name: String,
+    #[serde(rename = "type")]
+    node_type: String,
+    kind: String,
+}
+
+pub async fn test_get_candidate_nodes_by_label(db: &dyn GraphDBTrait) {
+    db.delete_graph().await.unwrap();
+
+    let interaction = TestNode::new("cl_i", "Chat 1", "UserInteraction", 0);
+    let noise = TestNode::new("cl_n", "Zulu", "Widget", 0);
+    db.add_nodes(&[&interaction, &noise]).await.unwrap();
+    db.add_node(&LabelledTestNode {
+        id: "cl_r".to_string(),
+        name: "Prefer explicit errors".to_string(),
+        node_type: "Node".to_string(),
+        kind: "CodingRule".to_string(),
+    })
+    .await
+    .unwrap();
+    db.add_edge("cl_i", "cl_n", "r", None).await.unwrap();
+
+    // The contract is a *superset* of the exact predicate, so only membership
+    // and the exclusion of a row with no trace of the needle are asserted.
+    let ids = |nodes: Vec<(String, cognee_graph::NodeData)>| {
+        let mut ids: Vec<String> = nodes.into_iter().map(|(id, _)| id).collect();
+        ids.sort();
+        ids
+    };
+
+    let interactions = ids(db
+        .get_candidate_nodes_by_label("interaction")
+        .await
+        .unwrap());
+    assert!(
+        interactions.contains(&"cl_i".to_string()),
+        "a node whose `type` column carries the label must be a candidate: {interactions:?}"
+    );
+    assert!(
+        !interactions.contains(&"cl_n".to_string()),
+        "an unrelated node must not be returned: {interactions:?}"
+    );
+
+    // `kind` lives inside the serialised properties, which is the half a
+    // column-only filter would miss.
+    let rules = ids(db.get_candidate_nodes_by_label("rule").await.unwrap());
+    assert!(
+        rules.contains(&"cl_r".to_string()),
+        "a node whose label sits in a property must be a candidate: {rules:?}"
+    );
+    assert!(
+        !rules.contains(&"cl_n".to_string()),
+        "an unrelated node must not be returned: {rules:?}"
+    );
+}
+
 pub async fn test_get_nodeset_subgraph_or(db: &dyn GraphDBTrait) {
     db.delete_graph().await.unwrap();
 

--- a/crates/graph/tests/common/mod.rs
+++ b/crates/graph/tests/common/mod.rs
@@ -492,6 +492,17 @@ struct LabelledTestNode {
     kind: String,
 }
 
+/// Node carrying prose in a `text` property, like a real `DocumentChunk`. Its
+/// body mentions the needle, but none of its *labels* do.
+#[derive(Debug, Clone, Serialize)]
+struct ProseTestNode {
+    id: String,
+    name: String,
+    #[serde(rename = "type")]
+    node_type: String,
+    text: String,
+}
+
 pub async fn test_get_candidate_nodes_by_label(db: &dyn GraphDBTrait) {
     db.delete_graph().await.unwrap();
 
@@ -503,6 +514,14 @@ pub async fn test_get_candidate_nodes_by_label(db: &dyn GraphDBTrait) {
         name: "Prefer explicit errors".to_string(),
         node_type: "Node".to_string(),
         kind: "CodingRule".to_string(),
+    })
+    .await
+    .unwrap();
+    db.add_node(&ProseTestNode {
+        id: "cl_prose".to_string(),
+        name: "Chunk 7".to_string(),
+        node_type: "DocumentChunk".to_string(),
+        text: "The coding rules below apply to every interaction with the agent.".to_string(),
     })
     .await
     .unwrap();
@@ -539,6 +558,37 @@ pub async fn test_get_candidate_nodes_by_label(db: &dyn GraphDBTrait) {
     assert!(
         !rules.contains(&"cl_n".to_string()),
         "an unrelated node must not be returned: {rules:?}"
+    );
+
+    // The needle is an ordinary English word, so a filter that matches the whole
+    // serialised property blob sweeps in every chunk of prose that happens to
+    // use it. On a large corpus that is thousands of full-text rows fetched for
+    // the caller's post-filter to discard — which is the cost this method exists
+    // to avoid, so it is part of the contract, not an implementation detail.
+    assert!(
+        !rules.contains(&"cl_prose".to_string()),
+        "a node that merely mentions the needle in its text must not be a \
+         candidate — the filter is on labels, not on content: {rules:?}"
+    );
+    assert!(
+        !ids(db
+            .get_candidate_nodes_by_label("interaction")
+            .await
+            .unwrap())
+        .contains(&"cl_prose".to_string()),
+        "likewise for the interaction needle"
+    );
+
+    // The needle's case is normalised by the implementation, not required of the
+    // caller: `PgGraphAdapter` lowercases it for its SQL, so a mixed-case needle
+    // used to return rows there and an empty vec from Ladybug.
+    assert_eq!(
+        ids(db
+            .get_candidate_nodes_by_label("InterAction")
+            .await
+            .unwrap()),
+        interactions,
+        "a mixed-case needle must behave exactly like its lowercase form"
     );
 }
 

--- a/crates/graph/tests/ladybug_integration.rs
+++ b/crates/graph/tests/ladybug_integration.rs
@@ -60,6 +60,7 @@ ladybug_test!(test_get_graph_data);
 ladybug_test!(test_get_graph_data_surfaces_created_at);
 ladybug_test!(test_get_graph_metrics);
 ladybug_test!(test_get_filtered_graph_data);
+ladybug_test!(test_get_candidate_nodes_by_label);
 ladybug_test!(test_get_nodeset_subgraph_or);
 ladybug_test!(test_get_nodeset_subgraph_and);
 ladybug_test!(test_get_id_filtered_graph_data);

--- a/crates/graph/tests/pg_graph_integration.rs
+++ b/crates/graph/tests/pg_graph_integration.rs
@@ -134,6 +134,7 @@ pggraph_test!(test_get_graph_data);
 pggraph_test!(test_get_graph_data_surfaces_created_at);
 pggraph_test!(test_get_graph_metrics);
 pggraph_test!(test_get_filtered_graph_data);
+pggraph_test!(test_get_candidate_nodes_by_label);
 pggraph_test!(test_get_nodeset_subgraph_or);
 pggraph_test!(test_get_nodeset_subgraph_and);
 pggraph_test!(test_get_id_filtered_graph_data);

--- a/crates/search/src/retrievers/lucky_feedback_rules_retrievers.rs
+++ b/crates/search/src/retrievers/lucky_feedback_rules_retrievers.rs
@@ -152,9 +152,8 @@ const DEFAULT_FEEDBACK_LAST_K: usize = 5;
 const DEFAULT_RULE_NODE_SET: &str = "coding_agent_rules";
 
 /// Substrings a node's type-ish label must contain to be an interaction / a
-/// coding rule. Must stay lowercase: `cognee_graph::node_label_contains`
-/// lowercases only the *stored* side of the comparison, and the same constant
-/// is what gets pushed into the store's own query.
+/// coding rule. The same constant is both pushed into the store's own query and
+/// re-applied to the rows that come back, so the two cannot disagree.
 const INTERACTION_LABEL_NEEDLE: &str = "interaction";
 const RULE_LABEL_NEEDLE: &str = "rule";
 
@@ -334,8 +333,10 @@ impl FeedbackRetriever {
         // Ask the store for interaction-labelled node rows instead of the whole
         // graph. The result is only a candidate set (see
         // `get_candidate_nodes_by_label`), so `is_interaction_node` still has
-        // the last word — but the edge half, which this method never looked at,
-        // is no longer read at all.
+        // the last word. On the adapters that override that method the edge
+        // half — which this function never looked at — is not read at all; on
+        // the trait default it still is, and this is then no worse than the
+        // `get_graph_data()` call it replaced.
         let nodes = self
             .graph_db
             .get_candidate_nodes_by_label(INTERACTION_LABEL_NEEDLE)
@@ -476,8 +477,8 @@ impl CodingRulesRetriever {
 
         let requested_sets = self.parse_rule_sets(query);
         // Same narrowing as `FeedbackRetriever::recent_interaction_ids`: rule
-        // rows only, no edges, and `is_rule_node` re-checked below because the
-        // store is allowed to hand back a superset.
+        // rows only on the overriding adapters, and `is_rule_node` re-checked
+        // below because the store is allowed to hand back a superset.
         let nodes = self
             .graph_db
             .get_candidate_nodes_by_label(RULE_LABEL_NEEDLE)

--- a/crates/search/src/retrievers/lucky_feedback_rules_retrievers.rs
+++ b/crates/search/src/retrievers/lucky_feedback_rules_retrievers.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use cognee_graph::{GraphDBTrait, GraphDBTraitExt};
+use cognee_graph::{GraphDBTrait, GraphDBTraitExt, node_label_contains};
 use cognee_llm::{GenerationOptions, Llm, LlmExt, Message};
 use cognee_session::SessionContext;
 use schemars::JsonSchema;
@@ -150,6 +150,13 @@ const DEFAULT_FEEDBACK_EDGE_REL: &str = "HAS_FEEDBACK";
 const DEFAULT_FEEDBACK_LAST_K: usize = 5;
 
 const DEFAULT_RULE_NODE_SET: &str = "coding_agent_rules";
+
+/// Substrings a node's type-ish label must contain to be an interaction / a
+/// coding rule. Must stay lowercase: `cognee_graph::node_label_contains`
+/// lowercases only the *stored* side of the comparison, and the same constant
+/// is what gets pushed into the store's own query.
+const INTERACTION_LABEL_NEEDLE: &str = "interaction";
+const RULE_LABEL_NEEDLE: &str = "rule";
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 struct FeedbackAnalysis {
@@ -310,22 +317,7 @@ impl FeedbackRetriever {
     }
 
     fn is_interaction_node(node_data: &HashMap<Cow<'static, str>, Value>) -> bool {
-        ["type", "node_type", "kind", "label", "labels"]
-            .iter()
-            .any(|key| {
-                node_data
-                    .get(*key)
-                    .map(|value| match value {
-                        Value::String(text) => text.to_ascii_lowercase().contains("interaction"),
-                        Value::Array(values) => values.iter().any(|item| {
-                            item.as_str()
-                                .map(|text| text.to_ascii_lowercase().contains("interaction"))
-                                .unwrap_or(false)
-                        }),
-                        _ => false,
-                    })
-                    .unwrap_or(false)
-            })
+        node_label_contains(node_data, INTERACTION_LABEL_NEEDLE)
     }
 
     fn parse_node_timestamp(
@@ -339,7 +331,15 @@ impl FeedbackRetriever {
     }
 
     async fn recent_interaction_ids(&self) -> Result<Vec<String>, SearchError> {
-        let (nodes, _) = self.graph_db.get_graph_data().await?;
+        // Ask the store for interaction-labelled node rows instead of the whole
+        // graph. The result is only a candidate set (see
+        // `get_candidate_nodes_by_label`), so `is_interaction_node` still has
+        // the last word — but the edge half, which this method never looked at,
+        // is no longer read at all.
+        let nodes = self
+            .graph_db
+            .get_candidate_nodes_by_label(INTERACTION_LABEL_NEEDLE)
+            .await?;
 
         let mut interactions = nodes
             .into_iter()
@@ -466,22 +466,7 @@ impl CodingRulesRetriever {
     }
 
     fn is_rule_node(node_data: &HashMap<Cow<'static, str>, Value>) -> bool {
-        ["type", "node_type", "kind", "label", "labels"]
-            .iter()
-            .any(|key| {
-                node_data
-                    .get(*key)
-                    .map(|value| match value {
-                        Value::String(text) => text.to_ascii_lowercase().contains("rule"),
-                        Value::Array(values) => values.iter().any(|item| {
-                            item.as_str()
-                                .map(|text| text.to_ascii_lowercase().contains("rule"))
-                                .unwrap_or(false)
-                        }),
-                        _ => false,
-                    })
-                    .unwrap_or(false)
-            })
+        node_label_contains(node_data, RULE_LABEL_NEEDLE)
     }
 
     async fn load_rules(&self, query: &str) -> Result<Vec<Rule>, SearchError> {
@@ -490,7 +475,13 @@ impl CodingRulesRetriever {
         }
 
         let requested_sets = self.parse_rule_sets(query);
-        let (nodes, _) = self.graph_db.get_graph_data().await?;
+        // Same narrowing as `FeedbackRetriever::recent_interaction_ids`: rule
+        // rows only, no edges, and `is_rule_node` re-checked below because the
+        // store is allowed to hand back a superset.
+        let nodes = self
+            .graph_db
+            .get_candidate_nodes_by_label(RULE_LABEL_NEEDLE)
+            .await?;
 
         let mut rules = nodes
             .into_iter()
@@ -698,6 +689,221 @@ mod tests {
         node_set: Option<String>,
         text: Option<String>,
         created_at: Option<String>,
+    }
+
+    /// A node whose label lives under a key other than `type`, to prove the
+    /// narrowed read still finds it. `MockGraphDB` stores whatever the writer
+    /// serialised, so `kind`/`labels` land in the flat node map exactly as they
+    /// would after `PgGraphAdapter` merges the `properties` jsonb back in.
+    #[derive(Serialize)]
+    struct LabelledNode {
+        id: String,
+        kind: Option<String>,
+        labels: Option<Vec<String>>,
+        node_set: Option<String>,
+        text: Option<String>,
+        created_at: Option<String>,
+    }
+
+    /// Fill the graph with rows neither retriever wants, so a full scan is
+    /// visibly more expensive than a narrowed read.
+    async fn add_noise(graph_db: &MockGraphDB) {
+        for i in 0..20 {
+            graph_db
+                .add_node(&TestNode {
+                    id: format!("chunk-{i}"),
+                    kind: "DocumentChunk".to_string(),
+                    node_set: None,
+                    text: Some(format!("body {i}")),
+                    created_at: None,
+                })
+                .await
+                .unwrap();
+        }
+        for i in 0..19 {
+            graph_db
+                .add_edge(
+                    &format!("chunk-{i}"),
+                    &format!("chunk-{}", i + 1),
+                    "NEXT",
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn coding_rules_retriever_does_not_scan_the_whole_graph() {
+        let graph_db = Arc::new(MockGraphDB::new());
+        add_noise(&graph_db).await;
+        graph_db
+            .add_node(&TestNode {
+                id: Uuid::new_v4().to_string(),
+                kind: "Rule".to_string(),
+                node_set: Some("coding_agent_rules".to_string()),
+                text: Some("Prefer explicit error handling".to_string()),
+                created_at: None,
+            })
+            .await
+            .unwrap();
+
+        let retriever = CodingRulesRetriever::new(graph_db.clone(), None);
+        let output = retriever
+            .get_completion(
+                "coding_agent_rules",
+                None,
+                &SessionContext::default(),
+                &SearchParams::default(),
+            )
+            .await
+            .unwrap();
+
+        match output {
+            SearchOutput::Rules(rules) => assert_eq!(rules.len(), 1),
+            _ => panic!("expected rules output"),
+        }
+
+        let log = graph_db.get_call_log();
+        assert!(
+            log.contains(&"get_candidate_nodes_by_label".to_string()),
+            "rule loading must go through the narrowed read, got {log:?}"
+        );
+        assert!(
+            !log.contains(&"get_graph_data".to_string())
+                && !log.contains(&"get_filtered_graph_data".to_string()),
+            "rule loading must not materialise the whole graph, got {log:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn feedback_retriever_does_not_scan_the_whole_graph() {
+        let graph_db = Arc::new(MockGraphDB::new());
+        add_noise(&graph_db).await;
+        graph_db
+            .add_node(&TestNode {
+                id: Uuid::new_v4().to_string(),
+                kind: "Interaction".to_string(),
+                node_set: None,
+                text: Some("Q/A interaction".to_string()),
+                created_at: Some(Utc::now().to_rfc3339()),
+            })
+            .await
+            .unwrap();
+
+        let llm = Arc::new(TestLlm {
+            plain_responses: Mutex::new(VecDeque::new()),
+            feedback_response: Some(FeedbackAnalysis {
+                sentiment: "positive".to_string(),
+                score: 0.5,
+            }),
+        });
+
+        let retriever = FeedbackRetriever::new(graph_db.clone(), llm, Some(3), None);
+        retriever
+            .get_completion(
+                "Great answer",
+                None,
+                &SessionContext::default(),
+                &SearchParams::default(),
+            )
+            .await
+            .unwrap();
+
+        // Snapshot before asserting on the graph itself — `get_graph_data` is
+        // logged, so reading it first would poison the assertion below.
+        let log = graph_db.get_call_log();
+        assert!(
+            log.contains(&"get_candidate_nodes_by_label".to_string()),
+            "interaction lookup must go through the narrowed read, got {log:?}"
+        );
+        assert!(
+            !log.contains(&"get_graph_data".to_string())
+                && !log.contains(&"get_filtered_graph_data".to_string()),
+            "interaction lookup must not materialise the whole graph, got {log:?}"
+        );
+
+        let (_nodes, edges) = graph_db.get_graph_data().await.unwrap();
+        assert!(
+            edges
+                .iter()
+                .any(|(_, _, relationship, _)| relationship == "HAS_FEEDBACK"),
+            "the feedback edge to the interaction node must still be written"
+        );
+    }
+
+    /// Equivalence pin (passes before and after the narrowing): the label may
+    /// sit under `kind` or `labels` rather than the `type` column, so the
+    /// narrowed read must not degenerate into an exact match on `type` — which
+    /// is all `get_filtered_graph_data` can express.
+    #[tokio::test]
+    async fn narrowed_read_still_finds_labels_outside_the_type_column() {
+        let graph_db = Arc::new(MockGraphDB::new());
+        add_noise(&graph_db).await;
+        graph_db
+            .add_node(&LabelledNode {
+                id: "rule-in-labels".to_string(),
+                kind: None,
+                labels: Some(vec!["Node".to_string(), "CodingRule".to_string()]),
+                node_set: Some("coding_agent_rules".to_string()),
+                text: Some("Labels-only rule".to_string()),
+                created_at: None,
+            })
+            .await
+            .unwrap();
+        graph_db
+            .add_node(&LabelledNode {
+                id: "interaction-in-kind".to_string(),
+                kind: Some("UserInteraction".to_string()),
+                labels: None,
+                node_set: None,
+                text: Some("kind-only interaction".to_string()),
+                created_at: Some(Utc::now().to_rfc3339()),
+            })
+            .await
+            .unwrap();
+
+        let rules = CodingRulesRetriever::new(graph_db.clone(), None)
+            .get_completion(
+                "coding_agent_rules",
+                None,
+                &SessionContext::default(),
+                &SearchParams::default(),
+            )
+            .await
+            .unwrap();
+        match rules {
+            SearchOutput::Rules(rules) => {
+                assert_eq!(rules.len(), 1);
+                assert_eq!(rules[0].text, "Labels-only rule");
+            }
+            _ => panic!("expected rules output"),
+        }
+
+        let llm = Arc::new(TestLlm {
+            plain_responses: Mutex::new(VecDeque::new()),
+            feedback_response: Some(FeedbackAnalysis {
+                sentiment: "positive".to_string(),
+                score: 1.0,
+            }),
+        });
+        FeedbackRetriever::new(graph_db.clone(), llm, Some(3), None)
+            .get_completion(
+                "Nice",
+                None,
+                &SessionContext::default(),
+                &SearchParams::default(),
+            )
+            .await
+            .unwrap();
+
+        let (_nodes, edges) = graph_db.get_graph_data().await.unwrap();
+        assert!(
+            edges.iter().any(|(_, target, relationship, _)| {
+                relationship == "HAS_FEEDBACK" && target == "interaction-in-kind"
+            }),
+            "the kind-only interaction node must still be linked to the feedback"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-up to #148, which left two items out deliberately.

## 1. `FEEDBACK` and `CODING_RULES` still full-scanned the graph

`FeedbackRetriever::recent_interaction_ids` and `CodingRulesRetriever::load_rules`
called `get_graph_data()`, destructured the edge half into `_`, and filtered the
nodes by type in Rust — every node row *and* every edge row parsed to keep a
handful of typed nodes.

**`get_filtered_graph_data` cannot express what these two test, so this does not
use it.** Both predicates are a case-insensitive *substring* match over five keys
(`type`, `node_type`, `kind`, `label`, `labels`), over JSON strings and string
arrays. Only `type` is a column; the other four arrive inside the `properties`
blob. `get_filtered_graph_data` is an exact `IN (…)` on `id`/`name`/`type`, and
`PgGraphAdapter` rejects any other attribute name outright — so pushing this
predicate through it would either drop every node whose label lives under
`kind`/`labels`, or fail the query. It is not a superset you can post-filter; it
is a subset.

Instead: a new `GraphDBTrait::get_candidate_nodes_by_label(needle)`, specified as
a loose *candidate* read — implementations may return a superset and callers must
re-apply the exact predicate, but nothing matching may be missing and **no edge
row may be read**.

| Backend | Behaviour |
|---|---|
| `PgGraphAdapter` | one `SELECT … FROM graph_node`, filtered by a `position($1 IN lower(…)) > 0` clause per label key — the `type` column plus `properties->>'<key>'` for each of `NODE_LABEL_KEYS`, built from that constant so it cannot drift. A documented superset of the Rust predicate; still a seq scan, but a handful of rows instead of two whole tables. (Revised in `5491e2c` — the first version matched `properties::text` wholesale, which swept in every chunk of prose containing the word "rule". See the review-response comment.) |
| `LadybugAdapter` | node query only, exact predicate on the parsed rows; the edge traversal never runs |
| trait default | `get_graph_data().0` — no worse than the status quo, keeps out-of-tree backends compiling |

The Rust predicate stays as a post-filter in both retrievers and is now one
shared `cognee_graph::node_label_contains` instead of two copies, so the needle
pushed into the query cannot drift from the one re-applied to the rows.

`MockGraphDB` now overrides `get_candidate_nodes_by_label` and logs it — and also
logs `get_filtered_graph_data`, which ignores its filters and delegates to
`get_graph_data`, so without its own entry no test could tell a pushed-down read
from a full scan.

## 2. The default `get_neighborhood` violated its own contract

The doc promises "every edge whose endpoints are both in that resolved set"; the
default collected edges *during* the BFS, keeping only those incident to the
current frontier, and so omitted every edge between two nodes discovered at the
same depth — the whole outermost layer. Same bug `MockGraphDB` had before #148,
fixed the same way: resolve the id set by undirected BFS, then return the induced
subgraph. Phase 2 re-reads the edges incident to every resolved node (reusing what
the walk already fetched) because the default can only see the graph one node at a
time.

Two behaviours change, both **towards** the real backends:

- `depth == 0` now returns seed-to-seed edges instead of none, matching all three
  overrides. The doc note claiming otherwise is gone.
- Edges are read via `get_edges`, not `get_connections`, which drops
  `relationship_name` — previously every edge came back with an empty relationship
  name and parallel edges collapsed under the `EdgeKey` dedup.

Direction is still passed through untouched, so a backend whose `get_edges`
rewrites direction (Ladybug) is still wrong on the default path — it overrides the
method, and the doc comment now says plainly what the default can and cannot
guarantee. `PgGraphAdapter`, `LadybugAdapter` and `MockGraphDB` are untouched.

## Tests

Ten new cases; **each guard verified to fail when its fix is reverted**. Two are
equivalence pins that pass either way and are labelled as such in place.

Observed failures on revert:

```
default_neighborhood_returns_the_induced_subgraph
  left:  [("a","b",""), ("a","c","")]
  right: [("a","b","r1"), ("a","c","r2"), ("b","c","r3")]
default_neighborhood_includes_seed_to_seed_edges_at_depth_zero
  left: []   right: [("a","b","r1")]
default_neighborhood_preserves_relationship_names_and_direction
  left:  [("b","a","")]
  right: [("b","a","authored"), ("b","a","reviewed")]
coding_rules_retriever_does_not_scan_the_whole_graph
  rule loading must go through the narrowed read, got ["get_graph_data"]
feedback_retriever_does_not_scan_the_whole_graph
  interaction lookup must go through the narrowed read, got ["get_graph_data"]
```

## Verification

- `cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test -p cognee-graph --features ladybug,postgres,testing --all-targets` — 155 passed.
- `cargo test -p cognee-search` — only `temporal_retriever_single_month_query` fails, the known non-deterministic LLM interval-extraction case that fails identically on a clean baseline.
- `pg_graph_integration` run against a live PostgreSQL 17 — **34/34**, including the new `test_get_candidate_nodes_by_label`, so the raw SQL is exercised rather than assumed.
- `cognee-http-server`, `cognee-cognify`, `cognee-delete`, `cognee-visualization` lib suites green (they hold `GraphDBTrait` doubles that use the changed default).

**Reviewer note:** `get_candidate_nodes_by_label` adds public API surface to
`GraphDBTrait`. It is non-breaking (it carries a full-scan default, following the
same convention as `get_degree_one_nodes` / `get_id_filtered_graph_data`), but the
shape of the method is the one judgement call in this PR and is worth a look.
It exists because `get_filtered_graph_data` could not express the predicate:
that method is an exact `IN` match on `id`/`name`/`type` only, and the real
predicate is a case-insensitive substring across five keys, four of which live in
the `properties` blob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2KsXSUu7FfnJdqMF3jppu


