### PR TITLE
docs(build): document the native build prerequisites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,10 @@ jobs:
 
       # A compile check alone cannot tell a slim tree from a fat one, so assert
       # the profile's actual contract: android-default excludes pdfium,
-      # postgres, tiktoken and lancedb. Marker crates beat a package-count
+      # tiktoken, lancedb and the AWS stack. It also excludes `postgres`, but
+      # that one is NOT asserted below and no marker can assert it:
+      # `sqlx-postgres` is in the android tree unconditionally, pulled by
+      # sea-orm via cognee-search. Marker crates beat a package-count
       # ceiling -- a count is host-dependent: the pre-fix fat tree measured 690
       # packages on the Linux runner but only 523 for aarch64-linux-android,
       # where lancedb is already target-gated away. A ceiling loose enough for
@@ -577,7 +580,10 @@ jobs:
         with:
           make-default: true
 
-      # cmake + protoc are needed by lbug's bundled C++ build (via cognee).
+      # cmake drives lbug's (and aws-lc-sys') bundled C++ builds; protoc is
+      # unrelated to lbug -- it comes from lancedb's Protobuf schemas. Both
+      # reach here via cognee's default features. See
+      # docs/build/prerequisites.md.
       - name: Install build deps
         run: sudo apt-get update && sudo apt-get install -y cmake protobuf-compiler
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,12 @@ cd cognee-rs
 cargo build
 ```
 
+The default features compile Ladybug's and AWS-LC's bundled C/C++ trees, so that
+build needs a C/C++ compiler, `cmake` and `protoc` on `PATH` (on x86-64 Linux,
+GCC ≥ 12 or Clang ≥ 16). `scripts/check_all.sh` checks for them up front. See
+[docs/build/prerequisites.md](docs/build/prerequisites.md) for the install
+one-liners, which feature sets need what, and the GCC 11 workaround.
+
 See [`.claude/CLAUDE.md`](.claude/CLAUDE.md) for an architecture overview and the crate map.
 
 ## Branching & PRs

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ feedback, **`forget`** what's stale.
 - **Rust toolchain** — install [rustup](https://rustup.rs); the repo's pinned
   toolchain (Rust 1.91.1, declared in `rust-toolchain.toml`) is selected
   automatically. The workspace is edition 2024 / resolver 3; MSRV is 1.91.1.
+- **Native build tools** — the default features compile two bundled C++ trees,
+  so you also need a C/C++ compiler, `cmake` and `protoc`:
+
+  ```bash
+  # Debian / Ubuntu
+  sudo apt-get install -y build-essential cmake protobuf-compiler
+  # macOS
+  brew install cmake protobuf
+  # Windows
+  choco install cmake protoc --no-progress
+  ```
+
+  On x86-64 Linux the compiler must be GCC ≥ 12 or Clang ≥ 16. Both tools are
+  feature-gated — builds that drop LanceDB need no `protoc`, and dropping
+  Ladybug and Bedrock too sheds `cmake`. See
+  [docs/build/prerequisites.md](docs/build/prerequisites.md) for the full
+  breakdown, per-feature requirements, and the GCC 11 workaround.
 - An **LLM API key** (OpenAI-compatible). 
 
 Build the CLI from source with Cargo. 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ signatures.
 - **[performance/cpu-profiling.md](performance/cpu-profiling.md)** — CPU profiling findings: where the pipeline spends CPU + prioritised optimisations.
 
 ### Build & release
+- **[build/prerequisites.md](build/prerequisites.md)** — native build tools (`cmake`, `protoc`, compiler floors), which feature sets need them, and the GCC 11 workaround.
 - **[build/lbug-rebuilds.md](build/lbug-rebuilds.md)** — Ladybug rebuild troubleshooting.
 - **Reclaiming disk space** — `bash scripts/clean_all.sh` cleans all four Cargo workspaces (a root `cargo clean` misses the binding workspaces); see [CONTRIBUTING.md § Cleaning build artifacts](../CONTRIBUTING.md#cleaning-build-artifacts).
 - **[RELEASE.md](RELEASE.md)** — release runbook.

--- a/docs/build/prerequisites.md
+++ b/docs/build/prerequisites.md
@@ -1,0 +1,132 @@
+# Native build prerequisites
+
+Building the default feature set compiles two bundled C/C++ trees from source,
+so a Rust toolchain alone is not enough. This page is the single source of
+truth for what else has to be on `PATH`; `README.md` and `CONTRIBUTING.md`
+link here rather than restating it.
+
+`scripts/check_all.sh` refuses to start when `protoc` or `cmake` is missing and
+prints the install line for your platform.
+
+## What you need
+
+| Tool | Needed for | Pulled in by |
+|---|---|---|
+| **Rust 1.91.1** | everything | `rust-toolchain.toml` selects it automatically |
+| **C/C++ compiler** | every build, including slim | `ring`, plus the bundled C++ trees below |
+| **`cmake`** | Ladybug (graph DB) and AWS-LC (Bedrock TLS) | `lbug`, `aws-lc-sys` |
+| **`protoc`** | LanceDB's Protobuf schemas | `lancedb` → `lance` → `prost-build` |
+| **Network at build time** | `ort-sys` downloads an ONNX Runtime build | the `onnx` feature |
+
+Point `ORT_CACHE_DIR` at a writable, persistent path to reuse that download
+across builds — the release workflows and both `Cross.toml` files do exactly
+this. `--no-default-features` (no `onnx`) skips the fetch.
+
+On x86-64 Linux the C++ compiler must be **GCC ≥ 12** (or Clang ≥ 16) unless
+you disable one SIMD kernel — see [GCC 11 hosts](#gcc-11-hosts-amazon-linux-2023)
+below. Other platforms need GCC ≥ 11 only, for C++20.
+
+### Install
+
+```bash
+# Debian / Ubuntu
+sudo apt-get update && sudo apt-get install -y build-essential cmake protobuf-compiler
+
+# Fedora / RHEL / Amazon Linux 2023
+sudo dnf install -y gcc-c++ cmake protobuf-compiler
+
+# macOS (Xcode command-line tools supply the compiler)
+brew install cmake protobuf
+
+# Windows
+choco install cmake protoc --no-progress
+```
+
+These are the same packages the CI workflows install; see the `Install build
+deps` steps in `.github/workflows/`.
+
+## Which builds need what
+
+Both native dependencies are feature-gated, and the slim build needs neither:
+
+| Build | `cmake` | `protoc` |
+|---|---|---|
+| `cargo build` (default features) | yes | yes |
+| `cargo build -p cognee-cli --no-default-features` | **no** | **no** |
+| `--features cognee-cli/android-default` | yes (Ladybug) | **no** (drops LanceDB) |
+
+A C compiler is still required even for the slim build — `ring` survives into
+every tree.
+
+> **The slim lane is a compile canary, not a usable CLI.** With no features on,
+> no backend factory is registered, while the runtime defaults still name
+> `sqlite`, `lancedb` and `ladybug`. The binary links and then fails on the
+> first `remember` / `recall` with `Unsupported … provider`. Use it to prove the
+> feature gates still subtract (which is what `check_all.sh` does with it), not
+> as a way to build a lighter working CLI. To actually run without `cmake` or
+> `protoc`, select the backends you do want — the factories have to come from
+> somewhere.
+
+Check any feature set yourself rather than trusting this table as it ages —
+`-i` prints who pulls the tool in:
+
+```bash
+cargo tree -p cognee-cli -e normal,build -i cmake
+```
+
+A tree that does not need the tool reports `package ID specification 'cmake'
+did not match any packages`. That message means the dependency is absent, which
+is the answer — not a broken command.
+
+### Dropping the dependencies
+
+- **`protoc`** comes only from LanceDB. Any build without the `lancedb`
+  feature — the slim CLI, `android-default`, the wasm logic crates — needs no
+  Protobuf compiler.
+- **`cmake`** has *two* independent sources. Ladybug (`lbug`) is the obvious
+  one; the second is `aws-lc-sys`, reached through `aws-config` from the
+  default-on `bedrock` feature. Dropping `ladybug` alone leaves `cmake`
+  required. Drop both features to shed it.
+
+## GCC 11 hosts (Amazon Linux 2023)
+
+Ladybug bundles [SimSIMD](https://github.com/ashvardanian/SimSIMD), whose
+dispatch shim force-enables every x86 kernel on Linux regardless of what the
+compiler supports:
+
+```c
+/*  - Linux: everything is available in GCC 12+ and Clang 16+. */
+#if !defined(SIMSIMD_TARGET_SAPPHIRE) && (defined(__linux__))
+#define SIMSIMD_TARGET_SAPPHIRE 1
+#endif
+```
+
+The Sapphire Rapids kernels use `__m512h`, which GCC only gained in 12. On a
+GCC 11 host — Amazon Linux 2023 ships 11.4 — the build fails inside SimSIMD.
+
+Either install GCC 12+, or pre-define the macro so the block above leaves it
+off:
+
+```bash
+export CFLAGS="-DSIMSIMD_TARGET_SAPPHIRE=0"
+export CXXFLAGS="-DSIMSIMD_TARGET_SAPPHIRE=0"
+cargo build --release
+```
+
+This costs the AVX512-FP16 distance kernels, which only Sapphire Rapids and
+newer hardware would have dispatched to anyway; every other kernel is
+unaffected.
+
+Four release workflows already pull the same lever for the ARM kernels the
+cross toolchain cannot assemble — `ts-prebuild.yml`, `java-prebuild.yml`,
+`capi-release.yml` and `ort-mirror.yml` set `SIMSIMD_TARGET_SVE=0` and friends
+through the per-target `CFLAGS_<target>` / `CXXFLAGS_<target>` variables. These
+are preprocessor defines, not CMake cache variables: the `cmake` crate forwards
+`CFLAGS`/`CXXFLAGS` into the bundled build.
+
+## See also
+
+- [lbug-rebuilds.md](lbug-rebuilds.md) — why the Ladybug C++ tree rebuilds and
+  the ccache setup that fixes it.
+- [CONTRIBUTING.md § Cleaning build artifacts](../../CONTRIBUTING.md#cleaning-build-artifacts)
+  — the bundled C++ builds are large; `scripts/clean_all.sh` reclaims them.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,9 @@ cargo build --release
 This produces the binary at `target/release/cognee-cli`. Everything below uses
 that binary (add it to your `PATH` or call it by path).
 
+Besides the Rust toolchain this needs a C/C++ compiler, `cmake` and `protoc` —
+see [build/prerequisites.md](build/prerequisites.md).
+
 ## 2. Configure an LLM
 
 cognee-rust needs an OpenAI-compatible chat endpoint. Set three env vars (a

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -29,6 +29,29 @@ if command -v sccache > /dev/null 2>&1; then
     export RUSTC_WRAPPER="${RUSTC_WRAPPER:-sccache}"
 fi
 
+# Native build tools. Unlike the sccache probe above -- which degrades
+# gracefully -- these are hard requirements for the default feature set this
+# script checks: `cmake` drives Ladybug's and AWS-LC's bundled C++ builds, and
+# `protoc` compiles LanceDB's Protobuf schemas. Without them the run dies
+# minutes later inside a dependency's build script with an error that names
+# neither this repo nor the missing package, so fail here instead.
+# Docs: docs/build/prerequisites.md
+missing_tools=()
+for tool in cmake protoc; do
+    command -v "$tool" > /dev/null 2>&1 || missing_tools+=("$tool")
+done
+if [ ${#missing_tools[@]} -gt 0 ]; then
+    echo "ERROR: missing native build tools: ${missing_tools[*]}" >&2
+    echo "" >&2
+    echo "  Debian/Ubuntu: sudo apt-get install -y build-essential cmake protobuf-compiler" >&2
+    echo "  Fedora/RHEL:   sudo dnf install -y gcc-c++ cmake protobuf-compiler" >&2
+    echo "  macOS:         brew install cmake protobuf" >&2
+    echo "  Windows:       choco install cmake protoc --no-progress" >&2
+    echo "" >&2
+    echo "  See docs/build/prerequisites.md (incl. the GCC 11 workaround)." >&2
+    exit 1
+fi
+
 echo "================================================================"
 echo "=== Rust: Checking formatting ==="
 echo "================================================================"
@@ -106,7 +129,11 @@ cargo check -p cognee-cli --no-default-features
 cargo check -p cognee-cli --no-default-features --features cognee-cli/android-default
 
 # Assert the profile's actual contract: android-default excludes pdfium,
-# postgres, tiktoken and lancedb. Marker crates beat a package count -- a count is
+# tiktoken, lancedb and the AWS stack. It also excludes `postgres`, but that one
+# is NOT asserted here and no marker can assert it: `sqlx-postgres` is in the
+# android tree unconditionally, pulled by sea-orm via cognee-search, so its
+# presence says nothing about whether cognee/postgres is on.
+# Marker crates beat a package count -- a count is
 # host-dependent: the pre-fix fat tree measured 690 packages on this host but
 # only 523 for aarch64-linux-android, where lancedb is already target-gated
 # away. A ceiling loose enough for one is blind for the other -- 520 would have


### PR DESCRIPTION
## What

`cmake`, `protoc` and a C/C++ compiler are required to build the default feature set. They are installed in **30 CI steps across 11 workflows** and mentioned in **zero** developer-facing docs, so a fresh clone fails inside a dependency's build script with an error that names neither this repo nor the missing package.

Adds `docs/build/prerequisites.md` as the single source of truth; `README.md`, `CONTRIBUTING.md`, `docs/README.md` and `docs/getting-started.md` link to it rather than restating it.

## What the investigation turned up

Three things that differ from the obvious reading:

- **`cmake` has two independent sources.** Ladybug (`lbug`) is the obvious one; the second is `aws-lc-sys`, reached through `aws-config` from the default-on `bedrock` feature. Dropping `ladybug` alone leaves `cmake` required.
- **The GCC floor is not flat.** `lbug` needs GCC ≥ 11 for C++20 — the ARM cross images run gcc-11 happily — but SimSIMD's `lib.c` force-defines `SIMSIMD_TARGET_SAPPHIRE 1` on Linux, and those kernels use `__m512h`, which arrived in GCC 12. That is what blocks Amazon Linux 2023 (GCC 11.4). A flat "GCC 12+" would have been wrong for ARM.
- **The escape hatch works because the guard tests `!defined`.** A command-line `-DSIMSIMD_TARGET_SAPPHIRE=0` pre-empts the force-to-1, and `types.h`'s auto-detect block is then skipped. This mirrors the SVE-disable idiom `ts-prebuild`, `java-prebuild`, `capi-release` and `ort-mirror` already use for ARM — note those are **preprocessor defines via `CFLAGS`/`CXXFLAGS`**, not CMake cache variables.

Also documents two prerequisites in the same class that are easy to miss: the slim build still needs a **C compiler** (`ring` survives into every tree), and `ort-sys` **downloads ONNX Runtime at build time**.

## Preflight

`scripts/check_all.sh` gains a `command -v` check for `cmake`/`protoc`. Unlike the `sccache` probe above it — which degrades gracefully — these are hard requirements for the feature set the script checks, so it fails immediately with per-platform install lines instead of dying minutes later inside a dependency build script. Both branches tested.

## Comment corrections

Two comments overstated what they described:

- `ci.yml` attributed `protoc` to lbug's C++ build. It comes from lancedb's Protobuf schemas; lbug needs only `cmake`.
- Both copies of the `android-default` guard comment claimed `postgres` was among the asserted exclusions. It is excluded from the profile but **not** asserted, and no marker crate can assert it — `sqlx-postgres` is in the android tree unconditionally via `sea-orm` ← `cognee-search`. A regression re-adding `cognee/postgres` would pass the guard green.

## Testing

`scripts/check_all.sh` green end to end (86 stages, exit 0) before the comment-only follow-ups; `bash -n` and a YAML parse after. Every dependency claim was verified with `cargo tree -e normal,build -i <tool>` rather than read off the manifests.

## Note

No code paths change — docs, one shell preflight, and comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019i3unYvzNqyKqMGK92gTBU