### PR TITLE
fix(cli): declare the --version flag and answer it before startup I/O

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Debug, Parser)]
-#[command(name = "cognee-cli")]
+#[command(name = "cognee-cli", version)]
 #[command(about = "Cognee CLI - Manage your knowledge graphs and cognitive processing pipelines.")]
 pub struct Cli {
     #[arg(long)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -58,7 +58,43 @@ fn dispatch(command: Commands, cm: &Arc<ComponentManager>) -> Result<(), CliErro
     }
 }
 
+/// Answer `--version`/`--help` before any config or logging I/O.
+///
+/// `run()` parses argv only after `load_settings()` and the subscriber install,
+/// so without this both flags depend on a readable `config.json` and print a
+/// `Logging initialized` line (plus create a log file) ahead of their own
+/// output. That defeats their main use — a cheap probe of an installed binary.
+///
+/// Returns `Some(exit)` only for the two display kinds, which clap prints to
+/// stdout. Every other outcome yields `None` so the real parse in `run()`
+/// produces the diagnostics unchanged — a bare `cognee-cli` still reports a
+/// missing subcommand exactly as before. Decision 11's ordering is untouched:
+/// this returns before either step rather than reordering them.
+fn short_circuit_version_or_help() -> Option<StdExitCode> {
+    use clap::CommandFactory as _;
+    use clap::error::ErrorKind;
+
+    match Cli::command().try_get_matches_from(std::env::args_os()) {
+        Err(err)
+            if matches!(
+                err.kind(),
+                ErrorKind::DisplayVersion | ErrorKind::DisplayHelp
+            ) =>
+        {
+            // Ignoring the write error is deliberate: a closed stdout leaves
+            // nothing to report it on, and the exit code still carries.
+            let _ = err.print();
+            Some(StdExitCode::from(ExitCode::Success as u8))
+        }
+        _ => None,
+    }
+}
+
 fn main() -> StdExitCode {
+    if let Some(exit) = short_circuit_version_or_help() {
+        return exit;
+    }
+
     // Settings load runs before subscriber install so init_telemetry sees the
     // correct configuration on the first span (decision 11). No subscriber is
     // installed yet, so failures must go to stderr directly.

--- a/crates/cli/tests/cli_e2e.rs
+++ b/crates/cli/tests/cli_e2e.rs
@@ -783,16 +783,35 @@ fn top_level_version_and_help_survive_an_unreadable_config() {
 fn top_level_version_output_is_machine_readable() {
     // Logging init used to run first and put `Logging initialized ...` on stdout
     // ahead of the version, so a naive `cognee-cli --version` comparison failed.
+    //
+    // Both halves of "no logging I/O" are asserted: the stdout shape, and that
+    // the subscriber never ran at all. Checking stdout alone would still pass if
+    // logging were reintroduced ahead of version handling in a file-only
+    // configuration, so the log directory is isolated and required to stay empty.
     let config_home = TempDir::new().expect("temp dir should be created");
+    let logs_dir = TempDir::new().expect("temp dir should be created");
+
     let output = make_cmd(&config_home)
+        .env("COGNEE_LOGS_DIR", logs_dir.path())
         .args(["--version"])
         .output()
         .expect("command should run");
+
     let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
     assert_eq!(
         stdout.trim(),
         format!("cognee-cli {}", env!("CARGO_PKG_VERSION")),
         "--version must print exactly one line with no log preamble"
+    );
+
+    let log_entries: Vec<_> = std::fs::read_dir(logs_dir.path())
+        .expect("logs dir should be readable")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name())
+        .collect();
+    assert!(
+        log_entries.is_empty(),
+        "--version must not initialise logging; found {log_entries:?}"
     );
 }
 

--- a/crates/cli/tests/cli_e2e.rs
+++ b/crates/cli/tests/cli_e2e.rs
@@ -9,6 +9,9 @@ use predicates::prelude::*;
 use rusqlite::Connection;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
+// Only used by the `ladybug`-gated case below, so the import carries the same
+// gate — otherwise a slim build (`--no-default-features`) trips `unused_imports`.
+#[cfg(feature = "ladybug")]
 use uuid::Uuid;
 
 fn make_cmd(config_home: &TempDir) -> Command {
@@ -737,16 +740,18 @@ fn top_level_help_flag_prints_usage() {
 }
 
 #[test]
-fn top_level_version_flag_exits_gracefully() {
-    // The CLI does not currently declare a --version flag, so this should
-    // exit with a non-zero code but must not panic or crash.
+fn top_level_version_flag_prints_version() {
+    // clap 4's derive only synthesises --version/-V when `version` is set on the
+    // root command, so this is a regression guard for that attribute: without it
+    // both spellings are rejected as unknown arguments (exit 2).
     let config_home = TempDir::new().expect("temp dir should be created");
-    let output = make_cmd(&config_home)
-        .args(["--version"])
-        .output()
-        .expect("command should run without crashing");
-    // Either success (if version is added in future) or clean failure is acceptable.
-    let _ = output.status;
+    for flag in ["--version", "-V"] {
+        make_cmd(&config_home)
+            .args([flag])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/cli/tests/cli_e2e.rs
+++ b/crates/cli/tests/cli_e2e.rs
@@ -754,6 +754,48 @@ fn top_level_version_flag_prints_version() {
     }
 }
 
+#[test]
+fn top_level_version_and_help_survive_an_unreadable_config() {
+    // --version is the canonical probe of an installed binary, so it must not
+    // depend on config state: argv is answered before `load_settings()` runs.
+    // Guards against a regression where both flags parsed only after the config
+    // was read, making a corrupt file exit 1 with no version printed.
+    let config_home = TempDir::new().expect("temp dir should be created");
+    let config_dir = config_home.path().join("cognee-rust");
+    std::fs::create_dir_all(&config_dir).expect("config dir should be created");
+    std::fs::write(config_dir.join("config.json"), "{ this is not json")
+        .expect("corrupt config should be written");
+
+    make_cmd(&config_home)
+        .args(["--version"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+
+    make_cmd(&config_home)
+        .args(["--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("cognee"));
+}
+
+#[test]
+fn top_level_version_output_is_machine_readable() {
+    // Logging init used to run first and put `Logging initialized ...` on stdout
+    // ahead of the version, so a naive `cognee-cli --version` comparison failed.
+    let config_home = TempDir::new().expect("temp dir should be created");
+    let output = make_cmd(&config_home)
+        .args(["--version"])
+        .output()
+        .expect("command should run");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    assert_eq!(
+        stdout.trim(),
+        format!("cognee-cli {}", env!("CARGO_PKG_VERSION")),
+        "--version must print exactly one line with no log preamble"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Gap 2 — Per-command --help flags
 // ---------------------------------------------------------------------------

--- a/e2e-cross-sdk/harness/test_logging_parity.py
+++ b/e2e-cross-sdk/harness/test_logging_parity.py
@@ -112,11 +112,23 @@ def _python_setup_script(logs_dir: Path) -> str:
     )
 
 
-def _rust_env(logs_dir: Path) -> dict[str, str]:
+def _rust_env(logs_dir: Path, config_home: Path) -> dict[str, str]:
     """Env for the Rust CLI invocation. Strips any inherited
     ``LOG_FILE_NAME`` so the child picks its own timestamped filename
-    under the shared logs dir."""
-    env = {**os.environ, "COGNEE_LOGS_DIR": str(logs_dir)}
+    under the shared logs dir.
+
+    ``COGNEE_CONFIG_HOME`` is pinned to an isolated absolute directory so
+    :data:`RUST_LOG_TRIGGER` reads a pristine config instead of the runner's
+    own: an unrelated invalid ``config.json`` would otherwise fail the CLI
+    before the subscriber is installed, turning an ambient condition into a
+    logging-parity failure. This mirrors ``make_cmd`` in
+    ``crates/cli/tests/cli_e2e.rs``.
+    """
+    env = {
+        **os.environ,
+        "COGNEE_LOGS_DIR": str(logs_dir),
+        "COGNEE_CONFIG_HOME": str(config_home),
+    }
     env.pop("LOG_FILE_NAME", None)
     env.pop("RUST_LOG", None)
     env.pop("LOG_LEVEL", None)
@@ -129,8 +141,10 @@ def _rust_env(logs_dir: Path) -> dict[str, str]:
 def test_both_sdks_create_log_files(tmp_path: Path) -> None:
     py_logs = tmp_path / "py_logs"
     rs_logs = tmp_path / "rs_logs"
+    rs_config = tmp_path / "rs_config"
     py_logs.mkdir()
     rs_logs.mkdir()
+    rs_config.mkdir()
 
     # --- Python side --------------------------------------------------
     py_result = subprocess.run(
@@ -148,7 +162,7 @@ def test_both_sdks_create_log_files(tmp_path: Path) -> None:
     # --- Rust side ----------------------------------------------------
     rs_result = subprocess.run(
         [RUST_CLI, *RUST_LOG_TRIGGER],
-        env=_rust_env(rs_logs),
+        env=_rust_env(rs_logs, rs_config),
         capture_output=True,
         text=True,
         timeout=60,
@@ -168,8 +182,10 @@ def test_both_sdks_create_log_files(tmp_path: Path) -> None:
 def test_anchor_message_matches_after_normalization(tmp_path: Path) -> None:
     py_logs = tmp_path / "py_logs"
     rs_logs = tmp_path / "rs_logs"
+    rs_config = tmp_path / "rs_config"
     py_logs.mkdir()
     rs_logs.mkdir()
+    rs_config.mkdir()
 
     py_result = subprocess.run(
         [PYTHON_RUNNER, "-c", _python_setup_script(py_logs)],
@@ -185,7 +201,7 @@ def test_anchor_message_matches_after_normalization(tmp_path: Path) -> None:
 
     rs_result = subprocess.run(
         [RUST_CLI, *RUST_LOG_TRIGGER],
-        env=_rust_env(rs_logs),
+        env=_rust_env(rs_logs, rs_config),
         capture_output=True,
         text=True,
         timeout=60,

--- a/e2e-cross-sdk/harness/test_logging_parity.py
+++ b/e2e-cross-sdk/harness/test_logging_parity.py
@@ -2,7 +2,8 @@
 
 Asserts:
   1. Both Python and Rust SDKs create at least one ``*.log`` file under
-     a shared ``COGNEE_LOGS_DIR`` after invoking a known no-op command.
+     a shared ``COGNEE_LOGS_DIR`` after invoking a known read-only command
+     (see :data:`RUST_LOG_TRIGGER` for why it is not ``--help``).
   2. The shared anchor message ``"Logging initialized"`` appears at the
      start of the body of at least one formatted line in each SDK's log
      output, with the body extracted between the timestamp and the
@@ -51,6 +52,14 @@ LINE_RE = re.compile(
 )
 
 ANCHOR = "Logging initialized"
+
+# Read-only subcommand used purely to boot the Rust CLI far enough to install
+# its logging subscriber. Deliberately NOT ``--help``/``--version``: those are
+# answered before any config or logging I/O (see
+# ``short_circuit_version_or_help`` in ``crates/cli/src/main.rs``), so they
+# create no log file. The Python side calls ``setup_logging()`` directly, so a
+# real subcommand is also the closer analogue of what it does.
+RUST_LOG_TRIGGER = ["config", "get"]
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -138,15 +147,15 @@ def test_both_sdks_create_log_files(tmp_path: Path) -> None:
 
     # --- Rust side ----------------------------------------------------
     rs_result = subprocess.run(
-        [RUST_CLI, "--help"],
+        [RUST_CLI, *RUST_LOG_TRIGGER],
         env=_rust_env(rs_logs),
         capture_output=True,
         text=True,
         timeout=60,
     )
     assert rs_result.returncode == 0, (
-        f"Rust CLI --help failed (exit {rs_result.returncode}); "
-        f"stderr=\n{rs_result.stderr}"
+        f"Rust CLI {' '.join(RUST_LOG_TRIGGER)} failed "
+        f"(exit {rs_result.returncode}); stderr=\n{rs_result.stderr}"
     )
 
     # (1) Both SDKs created at least one .log file in their shared dir.
@@ -175,14 +184,15 @@ def test_anchor_message_matches_after_normalization(tmp_path: Path) -> None:
         )
 
     rs_result = subprocess.run(
-        [RUST_CLI, "--help"],
+        [RUST_CLI, *RUST_LOG_TRIGGER],
         env=_rust_env(rs_logs),
         capture_output=True,
         text=True,
         timeout=60,
     )
     assert rs_result.returncode == 0, (
-        f"Rust CLI --help failed: stderr=\n{rs_result.stderr}"
+        f"Rust CLI {' '.join(RUST_LOG_TRIGGER)} failed: "
+        f"stderr=\n{rs_result.stderr}"
     )
 
     py_anchor = _anchor_prefix(_read_logs(py_logs))


### PR DESCRIPTION
Closes the `cognee-cli --version` gap (finding 19 of the corpus-run triage).

## The bug

clap 4's derive only synthesises `--version`/`-V` when `version` is set explicitly on the command — it does not read `CARGO_PKG_VERSION` implicitly. The root `Cli` set `name` and `about` but not `version`, so both spellings were rejected as unknown arguments (exit 2) while `--help` worked fine. The sibling `cognee-http-server` binary already sets it.

Declaring the attribute made the flag exist, but it was still not usable as a probe of an installed binary, because `run()` parses argv only after `load_settings()` and the subscriber install:

- **A corrupt `config.json` made `--version` exit 1 with no version printed.** Reproduced: `Error: Failed to parse config file: key must be a string at line 1 column 3`, `rc=1`. The canonical probe of an install failed on exactly the broken install you would be probing.
- **Logging init put `Logging initialized …` on stdout ahead of the version** (and created a log file), so a naive `[ "$(cognee-cli --version)" = "cognee-cli 0.2.0" ]` failed even on a healthy install.

## The change

1. `version` on the root command.
2. Short-circuit **only** `ErrorKind::DisplayVersion` and `DisplayHelp` before config and logging I/O.

Everything else falls through to the real parse in `run()`, so diagnostics are unchanged — a bare `cognee-cli` still exits 2 with a missing subcommand, and a real command still surfaces the config error. **Decision 11's ordering (settings before subscriber install) is untouched**: the short-circuit returns ahead of both rather than reordering them.

## Tests

`crates/cli/tests/cli_e2e.rs` previously *enshrined* the bug — the test commented that the flag did not exist and discarded the exit status, so it could never fail. It now asserts both spellings exit 0 and print the crate version via `env!`, so it survives version bumps. Two further regression tests cover the startup-order half: both flags succeed against a deliberately corrupt config, and `--version` stdout is exactly one line with no preamble.

## Drive-by

Gates the `uuid::Uuid` import in `cli_e2e.rs` behind `ladybug`, matching the one case that uses it. Since #150 made slim CLI builds reachable, `cargo clippy -p cognee-cli --no-default-features … --all-targets` failed on `unused_imports`.

> **Worth a follow-up:** the slim CI lane added in #150 runs `cargo check` **without** `--all-targets`, so cognee-cli's test targets are never compiled there — which is why this stayed green on main. Adding `--all-targets` would close that blind spot.

## Verification

- `cargo clippy -p cognee-cli --all-targets -- -D warnings` — clean
- same with `--no-default-features --features postgres,pgvector,pggraph,hf-tokenizer,tiktoken,telemetry,csv-loader,html-loader,unstructured,mock-llm` — clean
- `cargo test -p cognee-cli --test cli_e2e` — 27 passed
- `cargo fmt --all -- --check` — clean
- By hand: `--version` and `-V` print `cognee-cli 0.2.0` (exit 0) with a valid config, a corrupt config, and no config; bare `cognee-cli` still exits 2; `config get` against a corrupt config still reports the parse error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQoh6pq3ykBF85zVmNaG1G
