### PR TITLE
fix(llm): detect truncated structured output instead of cascading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,7 +53,12 @@ LLM_API_KEY="your_api_key"
 ################################################################################
 #  LLM — Advanced Settings
 ################################################################################
-#LLM_MAX_TOKENS=16384
+#LLM_MAX_TOKENS=16384            # answer-length ceiling; NOT applied to structured extraction
+                                 # (cognify passes no cap there, matching Python)
+#LLM_ARGS='{"max_tokens": 16384}' # extra JSON merged into every request body, including the
+                                 # structured-extraction calls LLM_MAX_TOKENS does not reach.
+                                 # Set this when a provider's own default output budget is small
+                                 # enough to truncate extracted JSON (Baseten defaults to 4096).
 #LLM_API_VERSION=""               # needed for Azure OpenAI
 #LLM_REASONING="auto"            # auto | always | never — override OpenAI reasoning-model (o1/o3/o4/gpt-5)
                                  # parameter detection; use "never" for a remote gateway that serves a

--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,7 @@ LLM_API_KEY="your_api_key"
                                  # structured-extraction calls LLM_MAX_TOKENS does not reach.
                                  # Set this when a provider's own default output budget is small
                                  # enough to truncate extracted JSON (Baseten defaults to 4096).
+                                 # CLI and SDK only: the HTTP server does not read LLM_ARGS.
 #LLM_API_VERSION=""               # needed for Azure OpenAI
 #LLM_REASONING="auto"            # auto | always | never — override OpenAI reasoning-model (o1/o3/o4/gpt-5)
                                  # parameter detection; use "never" for a remote gateway that serves a

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -612,54 +612,118 @@ impl OpenAIAdapter {
         )
     }
 
-    /// The output budget currently on the wire, or `0` when the request carries no
-    /// cap at all.
+    /// The output budget that will actually reach the provider, or `0` when the
+    /// request carries no cap and none can be inferred.
     ///
-    /// `0` is the *common* case on the structured-output path: the cognify call
-    /// sites deliberately pass `max_tokens: None` for Python parity, so no key is
-    /// written and the provider's own default applies (Baseten's is 4096).
-    /// Reporting that as `0` is what lets the first truncation raise the budget to
-    /// the configured ceiling instead of re-asking into the same silent default.
-    fn current_output_budget(&self, body: &Value) -> u32 {
+    /// Reading the body alone is not enough. [`apply_extra_args`](Self::apply_extra_args)
+    /// merges `LLM_ARGS` inside `call_api`, *after* this request is built, and it
+    /// only fills keys that are absent — so a body with no cap is not uncapped, it
+    /// may still carry an `LLM_ARGS` budget on the wire. Writing a key here would
+    /// suppress that value; a raise computed from the body alone could therefore
+    /// *lower* the budget that just truncated, and re-truncate at a smaller one.
+    ///
+    /// `0` means genuinely unknown — the provider's own default applies. That is
+    /// the common case on the structured-output path, because the cognify call
+    /// sites deliberately pass `max_tokens: None` for Python parity (Baseten then
+    /// defaults to 4096). Reporting it as `0` is what lets the first truncation
+    /// replace that silent default with an explicit ceiling.
+    fn effective_output_budget(&self, body: &Value) -> u32 {
         let key = if self.is_reasoning_model() {
             "max_completion_tokens"
         } else {
             "max_tokens"
         };
-        body[key].as_u64().unwrap_or(0) as u32
+        if let Some(explicit) = body[key].as_u64() {
+            return explicit as u32;
+        }
+        // Absent from the body: `apply_extra_args` may still supply one. It folds
+        // a bare `max_tokens` into `max_completion_tokens` for reasoning models,
+        // so accept either spelling there.
+        let from_extra_args = if self.is_reasoning_model() {
+            self.extra_args
+                .get("max_completion_tokens")
+                .or_else(|| self.extra_args.get("max_tokens"))
+        } else {
+            self.extra_args.get(key)
+        };
+        from_extra_args.and_then(|v| v.as_u64()).unwrap_or(0) as u32
     }
 
     /// React to a length-truncated structured-output attempt by raising the
-    /// request's output budget, or fail terminally when it is already at the
-    /// ceiling.
+    /// request's output budget, or fail terminally when it cannot be raised.
     ///
-    /// Re-asking with the same budget would truncate at the same point, so the
-    /// next attempt is sent at `llm_max_completion_tokens`. When the request is
-    /// already there the truncation is unrecoverable: the ceiling is a deliberate
-    /// cost bound, and falling through to another request *mode* cannot help,
-    /// because the legacy and JSON-mode requests carry the same budget and would
-    /// truncate identically. Mirrors the Anthropic adapter, which has rejected a
-    /// `stop_reason == "max_tokens"` response since it shipped.
-    fn raise_budget_after_truncation(&self, body: &mut Value, mode: &str) -> LlmResult<String> {
-        let cap = self.max_completion_tokens().max(1);
-        let current = self.current_output_budget(body);
-        if current >= cap {
+    /// Re-asking at the budget that just truncated would truncate at the same
+    /// point, so the next attempt is sent at the configured
+    /// `llm_max_completion_tokens` ceiling. Returns the reason to carry into the
+    /// corrective instruction, and the new budget so later cascade modes inherit
+    /// it (they rebuild their bodies from `opts` and would otherwise drop back to
+    /// the budget that already failed).
+    ///
+    /// Two cases are terminal rather than raised:
+    ///
+    /// - **The caller set `max_tokens` itself.** Overriding it would silently bill
+    ///   a much larger completion than was asked for — the HTTP `custom-prompt`
+    ///   route forwards client-supplied budgets straight into structured output,
+    ///   so a client requesting 200 tokens could be re-issued at the ceiling.
+    ///   A deliberate budget is treated as a constraint, not a suggestion.
+    /// - **The budget is already at or above the ceiling.** Raising is impossible
+    ///   and falling through to another request *mode* cannot help, because the
+    ///   legacy and JSON-mode requests carry the same budget and truncate
+    ///   identically.
+    ///
+    /// Mirrors the Anthropic adapter, which has rejected a `stop_reason ==
+    /// "max_tokens"` response since it shipped, with one deliberate difference:
+    /// Anthropic raises over a caller-supplied budget, this does not.
+    fn raise_budget_after_truncation(
+        &self,
+        body: &mut Value,
+        mode: &str,
+        caller_requested: Option<u32>,
+    ) -> LlmResult<(String, u32)> {
+        let current = self.effective_output_budget(body);
+        let ceiling = self.max_completion_tokens().max(1);
+
+        if let Some(requested) = caller_requested {
             return Err(LlmError::InvalidResponse(format!(
-                "{mode} structured output was truncated at the {cap}-token output budget \
-                 (llm_max_completion_tokens) before the JSON object was complete. Raise \
-                 LLM_MAX_COMPLETION_TOKENS, or set a larger per-request cap with \
-                 LLM_ARGS='{{\"max_tokens\": N}}'"
+                "{mode} structured output was truncated at the caller-requested \
+                 {requested}-token output budget before the JSON object was complete. An \
+                 explicit max_tokens is not raised automatically; request a larger one"
             )));
         }
-        self.write_max_tokens(body, Some(cap));
+
+        if current >= ceiling {
+            // Name the budget that actually truncated, not the ceiling — they
+            // differ whenever an option-less call sends the GenerationOptions
+            // default while a lower ceiling is configured, and pointing at the
+            // ceiling there sends the operator to raise a setting that changes
+            // nothing.
+            let what = if current == 0 {
+                "its output budget".to_string()
+            } else {
+                format!("its {current}-token output budget")
+            };
+            return Err(LlmError::InvalidResponse(format!(
+                "{mode} structured output was truncated at {what} before the JSON object was \
+                 complete, and the configured ceiling (llm_max_completion_tokens = {ceiling}) \
+                 is no higher, so the budget cannot be raised automatically. Raise \
+                 LLM_MAX_COMPLETION_TOKENS above {current}, or set a larger cap with \
+                 LLM_ARGS='{{\"max_tokens\": N}}' (CLI and SDK only — the HTTP server does not \
+                 read LLM_ARGS)"
+            )));
+        }
+
+        self.write_max_tokens(body, Some(ceiling));
         let previous = if current == 0 {
-            "provider default".to_string()
+            "provider-default".to_string()
         } else {
-            current.to_string()
+            format!("{current}-token")
         };
-        Ok(format!(
-            "the previous answer was cut off at the {previous} output-token budget before the \
-             JSON object was complete; the budget has been raised to {cap}"
+        Ok((
+            format!(
+                "the previous answer was cut off at the {previous} output budget before the \
+                 JSON object was complete; the budget has been raised to {ceiling}"
+            ),
+            ceiling,
         ))
     }
 
@@ -1222,6 +1286,12 @@ impl OpenAIAdapter {
         // lowering the answer ceiling never silently breaks internal structured
         // calls (e.g. feedback detection). Callers that want NO cap at all pass
         // explicit `max_tokens: None` (as cognify's extraction paths do).
+        // A budget the caller *chose*, as distinct from the one
+        // `GenerationOptions::default()` supplies when no options were passed at
+        // all. Only the former is a deliberate constraint that must not be raised
+        // on truncation; the default's 16384 is a library value and carries no
+        // caller intent.
+        let caller_max_tokens = options.as_ref().and_then(|o| o.max_tokens);
         let opts = options.unwrap_or_default();
         // Align the advertised `required` array with what instructor sends on its
         // default TOOLS path (every non-default property is required). See
@@ -1300,6 +1370,17 @@ impl OpenAIAdapter {
             ParseFailure,
         }
         let mut outcome = ToolOutcome::NoUsableOutput;
+        // A budget raised after a truncation, carried into the legacy and
+        // JSON-mode requests below. Without this the later modes rebuild their
+        // bodies from `opts` and drop straight back to the budget that already
+        // truncated — which, with `LLM_MAX_RETRIES=1`, turns this fix back into
+        // the three-mode cascade it exists to prevent.
+        let mut raised_budget: Option<u32> = None;
+        // Set whenever a truncation was detected and the budget raised. If every
+        // mode still runs out of attempts afterwards, this is what the caller
+        // hears about — the generic "retries exhausted" message would otherwise
+        // bury the one fact that explains the failure and says how to fix it.
+        let mut truncation_seen: Option<String> = None;
         // Most recent failure reason, threaded into the next corrective retry.
         let mut last_reason: Option<String> = None;
         for attempt in 0..self.structured_output_retries {
@@ -1329,8 +1410,13 @@ impl OpenAIAdapter {
                     // parsing a string"), or entirely blank when the budget was
                     // consumed by reasoning tokens.
                     if Self::is_length_truncated(choice) {
-                        let reason =
-                            self.raise_budget_after_truncation(&mut tools_request, "Tool-call")?;
+                        let (reason, budget) = self.raise_budget_after_truncation(
+                            &mut tools_request,
+                            "Tool-call",
+                            caller_max_tokens,
+                        )?;
+                        raised_budget = Some(budget);
+                        truncation_seen = Some(reason.clone());
                         debug!(
                             attempt,
                             %reason,
@@ -1466,6 +1552,9 @@ impl OpenAIAdapter {
             request_body["temperature"] = json!(temp);
         }
         self.write_max_tokens(&mut request_body, opts.max_tokens);
+        // A truncation in tool-calling mode already established that `opts` is too
+        // small; inherit the raised budget rather than repeating the failure.
+        self.write_max_tokens(&mut request_body, raised_budget);
         if self.should_disable_thinking() {
             request_body["think"] = json!(false);
             request_body["reasoning"] = json!({"effort": "none"});
@@ -1496,8 +1585,13 @@ impl OpenAIAdapter {
                 .ok_or_else(|| LlmError::InvalidResponse("No choices in response".to_string()))?;
 
             if Self::is_length_truncated(choice) {
-                let reason =
-                    self.raise_budget_after_truncation(&mut request_body, "Function-call")?;
+                let (reason, budget) = self.raise_budget_after_truncation(
+                    &mut request_body,
+                    "Function-call",
+                    caller_max_tokens,
+                )?;
+                raised_budget = Some(budget);
+                truncation_seen = Some(reason.clone());
                 debug!(attempt, %reason, "function-call response truncated at the output budget");
                 legacy_last_reason = Some(reason);
                 continue;
@@ -1579,6 +1673,7 @@ impl OpenAIAdapter {
             json_request["temperature"] = json!(temp);
         }
         self.write_max_tokens(&mut json_request, opts.max_tokens);
+        self.write_max_tokens(&mut json_request, raised_budget);
         if self.should_disable_thinking() {
             json_request["think"] = json!(false);
             json_request["reasoning"] = json!({"effort": "none"});
@@ -1615,7 +1710,13 @@ impl OpenAIAdapter {
             // otherwise surface as the misleading "No content in JSON mode
             // response".
             if Self::is_length_truncated(json_choice) {
-                let reason = self.raise_budget_after_truncation(&mut json_request, "JSON-mode")?;
+                let (reason, budget) = self.raise_budget_after_truncation(
+                    &mut json_request,
+                    "JSON-mode",
+                    caller_max_tokens,
+                )?;
+                let _ = budget; // JSON mode is last; nothing downstream inherits it.
+                truncation_seen = Some(reason.clone());
                 debug!(attempt, %reason, "JSON-mode response truncated at the output budget");
                 continue;
             }
@@ -1657,6 +1758,12 @@ impl OpenAIAdapter {
             }
         }
 
+        if let Some(reason) = truncation_seen {
+            return Err(LlmError::InvalidResponse(format!(
+                "Structured output retries exhausted after a truncated response: {reason}. The \
+                 answer does not fit the available output budget"
+            )));
+        }
         Err(LlmError::InvalidResponse(
             "Structured output retries exhausted without a parseable response".to_string(),
         ))

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -599,6 +599,70 @@ impl OpenAIAdapter {
         }
     }
 
+    /// `finish_reason` values meaning the answer was cut off at the output budget
+    /// rather than finishing on its own.
+    ///
+    /// OpenAI and vLLM report `length`. Some OpenAI-compatible gateways front an
+    /// Anthropic backend and echo its `max_tokens` spelling instead, so both are
+    /// treated as truncation.
+    fn is_length_truncated(choice: &OpenAIChoice) -> bool {
+        matches!(
+            choice.finish_reason.as_deref(),
+            Some("length") | Some("max_tokens")
+        )
+    }
+
+    /// The output budget currently on the wire, or `0` when the request carries no
+    /// cap at all.
+    ///
+    /// `0` is the *common* case on the structured-output path: the cognify call
+    /// sites deliberately pass `max_tokens: None` for Python parity, so no key is
+    /// written and the provider's own default applies (Baseten's is 4096).
+    /// Reporting that as `0` is what lets the first truncation raise the budget to
+    /// the configured ceiling instead of re-asking into the same silent default.
+    fn current_output_budget(&self, body: &Value) -> u32 {
+        let key = if self.is_reasoning_model() {
+            "max_completion_tokens"
+        } else {
+            "max_tokens"
+        };
+        body[key].as_u64().unwrap_or(0) as u32
+    }
+
+    /// React to a length-truncated structured-output attempt by raising the
+    /// request's output budget, or fail terminally when it is already at the
+    /// ceiling.
+    ///
+    /// Re-asking with the same budget would truncate at the same point, so the
+    /// next attempt is sent at `llm_max_completion_tokens`. When the request is
+    /// already there the truncation is unrecoverable: the ceiling is a deliberate
+    /// cost bound, and falling through to another request *mode* cannot help,
+    /// because the legacy and JSON-mode requests carry the same budget and would
+    /// truncate identically. Mirrors the Anthropic adapter, which has rejected a
+    /// `stop_reason == "max_tokens"` response since it shipped.
+    fn raise_budget_after_truncation(&self, body: &mut Value, mode: &str) -> LlmResult<String> {
+        let cap = self.max_completion_tokens().max(1);
+        let current = self.current_output_budget(body);
+        if current >= cap {
+            return Err(LlmError::InvalidResponse(format!(
+                "{mode} structured output was truncated at the {cap}-token output budget \
+                 (llm_max_completion_tokens) before the JSON object was complete. Raise \
+                 LLM_MAX_COMPLETION_TOKENS, or set a larger per-request cap with \
+                 LLM_ARGS='{{\"max_tokens\": N}}'"
+            )));
+        }
+        self.write_max_tokens(body, Some(cap));
+        let previous = if current == 0 {
+            "provider default".to_string()
+        } else {
+            current.to_string()
+        };
+        Ok(format!(
+            "the previous answer was cut off at the {previous} output-token budget before the \
+             JSON object was complete; the budget has been raised to {cap}"
+        ))
+    }
+
     /// Call the OpenAI chat completions API, retrying on transient network/server errors.
     ///
     /// Retries up to `self.network_retries` times with exponential backoff (1 s, 2 s, 4 s …
@@ -1256,6 +1320,27 @@ impl OpenAIAdapter {
                         LlmError::InvalidResponse("No choices in tool-call response".to_string())
                     })?;
 
+                    // Truncation is checked before the payload is inspected,
+                    // because a cut-off answer arrives in one of two disguises and
+                    // neither is self-describing: usually non-blank but
+                    // unparseable (which would be recorded as `ParseFailure` and
+                    // fall through the *whole* cascade, re-truncating identically
+                    // in legacy and JSON mode and surfacing as a bare "EOF while
+                    // parsing a string"), or entirely blank when the budget was
+                    // consumed by reasoning tokens.
+                    if Self::is_length_truncated(choice) {
+                        let reason =
+                            self.raise_budget_after_truncation(&mut tools_request, "Tool-call")?;
+                        debug!(
+                            attempt,
+                            %reason,
+                            "tool-call response truncated at the output budget; re-asking with a raised budget",
+                        );
+                        last_reason = Some(reason);
+                        outcome = ToolOutcome::NoUsableOutput;
+                        continue;
+                    }
+
                     // Prefer a modern `tool_calls[0]`, then a legacy
                     // `function_call`, then raw `content` (some servers echo the
                     // JSON directly).
@@ -1410,6 +1495,14 @@ impl OpenAIAdapter {
                 .first()
                 .ok_or_else(|| LlmError::InvalidResponse("No choices in response".to_string()))?;
 
+            if Self::is_length_truncated(choice) {
+                let reason =
+                    self.raise_budget_after_truncation(&mut request_body, "Function-call")?;
+                debug!(attempt, %reason, "function-call response truncated at the output budget");
+                legacy_last_reason = Some(reason);
+                continue;
+            }
+
             if let Some(function_call) = &choice.message.function_call {
                 let last_attempt = attempt + 1 >= self.structured_output_retries;
                 match parse_json(&function_call.arguments) {
@@ -1516,6 +1609,16 @@ impl OpenAIAdapter {
             let json_choice = json_response.choices.first().ok_or_else(|| {
                 LlmError::InvalidResponse("No choices in JSON mode response".to_string())
             })?;
+
+            // Checked before `content` is unwrapped: a truncation that spent the
+            // whole budget on reasoning tokens leaves content absent, which would
+            // otherwise surface as the misleading "No content in JSON mode
+            // response".
+            if Self::is_length_truncated(json_choice) {
+                let reason = self.raise_budget_after_truncation(&mut json_request, "JSON-mode")?;
+                debug!(attempt, %reason, "JSON-mode response truncated at the output budget");
+                continue;
+            }
 
             let content = json_choice.message.content.as_ref().ok_or_else(|| {
                 LlmError::InvalidResponse("No content in JSON mode response".to_string())

--- a/crates/llm/tests/openai_truncation_retry.rs
+++ b/crates/llm/tests/openai_truncation_retry.rs
@@ -1,0 +1,314 @@
+//! `httpmock` integration tests for OpenAI structured-output truncation
+//! detection (no real API calls).
+//!
+//! A `finish_reason` of `length` means the answer was cut off at the output
+//! budget. Before this was detected, a cut-off tool call reached
+//! `serde_json::from_str` as a mid-string-truncated payload, failed to parse,
+//! was recorded as a *parse failure*, and therefore fell through the entire
+//! three-mode cascade — tool calling, legacy functions, JSON mode — each of
+//! which re-truncated at the same budget. The operator saw
+//! `Deserialization error: EOF while parsing a string` and paid for three modes
+//! of identical failure.
+//!
+//! These tests pin the two behaviours that replace it: a budget below the
+//! ceiling is raised for the retry, and a budget already at the ceiling fails
+//! terminally with an error naming truncation, without issuing the legacy or
+//! JSON-mode requests.
+//!
+//! The `max_tokens: None` case is the one that matters in production: the
+//! cognify fact-extraction and summarization call sites deliberately pass no cap
+//! (Python parity), so the *provider's* default applies — 4096 on Baseten — and
+//! nothing in the request records it.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+
+use cognee_llm::adapters::OpenAIAdapter;
+use cognee_llm::{GenerationOptions, Llm, Message, MessageRole};
+use httpmock::prelude::*;
+
+fn user_msg() -> Vec<Message> {
+    vec![Message {
+        role: MessageRole::User,
+        content: "extract a person".to_string(),
+    }]
+}
+
+fn schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"],
+    })
+}
+
+/// A tool call whose `arguments` string was cut off mid-value, flagged with the
+/// `finish_reason` the server reports when it hits the output budget.
+fn truncated_tool_call(finish_reason: &str) -> String {
+    // Deliberately unparseable in the same way a real truncation is: the JSON
+    // string value is left open. This is what produced "EOF while parsing a
+    // string" before truncation was detected.
+    let cut_off = serde_json::to_string(r#"{"name": "Alexander Gra"#).expect("string escapes");
+    format!(
+        r#"{{"id":"x","object":"chat.completion","created":1,"model":"m",
+            "choices":[{{"index":0,"message":{{"role":"assistant","tool_calls":[
+                {{"id":"c1","type":"function","function":{{
+                    "name":"extract_structured_data","arguments":{cut_off}
+                }}}}
+            ]}},"finish_reason":"{finish_reason}"}}]}}"#
+    )
+}
+
+/// A complete, parseable tool call.
+fn complete_tool_call() -> String {
+    let payload =
+        serde_json::to_string(r#"{"name": "Alexander Graham Bell"}"#).expect("string escapes");
+    format!(
+        r#"{{"id":"x","object":"chat.completion","created":1,"model":"m",
+            "choices":[{{"index":0,"message":{{"role":"assistant","tool_calls":[
+                {{"id":"c1","type":"function","function":{{
+                    "name":"extract_structured_data","arguments":{payload}
+                }}}}
+            ]}},"finish_reason":"tool_calls"}}]}}"#
+    )
+}
+
+/// A truncation that spent the whole budget on reasoning tokens: flagged
+/// `length`, but with no content and no tool call at all.
+const BLANK_TRUNCATED: &str = r#"{"id":"x","object":"chat.completion","created":1,"model":"m",
+    "choices":[{"index":0,"message":{"role":"assistant","content":""},
+    "finish_reason":"length"}],
+    "usage":{"prompt_tokens":10,"completion_tokens":16384,"total_tokens":16394}}"#;
+
+fn adapter(base_url: String) -> OpenAIAdapter {
+    OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(base_url))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(2)
+}
+
+/// A caller-supplied budget below the ceiling has headroom, so the retry is sent
+/// at the ceiling rather than re-asking at the budget that already truncated.
+#[tokio::test]
+async fn truncated_tool_call_raises_the_budget_to_the_ceiling() {
+    let server = MockServer::start_async().await;
+
+    let truncated = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(r#""max_tokens":1000"#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(truncated_tool_call("length"));
+        })
+        .await;
+
+    // The retry must arrive at the configured ceiling (16384), not the 1000 that
+    // truncated. Only then is a complete object returned.
+    let completed = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(format!(
+                    r#""max_tokens":{}"#,
+                    OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS
+                ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(complete_tool_call());
+        })
+        .await;
+
+    let value = adapter(server.base_url())
+        .create_structured_output_with_messages_raw(
+            user_msg(),
+            &schema(),
+            Some(GenerationOptions {
+                max_tokens: Some(1000),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("the raised retry must succeed");
+
+    assert_eq!(value["name"], "Alexander Graham Bell");
+    truncated.assert_calls_async(1).await;
+    completed.assert_calls_async(1).await;
+}
+
+/// The production shape: cognify passes `max_tokens: None`, so the first request
+/// carries no cap at all and the provider's own default silently applies. The
+/// truncation must raise the budget to the ceiling and make it explicit.
+#[tokio::test]
+async fn truncation_under_the_provider_default_raises_to_the_ceiling() {
+    let server = MockServer::start_async().await;
+
+    // No `max_tokens` key at all — the request cognify actually sends.
+    let uncapped = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions").is_true(|req| {
+                let body = req.body_string();
+                body.contains(r#""tools""#) && !body.contains("max_tokens")
+            });
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(truncated_tool_call("length"));
+        })
+        .await;
+
+    let completed = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(format!(
+                    r#""max_tokens":{}"#,
+                    OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS
+                ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(complete_tool_call());
+        })
+        .await;
+
+    let value = adapter(server.base_url())
+        .create_structured_output_with_messages_raw(
+            user_msg(),
+            &schema(),
+            Some(GenerationOptions {
+                max_tokens: None,
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("an uncapped truncation must recover by sending an explicit ceiling");
+
+    assert_eq!(value["name"], "Alexander Graham Bell");
+    uncapped.assert_calls_async(1).await;
+    completed.assert_calls_async(1).await;
+}
+
+/// The regression that matters most: at the ceiling there is no headroom, so the
+/// call must fail with an error that names truncation — and must NOT fall through
+/// to legacy function calling or JSON mode, which carry the same budget and would
+/// truncate identically.
+#[tokio::test]
+async fn truncation_at_the_ceiling_fails_without_running_the_cascade() {
+    let server = MockServer::start_async().await;
+
+    // Option-less structured calls already send the ceiling, so there is no
+    // headroom on the very first attempt.
+    let tools = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(r#""tools""#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(truncated_tool_call("length"));
+        })
+        .await;
+
+    // Mode 2 of the cascade: legacy `functions`. Must never be issued.
+    let legacy = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(r#""functions""#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(complete_tool_call());
+        })
+        .await;
+
+    // Mode 3 of the cascade: JSON mode. Must never be issued either.
+    let json_mode = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(r#""response_format""#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(complete_tool_call());
+        })
+        .await;
+
+    let err = adapter(server.base_url())
+        .create_structured_output_with_messages_raw(user_msg(), &schema(), None)
+        .await
+        .expect_err("a truncation at the ceiling is unrecoverable");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("truncated"),
+        "the error must name truncation, not deserialization; got: {msg}"
+    );
+    assert!(
+        msg.contains("LLM_MAX_COMPLETION_TOKENS"),
+        "the error must say how to fix it; got: {msg}"
+    );
+    assert!(
+        !msg.contains("EOF while parsing"),
+        "the raw serde error must not be what surfaces; got: {msg}"
+    );
+
+    // One attempt, then a terminal error. No second mode, no third.
+    tools.assert_calls_async(1).await;
+    legacy.assert_calls_async(0).await;
+    json_mode.assert_calls_async(0).await;
+}
+
+/// A truncation that consumed the budget entirely on reasoning tokens leaves no
+/// content and no tool call. That must be reported as truncation rather than
+/// slipping through as "no usable output" and cascading.
+#[tokio::test]
+async fn blank_truncated_response_is_reported_as_truncation() {
+    let server = MockServer::start_async().await;
+
+    let tools = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(r#""tools""#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(BLANK_TRUNCATED);
+        })
+        .await;
+
+    let err = adapter(server.base_url())
+        .create_structured_output_with_messages_raw(user_msg(), &schema(), None)
+        .await
+        .expect_err("a blank truncation at the ceiling is still a truncation");
+
+    assert!(err.to_string().contains("truncated"), "got: {err}",);
+    tools.assert_calls_async(1).await;
+}
+
+/// Some OpenAI-compatible gateways front an Anthropic backend and echo its
+/// `max_tokens` spelling of the stop reason. Treat it as truncation too.
+#[tokio::test]
+async fn gateway_max_tokens_finish_reason_is_treated_as_truncation() {
+    let server = MockServer::start_async().await;
+
+    let tools = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(r#""tools""#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(truncated_tool_call("max_tokens"));
+        })
+        .await;
+
+    let err = adapter(server.base_url())
+        .create_structured_output_with_messages_raw(user_msg(), &schema(), None)
+        .await
+        .expect_err("the Anthropic spelling must be recognised");
+
+    assert!(err.to_string().contains("truncated"), "got: {err}");
+    tools.assert_calls_async(1).await;
+}

--- a/crates/llm/tests/openai_truncation_retry.rs
+++ b/crates/llm/tests/openai_truncation_retry.rs
@@ -75,6 +75,18 @@ fn complete_tool_call() -> String {
     )
 }
 
+/// A complete legacy `function_call` response (cascade mode 2).
+fn legacy_function_call() -> String {
+    let payload =
+        serde_json::to_string(r#"{"name": "Alexander Graham Bell"}"#).expect("string escapes");
+    format!(
+        r#"{{"id":"x","object":"chat.completion","created":1,"model":"m",
+            "choices":[{{"index":0,"message":{{"role":"assistant","function_call":{{
+                "name":"extract_structured_data","arguments":{payload}
+            }}}},"finish_reason":"function_call"}}]}}"#
+    )
+}
+
 /// A truncation that spent the whole budget on reasoning tokens: flagged
 /// `length`, but with no content and no tool call at all.
 const BLANK_TRUNCATED: &str = r#"{"id":"x","object":"chat.completion","created":1,"model":"m",
@@ -89,13 +101,15 @@ fn adapter(base_url: String) -> OpenAIAdapter {
         .with_structured_output_retries(2)
 }
 
-/// A caller-supplied budget below the ceiling has headroom, so the retry is sent
-/// at the ceiling rather than re-asking at the budget that already truncated.
+/// A budget the *caller* chose is a constraint, not a suggestion: it must not be
+/// silently re-issued at the ceiling. The HTTP `custom-prompt` route forwards
+/// client-supplied budgets straight into structured output, so raising one would
+/// bill a much larger completion than the client asked for.
 #[tokio::test]
-async fn truncated_tool_call_raises_the_budget_to_the_ceiling() {
+async fn caller_supplied_budget_is_not_raised_silently() {
     let server = MockServer::start_async().await;
 
-    let truncated = server
+    let tools = server
         .mock_async(|when, then| {
             when.method(POST)
                 .path("/chat/completions")
@@ -106,9 +120,8 @@ async fn truncated_tool_call_raises_the_budget_to_the_ceiling() {
         })
         .await;
 
-    // The retry must arrive at the configured ceiling (16384), not the 1000 that
-    // truncated. Only then is a complete object returned.
-    let completed = server
+    // Raising to the ceiling would look like this. It must never be issued.
+    let raised = server
         .mock_async(|when, then| {
             when.method(POST)
                 .path("/chat/completions")
@@ -122,7 +135,7 @@ async fn truncated_tool_call_raises_the_budget_to_the_ceiling() {
         })
         .await;
 
-    let value = adapter(server.base_url())
+    let err = adapter(server.base_url())
         .create_structured_output_with_messages_raw(
             user_msg(),
             &schema(),
@@ -132,11 +145,142 @@ async fn truncated_tool_call_raises_the_budget_to_the_ceiling() {
             }),
         )
         .await
-        .expect("the raised retry must succeed");
+        .expect_err("an explicit caller budget must not be overridden");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("truncated"),
+        "must name truncation; got: {msg}"
+    );
+    assert!(
+        msg.contains("1000"),
+        "must name the caller's own budget; got: {msg}"
+    );
+    tools.assert_calls_async(1).await;
+    raised.assert_calls_async(0).await;
+}
+
+/// `LLM_ARGS` is merged inside `call_api` and only fills *absent* keys, so the
+/// budget on the wire can exceed anything visible in the request being built.
+/// Writing the ceiling into the body would suppress that value — turning the
+/// "raise" into a silent halving, which then re-truncates at the smaller budget
+/// and reports an error recommending the very setting it just overrode.
+#[tokio::test]
+async fn llm_args_budget_is_not_clobbered_by_the_raise() {
+    let server = MockServer::start_async().await;
+
+    // LLM_ARGS asks for double the 16384 ceiling. The request cognify builds
+    // carries no cap, so this is what actually reaches the provider.
+    let mut extra = serde_json::Map::new();
+    extra.insert("max_tokens".to_string(), serde_json::json!(32768));
+
+    let uncapped = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(r#""max_tokens":32768"#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(truncated_tool_call("length"));
+        })
+        .await;
+
+    // The bug this pins: a retry sent at the 16384 ceiling, i.e. *below* the
+    // budget that just truncated.
+    let lowered = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(format!(
+                    r#""max_tokens":{}"#,
+                    OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS
+                ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(complete_tool_call());
+        })
+        .await;
+
+    let err = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(2)
+        .with_extra_args(extra)
+        .create_structured_output_with_messages_raw(
+            user_msg(),
+            &schema(),
+            Some(GenerationOptions {
+                max_tokens: None,
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect_err("32768 already exceeds the ceiling, so there is nothing to raise to");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("32768"),
+        "the error must name the budget that actually truncated, not the ceiling; got: {msg}"
+    );
+    uncapped.assert_calls_async(1).await;
+    lowered.assert_calls_async(0).await;
+}
+
+/// A raise established in tool-calling mode must be inherited by the later
+/// cascade modes, which rebuild their bodies from `opts`. Without this, a single
+/// structured-output attempt per mode (`LLM_MAX_RETRIES=1`) walks the whole
+/// cascade at the budget that already truncated.
+#[tokio::test]
+async fn a_raised_budget_is_inherited_by_the_next_cascade_mode() {
+    let server = MockServer::start_async().await;
+
+    // One attempt per mode: the tools loop raises, then immediately runs out.
+    let uncapped_tools = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions").is_true(|req| {
+                let body = req.body_string();
+                body.contains(r#""tools""#) && !body.contains("max_tokens")
+            });
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(truncated_tool_call("length"));
+        })
+        .await;
+
+    // Legacy mode must arrive carrying the raised budget, not no cap at all.
+    let legacy_raised = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(r#""functions""#)
+                .body_includes(format!(
+                    r#""max_tokens":{}"#,
+                    OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS
+                ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(legacy_function_call());
+        })
+        .await;
+
+    let value = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(1)
+        .create_structured_output_with_messages_raw(
+            user_msg(),
+            &schema(),
+            Some(GenerationOptions {
+                max_tokens: None,
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("legacy mode should succeed at the inherited budget");
 
     assert_eq!(value["name"], "Alexander Graham Bell");
-    truncated.assert_calls_async(1).await;
-    completed.assert_calls_async(1).await;
+    uncapped_tools.assert_calls_async(1).await;
+    legacy_raised.assert_calls_async(1).await;
 }
 
 /// The production shape: cognify passes `max_tokens: None`, so the first request


### PR DESCRIPTION
Finding 5b of the corpus-run triage: every structured extraction against a Baseten deployment failed with `Deserialization error: EOF while parsing a string`.

## The bug

An OpenAI-compatible response with `finish_reason: "length"` was cut off at the output budget, but the adapter never inspected it. A truncated tool call reached `serde_json::from_str` as a mid-string-cut payload, failed to parse, was recorded as a *parse failure*, and so fell through the entire three-mode cascade — tool calling, legacy `functions`, JSON mode — each re-truncating at the same budget. Three modes of identical failure, and an error message naming none of the cause.

The reason it bit so hard: the cognify fact-extraction and summarization call sites deliberately pass `max_tokens: None` for Python parity, so no cap reaches the wire and the provider's own default applies — 4096 on Baseten, well under a dense extracted graph.

## The fix

Detect it in all three modes and react the way `AnthropicAdapter` already does for `stop_reason == "max_tokens"`:

- **Below the ceiling** — raise the budget to `llm_max_completion_tokens` and re-ask. Re-asking at the budget that just truncated would truncate at the same point.
- **At or above the ceiling** — fail terminally, naming truncation and the remedy. Falling through cannot help: the legacy and JSON-mode requests carry the same budget.
- **Caller set `max_tokens` itself** — fail terminally rather than override it (see below).

The check runs *before* the payload is inspected, because a cut-off answer arrives in two disguises and neither is self-describing: usually non-blank but unparseable, or entirely blank when the budget went to reasoning tokens.

`LLM_ARGS` is now documented in `.env.example`. The new error points operators at it, and it was the one existing workaround that reaches the structured-output path — previously mentioned only in `docs/configuration.md`, while the neighbouring `LLM_MAX_TOKENS` does not apply there at all.

## Second commit: review fixes

Four defects in the first commit, the first of which made things worse than no fix at all.

- **`apply_extra_args` merges `LLM_ARGS` inside `call_api`, after the request is built, and only fills *absent* keys.** Reading the budget off the local body missed it entirely: with `LLM_ARGS='{"max_tokens": 32768}'` and a 16384 ceiling, cognify's uncapped request went out at 32768, truncated, and the "raise" wrote 16384 — suppressing the `LLM_ARGS` value and re-asking at *half* the failed budget, then reporting an error recommending the setting it had just overridden. `effective_output_budget` now consults `extra_args` when the body has no key, accepting both spellings for reasoning models.
- **The terminal error named the ceiling as the truncating budget.** Those differ whenever an option-less call sends the `GenerationOptions` default under a lower configured ceiling — supported since d97499d made `LLM_MAX_COMPLETION_TOKENS` govern chunk size. The operator was told to raise a setting that changes nothing. It now names the budget that actually truncated.
- **A caller-chosen `max_tokens` was silently re-issued at the ceiling.** `POST /api/v1/llm/custom-prompt` forwards client-supplied budgets straight into structured output, so a client asking for 200 tokens could be billed for 16384. An explicit budget is now a constraint. This is a deliberate divergence from `AnthropicAdapter`, which does raise over a caller budget. The discriminator is whether options were supplied at all — `GenerationOptions::default()` carries `Some(16384)`, a library value, not caller intent.
- **Later cascade modes rebuild their bodies from `opts`, dropping the raise.** With `LLM_MAX_RETRIES=1` — one attempt per mode, and `.env.example` documents `0` as a valid fail-fast value — that walked the whole cascade at the already-failed budget and ended in the generic "retries exhausted". The raised budget is now inherited, and a truncation surviving every mode is reported as a truncation.

## Deliberately not changed

Rejecting a *parseable* payload flagged `finish_reason: "length"` matches `AnthropicAdapter` and Python instructor, both of which refuse a length-truncated structured response outright rather than risk returning a silently incomplete object — a shallow top-level check cannot distinguish an object that finished at the budget from one whose nested value was cut off.

## Testing

7 `httpmock` cases, no live calls: the raise-and-retry path, the production `max_tokens: None` shape, terminal failure at the ceiling asserting the legacy and JSON-mode requests are never issued, the reasoning-token blank truncation, the `max_tokens` `finish_reason` spelling used by gateways fronting Anthropic, the `LLM_ARGS` clobber, the caller-budget constraint, and cross-mode budget inheritance.

Verified green: 33 tests across the five related suites, 115 `--lib` tests, `cargo fmt --check`, `cargo clippy -D warnings`.

Verified against #155 (merged after this branch was cut): rebased locally onto it, clean, all tests pass. The branch itself is left un-rebased so no force-push is needed.

One pre-existing failure is **not** from this change: `integration_openai::test_simple_text_generation` fails against a live endpoint on a pristine tree — `openai/gpt-oss-120b` returning 10 completion tokens and empty content, which is finding #18's symptom reproducing on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfMpPmtiuoT7VzLGcvipq1
