### PR TITLE
docs(ts): note that token_count reads -1 until cognify() runs (#99)

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -146,6 +146,22 @@ await c.add([
 ], "my-dataset");
 ```
 
+> **`token_count` is `-1` on the returned records.** It is a "not computed yet"
+> sentinel, not a real count — token counting happens during `cognify`, not at
+> ingestion. To read the actual count, run `cognify()` and then re-fetch the
+> record:
+>
+> ```ts
+> const { added } = await c.add({ type: "text", text: "…" }, "my-dataset");
+> added[0].token_count; // -1
+>
+> await c.cognify("my-dataset");
+> const items = await c.datasets.listData(datasetId);
+> items.find(d => d.id === added[0].id)?.token_count; // real count
+> ```
+>
+> See [issue #99](https://github.com/topoteretes/cognee-rs/issues/99).
+
 ### cognify
 
 Extract entities and relationships into the knowledge graph.
@@ -171,6 +187,11 @@ const { add, cognify } = await c.addAndCognify(
   "my-dataset"
 );
 ```
+
+> The `add` half of the result is captured *before* extraction runs, so
+> `add.added[i].token_count` is still `-1` even though cognify has completed in
+> the same call. Re-fetch the record with `datasets.listData()` to read the real
+> count — see the note under [`add`](#add).
 
 ## Search and recall
 

--- a/ts/src/cognee.ts
+++ b/ts/src/cognee.ts
@@ -514,6 +514,10 @@ export class Cognee {
    * - `{ type: "file", path: "/abs/path" }`
    * - `{ type: "url", url: "https://…" }`
    * - `{ type: "binary", bytes: Buffer, name: "doc.pdf" }`
+   *
+   * The returned records have `token_count === -1`: the count is computed by
+   * {@link cognify}, not at ingestion time. Run `cognify()` and re-fetch the
+   * record with `datasets.listData()` to read the real count. See issue #99.
    */
   async add(
     dataInput: CogneeDataInput | CogneeDataInput[],
@@ -543,6 +547,11 @@ export class Cognee {
 
   /**
    * Ingest data and immediately run knowledge-graph extraction in a single call.
+   *
+   * The `add` half of the result is snapshotted *before* extraction runs, so
+   * its records still carry `token_count === -1` even though cognify completed.
+   * Re-fetch them with `datasets.listData()` to read the real count. See
+   * issue #99.
    */
   async addAndCognify(
     dataInput: CogneeDataInput | CogneeDataInput[],

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -60,6 +60,15 @@ export interface CogneeDataRecord {
   external_metadata: string | null;
   node_set: string | null;
   pipeline_status: string | null;
+  /**
+   * Token count of the raw data, or `-1` when it has not been computed yet.
+   *
+   * The count is written by `cognify()`, not by `add()`, so a record read
+   * straight out of a {@link CogneeAddResult} reports `-1`. That includes the
+   * `add` half of `addAndCognify()`, which is snapshotted before extraction
+   * runs. Re-fetch the record with `datasets.listData()` once `cognify()` has
+   * completed to read the real count. See issue #99.
+   */
   token_count: number;
   data_size: number;
   last_accessed: string | null;


### PR DESCRIPTION
## What

Documents that `CogneeDataRecord.token_count` reads `-1` — an internal
"not computed yet" sentinel — on records returned by `add()` and by the
`add` half of `addAndCognify()`.

Addresses #99.

## Why

`Data::from` hardcodes `token_count: -1` at ingestion
(`crates/models/src/data.rs`), carrying a `TODO(COG-4456)` noting it should
be computed there. The column is only populated later, by cognify's
`update_data_token_count` task (`crates/cognify/src/tasks.rs`).

One wrinkle the issue didn't cover: `addAndCognify()` is affected too, and
less obviously. `add_and_cognify` serializes the `add` half of its result
*before* running extraction (`crates/bindings-common/src/ops/pipeline.rs`),
so `result.add.added[i].token_count` still reads `-1` even though cognify
completed in the same call.

## What changed

Docs only — three places, no behavior change:

- `ts/src/types.ts` — JSDoc on the field itself, so it surfaces on hover.
- `ts/src/cognee.ts` — JSDoc on `add()` and `addAndCognify()`.
- `ts/README.md` — a callout under `add` with a before/after snippet, and a
  shorter one under `addAndCognify`.

The documented workaround is the one from the issue: run `cognify()`, then
re-fetch via `datasets.listData()`.

## What this deliberately doesn't do

The issue offered `number | null` as an alternative. I left the type as
`number`: the runtime value is `-1` and never actually `null`, so making it
nullable would describe a state that doesn't occur, and would force a null
check that can never fire.

This is the documentation half of #99. Computing the count at ingestion is
still the real fix, and the `TODO(COG-4456)` in `data.rs` looks like the
existing tracker for it — happy to close this in favour of that if you'd
rather go straight there.

## Testing

`npx tsc --noEmit` passes. I skipped the full `ts/scripts/check.sh` locally
since it runs a release build of the Neon binding and this diff is
comments and markdown only.
