### PR TITLE
feat(java,bindings): make the JNI binding work on Android, and expose COGX export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,9 @@ pbkdf2 = { version = "0.12", default-features = false }
 pdf-extract = "0.10"
 quick-xml = "0.39"
 pdfium-auto = "0.3"
-pdfium-render = { version = "0.9", features = ["thread_safe"] }
+# 0.9.3 is the floor for Android: 0.9.2 hardcodes `*const i8` where c_char is
+# unsigned on aarch64-linux-android, so it fails to compile there (E0308).
+pdfium-render = { version = "0.9.3", features = ["thread_safe"] }
 predicates = "3.1"
 rand = "0.8"
 rayon = "1.10"

--- a/crates/bindings-common/src/ops/migration.rs
+++ b/crates/bindings-common/src/ops/migration.rs
@@ -116,9 +116,20 @@ fn check_destination(destination: &Path) -> Result<(), SdkError> {
             "destination must be a non-empty path".to_string(),
         ));
     }
-    let Ok(mut entries) = std::fs::read_dir(destination) else {
-        // Absent (or unreadable — the export itself will report that better).
-        return Ok(());
+    let mut entries = match std::fs::read_dir(destination) {
+        Ok(entries) => entries,
+        // Genuinely absent: the export creates it.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        // Anything else means emptiness could not be verified — a file where a
+        // directory was expected, or a directory that cannot be read. A guard
+        // whose purpose is to keep unrelated files out of an uploaded tarball
+        // must not treat "cannot tell" as "nothing there".
+        Err(error) => {
+            return Err(SdkError::Validation(format!(
+                "destination '{}' cannot be checked for emptiness: {error}",
+                destination.display()
+            )));
+        }
     };
     if entries.next().is_some() {
         return Err(SdkError::Validation(format!(
@@ -211,6 +222,24 @@ mod tests {
                 "{path} should be rejected as invalid, got {error:?}"
             );
         }
+    }
+
+    #[test]
+    fn a_destination_whose_emptiness_cannot_be_verified_is_rejected() {
+        // A path that exists but is a *file* cannot be read as a directory. The
+        // guard used to treat any read_dir error as "absent" and wave it
+        // through, which is the opposite of what a guard against packing
+        // unrelated files should do when it cannot tell what is there.
+        let file = std::env::temp_dir().join(format!("cogx-not-a-dir-{}", std::process::id()));
+        std::fs::write(&file, b"x").expect("write");
+
+        let error = check_destination(&file).expect_err("a file is not a usable destination");
+        assert!(
+            matches!(error, SdkError::Validation(_)),
+            "expected a validation error, got {error:?}"
+        );
+
+        let _ = std::fs::remove_file(&file);
     }
 
     #[test]

--- a/crates/bindings-common/src/ops/migration.rs
+++ b/crates/bindings-common/src/ops/migration.rs
@@ -7,14 +7,31 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use cognee::migration::{ARCHIVE_SUFFIX, ExportOptions, export_graph, pack_archive};
+use cognee::migration::{ARCHIVE_SUFFIX, ExportOptions, ExportSummary, export_graph, pack_archive};
 
 use crate::{HandleState, SdkError};
+
+/// Keys of the JSON object [`export_cogx`] returns. The Java/TS/Python result
+/// types are deserialized by name and tolerate unknown fields, so a rename on
+/// either side degrades silently to a default value instead of failing — these
+/// constants exist so a test can pin the contract.
+#[cfg(test)]
+const RESULT_KEYS: &[&str] = &[
+    "archive",
+    "directory",
+    "numNodes",
+    "numEdges",
+    "numEntities",
+    "numDocuments",
+    "numFacts",
+    "numRawNodes",
+];
 
 /// Export the graph store as a COGX archive directory, then pack it into a
 /// `.cogx.tar.gz` tarball beside it.
 ///
-/// `destination` is the archive *directory* to write; the tarball is
+/// `destination` is the archive *directory* to write, and it must be **absent
+/// or empty** — see [`check_destination`]. The tarball is
 /// `{destination}{ARCHIVE_SUFFIX}`. Packing happens here rather than in the
 /// caller because the two halves have to agree on the suffix — Python's
 /// importer only accepts `manifest.json` at the tarball root or in a single
@@ -27,20 +44,17 @@ use crate::{HandleState, SdkError};
 ///   cognee-rs has no per-dataset graph partition, so the archive contains the
 ///   whole graph store. Callers that surface this to a user must say so.
 ///
-/// Returns JSON with the two paths plus the export counts:
-/// `{"archive":…,"directory":…,"numNodes":…,"numEdges":…,"numEntities":…,
-///   "numDocuments":…,"numFacts":…,"numRawNodes":…}`
+/// Returns JSON with the two paths plus the export counts (see [`RESULT_KEYS`]).
 pub async fn export_cogx(
     state: &HandleState,
     destination: &str,
     opts: &serde_json::Value,
 ) -> Result<serde_json::Value, SdkError> {
-    if destination.trim().is_empty() {
-        return Err(SdkError::Validation(
-            "destination must be a non-empty path".to_string(),
-        ));
-    }
-    let destination = PathBuf::from(destination);
+    let destination = PathBuf::from(destination.trim());
+    check_destination(&destination)?;
+    // Resolved before any work, so a destination that cannot name a tarball
+    // fails before the graph is read rather than after.
+    let archive = tarball_path(&destination)?;
 
     let options = ExportOptions {
         embedding_model: opt_string(opts, "embeddingModel"),
@@ -54,11 +68,25 @@ pub async fn export_cogx(
         .await
         .map_err(|e| SdkError::Runtime(format!("COGX export failed: {e}")))?;
 
-    let archive = tarball_path(&destination);
-    pack_archive(&destination, &archive)
-        .map_err(|e| SdkError::Runtime(format!("COGX archive packing failed: {e}")))?;
+    if let Err(error) = pack_archive(&destination, &archive) {
+        // `pack_archive` creates the file before it can fail, and never reaches
+        // `GzEncoder::finish`, so what is left behind is a truncated gzip stream
+        // sitting at exactly the path a successful call would have returned.
+        // Anything that keys off the file existing — a retry, a resumed upload —
+        // would ship a stream Python's importer rejects with an opaque error.
+        let _ = std::fs::remove_file(&archive);
+        return Err(SdkError::Runtime(format!(
+            "COGX archive packing failed: {error}"
+        )));
+    }
 
-    Ok(serde_json::json!({
+    Ok(result_json(&archive, &summary))
+}
+
+/// The op's return value. Split out so a test can assert the exact key set the
+/// bindings deserialize, rather than a copy of it.
+fn result_json(archive: &Path, summary: &ExportSummary) -> serde_json::Value {
+    serde_json::json!({
         "archive": archive.to_string_lossy(),
         "directory": summary.destination.to_string_lossy(),
         "numNodes": summary.num_nodes,
@@ -67,21 +95,65 @@ pub async fn export_cogx(
         "numDocuments": summary.num_documents,
         "numFacts": summary.num_facts,
         "numRawNodes": summary.num_raw_nodes,
-    }))
+    })
+}
+
+/// Require the destination to be absent or empty.
+///
+/// `pack_archive` tars **every** top-level file of the directory it is given,
+/// and the archive writer only removes the files it owns, so a caller who reads
+/// "the archive directory to write" as "somewhere I already keep things" would
+/// ship those things inside a tarball whose whole purpose is to be uploaded.
+/// `export.rs` calls a mislabelled archive "a disclosure hazard, not just a
+/// stale label"; the same bar applies to its contents.
+///
+/// This fails closed rather than filtering: enumerating the archive's own file
+/// names here would silently drift from the writer's list, and the failure mode
+/// of drift is leaking a file, so the check must not depend on that list.
+fn check_destination(destination: &Path) -> Result<(), SdkError> {
+    if destination.as_os_str().is_empty() {
+        return Err(SdkError::Validation(
+            "destination must be a non-empty path".to_string(),
+        ));
+    }
+    let Ok(mut entries) = std::fs::read_dir(destination) else {
+        // Absent (or unreadable — the export itself will report that better).
+        return Ok(());
+    };
+    if entries.next().is_some() {
+        return Err(SdkError::Validation(format!(
+            "destination '{}' is not empty; COGX export packs everything in the \
+             directory into the archive, so it must be given a fresh or empty one",
+            destination.display()
+        )));
+    }
+    Ok(())
 }
 
 /// `dir` -> `dir.cogx.tar.gz`, appended to the file name rather than replacing
 /// an extension: the suffix is multi-part, so `set_extension` would mangle it.
-fn tarball_path(destination: &Path) -> PathBuf {
-    let mut name = destination
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| "cognee".to_string());
+///
+/// A destination with no final component (`.`, `..`, `/`) is rejected. Such a
+/// path cannot name a tarball beside itself, and the previous fallback put one
+/// called `cognee.cogx.tar.gz` in the *current working directory* — which for
+/// `.` is inside the directory being packed, so `pack_archive` (which creates
+/// the file before it enumerates) appended the half-written tarball to itself.
+/// The result is a stream Python's `tarfile` reads as a single junk member with
+/// no `manifest.json`: a silently useless export.
+fn tarball_path(destination: &Path) -> Result<PathBuf, SdkError> {
+    let Some(name) = destination.file_name() else {
+        return Err(SdkError::Validation(format!(
+            "destination '{}' has no final path component, so the archive cannot \
+             be named after it; pass a path ending in a directory name",
+            destination.display()
+        )));
+    };
+    let mut name = name.to_string_lossy().to_string();
     name.push_str(ARCHIVE_SUFFIX);
-    match destination.parent() {
+    Ok(match destination.parent() {
         Some(parent) if !parent.as_os_str().is_empty() => parent.join(name),
         _ => PathBuf::from(name),
-    }
+    })
 }
 
 fn opt_string(opts: &serde_json::Value, key: &str) -> Option<String> {
@@ -93,13 +165,18 @@ fn opt_string(opts: &serde_json::Value, key: &str) -> Option<String> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
 mod tests {
     use super::*;
 
     #[test]
     fn tarball_sits_beside_the_directory() {
         assert_eq!(
-            tarball_path(Path::new("/tmp/exports/berlin_cogx")),
+            tarball_path(Path::new("/tmp/exports/berlin_cogx")).expect("named"),
             PathBuf::from("/tmp/exports/berlin_cogx.cogx.tar.gz")
         );
     }
@@ -109,9 +186,31 @@ mod tests {
         // set_extension would turn "trip.v2" into "trip.cogx.tar.gz",
         // silently dropping the ".v2" the caller chose.
         assert_eq!(
-            tarball_path(Path::new("trip.v2")),
+            tarball_path(Path::new("trip.v2")).expect("named"),
             PathBuf::from("trip.v2.cogx.tar.gz")
         );
+    }
+
+    #[test]
+    fn a_relative_name_packs_beside_itself_in_the_working_directory() {
+        assert_eq!(
+            tarball_path(Path::new("berlin_cogx")).expect("named"),
+            PathBuf::from("berlin_cogx.cogx.tar.gz")
+        );
+    }
+
+    #[test]
+    fn destinations_with_no_final_component_are_rejected() {
+        // Each of these used to yield "cognee.cogx.tar.gz" in the CWD. For "."
+        // that is inside the directory being packed, and the tarball ended up
+        // inside itself.
+        for path in [".", "..", "/", "a/.."] {
+            let error = tarball_path(Path::new(path)).expect_err(path);
+            assert!(
+                matches!(error, SdkError::Validation(_)),
+                "{path} should be rejected as invalid, got {error:?}"
+            );
+        }
     }
 
     #[test]
@@ -119,5 +218,71 @@ mod tests {
         let opts = serde_json::json!({ "embeddingModel": "  ", "datasetName": "berlin" });
         assert_eq!(opt_string(&opts, "embeddingModel"), None);
         assert_eq!(opt_string(&opts, "datasetName"), Some("berlin".to_string()));
+    }
+
+    #[test]
+    fn an_empty_destination_is_accepted_and_a_populated_one_is_not() {
+        let dir = std::env::temp_dir().join(format!("cogx-guard-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // Absent.
+        check_destination(&dir).expect("absent destination is fine");
+
+        // Empty.
+        std::fs::create_dir_all(&dir).expect("create");
+        check_destination(&dir).expect("empty destination is fine");
+
+        // Holding something that is not ours: this is the disclosure case.
+        std::fs::write(dir.join("private-notes.txt"), b"secret").expect("write");
+        let error = check_destination(&dir).expect_err("populated destination is rejected");
+        assert!(
+            matches!(error, SdkError::Validation(_)),
+            "expected a validation error, got {error:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_result_carries_exactly_the_documented_keys() {
+        // The bindings deserialize this object by name and ignore unknown
+        // fields, so a rename here does not fail — it silently yields 0 or null
+        // on the other side (ExportResult's counts are ints). Pin the real
+        // output of the function the op returns, not a copy of it.
+        let value = result_json(Path::new("/tmp/b.cogx.tar.gz"), &sample_summary());
+        let object = value.as_object().expect("object");
+
+        let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        let mut expected: Vec<&str> = RESULT_KEYS.to_vec();
+        expected.sort_unstable();
+        assert_eq!(keys, expected, "export_cogx result keys drifted");
+    }
+
+    #[test]
+    fn the_result_reports_the_summary_it_was_given() {
+        // Guards against the counts being wired to the wrong summary field —
+        // which no key check would catch, since the names would still match.
+        let value = result_json(Path::new("/tmp/b.cogx.tar.gz"), &sample_summary());
+        assert_eq!(value["archive"], "/tmp/b.cogx.tar.gz");
+        assert_eq!(value["directory"], "/tmp/b");
+        assert_eq!(value["numNodes"], 1);
+        assert_eq!(value["numEdges"], 2);
+        assert_eq!(value["numEntities"], 3);
+        assert_eq!(value["numDocuments"], 4);
+        assert_eq!(value["numFacts"], 5);
+        assert_eq!(value["numRawNodes"], 6);
+    }
+
+    fn sample_summary() -> ExportSummary {
+        ExportSummary {
+            destination: PathBuf::from("/tmp/b"),
+            num_nodes: 1,
+            num_edges: 2,
+            num_entities: 3,
+            num_documents: 4,
+            num_facts: 5,
+            num_raw_nodes: 6,
+        }
     }
 }

--- a/crates/bindings-common/src/ops/migration.rs
+++ b/crates/bindings-common/src/ops/migration.rs
@@ -1,0 +1,123 @@
+//! COGX archive export.
+//!
+//! Wraps `cognee::migration` so every binding can produce the one interchange
+//! format Python cognee re-imports, without each of them repeating the
+//! export-then-pack dance.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cognee::migration::{ARCHIVE_SUFFIX, ExportOptions, export_graph, pack_archive};
+
+use crate::{HandleState, SdkError};
+
+/// Export the graph store as a COGX archive directory, then pack it into a
+/// `.cogx.tar.gz` tarball beside it.
+///
+/// `destination` is the archive *directory* to write; the tarball is
+/// `{destination}{ARCHIVE_SUFFIX}`. Packing happens here rather than in the
+/// caller because the two halves have to agree on the suffix — Python's
+/// importer only accepts `manifest.json` at the tarball root or in a single
+/// subdirectory, which is what `pack_archive` guarantees.
+///
+/// `opts` keys, camelCase like every other binding op:
+/// - `embeddingModel` — recorded in the manifest (advisory; the archive carries
+///   no vectors, so the importing instance re-embeds).
+/// - `datasetName` — a manifest *label* only. It does not scope the export:
+///   cognee-rs has no per-dataset graph partition, so the archive contains the
+///   whole graph store. Callers that surface this to a user must say so.
+///
+/// Returns JSON with the two paths plus the export counts:
+/// `{"archive":…,"directory":…,"numNodes":…,"numEdges":…,"numEntities":…,
+///   "numDocuments":…,"numFacts":…,"numRawNodes":…}`
+pub async fn export_cogx(
+    state: &HandleState,
+    destination: &str,
+    opts: &serde_json::Value,
+) -> Result<serde_json::Value, SdkError> {
+    if destination.trim().is_empty() {
+        return Err(SdkError::Validation(
+            "destination must be a non-empty path".to_string(),
+        ));
+    }
+    let destination = PathBuf::from(destination);
+
+    let options = ExportOptions {
+        embedding_model: opt_string(opts, "embeddingModel"),
+        dataset_name: opt_string(opts, "datasetName"),
+    };
+
+    let svc = state.services().await?;
+    let graph_db = Arc::clone(&svc.graph_db);
+
+    let summary = export_graph(&*graph_db, &destination, &options)
+        .await
+        .map_err(|e| SdkError::Runtime(format!("COGX export failed: {e}")))?;
+
+    let archive = tarball_path(&destination);
+    pack_archive(&destination, &archive)
+        .map_err(|e| SdkError::Runtime(format!("COGX archive packing failed: {e}")))?;
+
+    Ok(serde_json::json!({
+        "archive": archive.to_string_lossy(),
+        "directory": summary.destination.to_string_lossy(),
+        "numNodes": summary.num_nodes,
+        "numEdges": summary.num_edges,
+        "numEntities": summary.num_entities,
+        "numDocuments": summary.num_documents,
+        "numFacts": summary.num_facts,
+        "numRawNodes": summary.num_raw_nodes,
+    }))
+}
+
+/// `dir` -> `dir.cogx.tar.gz`, appended to the file name rather than replacing
+/// an extension: the suffix is multi-part, so `set_extension` would mangle it.
+fn tarball_path(destination: &Path) -> PathBuf {
+    let mut name = destination
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "cognee".to_string());
+    name.push_str(ARCHIVE_SUFFIX);
+    match destination.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.join(name),
+        _ => PathBuf::from(name),
+    }
+}
+
+fn opt_string(opts: &serde_json::Value, key: &str) -> Option<String> {
+    opts.get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tarball_sits_beside_the_directory() {
+        assert_eq!(
+            tarball_path(Path::new("/tmp/exports/berlin_cogx")),
+            PathBuf::from("/tmp/exports/berlin_cogx.cogx.tar.gz")
+        );
+    }
+
+    #[test]
+    fn multi_part_suffix_is_appended_not_substituted() {
+        // set_extension would turn "trip.v2" into "trip.cogx.tar.gz",
+        // silently dropping the ".v2" the caller chose.
+        assert_eq!(
+            tarball_path(Path::new("trip.v2")),
+            PathBuf::from("trip.v2.cogx.tar.gz")
+        );
+    }
+
+    #[test]
+    fn opts_treat_blank_strings_as_absent() {
+        let opts = serde_json::json!({ "embeddingModel": "  ", "datasetName": "berlin" });
+        assert_eq!(opt_string(&opts, "embeddingModel"), None);
+        assert_eq!(opt_string(&opts, "datasetName"), Some("berlin".to_string()));
+    }
+}

--- a/crates/bindings-common/src/ops/mod.rs
+++ b/crates/bindings-common/src/ops/mod.rs
@@ -9,6 +9,7 @@ pub mod admin;
 pub mod data;
 pub mod datasets;
 pub mod memory;
+pub mod migration;
 pub mod pipeline;
 pub mod retrieval;
 pub mod sessions;

--- a/crates/database/src/migrator/mod.rs
+++ b/crates/database/src/migrator/mod.rs
@@ -1,9 +1,32 @@
+use std::sync::OnceLock;
+
 use sea_orm_migration::prelude::*;
 
 mod m20260914_000001_baseline;
 mod m20260915_000001_pipeline_run_claims;
 
 pub struct Migrator;
+
+/// Supplier of migrations that run after [`core_migrations`].
+pub type ExtraMigrations = fn() -> Vec<Box<dyn MigrationTrait>>;
+
+static EXTRA_MIGRATIONS: OnceLock<ExtraMigrations> = OnceLock::new();
+
+/// Register migrations to run after the core set.
+///
+/// Needed because sea-orm rejects a database whose `seaql_migrations` table
+/// records a migration the running migrator does not know about
+/// ("Migration file of version '…' is missing, this migration has been applied
+/// but its file is missing"). A downstream crate that adds tables must therefore
+/// extend the migrator that [`crate::initialize`] runs, rather than applying its
+/// own migrator afterwards — the closed `cognee-access-control` auth tables are
+/// the motivating case.
+///
+/// Call before the first connection is initialized; a second call is ignored and
+/// reports `Err`. OSS-only builds never call it and are unaffected.
+pub fn set_extra_migrations(supplier: ExtraMigrations) -> Result<(), ExtraMigrations> {
+    EXTRA_MIGRATIONS.set(supplier)
+}
 
 /// OSS core migrations, exposed so closed downstream crates (e.g. the
 /// closed `cognee-access-control::Migrator`) can compose this list with
@@ -21,6 +44,10 @@ pub fn core_migrations() -> Vec<Box<dyn MigrationTrait>> {
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        core_migrations()
+        let mut migrations = core_migrations();
+        if let Some(supplier) = EXTRA_MIGRATIONS.get() {
+            migrations.extend(supplier());
+        }
+        migrations
     }
 }

--- a/java/cognee-java-jni/Cargo.toml
+++ b/java/cognee-java-jni/Cargo.toml
@@ -16,7 +16,10 @@ workspace = "../../bindings"
 
 [lib]
 name = "cognee_java"
-crate-type = ["cdylib"]
+# `rlib` in addition to `cdylib` so a closed cloud binding can link this crate
+# and re-export its JNI entry points instead of forking ~2k lines of glue. The
+# cdylib output is unchanged for OSS consumers.
+crate-type = ["cdylib", "rlib"]
 
 [features]
 default = [

--- a/java/cognee-java-jni/Cargo.toml
+++ b/java/cognee-java-jni/Cargo.toml
@@ -47,9 +47,11 @@ sqlite        = ["cognee/sqlite",        "cognee-bindings-common/sqlite"]
 testing       = ["cognee/testing",       "cognee-bindings-common/testing"]
 html-loader   = ["cognee/html-loader"]
 # Document loaders, forwarded like html-loader (they have no
-# cognee-bindings-common half). pdf-pure-rust is the portable choice —
-# pdf-pdfium needs a per-platform pdfium binary, which rules it out for mobile;
-# `android-default` in cognee/lib makes the same call.
+# cognee-bindings-common half). pdf-pure-rust needs no native library, which is
+# why `android-default` in cognee/lib picks it; pdf-pdfium below is usable on
+# mobile too, but only by shipping a libpdfium and pointing PDFIUM_LIB_PATH at
+# it. Prefer pdf-pdfium where that is possible — the pure-Rust extractor
+# silently returns empty text for some real PDFs.
 pdf-pure-rust = ["cognee/pdf-pure-rust"]
 # PDFium extraction, preferred over pdf-pure-rust when both are on (see
 # cognee-ingestion's loaders/pdf/mod.rs). It reads PDFs the pure-Rust extractor

--- a/java/cognee-java-jni/Cargo.toml
+++ b/java/cognee-java-jni/Cargo.toml
@@ -46,6 +46,12 @@ tiktoken      = ["cognee/tiktoken",      "cognee-bindings-common/tiktoken"]
 sqlite        = ["cognee/sqlite",        "cognee-bindings-common/sqlite"]
 testing       = ["cognee/testing",       "cognee-bindings-common/testing"]
 html-loader   = ["cognee/html-loader"]
+# Document loaders, forwarded like html-loader (they have no
+# cognee-bindings-common half). pdf-pure-rust is the portable choice —
+# pdf-pdfium needs a per-platform pdfium binary, which rules it out for mobile;
+# `android-default` in cognee/lib makes the same call.
+pdf-pure-rust = ["cognee/pdf-pure-rust"]
+unstructured-eml = ["cognee/unstructured-eml"]
 
 [dependencies]
 cognee-bindings-common = { path = "../../crates/bindings-common", default-features = false }

--- a/java/cognee-java-jni/Cargo.toml
+++ b/java/cognee-java-jni/Cargo.toml
@@ -51,6 +51,13 @@ html-loader   = ["cognee/html-loader"]
 # pdf-pdfium needs a per-platform pdfium binary, which rules it out for mobile;
 # `android-default` in cognee/lib makes the same call.
 pdf-pure-rust = ["cognee/pdf-pure-rust"]
+# PDFium extraction, preferred over pdf-pure-rust when both are on (see
+# cognee-ingestion's loaders/pdf/mod.rs). It reads PDFs the pure-Rust extractor
+# silently returns empty text for — e.g. editions with Type3/undecodable font
+# encodings — at the cost of a libpdfium library the consumer must supply
+# (pdfium-auto's PDFIUM_LIB_PATH, or its own download on desktop targets; it has
+# no Android entry, so an Android consumer must ship the .so and set that var).
+pdf-pdfium = ["cognee/pdf-pdfium"]
 unstructured-eml = ["cognee/unstructured-eml"]
 
 [dependencies]

--- a/java/cognee-java-jni/src/handle.rs
+++ b/java/cognee-java-jni/src/handle.rs
@@ -1,6 +1,6 @@
 //! Handle lifecycle: `newHandle(settingsJson) -> long` and `destroy(long)`.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use jni::JNIEnv;
 use jni::objects::{JClass, JString};
@@ -13,6 +13,33 @@ use cognee_bindings_common::{HandleState, SdkError};
 
 use crate::errors::{throw_cognee_exception, throw_sdk_error};
 use crate::{guard_jlong, guard_void};
+
+/// Constructor used for every handle this binding creates.
+///
+/// OSS builds leave this unset and get [`HandleState::from_settings`], i.e. the
+/// built-in component registry. A cloud-flavored binding that links this crate
+/// installs its own constructor via [`set_handle_factory`] so handles are built
+/// with the closed registry (Qdrant vector store, LiteRT LLM on Android) and the
+/// access-control bootstrap — the same wiring the py/ts/c cloud cdylibs get from
+/// `cognee_bindings_cloud::handle_from_settings`.
+pub type HandleFactory = fn(Settings) -> HandleState;
+
+static HANDLE_FACTORY: OnceLock<HandleFactory> = OnceLock::new();
+
+/// Install the handle constructor. Call before the first handle is created; a
+/// second call is ignored and reports `Err`. Intended for a linking cdylib's
+/// module initializer, which runs at `dlopen` time before any native method.
+pub fn set_handle_factory(factory: HandleFactory) -> Result<(), HandleFactory> {
+    HANDLE_FACTORY.set(factory)
+}
+
+/// Build a handle through the installed factory, or the OSS default.
+fn new_handle_state(settings: Settings) -> HandleState {
+    match HANDLE_FACTORY.get() {
+        Some(factory) => factory(settings),
+        None => HandleState::from_settings(settings),
+    }
+}
 
 /// Borrow a `jlong` handle as `&Arc<HandleState>`.
 ///
@@ -106,7 +133,7 @@ pub extern "system" fn Java_ai_cognee_internal_Native_newHandle<'l>(
         };
         match build_settings(&json) {
             Ok(settings) => {
-                let state = Arc::new(HandleState::from_settings(settings));
+                let state = Arc::new(new_handle_state(settings));
                 Box::into_raw(Box::new(state)) as jlong
             }
             Err(e) => {

--- a/java/cognee-java-jni/src/lib.rs
+++ b/java/cognee-java-jni/src/lib.rs
@@ -9,6 +9,8 @@ mod config;
 mod errors;
 mod future;
 mod handle;
+// Re-exported for a cloud-flavored binding that links this crate as an rlib.
+pub use handle::{HandleFactory, set_handle_factory};
 mod runtime;
 mod sdk_admin;
 mod sdk_data;
@@ -25,7 +27,7 @@ use std::ffi::c_void;
 use std::sync::OnceLock;
 
 use jni::objects::JClass;
-use jni::sys::{JNI_VERSION_1_8, jint, jstring};
+use jni::sys::{jint, jstring};
 use jni::{JNIEnv, JavaVM};
 
 /// The process JavaVM, cached at load so tokio worker threads can attach.
@@ -38,6 +40,17 @@ pub(crate) fn java_vm() -> &'static JavaVM {
         .get()
         .expect("JNI_OnLoad ran before any native method could be called")
 }
+
+/// JNI version this binding declares to its host VM.
+///
+/// Android's ART accepts nothing above `JNI_VERSION_1_6` and fails the load with
+/// "Bad JNI version returned from JNI_OnLoad: 65544" (0x10008 = 1.8) otherwise,
+/// while the desktop JVMs keep declaring 1.8. Every JNI entry point here lives
+/// within the 1.6 surface, so the narrower version costs nothing on Android.
+#[cfg(target_os = "android")]
+const DECLARED_JNI_VERSION: jint = jni::sys::JNI_VERSION_1_6;
+#[cfg(not(target_os = "android"))]
+const DECLARED_JNI_VERSION: jint = jni::sys::JNI_VERSION_1_8;
 
 /// Called by the JVM when `System.load`/`System.loadLibrary` maps this library.
 /// Caches the `JavaVM` and declares the supported JNI version.
@@ -55,7 +68,7 @@ pub extern "system" fn JNI_OnLoad(vm: JavaVM, _reserved: *mut c_void) -> jint {
         sdk_static::install_default_subscriber();
         let _ = sdk_static::arm_analytics();
     });
-    JNI_VERSION_1_8
+    DECLARED_JNI_VERSION
 }
 
 // ---------------------------------------------------------------------------

--- a/java/cognee-java-jni/src/lib.rs
+++ b/java/cognee-java-jni/src/lib.rs
@@ -17,6 +17,7 @@ mod sdk_data;
 mod sdk_datasets;
 mod sdk_lifecycle;
 mod sdk_memory;
+mod sdk_migration;
 mod sdk_ops;
 mod sdk_retrieval;
 mod sdk_sessions;

--- a/java/cognee-java-jni/src/sdk_migration.rs
+++ b/java/cognee-java-jni/src/sdk_migration.rs
@@ -1,0 +1,42 @@
+//! Migration ops: COGX archive export.
+
+use jni::JNIEnv;
+use jni::objects::{JClass, JObject, JString};
+use jni::sys::jlong;
+
+use cognee_bindings_common::ops::migration;
+
+use crate::args::{arg_json, arg_string};
+use crate::errors::throw_sdk_error;
+use crate::future::spawn_future;
+use crate::guard_void;
+use crate::handle::checked_handle;
+
+/// `exportCogx(handle, destination, optsJson, future)` — completes with the
+/// export summary, including the path of the packed `.cogx.tar.gz`.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_ai_cognee_internal_Native_exportCogx<'l>(
+    mut env: JNIEnv<'l>,
+    _class: JClass<'l>,
+    handle: jlong,
+    destination: JString<'l>,
+    opts_json: JString<'l>,
+    future: JObject<'l>,
+) {
+    guard_void(&mut env, |env| {
+        let Some(state) = checked_handle(env, handle, &future) else {
+            return;
+        };
+        let destination = match arg_string(env, &destination) {
+            Ok(v) => v,
+            Err(e) => return throw_sdk_error(env, e),
+        };
+        let opts = match arg_json(env, &opts_json) {
+            Ok(v) => v,
+            Err(e) => return throw_sdk_error(env, e),
+        };
+        spawn_future(env, &future, async move {
+            migration::export_cogx(&state, &destination, &opts).await
+        });
+    })
+}

--- a/java/src/main/java/ai/cognee/AddAndCognifyResult.java
+++ b/java/src/main/java/ai/cognee/AddAndCognifyResult.java
@@ -1,7 +1,9 @@
 package ai.cognee;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** Result of {@link Cognee#addAndCognify}: the add and cognify results combined. */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record AddAndCognifyResult(AddResult add, CognifyResult cognify) {}
+public record AddAndCognifyResult(@JsonProperty("add") AddResult add,
+        @JsonProperty("cognify") CognifyResult cognify) {}

--- a/java/src/main/java/ai/cognee/AddResult.java
+++ b/java/src/main/java/ai/cognee/AddResult.java
@@ -1,13 +1,14 @@
 package ai.cognee;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /** Result of {@link Cognee#add}: which items were added versus deduplicated. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record AddResult(
-        String datasetName,
-        List<CogneeData> added,
-        int addedCount,
-        List<CogneeData> deduplicated,
-        int deduplicatedCount) {}
+        @JsonProperty("datasetName") String datasetName,
+        @JsonProperty("added") List<CogneeData> added,
+        @JsonProperty("addedCount") int addedCount,
+        @JsonProperty("deduplicated") List<CogneeData> deduplicated,
+        @JsonProperty("deduplicatedCount") int deduplicatedCount) {}

--- a/java/src/main/java/ai/cognee/Cognee.java
+++ b/java/src/main/java/ai/cognee/Cognee.java
@@ -335,6 +335,33 @@ public final class Cognee implements AutoCloseable {
         return f.thenApply(json -> ai.cognee.internal.Json.fromJson(json, String.class));
     }
 
+    // --- migration ---
+    /**
+     * Export the graph store as a COGX archive and pack it into a
+     * {@code .cogx.tar.gz} tarball beside {@code destination}.
+     *
+     * <p>COGX is the interchange format Python cognee re-imports, so the tarball
+     * can be uploaded to a Cognee instance ({@code POST /api/v1/remember} with
+     * {@code content_type=cogx-archive}).
+     *
+     * <p>The archive carries the <em>entire</em> graph store — cognee-rs has no
+     * per-dataset graph partition — and no vectors, so the importing instance
+     * re-embeds.
+     *
+     * @param destination archive directory to write; the tarball is this path
+     *                    plus {@code .cogx.tar.gz}
+     */
+    public CompletableFuture<ExportResult> exportCogx(String destination, ExportOptions opts) {
+        CompletableFuture<String> f = new CompletableFuture<>();
+        dispatchVoid(h -> Native.exportCogx(h, destination, Options.jsonOf(opts), f));
+        return f.thenApply(json -> ai.cognee.internal.Json.fromJson(json, ExportResult.class));
+    }
+
+    /** Export with default options. */
+    public CompletableFuture<ExportResult> exportCogx(String destination) {
+        return exportCogx(destination, null);
+    }
+
     // --- module-level statics ---
     /** Initialize file logging from env vars (idempotent). */
     public static void setupLogging() {

--- a/java/src/main/java/ai/cognee/CogneeData.java
+++ b/java/src/main/java/ai/cognee/CogneeData.java
@@ -1,7 +1,9 @@
 package ai.cognee;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** A single ingested data item ({@code id} + {@code name}). */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record CogneeData(String id, String name) {}
+public record CogneeData(@JsonProperty("id") String id,
+        @JsonProperty("name") String name) {}

--- a/java/src/main/java/ai/cognee/CogneeDataset.java
+++ b/java/src/main/java/ai/cognee/CogneeDataset.java
@@ -1,7 +1,9 @@
 package ai.cognee;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** A dataset ({@code id} + {@code name}). */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record CogneeDataset(String id, String name) {}
+public record CogneeDataset(@JsonProperty("id") String id,
+        @JsonProperty("name") String name) {}

--- a/java/src/main/java/ai/cognee/CogneeUser.java
+++ b/java/src/main/java/ai/cognee/CogneeUser.java
@@ -1,7 +1,9 @@
 package ai.cognee;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** A user ({@code id} + {@code email}). */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record CogneeUser(String id, String email) {}
+public record CogneeUser(@JsonProperty("id") String id,
+        @JsonProperty("email") String email) {}

--- a/java/src/main/java/ai/cognee/CognifyResult.java
+++ b/java/src/main/java/ai/cognee/CognifyResult.java
@@ -1,14 +1,15 @@
 package ai.cognee;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** Result of {@link Cognee#cognify}: counts of extracted graph elements. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record CognifyResult(
-        int chunks,
-        int entities,
-        int edges,
-        int summaries,
-        int embeddings,
-        boolean alreadyCompleted,
-        String priorPipelineRunId) {}
+        @JsonProperty("chunks") int chunks,
+        @JsonProperty("entities") int entities,
+        @JsonProperty("edges") int edges,
+        @JsonProperty("summaries") int summaries,
+        @JsonProperty("embeddings") int embeddings,
+        @JsonProperty("alreadyCompleted") boolean alreadyCompleted,
+        @JsonProperty("priorPipelineRunId") String priorPipelineRunId) {}

--- a/java/src/main/java/ai/cognee/ExportOptions.java
+++ b/java/src/main/java/ai/cognee/ExportOptions.java
@@ -1,0 +1,13 @@
+package ai.cognee;
+
+/**
+ * Per-call options for {@link Cognee#exportCogx}.
+ *
+ * <p>{@code datasetName} is a manifest <em>label</em> only. It does not scope
+ * the export: cognee-rs has no per-dataset graph partition, so the archive
+ * always contains the whole graph store.
+ */
+public final class ExportOptions extends Options {
+    public ExportOptions embeddingModel(String m) { put("embeddingModel", m); return this; }
+    public ExportOptions datasetName(String n) { put("datasetName", n); return this; }
+}

--- a/java/src/main/java/ai/cognee/ExportResult.java
+++ b/java/src/main/java/ai/cognee/ExportResult.java
@@ -1,0 +1,22 @@
+package ai.cognee;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Result of {@link Cognee#exportCogx}: where the COGX archive landed and what
+ * went into it.
+ *
+ * @param archive   the packed {@code .cogx.tar.gz} tarball — the file Python
+ *                  cognee re-imports
+ * @param directory the unpacked archive directory the tarball was built from
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExportResult(
+        String archive,
+        String directory,
+        int numNodes,
+        int numEdges,
+        int numEntities,
+        int numDocuments,
+        int numFacts,
+        int numRawNodes) {}

--- a/java/src/main/java/ai/cognee/ExportResult.java
+++ b/java/src/main/java/ai/cognee/ExportResult.java
@@ -1,6 +1,7 @@
 package ai.cognee;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Result of {@link Cognee#exportCogx}: where the COGX archive landed and what
@@ -12,11 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ExportResult(
-        String archive,
-        String directory,
-        int numNodes,
-        int numEdges,
-        int numEntities,
-        int numDocuments,
-        int numFacts,
-        int numRawNodes) {}
+        @JsonProperty("archive") String archive,
+        @JsonProperty("directory") String directory,
+        @JsonProperty("numNodes") int numNodes,
+        @JsonProperty("numEdges") int numEdges,
+        @JsonProperty("numEntities") int numEntities,
+        @JsonProperty("numDocuments") int numDocuments,
+        @JsonProperty("numFacts") int numFacts,
+        @JsonProperty("numRawNodes") int numRawNodes) {}

--- a/java/src/main/java/ai/cognee/ImproveResult.java
+++ b/java/src/main/java/ai/cognee/ImproveResult.java
@@ -1,14 +1,15 @@
 package ai.cognee;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /** Result of {@link Cognee#improve}: which stages ran and what they applied. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ImproveResult(
-        List<String> stagesRun,
-        MemifyResult memifyResult,
-        long feedbackEntriesProcessed,
-        long feedbackEntriesApplied,
-        long sessionsPersisted,
-        long edgesSynced) {}
+        @JsonProperty("stagesRun") List<String> stagesRun,
+        @JsonProperty("memifyResult") MemifyResult memifyResult,
+        @JsonProperty("feedbackEntriesProcessed") long feedbackEntriesProcessed,
+        @JsonProperty("feedbackEntriesApplied") long feedbackEntriesApplied,
+        @JsonProperty("sessionsPersisted") long sessionsPersisted,
+        @JsonProperty("edgesSynced") long edgesSynced) {}

--- a/java/src/main/java/ai/cognee/MemifyResult.java
+++ b/java/src/main/java/ai/cognee/MemifyResult.java
@@ -1,12 +1,13 @@
 package ai.cognee;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** Result of {@link Cognee#memify}: triplet indexing counts. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record MemifyResult(
-        long tripletCount,
-        long indexedCount,
-        long batchCount,
-        boolean alreadyCompleted,
-        String priorPipelineRunId) {}
+        @JsonProperty("tripletCount") long tripletCount,
+        @JsonProperty("indexedCount") long indexedCount,
+        @JsonProperty("batchCount") long batchCount,
+        @JsonProperty("alreadyCompleted") boolean alreadyCompleted,
+        @JsonProperty("priorPipelineRunId") String priorPipelineRunId) {}

--- a/java/src/main/java/ai/cognee/PruneResult.java
+++ b/java/src/main/java/ai/cognee/PruneResult.java
@@ -1,12 +1,13 @@
 package ai.cognee;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** Result of {@link Cognee#pruneSystem}: which backends were pruned. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record PruneResult(
-        boolean dataPruned,
-        boolean graphPruned,
-        boolean vectorPruned,
-        boolean metadataPruned,
-        boolean cachePruned) {}
+        @JsonProperty("dataPruned") boolean dataPruned,
+        @JsonProperty("graphPruned") boolean graphPruned,
+        @JsonProperty("vectorPruned") boolean vectorPruned,
+        @JsonProperty("metadataPruned") boolean metadataPruned,
+        @JsonProperty("cachePruned") boolean cachePruned) {}

--- a/java/src/main/java/ai/cognee/internal/Json.java
+++ b/java/src/main/java/ai/cognee/internal/Json.java
@@ -5,31 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 /** Shared JSON marshalling for the cognee Java SDK (internal). */
 public final class Json {
-    private static final ObjectMapper MAPPER = newMapper();
-
-    /**
-     * The shared mapper.
-     *
-     * <p>On a JVM this is a plain {@code ObjectMapper}, exactly as before — no
-     * module discovery, so host classpath contents cannot alter this binding's
-     * marshalling.
-     *
-     * <p>On Android it additionally registers whatever Jackson modules are on the
-     * classpath. D8 desugars this SDK's result {@code record}s away when minSdk is
-     * below 34, stripping the record metadata Jackson's built-in record support
-     * relies on; deserialization then fails with "no Creators, like default
-     * constructor, exist". With {@code jackson-module-parameter-names} packaged
-     * (and {@code -parameters} at compile time) the canonical constructor is used
-     * as a property-based creator instead.
-     */
-    private static ObjectMapper newMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        String vm = System.getProperty("java.vm.name", "");
-        if (vm.contains("Dalvik") || vm.contains("ART")) {
-            mapper.findAndRegisterModules();
-        }
-        return mapper;
-    }
+    // A plain mapper on every platform. The SDK's result types are records, and
+    // D8 desugars records away below minSdk 34, which used to leave Jackson
+    // unable to find a creator ("no Creators, like default constructor, exist").
+    // Their components carry @JsonProperty, so the canonical constructor is a
+    // properties-based creator by name alone — no module registration, no
+    // javac -parameters, and no runtime platform check here.
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private Json() {}
 

--- a/java/src/main/java/ai/cognee/internal/Json.java
+++ b/java/src/main/java/ai/cognee/internal/Json.java
@@ -5,7 +5,31 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 /** Shared JSON marshalling for the cognee Java SDK (internal). */
 public final class Json {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = newMapper();
+
+    /**
+     * The shared mapper.
+     *
+     * <p>On a JVM this is a plain {@code ObjectMapper}, exactly as before — no
+     * module discovery, so host classpath contents cannot alter this binding's
+     * marshalling.
+     *
+     * <p>On Android it additionally registers whatever Jackson modules are on the
+     * classpath. D8 desugars this SDK's result {@code record}s away when minSdk is
+     * below 34, stripping the record metadata Jackson's built-in record support
+     * relies on; deserialization then fails with "no Creators, like default
+     * constructor, exist". With {@code jackson-module-parameter-names} packaged
+     * (and {@code -parameters} at compile time) the canonical constructor is used
+     * as a property-based creator instead.
+     */
+    private static ObjectMapper newMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        String vm = System.getProperty("java.vm.name", "");
+        if (vm.contains("Dalvik") || vm.contains("ART")) {
+            mapper.findAndRegisterModules();
+        }
+        return mapper;
+    }
 
     private Json() {}
 

--- a/java/src/main/java/ai/cognee/internal/Native.java
+++ b/java/src/main/java/ai/cognee/internal/Native.java
@@ -125,6 +125,9 @@ public final class Native {
             CompletableFuture<String> future);
     public static native void visualizeToFile(long handle, String optsJson,
             CompletableFuture<String> future);
+    // migration
+    public static native void exportCogx(long handle, String destination, String optsJson,
+            CompletableFuture<String> future);
     // module-level statics
     public static native void setupLogging();
     public static native void initOtlp();


### PR DESCRIPTION
Makes the Java binding usable on Android, and gives the bindings a COGX export op.

**Stacked on #161** (`feat/cogx-export`) — base is that branch, not `main`, so this diff is only the 7 commits here. Needs #161 to land first.

All of this came out of embedding the SDK in an Android app and hitting each wall in turn; everything below was verified on a physical device (Android 16, arm64-v8a) unless noted.

## Bug fixes

**The binding could not load on Android at all.** `JNI_OnLoad` returned `JNI_VERSION_1_8`; ART accepts nothing above 1.6 and fails the load outright with `Bad JNI version returned from JNI_OnLoad: 65544`. The declared version is now `cfg`'d per target — every entry point here is already inside the 1.6 surface.

**Nothing with a structured result could be deserialized on Android.** D8 desugars `record` declarations for minSdk < 34, stripping the metadata Jackson's record support needs, so every op failed with `Cannot construct instance of ai.cognee.CogneeDataset (no Creators, like default constructor, exist)`. It hid at first because an *empty* dataset list never constructs an element — the failure only appeared once a dataset existed.

The result records now carry `@JsonProperty` on every component. The annotation propagates to the canonical constructor's parameters and survives desugaring, so the constructor is a properties-based creator by name alone: no module registration, no javac `-parameters`, no runtime platform check. `Json` keeps a plain `ObjectMapper` on every platform, so JVM marshalling is unchanged and cannot be perturbed by whatever modules a host has on its classpath. This also fixes *serialization* of desugared records.

**`pdfium-render` 0.9.2 does not compile for `aarch64-linux-android`** — it hardcodes `*const i8` where `c_char` is unsigned there. Floor raised to 0.9.3 in the workspace manifest rather than a lockfile pin, since consumers that gitignore `Cargo.lock` resolve versions themselves.

## New capability

**`set_handle_factory` + `rlib`.** The Java binding was the only one without a cloud-flavored counterpart, so it always built handles with the OSS registry, ruling out the closed adapters on the platform that needs them most. Rather than fork ~2k lines of glue the way the other cloud cdylibs do, the crate now also builds as an `rlib` and exposes a handle-constructor seam. Unset, behaviour is identical to before.

**`set_extra_migrations`.** sea-orm rejects a database whose `seaql_migrations` records a migration the running migrator does not know (`Migration file of version '…' is missing`), so a downstream crate that adds tables cannot just run its own migrator afterwards — the next schema init fails and the database is stuck until someone deletes it. This lets one migrator own the whole applied set. OSS-only builds never call it.

**COGX export through the bindings.** The migration crate from #161 has a Rust API and a CLI command, so only a process with a shell could produce an archive — which rules out the case the format exists for on mobile. `ops::migration::export_cogx` runs `export_graph` then `pack_archive` (the two halves must agree on the `.cogx.tar.gz` suffix and on `manifest.json` at the tarball root, which is all Python's `find_archive_root` accepts), plus `Cognee.exportCogx` / `ExportOptions` / `ExportResult`.

Verified end to end: 105 nodes / 310 edges from a phone into a 141 KB tarball, imported by a cognee Cloud tenant via `POST /api/v1/remember` with `content_type=cogx-archive`.

**PDF and EML loaders exposed** (`pdf-pdfium`, `pdf-pure-rust`, `unstructured-eml`) — only `html-loader` was forwarded before. PDFium is the one to use: `pdf-extract 0.10.0` returns `Ok` with **empty text** for real PDFs (measured on a 3 MB Alice in Wonderland edition — 105 pages, 0 characters, where poppler read 179,173 from the same file), and an empty document then ingests as a *success*, surfacing three steps later as a search failing on a missing vector collection. PDFium reads it correctly: 181,398 bytes, 77,782 tokens, 10 chunks, 64 entities.

Consumers supply `libpdfium` themselves — note `pdfium-auto` has no Android entry in its target table at all, so an Android consumer must ship the `.so` and set `PDFIUM_LIB_PATH` (plus `PDFIUM_NO_AUTO_DOWNLOAD=1`, or a phone tries to fetch a native library at runtime).

## Review hardening

The last commit addresses findings from two review passes over this branch:

- **`export_cogx` could ship files it never wrote.** `pack_archive` tars every top-level file of its directory, so a caller reading "the archive directory to write" as "somewhere I already keep things" would upload those things. The destination must now be absent or empty. It fails **closed** rather than filtering by name — only 3 of the archive's 9 filenames are public, so a name filter would drift from the writer's list, and the failure mode of drift is leaking a file.
- **Destinations with no final component produced a useless archive.** `.`, `..`, `/` all fell back to `cognee.cogx.tar.gz` in the CWD; for `.` that is inside the directory being packed, and since `pack_archive` creates the file before enumerating, the half-written tarball was appended to itself. Downstream, Python's `tarfile` silently yields only that junk member — no manifest. Now rejected before the graph is read.
- **A failed pack left a truncated tarball** at exactly the path a successful call returns, so anything keying off the file existing would ship a stream the importer rejects opaquely. Removed on failure.

## Verification

`cargo check --all-targets` on both workspaces (the `cognee-java-jni` crate is its own workspace), `cargo fmt --check`, `cargo clippy -- -D warnings`, and 13 unit tests. The new tests cover the destination guard, the rejected path shapes, and the eight result keys **plus their values** — the bindings deserialize that object by name with `ignoreUnknown = true` and `int` counts, so a rename or a mis-wired field silently yields `0` rather than failing.

Two things a reviewer should know rather than discover:

- **The Java sources are uncompiled here** — no Maven in the environment where this was built. They were reviewed by reading.
- **The `@JsonProperty` path has not been exercised at runtime**, because the test device was disconnected before that run. The evidence is `d8 --min-api 26` output showing the annotations landing on the constructor parameters after desugaring, plus a desugared-record simulation deserializing with a plain mapper and a negative control reproducing the original `no Creators` error. It wants one on-device check against a populated store before anyone relies on it.
- The 8 failing `handle_close.rs` tests are pre-existing (they come from #161 and need backends that `--no-default-features` disables) — confirmed by stashing this branch's changes and reproducing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
