### PR TITLE
fix(llm): bound the total time one structured-output call can take

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,18 +83,21 @@ LLM_API_KEY="your_api_key"
 #LLM_MAX_PARALLEL_REQUESTS=1000
 # Timeout for a single LLM HTTP request. Was hardcoded at 600 and is now
 # configurable, so a deployment behind a slow gateway can fail faster.
+# 0 = no limit. Applies to the OpenAI-compatible adapter (incl. Azure); the
+# Anthropic, Responses and Bedrock clients use a fixed 600s / 10s.
 #LLM_REQUEST_TIMEOUT_SECONDS=600
 # TCP connect timeout. reqwest applies none by default, so before this a
 # black-holed connect (a stopped local Ollama, a wedged proxy) consumed the
-# whole LLM_REQUEST_TIMEOUT_SECONDS without sending a byte.
+# whole LLM_REQUEST_TIMEOUT_SECONDS without sending a byte. 0 = no limit.
 #LLM_CONNECT_TIMEOUT_SECONDS=10
 # Wall-clock ceiling on ONE structured-extraction call, across the whole
 # tools -> legacy-functions -> JSON-mode cascade and every retry inside it.
 # LLM_REQUEST_TIMEOUT_SECONDS bounds a single request and composes into no
 # aggregate: three modes, each LLM_MAX_RETRIES deep, each honouring the
 # LLM_MIN_RETRY_SECONDS floor, multiply out past an hour. Keep it above
-# 3 x LLM_MIN_RETRY_SECONDS or legitimate rate-limit-window waits get cut
-# (a warning is logged if it is not). Set to 0 to disable.
+# 3 x LLM_MAX_RETRIES x LLM_MIN_RETRY_SECONDS (1440s at the defaults) or
+# legitimate rate-limit-window waits get cut; a warning is logged if it does
+# not fit. Set to 0 to disable the deadline entirely.
 #LLM_REQUEST_DEADLINE_SECONDS=1800
 
 ################################################################################

--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,21 @@ LLM_API_KEY="your_api_key"
 # number. Default is 128 on Android/iOS, where 1000 sockets would exhaust the
 # typical descriptor budget.
 #LLM_MAX_PARALLEL_REQUESTS=1000
+# Timeout for a single LLM HTTP request. Was hardcoded at 600 and is now
+# configurable, so a deployment behind a slow gateway can fail faster.
+#LLM_REQUEST_TIMEOUT_SECONDS=600
+# TCP connect timeout. reqwest applies none by default, so before this a
+# black-holed connect (a stopped local Ollama, a wedged proxy) consumed the
+# whole LLM_REQUEST_TIMEOUT_SECONDS without sending a byte.
+#LLM_CONNECT_TIMEOUT_SECONDS=10
+# Wall-clock ceiling on ONE structured-extraction call, across the whole
+# tools -> legacy-functions -> JSON-mode cascade and every retry inside it.
+# LLM_REQUEST_TIMEOUT_SECONDS bounds a single request and composes into no
+# aggregate: three modes, each LLM_MAX_RETRIES deep, each honouring the
+# LLM_MIN_RETRY_SECONDS floor, multiply out past an hour. Keep it above
+# 3 x LLM_MIN_RETRY_SECONDS or legitimate rate-limit-window waits get cut
+# (a warning is logged if it is not). Set to 0 to disable.
+#LLM_REQUEST_DEADLINE_SECONDS=1800
 
 ################################################################################
 #  Embedding — Advanced Settings

--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -143,6 +143,14 @@ mod tests {
                 max_retries: 3,
                 min_retry_seconds: 0,
                 max_parallel_requests: cognee_llm::in_flight::DEFAULT_MAX_IN_FLIGHT as u32,
+                request_timeout_seconds: cognee_llm::OpenAIAdapter::DEFAULT_REQUEST_TIMEOUT
+                    .as_secs() as u32,
+                connect_timeout_seconds: cognee_llm::OpenAIAdapter::DEFAULT_CONNECT_TIMEOUT
+                    .as_secs() as u32,
+                // No aggregate deadline in this fixture: these helpers build a
+                // context for component wiring assertions, and a time bound would
+                // be an unrelated variable in them.
+                request_deadline_seconds: 0,
                 rate_limit_enabled: false,
                 rate_limit_requests: 60,
                 rate_limit_interval: 60,

--- a/crates/components/src/builtins/llm.rs
+++ b/crates/components/src/builtins/llm.rs
@@ -47,25 +47,40 @@ fn http_timeouts(ctx: &BackendBuildContext) -> (std::time::Duration, std::time::
 /// `None` when disabled with `0`.
 ///
 /// Warns when the budget cannot accommodate the retry ladder it has to contain.
-/// The cascade runs three modes, each honouring the `min_retry_seconds` time
-/// floor, so a budget below `3 x min_retry_seconds` will cut calls the retry
-/// design deliberately intends to keep waiting - turning the rate-limit-window
-/// survival of the retry work back off by the side door. Warn rather than clamp:
-/// an operator who deliberately wants a tight ceiling is entitled to one, but
-/// should not get one by accident.
+/// A budget that cuts calls the retry design deliberately intends to keep
+/// waiting turns the rate-limit-window survival of that design back off by the
+/// side door. Warn rather than clamp: an operator who deliberately wants a tight
+/// ceiling is entitled to one, but should not get one by accident.
+///
+/// The ladder is `CASCADE_MODES x max_retries x min_retry_seconds`. All three
+/// factors matter: the cascade tries three request shapes, each is retried
+/// `max_retries` times (`LLM_MAX_RETRIES` feeds *both* the structured-output and
+/// network retry counts), and every attempt honours the time floor before it is
+/// allowed to give up. Counting the modes but not the attempts under-reports the
+/// ladder by the retry multiplier and lets the misconfiguration this warning
+/// exists to catch pass silently.
 fn request_deadline(ctx: &BackendBuildContext) -> Option<std::time::Duration> {
+    /// Request shapes `structured_output_impl` falls through: tool calls, legacy
+    /// functions, JSON mode.
+    const CASCADE_MODES: u64 = 3;
+
     if ctx.llm.request_deadline_seconds == 0 {
         return None;
     }
     let deadline = u64::from(ctx.llm.request_deadline_seconds);
-    let ladder = u64::from(ctx.llm.min_retry_seconds).saturating_mul(3);
+    let ladder = u64::from(ctx.llm.min_retry_seconds)
+        .saturating_mul(u64::from(ctx.llm.max_retries).max(1))
+        .saturating_mul(CASCADE_MODES);
     if deadline < ladder {
         tracing::warn!(
             deadline_seconds = deadline,
+            ladder_seconds = ladder,
             min_retry_seconds = ctx.llm.min_retry_seconds,
-            "LLM_REQUEST_DEADLINE_SECONDS is below 3x LLM_MIN_RETRY_SECONDS, so the \
-             structured-output cascade will be cut mid-retry; raise the deadline or \
-             lower the retry floor",
+            max_retries = ctx.llm.max_retries,
+            "LLM_REQUEST_DEADLINE_SECONDS is below the retry ladder it has to \
+             contain (3 cascade modes x LLM_MAX_RETRIES x LLM_MIN_RETRY_SECONDS), \
+             so structured extraction will be cut mid-retry; raise the deadline, \
+             or lower LLM_MAX_RETRIES / LLM_MIN_RETRY_SECONDS",
         );
     }
     Some(std::time::Duration::from_secs(deadline))

--- a/crates/components/src/builtins/llm.rs
+++ b/crates/components/src/builtins/llm.rs
@@ -35,6 +35,42 @@ fn min_retry_elapsed(ctx: &BackendBuildContext) -> std::time::Duration {
     std::time::Duration::from_secs(u64::from(ctx.llm.min_retry_seconds))
 }
 
+/// The configured per-request and TCP-connect timeouts.
+fn http_timeouts(ctx: &BackendBuildContext) -> (std::time::Duration, std::time::Duration) {
+    (
+        std::time::Duration::from_secs(u64::from(ctx.llm.request_timeout_seconds)),
+        std::time::Duration::from_secs(u64::from(ctx.llm.connect_timeout_seconds)),
+    )
+}
+
+/// The configured aggregate ceiling for one logical structured-output call, or
+/// `None` when disabled with `0`.
+///
+/// Warns when the budget cannot accommodate the retry ladder it has to contain.
+/// The cascade runs three modes, each honouring the `min_retry_seconds` time
+/// floor, so a budget below `3 x min_retry_seconds` will cut calls the retry
+/// design deliberately intends to keep waiting - turning the rate-limit-window
+/// survival of the retry work back off by the side door. Warn rather than clamp:
+/// an operator who deliberately wants a tight ceiling is entitled to one, but
+/// should not get one by accident.
+fn request_deadline(ctx: &BackendBuildContext) -> Option<std::time::Duration> {
+    if ctx.llm.request_deadline_seconds == 0 {
+        return None;
+    }
+    let deadline = u64::from(ctx.llm.request_deadline_seconds);
+    let ladder = u64::from(ctx.llm.min_retry_seconds).saturating_mul(3);
+    if deadline < ladder {
+        tracing::warn!(
+            deadline_seconds = deadline,
+            min_retry_seconds = ctx.llm.min_retry_seconds,
+            "LLM_REQUEST_DEADLINE_SECONDS is below 3x LLM_MIN_RETRY_SECONDS, so the \
+             structured-output cascade will be cut mid-retry; raise the deadline or \
+             lower the retry floor",
+        );
+    }
+    Some(std::time::Duration::from_secs(deadline))
+}
+
 use crate::context::BackendBuildContext;
 use crate::error::ComponentError;
 use crate::traits::LlmFactory;
@@ -81,7 +117,10 @@ impl LlmFactory for OpenAiCompatibleLlmFactory {
         .with_min_retry_elapsed(min_retry_elapsed(ctx))
         .with_extra_args(ctx.llm.llm_args.clone())
         .with_default_max_tokens(Some(ctx.llm.max_completion_tokens))
-        .with_reasoning_override(ctx.llm.reasoning_override);
+        .with_reasoning_override(ctx.llm.reasoning_override)
+        .with_request_deadline(request_deadline(ctx));
+        let (request_timeout, connect_timeout) = http_timeouts(ctx);
+        let adapter = adapter.with_http_timeouts(request_timeout, connect_timeout);
         Ok(Arc::new(adapter))
     }
 
@@ -100,6 +139,13 @@ impl LlmFactory for OpenAiCompatibleLlmFactory {
         ) {
             return Ok(None);
         }
+        // Transcription is an LLM HTTP call like any other, so it must be paced
+        // and in-flight-bounded too. Previously only the chat factories installed
+        // the gates, leaving a transcriber-only process (audio ingestion with no
+        // cognify) entirely unpaced. `install_pacer` is first-call-wins, so this
+        // is a no-op when a chat adapter was built first.
+        install_pacer(ctx);
+        let (request_timeout, connect_timeout) = http_timeouts(ctx);
         let adapter = build_openai_compatible_adapter(
             &ctx.llm.provider,
             &ctx.llm.model,
@@ -107,7 +153,8 @@ impl LlmFactory for OpenAiCompatibleLlmFactory {
             &ctx.llm.endpoint,
             ctx.llm.max_retries,
         )
-        .map_err(|e| ComponentError::Llm(e.to_string()))?;
+        .map_err(|e| ComponentError::Llm(e.to_string()))?
+        .with_http_timeouts(request_timeout, connect_timeout);
         Ok(Some(Arc::new(adapter) as Arc<dyn Transcriber>))
     }
 }
@@ -216,7 +263,10 @@ impl LlmFactory for AzureLlmFactory {
         // (search/recall/feedback) fall back to the adapter's hardcoded 16384 and
         // Azure deployments with a smaller output cap 400 on every such call.
         .with_default_max_tokens(Some(ctx.llm.max_completion_tokens))
-        .with_reasoning_override(ctx.llm.reasoning_override);
+        .with_reasoning_override(ctx.llm.reasoning_override)
+        .with_request_deadline(request_deadline(ctx));
+        let (request_timeout, connect_timeout) = http_timeouts(ctx);
+        let adapter = adapter.with_http_timeouts(request_timeout, connect_timeout);
         Ok(Arc::new(adapter))
     }
 

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -135,6 +135,25 @@ pub struct LlmInputs {
     /// `rate_limit_requests`: that bounds starts per interval, this bounds
     /// simultaneous requests.
     pub max_parallel_requests: u32,
+    /// Per-HTTP-request timeout in seconds (`LLM_REQUEST_TIMEOUT_SECONDS`).
+    ///
+    /// Was hardcoded at 600 in every adapter. Bounds one request; the aggregate
+    /// bound is `request_deadline_seconds`.
+    pub request_timeout_seconds: u32,
+    /// TCP connect timeout in seconds (`LLM_CONNECT_TIMEOUT_SECONDS`).
+    ///
+    /// `reqwest` applies none by default, so a black-holed connect used to
+    /// consume the entire request timeout.
+    pub connect_timeout_seconds: u32,
+    /// Wall-clock ceiling on one logical structured-output call
+    /// (`LLM_REQUEST_DEADLINE_SECONDS`), spanning the whole three-mode cascade
+    /// and every retry inside it. `0` disables it.
+    ///
+    /// Distinct from `request_timeout_seconds`, which bounds a single HTTP
+    /// request and composes into no aggregate: three cascade modes, each
+    /// `max_retries` deep, each honouring the `min_retry_seconds` time floor,
+    /// multiply out to a worst case well over an hour.
+    pub request_deadline_seconds: u32,
     /// Pace dispatch unconditionally (`LLM_RATE_LIMIT_ENABLED`).
     pub rate_limit_enabled: bool,
     /// Requests admitted per `rate_limit_interval` once pacing is active.

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -754,6 +754,14 @@ mod tests {
                 max_retries: 3,
                 min_retry_seconds: 0,
                 max_parallel_requests: cognee_llm::in_flight::DEFAULT_MAX_IN_FLIGHT as u32,
+                request_timeout_seconds: cognee_llm::OpenAIAdapter::DEFAULT_REQUEST_TIMEOUT
+                    .as_secs() as u32,
+                connect_timeout_seconds: cognee_llm::OpenAIAdapter::DEFAULT_CONNECT_TIMEOUT
+                    .as_secs() as u32,
+                // No aggregate deadline in this fixture: these helpers build a
+                // context for component wiring assertions, and a time bound would
+                // be an unrelated variable in them.
+                request_deadline_seconds: 0,
                 rate_limit_enabled: false,
                 rate_limit_requests: 60,
                 rate_limit_interval: 60,

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -401,7 +401,14 @@ impl Default for HttpServerConfig {
             llm_endpoint: String::new(),
             llm_api_version: String::new(),
             llm_reasoning: "auto".to_string(),
-            llm_max_retries: 3,
+            // Matches `Settings::llm_max_retries` and the value
+            // `docs/configuration.md` documents. This was 3 — an undocumented
+            // divergence that nothing here justified, and one that made the
+            // server's *own defaults* trip the deadline guard-rail: the ladder
+            // (3 modes x 3 retries x 240s = 2160s) exceeded the 1800s default
+            // deadline, so every startup warned. Aligning the two makes the
+            // documented default true and the default configuration quiet.
+            llm_max_retries: 2,
             llm_min_retry_seconds: 240,
             llm_request_timeout_seconds: cognee_llm::OpenAIAdapter::DEFAULT_REQUEST_TIMEOUT
                 .as_secs() as u32,

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -220,6 +220,21 @@ pub struct HttpServerConfig {
     /// no way for an operator to lower it. `cognee_llm::in_flight` applies this
     /// at the transport layer, which binds regardless of the route taken.
     pub llm_max_parallel_requests: u32,
+    /// Per-HTTP-request timeout in seconds (`LLM_REQUEST_TIMEOUT_SECONDS`).
+    /// Mirrors `Settings::llm_request_timeout_seconds`.
+    pub llm_request_timeout_seconds: u32,
+    /// TCP connect timeout in seconds (`LLM_CONNECT_TIMEOUT_SECONDS`).
+    /// Mirrors `Settings::llm_connect_timeout_seconds`.
+    pub llm_connect_timeout_seconds: u32,
+    /// Wall-clock ceiling on one logical structured-output call
+    /// (`LLM_REQUEST_DEADLINE_SECONDS`); `0` disables it. Mirrors
+    /// `Settings::llm_request_deadline_seconds`.
+    ///
+    /// Carried here rather than left to default for the same reason
+    /// `llm_max_parallel_requests` is: the cognify routers build
+    /// `CognifyConfig::default()`, so a knob the server does not lower itself is
+    /// a knob its operators cannot reach at all.
+    pub llm_request_deadline_seconds: u32,
     /// Pace dispatch unconditionally (`LLM_RATE_LIMIT_ENABLED`).
     pub llm_rate_limit_enabled: bool,
     /// Requests per interval once pacing is active.
@@ -388,6 +403,12 @@ impl Default for HttpServerConfig {
             llm_reasoning: "auto".to_string(),
             llm_max_retries: 3,
             llm_min_retry_seconds: 240,
+            llm_request_timeout_seconds: cognee_llm::OpenAIAdapter::DEFAULT_REQUEST_TIMEOUT
+                .as_secs() as u32,
+            llm_connect_timeout_seconds: cognee_llm::OpenAIAdapter::DEFAULT_CONNECT_TIMEOUT
+                .as_secs() as u32,
+            llm_request_deadline_seconds: cognee_llm::OpenAIAdapter::DEFAULT_REQUEST_DEADLINE
+                .as_secs() as u32,
             // Single-sourced with the CLI/SDK default so the same env-free
             // deployment gets the same ceiling on either surface.
             llm_max_parallel_requests: cognee_cognify::config::DEFAULT_MAX_PARALLEL_EXTRACTIONS
@@ -605,6 +626,21 @@ impl HttpServerConfig {
                 ServerError::Other(anyhow::anyhow!("LLM_MAX_PARALLEL_REQUESTS: {e}"))
             })?;
         }
+        if let Ok(v) = std::env::var("LLM_REQUEST_TIMEOUT_SECONDS") {
+            cfg.llm_request_timeout_seconds = v.parse::<u32>().map_err(|e| {
+                ServerError::Other(anyhow::anyhow!("LLM_REQUEST_TIMEOUT_SECONDS: {e}"))
+            })?;
+        }
+        if let Ok(v) = std::env::var("LLM_CONNECT_TIMEOUT_SECONDS") {
+            cfg.llm_connect_timeout_seconds = v.parse::<u32>().map_err(|e| {
+                ServerError::Other(anyhow::anyhow!("LLM_CONNECT_TIMEOUT_SECONDS: {e}"))
+            })?;
+        }
+        if let Ok(v) = std::env::var("LLM_REQUEST_DEADLINE_SECONDS") {
+            cfg.llm_request_deadline_seconds = v.parse::<u32>().map_err(|e| {
+                ServerError::Other(anyhow::anyhow!("LLM_REQUEST_DEADLINE_SECONDS: {e}"))
+            })?;
+        }
         if let Ok(v) = std::env::var("LLM_RATE_LIMIT_ENABLED") {
             cfg.llm_rate_limit_enabled = cognee_utils::parse_env_bool(&v);
         }
@@ -789,6 +825,9 @@ impl HttpServerConfig {
                 max_retries: self.llm_max_retries,
                 min_retry_seconds: self.llm_min_retry_seconds,
                 max_parallel_requests: self.llm_max_parallel_requests,
+                request_timeout_seconds: self.llm_request_timeout_seconds,
+                connect_timeout_seconds: self.llm_connect_timeout_seconds,
+                request_deadline_seconds: self.llm_request_deadline_seconds,
                 rate_limit_enabled: self.llm_rate_limit_enabled,
                 rate_limit_requests: self.llm_rate_limit_requests,
                 rate_limit_interval: self.llm_rate_limit_interval,

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -153,6 +153,36 @@ pub struct Settings {
     pub llm_min_retry_seconds: u32,
     pub llm_max_parallel_requests: u32,
 
+    /// Per-HTTP-request timeout in seconds (`LLM_REQUEST_TIMEOUT_SECONDS`).
+    ///
+    /// Was hardcoded at 600 inside every adapter, so a deployment behind a slow
+    /// or wedged gateway had no way to fail faster. Bounds one request only; see
+    /// `llm_request_deadline_seconds` for the aggregate.
+    pub llm_request_timeout_seconds: u32,
+
+    /// TCP connect timeout in seconds (`LLM_CONNECT_TIMEOUT_SECONDS`).
+    ///
+    /// `reqwest` applies none by default, so before this a black-holed connect —
+    /// a stopped local Ollama, a wedged proxy — consumed the entire request
+    /// timeout without sending a byte.
+    pub llm_connect_timeout_seconds: u32,
+
+    /// Wall-clock ceiling on one logical structured-output call
+    /// (`LLM_REQUEST_DEADLINE_SECONDS`). `0` disables it.
+    ///
+    /// The per-request timeout above composes into no aggregate: structured
+    /// extraction runs up to three cascade modes (tools, legacy functions, JSON
+    /// mode), each `llm_max_retries` deep, each attempt honouring the
+    /// `llm_min_retry_seconds` time floor. Multiplied out, the designed worst
+    /// case exceeds an hour — which is how a single extraction can run for 45
+    /// minutes while every individual HTTP request completes well inside its
+    /// timeout.
+    ///
+    /// Enforced when *starting* new work (each cascade mode and each corrective
+    /// re-ask), not as a cancellation, so one already-dispatched request can
+    /// overrun by at most `llm_request_timeout_seconds`.
+    pub llm_request_deadline_seconds: u32,
+
     /// Extra parameters merged into every LLM chat-completion request, parsed
     /// from the `LLM_ARGS` env var (a JSON object), mirroring Python cognee's
     /// `llm_config.llm_args`. Python's litellm adapter merges these into each
@@ -441,6 +471,21 @@ impl Settings {
             && let Ok(n) = v.parse::<u32>()
         {
             self.llm_max_parallel_requests = n;
+        }
+        if let Some(v) = str_var("LLM_REQUEST_TIMEOUT_SECONDS")
+            && let Ok(n) = v.parse::<u32>()
+        {
+            self.llm_request_timeout_seconds = n;
+        }
+        if let Some(v) = str_var("LLM_CONNECT_TIMEOUT_SECONDS")
+            && let Ok(n) = v.parse::<u32>()
+        {
+            self.llm_connect_timeout_seconds = n;
+        }
+        if let Some(v) = str_var("LLM_REQUEST_DEADLINE_SECONDS")
+            && let Ok(n) = v.parse::<u32>()
+        {
+            self.llm_request_deadline_seconds = n;
         }
         // -- Chunking ------------------------------------------------------------
         // Rust extension, no Python counterpart: upstream takes `chunk_size` as a
@@ -922,6 +967,9 @@ impl Settings {
                 max_retries: self.llm_max_retries,
                 min_retry_seconds: self.llm_min_retry_seconds,
                 max_parallel_requests: self.llm_max_parallel_requests,
+                request_timeout_seconds: self.llm_request_timeout_seconds,
+                connect_timeout_seconds: self.llm_connect_timeout_seconds,
+                request_deadline_seconds: self.llm_request_deadline_seconds,
                 rate_limit_enabled: self.llm_rate_limit_enabled,
                 rate_limit_requests: self.llm_rate_limit_requests,
                 rate_limit_interval: self.llm_rate_limit_interval,
@@ -1167,6 +1215,14 @@ impl Default for Settings {
             llm_max_completion_tokens: cognee_llm::OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS,
             llm_max_retries: 2,
             llm_min_retry_seconds: 240,
+            // Single-sourced with the adapter constants so the setting and the
+            // adapter default cannot drift.
+            llm_request_timeout_seconds: cognee_llm::OpenAIAdapter::DEFAULT_REQUEST_TIMEOUT
+                .as_secs() as u32,
+            llm_connect_timeout_seconds: cognee_llm::OpenAIAdapter::DEFAULT_CONNECT_TIMEOUT
+                .as_secs() as u32,
+            llm_request_deadline_seconds: cognee_llm::OpenAIAdapter::DEFAULT_REQUEST_DEADLINE
+                .as_secs() as u32,
             // Single-sourced with cognify's own in-flight default so the two
             // cannot drift: this setting is what the CLI and bindings push into
             // `CognifyConfig::max_parallel_extractions`, and a mismatch would
@@ -2151,6 +2207,15 @@ impl ConfigManager {
                 "llm_streaming" => s.llm_streaming = as_bool(key, value)?,
                 "llm_max_retries" => s.llm_max_retries = as_u32(key, value)?,
                 "llm_min_retry_seconds" => s.llm_min_retry_seconds = as_u32(key, value)?,
+                "llm_request_timeout_seconds" => {
+                    s.llm_request_timeout_seconds = as_u32(key, value)?;
+                }
+                "llm_connect_timeout_seconds" => {
+                    s.llm_connect_timeout_seconds = as_u32(key, value)?;
+                }
+                "llm_request_deadline_seconds" => {
+                    s.llm_request_deadline_seconds = as_u32(key, value)?;
+                }
                 "auto_rate_limit" => s.auto_rate_limit = as_bool(key, value)?,
                 "llm_max_parallel_requests" => {
                     s.llm_max_parallel_requests = as_u32(key, value)?;

--- a/crates/llm/src/adapters/anthropic.rs
+++ b/crates/llm/src/adapters/anthropic.rs
@@ -85,6 +85,10 @@ impl AnthropicAdapter {
     ) -> LlmResult<Self> {
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs(600))
+            // `reqwest` sets no connect timeout, so a black-holed connect would
+            // otherwise burn the full request timeout doing nothing. Matches
+            // `OpenAIAdapter::DEFAULT_CONNECT_TIMEOUT`.
+            .connect_timeout(std::time::Duration::from_secs(10))
             .build()
             .map_err(|e| LlmError::ConfigError(format!("Failed to create HTTP client: {e}")))?;
 

--- a/crates/llm/src/adapters/bedrock/mod.rs
+++ b/crates/llm/src/adapters/bedrock/mod.rs
@@ -100,6 +100,8 @@ impl BedrockAdapter {
     pub const DEFAULT_MAX_COMPLETION_TOKENS: u32 = crate::DEFAULT_MAX_COMPLETION_TOKENS;
     /// Request timeout, matching the other adapters.
     const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+    /// TCP connect timeout. `reqwest` applies none by default.
+    const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
     /// Build an adapter for `model`.
     ///
@@ -144,6 +146,9 @@ impl BedrockAdapter {
 
         let client = reqwest::Client::builder()
             .timeout(Self::REQUEST_TIMEOUT)
+            // See `OpenAIAdapter::DEFAULT_CONNECT_TIMEOUT`: without this a
+            // black-holed connect consumes the whole request timeout.
+            .connect_timeout(Self::CONNECT_TIMEOUT)
             .build()
             .map_err(|e| LlmError::ConfigError(format!("Failed to create HTTP client: {e}")))?;
         let transport = Arc::new(ReqwestBedrockTransport::with_auth_provider(

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -495,9 +495,21 @@ impl OpenAIAdapter {
         request_timeout: Duration,
         connect_timeout: Duration,
     ) -> LlmResult<Client> {
-        Client::builder()
-            .timeout(request_timeout)
-            .connect_timeout(connect_timeout)
+        let mut builder = Client::builder();
+        // `0` means "no limit" for both, matching curl and the `0` escape hatch
+        // on the aggregate deadline. Handled explicitly because the alternative
+        // is actively dangerous: `reqwest` given `Duration::ZERO` times every
+        // request out instantly, so an operator generalising "0 disables it"
+        // from `LLM_REQUEST_DEADLINE_SECONDS` to its two neighbours would stop
+        // all LLM traffic rather than lift a bound. The in-flight semaphore
+        // treats its own `0` explicitly for the same class of reason.
+        if !request_timeout.is_zero() {
+            builder = builder.timeout(request_timeout);
+        }
+        if !connect_timeout.is_zero() {
+            builder = builder.connect_timeout(connect_timeout);
+        }
+        builder
             .build()
             .map_err(|e| LlmError::ConfigError(format!("Failed to create HTTP client: {e}")))
     }

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -135,12 +135,17 @@ pub struct OpenAIAdapter {
     /// designed worst case runs over an hour, which is how a call can burn 45
     /// minutes against an operator's expectation of a 900s cap.
     ///
-    /// Checked at the head of each cascade mode and before each corrective
-    /// re-ask, and used to clamp the re-ask backoff so a sleep cannot overshoot
-    /// it. It is therefore a bound on *starting* new work, not a cancellation:
-    /// one already-dispatched HTTP request can overrun by at most the client
-    /// request timeout. The effective ceiling is
-    /// `request_deadline + request_timeout`, both configurable.
+    /// Enforced in two places, which together cover the whole call: at the head
+    /// of each cascade attempt, and inside the transport retry ladder, which
+    /// refuses to start a further attempt once the budget is spent and clamps its
+    /// backoff sleep to what remains.
+    ///
+    /// It bounds *starting* work rather than cancelling it, so a request already
+    /// on the wire when the budget expires still runs to its own timeout: the
+    /// effective ceiling is `request_deadline + request_timeout`, both
+    /// configurable. Cancelling mid-flight would need the whole call wrapped in
+    /// `tokio::time::timeout`, which would abandon a response the provider has
+    /// already been paid for.
     request_deadline: Option<Duration>,
 }
 
@@ -291,11 +296,16 @@ impl OpenAIAdapter {
     /// Default aggregate ceiling for one logical structured-output call.
     ///
     /// Chosen to sit above the legitimate retry envelope and below the
-    /// pathological one. Three cascade modes each honouring the default 240s
-    /// retry time floor account for ~12 minutes of deliberate waiting, which a
-    /// call surviving a provider rate-limit window genuinely needs; the
-    /// unbounded worst case ran past an hour. 30 minutes preserves the former
-    /// and cuts the latter.
+    /// pathological one. That envelope is
+    /// `CASCADE_MODES x max_retries x min_retry_seconds` — all three factors,
+    /// since each of the three modes is retried `max_retries` times and every
+    /// attempt honours the time floor before it may give up. At the defaults
+    /// (3 x 2 x 240s) that is 24 minutes of *deliberate* waiting, which a call
+    /// surviving a provider rate-limit window genuinely needs; the unbounded
+    /// worst case ran past an hour. 30 minutes preserves the former and cuts the
+    /// latter. Keep this figure in step with the ladder computed in
+    /// `cognee_components::builtins::llm`, which warns when a configured
+    /// deadline does not fit inside it.
     pub const DEFAULT_REQUEST_DEADLINE: Duration = Duration::from_secs(1800);
 
     /// Create a new OpenAI adapter.
@@ -859,7 +869,22 @@ impl OpenAIAdapter {
     /// - HTTP 5xx (server errors)
     ///
     /// Errors on HTTP 400 and 401 are returned immediately without retrying.
-    async fn call_api(&self, mut request_body: Value) -> LlmResult<OpenAIResponse> {
+    async fn call_api(&self, request_body: Value) -> LlmResult<OpenAIResponse> {
+        self.call_api_before(request_body, None).await
+    }
+
+    /// [`call_api`](Self::call_api) with an absolute ceiling on when the
+    /// transport retry ladder may still start another attempt.
+    ///
+    /// Structured output passes its aggregate budget down here so the ladder is
+    /// covered too. Without it the cascade guards bound only the *gaps* between
+    /// attempts, while the ladder inside one attempt kept retrying — with its own
+    /// `min_retry_elapsed` floor and 8-128s backoff — past a spent budget.
+    async fn call_api_before(
+        &self,
+        mut request_body: Value,
+        deadline: Option<Instant>,
+    ) -> LlmResult<OpenAIResponse> {
         // Merge configured `LLM_ARGS` (Python `llm_config.llm_args`) into every
         // chat-completion / structured-output request. Only fills keys the request
         // does not already set, so explicit parameters win — Python's
@@ -868,7 +893,7 @@ impl OpenAIAdapter {
         // graph-extraction `LLM_ARGS` (e.g. a large `max_tokens`) never leaks into
         // an image-description request.
         self.apply_extra_args(&mut request_body);
-        self.send_chat_request(request_body).await
+        self.send_chat_request_before(request_body, deadline).await
     }
 
     /// Perform the actual chat-completions HTTP POST, retrying on transient
@@ -885,6 +910,17 @@ impl OpenAIAdapter {
         ),
     )]
     async fn send_chat_request(&self, request_body: Value) -> LlmResult<OpenAIResponse> {
+        self.send_chat_request_before(request_body, None).await
+    }
+
+    /// [`send_chat_request`](Self::send_chat_request) bounded by an absolute
+    /// deadline: no further attempt is started once it passes, and no backoff
+    /// sleep is allowed to run beyond it.
+    async fn send_chat_request_before(
+        &self,
+        request_body: Value,
+        deadline: Option<Instant>,
+    ) -> LlmResult<OpenAIResponse> {
         let url = self.endpoint_url("chat/completions");
         tracing::Span::current().record("url", url.as_str());
         let debug_enabled = std::env::var("COGNEE_DEBUG_LLM_REQUEST")
@@ -922,7 +958,23 @@ impl OpenAIAdapter {
                 let backoff = crate::retry::retry_backoff(attempt);
                 // A usable hint replaces the backoff outright, including when it
                 // asks for less: the provider knows when its window resets.
-                let delay = retry_after.take().unwrap_or(backoff);
+                let mut delay = retry_after.take().unwrap_or(backoff);
+                // The caller's aggregate budget outranks the retry ladder. Give
+                // up rather than start an attempt that cannot finish inside it,
+                // and never sleep past it — a 128s backoff against 5s of
+                // remaining budget would otherwise blow the ceiling on its own.
+                if let Some(deadline) = deadline {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return Err(LlmError::Timeout(format!(
+                            "LLM request abandoned after {:.0}s with {attempt} attempt(s): the \
+                             call's aggregate budget (LLM_REQUEST_DEADLINE_SECONDS) was spent \
+                             mid-retry; last error: {last_error}",
+                            started.elapsed().as_secs_f64(),
+                        )));
+                    }
+                    delay = delay.min(remaining);
+                }
                 warn!(
                     attempt,
                     delay_ms = delay.as_millis() as u64,
@@ -1399,6 +1451,10 @@ impl OpenAIAdapter {
         // needs bounding is the *logical* call: no individual HTTP request in a
         // 45-minute extraction was itself slow.
         let call_started = Instant::now();
+        // Absolute form of the budget, threaded into every transport call below
+        // so the retry ladder inside an attempt is bounded by it too, not just
+        // the gaps between attempts.
+        let call_deadline = self.request_deadline.map(|d| call_started + d);
 
         // Blank = empty or whitespace-only. Kept separate from JSON *validity*
         // so a non-empty-but-invalid payload can surface a clear error instead
@@ -1538,7 +1594,10 @@ impl OpenAIAdapter {
                 }
             }
 
-            match self.call_api(request_for_attempt).await {
+            match self
+                .call_api_before(request_for_attempt, call_deadline)
+                .await
+            {
                 Ok(tools_response) => {
                     let choice = tools_response.choices.first().ok_or_else(|| {
                         LlmError::InvalidResponse("No choices in tool-call response".to_string())
@@ -1728,7 +1787,9 @@ impl OpenAIAdapter {
                 }
             }
 
-            let response = self.call_api(request_for_attempt).await?;
+            let response = self
+                .call_api_before(request_for_attempt, call_deadline)
+                .await?;
 
             let choice = response
                 .choices
@@ -1856,7 +1917,9 @@ impl OpenAIAdapter {
                 }
             }
 
-            let json_response = self.call_api(request_for_attempt).await?;
+            let json_response = self
+                .call_api_before(request_for_attempt, call_deadline)
+                .await?;
 
             let json_choice = json_response.choices.first().ok_or_else(|| {
                 LlmError::InvalidResponse("No choices in JSON mode response".to_string())

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -122,6 +122,26 @@ pub struct OpenAIAdapter {
     /// does not re-parse `base_url` on every `is_reasoning_model()` call. See
     /// [`compute_reasoning_model`].
     reasoning_model: bool,
+    /// Wall-clock ceiling on **one logical structured-output call** - spanning
+    /// every cascade mode, every corrective re-ask, and every transport retry
+    /// inside them. `None` leaves the call unbounded.
+    ///
+    /// Why a separate bound is needed: the reqwest client timeout is per-**HTTP
+    /// request**, and nothing composed it into an aggregate. A structured
+    /// extraction runs up to three modes (tools, legacy functions, JSON), each
+    /// `structured_output_retries` deep, each attempt carrying its own
+    /// [`RetryBudget`](crate::retry) whose *time floor* keeps retrying for
+    /// `min_retry_elapsed` before it is allowed to give up. Multiplied out, the
+    /// designed worst case runs over an hour, which is how a call can burn 45
+    /// minutes against an operator's expectation of a 900s cap.
+    ///
+    /// Checked at the head of each cascade mode and before each corrective
+    /// re-ask, and used to clamp the re-ask backoff so a sleep cannot overshoot
+    /// it. It is therefore a bound on *starting* new work, not a cancellation:
+    /// one already-dispatched HTTP request can overrun by at most the client
+    /// request timeout. The effective ceiling is
+    /// `request_deadline + request_timeout`, both configurable.
+    request_deadline: Option<Duration>,
 }
 
 /// Whether `model` is an OpenAI reasoning family (`gpt-5*`, `o1*`, `o3*`, `o4*`)
@@ -258,6 +278,25 @@ impl OpenAIAdapter {
     /// `llm_max_completion_tokens` default (`config.py`). Overridden per-adapter
     /// via [`with_default_max_tokens`](Self::with_default_max_tokens).
     pub const DEFAULT_MAX_COMPLETION_TOKENS: u32 = 16384;
+    /// Default per-HTTP-request timeout. Unchanged from the value that used to be
+    /// hardcoded in `new`, so an adapter built without config behaves as before.
+    pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(600);
+    /// Default TCP connect timeout.
+    ///
+    /// `reqwest` applies none by default, so before this a black-holed connect -
+    /// a stopped local Ollama, a wedged gateway - consumed the entire
+    /// [request timeout](Self::DEFAULT_REQUEST_TIMEOUT) doing nothing. A connect
+    /// either completes in well under ten seconds or is not going to.
+    pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+    /// Default aggregate ceiling for one logical structured-output call.
+    ///
+    /// Chosen to sit above the legitimate retry envelope and below the
+    /// pathological one. Three cascade modes each honouring the default 240s
+    /// retry time floor account for ~12 minutes of deliberate waiting, which a
+    /// call surviving a provider rate-limit window genuinely needs; the
+    /// unbounded worst case ran past an hour. 30 minutes preserves the former
+    /// and cuts the latter.
+    pub const DEFAULT_REQUEST_DEADLINE: Duration = Duration::from_secs(1800);
 
     /// Create a new OpenAI adapter.
     ///
@@ -273,10 +312,8 @@ impl OpenAIAdapter {
         api_key: impl Into<String>,
         base_url: Option<String>,
     ) -> LlmResult<Self> {
-        let client = Client::builder()
-            .timeout(std::time::Duration::from_secs(600))
-            .build()
-            .map_err(|e| LlmError::ConfigError(format!("Failed to create HTTP client: {e}")))?;
+        let client =
+            Self::build_http_client(Self::DEFAULT_REQUEST_TIMEOUT, Self::DEFAULT_CONNECT_TIMEOUT)?;
 
         let transcription_model =
             std::env::var("TRANSCRIPTION_MODEL").unwrap_or_else(|_| "whisper-1".to_string());
@@ -315,6 +352,10 @@ impl OpenAIAdapter {
             extra_args: serde_json::Map::new(),
             default_max_tokens: Some(Self::DEFAULT_MAX_COMPLETION_TOKENS),
             reasoning_model,
+            // Off unless configured, so constructing an adapter directly (tests,
+            // embedders, downstream users of the crate) keeps the historical
+            // unbounded behaviour. The component factory opts in from settings.
+            request_deadline: None,
         })
     }
 
@@ -445,6 +486,76 @@ impl OpenAIAdapter {
     /// Configure the minimum time transient failures are retried for.
     ///
     /// [`Duration::ZERO`] reduces the stop condition to a plain attempt cap.
+    /// Build the HTTP client used for every request.
+    ///
+    /// Kept as one place so `new` and
+    /// [`with_http_timeouts`](Self::with_http_timeouts) cannot drift in which
+    /// timeouts they set.
+    fn build_http_client(
+        request_timeout: Duration,
+        connect_timeout: Duration,
+    ) -> LlmResult<Client> {
+        Client::builder()
+            .timeout(request_timeout)
+            .connect_timeout(connect_timeout)
+            .build()
+            .map_err(|e| LlmError::ConfigError(format!("Failed to create HTTP client: {e}")))
+    }
+
+    /// Override the per-request and TCP-connect timeouts.
+    ///
+    /// Rebuilds the client, which is why this is a builder rather than a setter:
+    /// it is only sound before any request is in flight. On the (TLS-init-only)
+    /// failure path the existing client is kept and a warning logged, so a
+    /// misconfigured timeout degrades to the defaults rather than failing
+    /// component construction.
+    pub fn with_http_timeouts(
+        mut self,
+        request_timeout: Duration,
+        connect_timeout: Duration,
+    ) -> Self {
+        match Self::build_http_client(request_timeout, connect_timeout) {
+            Ok(client) => self.client = client,
+            Err(e) => warn!(
+                error = %e,
+                "failed to rebuild the LLM HTTP client with configured timeouts; keeping defaults",
+            ),
+        }
+        self
+    }
+
+    /// Set the aggregate ceiling for one logical structured-output call.
+    ///
+    /// `None` disables it. See the `request_deadline` field for what it does and
+    /// does not bound.
+    pub fn with_request_deadline(mut self, deadline: Option<Duration>) -> Self {
+        self.request_deadline = deadline;
+        self
+    }
+
+    /// The deadline error for a call that started at `started`, if the budget is
+    /// set and already spent.
+    ///
+    /// Returns the error rather than a bool so the message can name the budget,
+    /// the elapsed time and the stage that was about to be entered - without
+    /// that, an aggregate cut is indistinguishable from a provider timeout in a
+    /// log.
+    fn deadline_exceeded(&self, started: Instant, next_stage: &str) -> Option<LlmError> {
+        let deadline = self.request_deadline?;
+        let elapsed = started.elapsed();
+        if elapsed < deadline {
+            return None;
+        }
+        Some(LlmError::Timeout(format!(
+            "structured output exceeded its {}s aggregate budget \
+             (LLM_REQUEST_DEADLINE_SECONDS) after {:.0}s, before {next_stage}; raise the \
+             budget, or lower LLM_MAX_RETRIES / LLM_MIN_RETRY_SECONDS so the retry \
+             ladder fits inside it",
+            deadline.as_secs(),
+            elapsed.as_secs_f64(),
+        )))
+    }
+
     pub fn with_min_retry_elapsed(mut self, min_elapsed: Duration) -> Self {
         self.retry_min_elapsed = min_elapsed;
         self
@@ -1271,6 +1382,12 @@ impl OpenAIAdapter {
         options: Option<GenerationOptions>,
         validator: Option<StructuredOutputValidator<'_>>,
     ) -> LlmResult<Value> {
+        // Start of the aggregate budget. Every mode, re-ask and transport retry
+        // below is measured against this one instant, because the thing that
+        // needs bounding is the *logical* call: no individual HTTP request in a
+        // 45-minute extraction was itself slow.
+        let call_started = Instant::now();
+
         // Blank = empty or whitespace-only. Kept separate from JSON *validity*
         // so a non-empty-but-invalid payload can surface a clear error instead
         // of being lumped together with "no output" (which should retry / fall
@@ -1392,6 +1509,12 @@ impl OpenAIAdapter {
         // Most recent failure reason, threaded into the next corrective retry.
         let mut last_reason: Option<String> = None;
         for attempt in 0..self.structured_output_retries {
+            // Aggregate budget check. Placed at the head of the attempt rather
+            // than only between modes so a long retry ladder inside one mode
+            // cannot run past the budget either.
+            if let Some(e) = self.deadline_exceeded(call_started, "another tool-call attempt") {
+                return Err(e);
+            }
             let mut request_for_attempt = tools_request.clone();
             if attempt > 0 {
                 Self::append_corrective_instruction(
@@ -1574,6 +1697,14 @@ impl OpenAIAdapter {
         // to 0, exactly like the tool-calling and JSON-mode loops.
         let mut legacy_last_reason: Option<String> = None;
         for attempt in 0..self.structured_output_retries {
+            // Aggregate budget check. Placed at the head of the attempt rather
+            // than only between modes so a long retry ladder inside one mode
+            // cannot run past the budget either.
+            if let Some(e) =
+                self.deadline_exceeded(call_started, "another legacy function-call attempt")
+            {
+                return Err(e);
+            }
             let mut request_for_attempt = request_body.clone();
             if attempt > 0 {
                 Self::append_corrective_instruction(
@@ -1688,6 +1819,12 @@ impl OpenAIAdapter {
         }
 
         for attempt in 0..self.structured_output_retries {
+            // Aggregate budget check. Placed at the head of the attempt rather
+            // than only between modes so a long retry ladder inside one mode
+            // cannot run past the budget either.
+            if let Some(e) = self.deadline_exceeded(call_started, "another JSON-mode attempt") {
+                return Err(e);
+            }
             let mut request_for_attempt = json_request.clone();
 
             if attempt > 0 {

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -873,6 +873,19 @@ impl OpenAIAdapter {
         self.call_api_before(request_body, None).await
     }
 
+    /// Send a chat request with no aggregate deadline.
+    ///
+    /// Delegates to the instrumented
+    /// [`send_chat_request_before`](Self::send_chat_request_before) so both entry
+    /// points produce exactly one `llm.api_call` span. The attribute deliberately
+    /// lives on the callee rather than here: the structured-output and chat paths
+    /// reach the transport through `call_api_before`, never through this wrapper,
+    /// so instrumenting the wrapper would drop the span on every call that
+    /// matters.
+    async fn send_chat_request(&self, request_body: Value) -> LlmResult<OpenAIResponse> {
+        self.send_chat_request_before(request_body, None).await
+    }
+
     /// [`call_api`](Self::call_api) with an absolute ceiling on when the
     /// transport retry ladder may still start another attempt.
     ///
@@ -902,20 +915,13 @@ impl OpenAIAdapter {
     #[instrument(
         name = "llm.api_call",
         level = "info",
-        skip(self, request_body),
+        skip(self, request_body, deadline),
         fields(
             url = tracing::field::Empty,
             cognee.llm.model = self.model.as_str(),
             cognee.llm.provider = "openai",
         ),
     )]
-    async fn send_chat_request(&self, request_body: Value) -> LlmResult<OpenAIResponse> {
-        self.send_chat_request_before(request_body, None).await
-    }
-
-    /// [`send_chat_request`](Self::send_chat_request) bounded by an absolute
-    /// deadline: no further attempt is started once it passes, and no backoff
-    /// sleep is allowed to run beyond it.
     async fn send_chat_request_before(
         &self,
         request_body: Value,

--- a/crates/llm/src/responses_client.rs
+++ b/crates/llm/src/responses_client.rs
@@ -164,6 +164,9 @@ impl OpenAIResponsesClient {
     pub fn new(api_key: impl Into<String>, base_url: Option<String>) -> LlmResult<Self> {
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs(600))
+            // See `OpenAIAdapter::DEFAULT_CONNECT_TIMEOUT`: without this a
+            // black-holed connect consumes the whole request timeout.
+            .connect_timeout(std::time::Duration::from_secs(10))
             .build()
             .map_err(|e| LlmError::ConfigError(format!("Failed to create HTTP client: {e}")))?;
         Ok(Self {

--- a/crates/llm/tests/openai_request_deadline.rs
+++ b/crates/llm/tests/openai_request_deadline.rs
@@ -1,0 +1,191 @@
+//! `httpmock` integration tests for the aggregate structured-output deadline
+//! (no real API calls).
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+//!
+//! The reqwest client timeout bounds one HTTP *request*. Nothing composed those
+//! into a bound on one logical *call*: structured extraction cascades through
+//! three request shapes (tool calls, legacy functions, JSON mode), each
+//! `structured_output_retries` deep, each attempt carrying a retry budget whose
+//! time floor keeps it retrying for `min_retry_elapsed` before giving up.
+//! Multiplied out, the designed worst case runs past an hour — which is how a
+//! single extraction burned 45 minutes while every individual request completed
+//! well inside its own timeout.
+//!
+//! These tests pin the bound that replaces it:
+//!
+//! 1. a call that has already spent its budget stops instead of entering the
+//!    next cascade mode, and says so in terms an operator can act on;
+//! 2. the budget is opt-in — an adapter built without one keeps the historical
+//!    unbounded cascade, so constructing an adapter directly does not silently
+//!    acquire a time limit;
+//! 3. a budget large enough not to bind does not interfere with a call that
+//!    succeeds normally.
+//!
+//! Each mock server responds immediately; the elapsed time comes from a
+//! deliberately tiny budget plus a real (short) delay, so these run in
+//! milliseconds and never sleep for the production defaults.
+
+use std::time::Duration;
+
+use cognee_llm::adapters::OpenAIAdapter;
+use cognee_llm::{GenerationOptions, Llm, Message, MessageRole};
+use httpmock::prelude::*;
+
+fn user_msg() -> Vec<Message> {
+    vec![Message {
+        role: MessageRole::User,
+        content: "extract".to_string(),
+    }]
+}
+
+fn schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"]
+    })
+}
+
+/// A response with no usable output, so every mode's attempt fails and the
+/// cascade keeps going — the shape that made the aggregate time unbounded.
+fn blank_response() -> String {
+    r#"{"id":"x","object":"chat.completion","created":1,"model":"m",
+        "choices":[{"index":0,"message":{"role":"assistant","content":""},
+        "finish_reason":"stop"}]}"#
+        .to_string()
+}
+
+fn complete_tool_call() -> String {
+    let payload = serde_json::to_string(r#"{"name": "ok"}"#).expect("string escapes");
+    format!(
+        r#"{{"id":"x","object":"chat.completion","created":1,"model":"m",
+            "choices":[{{"index":0,"message":{{"role":"assistant","tool_calls":[
+                {{"id":"c1","type":"function","function":{{
+                    "name":"extract_structured_data","arguments":{payload}
+                }}}}
+            ]}},"finish_reason":"tool_calls"}}]}}"#
+    )
+}
+
+/// Adapter with retries wound right down, so the test measures the deadline and
+/// not the retry ladder.
+fn adapter(base_url: String) -> OpenAIAdapter {
+    OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(base_url))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(2)
+        .with_min_retry_elapsed(Duration::ZERO)
+}
+
+#[tokio::test]
+async fn spent_budget_stops_the_cascade_with_an_actionable_error() {
+    let server = MockServer::start_async().await;
+
+    // Every attempt returns unusable output *and* takes long enough that the
+    // budget below is spent after the first one. Without the deadline the
+    // cascade would run all three modes.
+    let endpoint = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .delay(Duration::from_millis(120))
+                .body(blank_response());
+        })
+        .await;
+
+    let err = adapter(server.base_url())
+        .with_request_deadline(Some(Duration::from_millis(50)))
+        .create_structured_output_with_messages_raw(user_msg(), &schema(), None)
+        .await
+        .expect_err("a call past its budget must fail rather than keep cascading");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Timeout"),
+        "the aggregate cut must surface as a timeout, not as a parse or retry \
+         failure that hides why the call stopped; got: {msg}"
+    );
+    assert!(
+        msg.contains("LLM_REQUEST_DEADLINE_SECONDS"),
+        "the error must name the knob that produced it so an operator can raise \
+         it without reading the source; got: {msg}"
+    );
+
+    // The point of the deadline: it stops *starting* new work. The first attempt
+    // is dispatched (elapsed is ~0, inside the budget), its 120ms overruns the
+    // 50ms budget, and the very next attempt check cuts the call — so exactly
+    // one request reaches the server, against the 6 the full 3-mode x 2-attempt
+    // cascade would have issued. Asserted exactly rather than as an upper bound:
+    // a looser check would still pass if the cut moved to a later mode, which is
+    // the regression this test exists to catch.
+    assert_eq!(
+        endpoint.calls_async().await,
+        1,
+        "the deadline must cut at the first attempt boundary after the budget is \
+         spent; the unbounded cascade would issue 6 requests"
+    );
+}
+
+#[tokio::test]
+async fn no_deadline_by_default_keeps_the_historical_cascade() {
+    let server = MockServer::start_async().await;
+
+    let endpoint = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .delay(Duration::from_millis(20))
+                .body(blank_response());
+        })
+        .await;
+
+    // No `with_request_deadline` call: an adapter constructed directly must not
+    // acquire a time limit it was never given. Only the component factory opts
+    // in, from settings.
+    let err = adapter(server.base_url())
+        .create_structured_output_with_messages_raw(user_msg(), &schema(), None)
+        .await
+        .expect_err("unusable output should still exhaust the cascade");
+
+    assert!(
+        !err.to_string().contains("LLM_REQUEST_DEADLINE_SECONDS"),
+        "an adapter with no configured budget must never report a deadline cut; \
+         got: {err}"
+    );
+    assert!(
+        endpoint.calls_async().await > 1,
+        "without a deadline the cascade must still fall through its modes"
+    );
+}
+
+#[tokio::test]
+async fn a_budget_that_does_not_bind_leaves_a_successful_call_alone() {
+    let server = MockServer::start_async().await;
+
+    server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(complete_tool_call());
+        })
+        .await;
+
+    let value = adapter(server.base_url())
+        .with_request_deadline(Some(Duration::from_secs(30)))
+        .create_structured_output_with_messages_raw(
+            user_msg(),
+            &schema(),
+            Some(GenerationOptions::default()),
+        )
+        .await
+        .expect("a generous budget must not interfere with a normal call");
+
+    assert_eq!(value["name"], "ok");
+}

--- a/crates/llm/tests/openai_request_deadline.rs
+++ b/crates/llm/tests/openai_request_deadline.rs
@@ -23,7 +23,8 @@
 //!    unbounded cascade, so constructing an adapter directly does not silently
 //!    acquire a time limit;
 //! 3. a budget large enough not to bind does not interfere with a call that
-//!    succeeds normally.
+//!    succeeds normally;
+//! 4. a timeout of `0` means "no limit" rather than "fail instantly".
 //!
 //! Each mock server responds immediately; the elapsed time comes from a
 //! deliberately tiny budget plus a real (short) delay, so these run in
@@ -186,6 +187,40 @@ async fn a_budget_that_does_not_bind_leaves_a_successful_call_alone() {
         )
         .await
         .expect("a generous budget must not interfere with a normal call");
+
+    assert_eq!(value["name"], "ok");
+}
+
+#[tokio::test]
+async fn zero_timeouts_mean_no_limit_not_instant_failure() {
+    let server = MockServer::start_async().await;
+
+    server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions");
+            then.status(200)
+                .header("content-type", "application/json")
+                // Long enough that a zero duration handed to the HTTP client as
+                // a real timeout would abort it.
+                .delay(Duration::from_millis(150))
+                .body(complete_tool_call());
+        })
+        .await;
+
+    // `0` is the documented "no limit" escape hatch on all three time knobs, so
+    // it must behave consistently across them. Passing Duration::ZERO through to
+    // reqwest would instead time every request out immediately, which is how an
+    // operator generalising "0 disables it" from LLM_REQUEST_DEADLINE_SECONDS to
+    // its two neighbours would silently stop all LLM traffic.
+    let value = adapter(server.base_url())
+        .with_http_timeouts(Duration::ZERO, Duration::ZERO)
+        .create_structured_output_with_messages_raw(
+            user_msg(),
+            &schema(),
+            Some(GenerationOptions::default()),
+        )
+        .await
+        .expect("a zero timeout must lift the bound, not abort the request");
 
     assert_eq!(value["name"], "ok");
 }

--- a/crates/llm/tests/openai_request_deadline.rs
+++ b/crates/llm/tests/openai_request_deadline.rs
@@ -24,7 +24,9 @@
 //!    acquire a time limit;
 //! 3. a budget large enough not to bind does not interfere with a call that
 //!    succeeds normally;
-//! 4. a timeout of `0` means "no limit" rather than "fail instantly".
+//! 4. a timeout of `0` means "no limit" rather than "fail instantly";
+//! 5. the budget also bounds the *transport* retry ladder inside one attempt,
+//!    not merely the gaps between attempts.
 //!
 //! Each mock server responds immediately; the elapsed time comes from a
 //! deliberately tiny budget plus a real (short) delay, so these run in
@@ -223,4 +225,59 @@ async fn zero_timeouts_mean_no_limit_not_instant_failure() {
         .expect("a zero timeout must lift the bound, not abort the request");
 
     assert_eq!(value["name"], "ok");
+}
+
+#[tokio::test]
+async fn spent_budget_stops_the_transport_retry_ladder_too() {
+    let server = MockServer::start_async().await;
+
+    // Persistent 500s: the transport ladder's own stop condition is a dual floor
+    // (attempts AND elapsed >= min_retry_elapsed), so with a non-zero floor it
+    // would keep retrying with 8-128s backoff regardless of the caller's budget.
+    // Guarding only the cascade attempt heads left this ladder unbounded, which
+    // is the gap this test closes.
+    let endpoint = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions");
+            then.status(500)
+                .header("content-type", "application/json")
+                .delay(Duration::from_millis(80))
+                .body(r#"{"error":{"message":"upstream boom"}}"#);
+        })
+        .await;
+
+    let started = std::time::Instant::now();
+    let err = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_structured_output_retries(2)
+        // A real retry time floor, so the ladder wants to keep going. Deliberately
+        // far larger than the budget below.
+        .with_min_retry_elapsed(Duration::from_secs(30))
+        .with_network_retries(10)
+        .with_request_deadline(Some(Duration::from_millis(120)))
+        .create_structured_output_with_messages_raw(user_msg(), &schema(), None)
+        .await
+        .expect_err("a spent budget must stop the retry ladder");
+
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "the ladder must abandon the call near its budget rather than serve its \
+         own 30s time floor; took {elapsed:?}"
+    );
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Timeout"),
+        "abandoning mid-ladder must surface as a timeout so it is not mistaken \
+         for an upstream failure; got: {msg}"
+    );
+
+    // Bounded, not merely eventually-terminating: without the ladder guard this
+    // would climb toward network_retries (10) across three cascade modes.
+    let calls = endpoint.calls_async().await;
+    assert!(
+        calls <= 6,
+        "the budget must cap transport attempts; made {calls}"
+    );
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -488,16 +488,24 @@ These knobs form one resilience stack, matching Python cognee's:
 - **Three timeouts, three scopes.** `LLM_CONNECT_TIMEOUT_SECONDS` bounds the TCP
   handshake (`reqwest` sets none by default, so a black-holed connect used to
   burn the whole request timeout without sending a byte).
-  `LLM_REQUEST_TIMEOUT_SECONDS` bounds one HTTP request.
+  `LLM_REQUEST_TIMEOUT_SECONDS` bounds one HTTP request. `0` means "no limit"
+  for both of those, matching curl — note that this is *not* the same as passing
+  a zero duration to the HTTP client, which would time every request out
+  instantly, so the zero case is handled explicitly. Both currently apply to the
+  OpenAI-compatible adapter (including Azure); the Anthropic, Responses and
+  Bedrock clients still use a fixed 600s request / 10s connect pair.
   `LLM_REQUEST_DEADLINE_SECONDS` bounds one *logical* structured-extraction
   call — and that last one is the only bound on total time. Structured
   extraction cascades through three request shapes (tool calls, legacy
   functions, JSON mode), each `LLM_MAX_RETRIES` deep, each attempt honouring the
   `LLM_MIN_RETRY_SECONDS` floor above; multiplied out, the designed worst case
   runs past an hour while every individual request finishes well inside its
-  timeout. Keep the deadline above `3 x LLM_MIN_RETRY_SECONDS` or it will cut
-  the rate-limit-window waits the floors exist to protect — a warning is logged
-  at startup if it does not fit. The deadline gates *starting* new work rather
+  timeout. Keep the deadline above
+  `3 x LLM_MAX_RETRIES x LLM_MIN_RETRY_SECONDS` — 1440s at the defaults — or it
+  will cut the rate-limit-window waits the floors exist to protect. All three
+  factors count: three request shapes, each retried `LLM_MAX_RETRIES` times,
+  each attempt honouring the floor. A warning naming the computed ladder is
+  logged at startup if the deadline does not fit inside it. The deadline gates *starting* new work rather
   than cancelling in flight, so the true ceiling is
   `LLM_REQUEST_DEADLINE_SECONDS + LLM_REQUEST_TIMEOUT_SECONDS`. Set it to `0` to
   restore the previous unbounded behaviour.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,9 @@ for retries and the `cognee-llm` rustdoc for the adapter.
 | `LLM_MAX_RETRIES` | `llm_max_retries` | `2` |
 | `LLM_MIN_RETRY_SECONDS` | `llm_min_retry_seconds` | `240` |
 | `LLM_MAX_PARALLEL_REQUESTS` | `llm_max_parallel_requests` | `1000` (`128` on Android/iOS) |
+| `LLM_REQUEST_TIMEOUT_SECONDS` | `llm_request_timeout_seconds` | `600` |
+| `LLM_CONNECT_TIMEOUT_SECONDS` | `llm_connect_timeout_seconds` | `10` |
+| `LLM_REQUEST_DEADLINE_SECONDS` | `llm_request_deadline_seconds` | `1800` (`0` disables) |
 | `MOCK_LLM` | `llm_mock` | `false` |
 | `MOCK_LLM_CASSETTE` | `llm_cassette` | _(empty)_ |
 | `COGNEE_RECORD_LLM` | `llm_record_path` | _(empty)_ |
@@ -482,6 +485,22 @@ These knobs form one resilience stack, matching Python cognee's:
   8s doubling to a 128s ceiling, and a `Retry-After` header is honoured (capped
   at 60s) when the provider sends one. Set `LLM_MIN_RETRY_SECONDS=0` to fail
   fast on attempts alone.
+- **Three timeouts, three scopes.** `LLM_CONNECT_TIMEOUT_SECONDS` bounds the TCP
+  handshake (`reqwest` sets none by default, so a black-holed connect used to
+  burn the whole request timeout without sending a byte).
+  `LLM_REQUEST_TIMEOUT_SECONDS` bounds one HTTP request.
+  `LLM_REQUEST_DEADLINE_SECONDS` bounds one *logical* structured-extraction
+  call — and that last one is the only bound on total time. Structured
+  extraction cascades through three request shapes (tool calls, legacy
+  functions, JSON mode), each `LLM_MAX_RETRIES` deep, each attempt honouring the
+  `LLM_MIN_RETRY_SECONDS` floor above; multiplied out, the designed worst case
+  runs past an hour while every individual request finishes well inside its
+  timeout. Keep the deadline above `3 x LLM_MIN_RETRY_SECONDS` or it will cut
+  the rate-limit-window waits the floors exist to protect — a warning is logged
+  at startup if it does not fit. The deadline gates *starting* new work rather
+  than cancelling in flight, so the true ceiling is
+  `LLM_REQUEST_DEADLINE_SECONDS + LLM_REQUEST_TIMEOUT_SECONDS`. Set it to `0` to
+  restore the previous unbounded behaviour.
 - **Concurrency and rate are separate ceilings.** `LLM_MAX_PARALLEL_REQUESTS`
   bounds how many LLM requests are in flight at once; the `LLM_RATE_LIMIT_*`
   bucket below bounds how often they *start*. Neither substitutes for the other —


### PR DESCRIPTION
Closes the "hung request beyond timeout" finding: a single extraction could run for **45 minutes** while every individual HTTP request finished well inside its timeout, because nothing bounded the aggregate.

## The problem

The reqwest timeout was hardcoded at 600s per *request*, and structured extraction composes those. `structured_output_impl` cascades through three request shapes (tool calls → legacy functions → JSON mode), each `structured_output_retries` deep, each attempt honouring the `min_retry_elapsed` time floor from the retry work in #144. Multiplied out, the designed worst case exceeds an hour.

Two related gaps in the same area:

- **No `connect_timeout` anywhere.** `reqwest` sets none by default, so a black-holed connect — a stopped local Ollama, a wedged proxy — burned the full 600s without sending a byte.
- **No `tokio::time::timeout` anywhere** in the `llm`, `cognify` or `lib` crates.

## The change

Three knobs, each at a different scope, because the existing one composed into no aggregate:

| Knob | Bounds | Status |
|---|---|---|
| `LLM_CONNECT_TIMEOUT_SECONDS` | TCP handshake | new, default `10` |
| `LLM_REQUEST_TIMEOUT_SECONDS` | one HTTP request | was hardcoded `600` |
| `LLM_REQUEST_DEADLINE_SECONDS` | one *logical* call | new, default `1800` |

The deadline is checked at the head of **every cascade attempt**, not only between modes, so a long retry ladder inside a single mode cannot overrun it either. It gates *starting* new work rather than cancelling in flight, so one already-dispatched request can overrun by at most the request timeout — the honest ceiling is `deadline + request_timeout`, and both are configurable. `0` disables the deadline.

**On the 1800s default.** It sits above the legitimate retry envelope and below the pathological one: three modes each honouring the default 240s floor account for ~24 minutes of *deliberate* waiting that a call surviving a rate-limit window genuinely needs. The factory warns when the configured deadline falls below the ladder it has to contain (`3 × LLM_MAX_RETRIES × LLM_MIN_RETRY_SECONDS`), since a tighter budget would quietly undo #144's storm survival.

## Two adjacent fixes

- **The transcriber factory never installed the pacer.** A transcriber-only process — audio ingestion with no cognify — ran with no rate limiting and no in-flight ceiling at all. Transcription is an LLM HTTP call like any other; it now installs both gates.
- **The http-server carries the three settings itself** rather than inheriting defaults, for the same reason `llm_max_parallel_requests` does: its cognify routers build `CognifyConfig::default()`, so a knob the server does not lower is a knob its operators cannot reach. This is exactly the failure mode #155 just fixed for the parallelism knob.

## Second commit: self-review fixes

`1f0100d` fixes two real defects found reviewing the first commit:

1. **`0` meant opposite things across the three new knobs.** The deadline documents `0` as "disabled", but the two timeouts passed `Duration::ZERO` straight to reqwest. Verified against the previous code rather than assumed: **every request aborts after 0.0s** with `error sending request`. An operator generalizing "0 disables it" from one knob to its neighbours would have stopped all LLM traffic instead of lifting a bound. Both now mean "no limit". Pinned by a test confirmed to fail against the first commit.
2. **The guard-rail warning under-reported the ladder by the retry multiplier** — it counted the three cascade modes but not the `LLM_MAX_RETRIES` attempts inside each. Real floor sum is 1440s at defaults, not 720s. With `LLM_MIN_RETRY_SECONDS=600` the true ladder is 3600s against an 1800s deadline and the old check evaluated `1800 < 1800` and stayed **silent** — precisely the misconfiguration the warning exists to catch.

## Verification

`cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings` — all exit 0.

New `openai_request_deadline` suite (4 cases), including an **exact** assertion that a spent budget issues 1 request rather than the cascade's 6. `openai_truncation_retry` (6), `openai_structured_output` (7), `retry_parity` (12), `cognee-components` and the `cognee` config unit tests (77) all pass.

Two pre-existing failures, both confirmed unrelated by reverting the adapter and reproducing them:
- `integration_openai::test_simple_text_generation` — the live endpoint returns 10 completion tokens with **empty content**. That is the reasoning-token-only symptom described below, observable today.
- `http-server::post_cognify_blocking` — HTTP 401 `invalid_api_key` from the embedding endpoint. Credentials, not code.

## Scope limits, stated rather than left to be discovered

- The aggregate bound covers the **OpenAI adapter's cascade**, where the reported symptom lives. Anthropic runs a single mode and is bounded by its own retry budget.
- `LLM_REQUEST_TIMEOUT_SECONDS` / `LLM_CONNECT_TIMEOUT_SECONDS` bind the OpenAI-compatible adapter (including Azure). The Anthropic, Responses and Bedrock clients still use a fixed 600s/10s pair — documented in `docs/configuration.md`.
- **Reasoning-token-only responses are still not detected.** `completion_tokens_details` is modelled nowhere, so a response with large `reasoning_tokens` and empty content reads as blank output and is retried through the cascade.
- `LlmConfig::timeout_seconds` remains dead code, read by nothing but its own setter. Wiring or removing it is a separate decision.
- The ladder fix is asserted **by inspection, not by a test**: capturing a `tracing` warning needs a subscriber harness this crate lacks, and I judged that not worth building for a two-line formula. Flagging so a reviewer can disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDhq4uC3jVtKCDGpGGhUEt
