### PR TITLE
fix(delete): key EdgeType vector removal on the edge's retrieval text (SDK-505)

### DIFF
--- a/crates/delete/src/lib.rs
+++ b/crates/delete/src/lib.rs
@@ -1192,10 +1192,20 @@ impl DeleteService {
 
             // Edges contribute to EdgeType_relationship_name and Triplet_text.
             for edge in edges {
-                by_collection
-                    .entry(("EdgeType".to_string(), "relationship_name".to_string()))
-                    .or_default()
-                    .push(EdgeType::deterministic_id(&edge.relationship_name));
+                // The EdgeType point id is derived at write time from the edge's
+                // *retrieval text*, not its relationship name — cognify's
+                // `edge_retrieval_text` prefers the nonblank `edge_text` property
+                // (the trimmed LLM edge description) and only falls back to the
+                // relationship name. Recomputing from the bare relationship name
+                // here targeted a UUID that was never written for any described
+                // edge, leaving its vector behind permanently.
+                let retrieval_text = edge_type_retrieval_text(edge);
+                if !retrieval_text.is_empty() {
+                    by_collection
+                        .entry(("EdgeType".to_string(), "relationship_name".to_string()))
+                        .or_default()
+                        .push(EdgeType::deterministic_id(&retrieval_text));
+                }
 
                 by_collection
                     .entry(("Triplet".to_string(), "text".to_string()))
@@ -1792,6 +1802,24 @@ fn parse_indexed_fields(value: &serde_json::Value) -> Vec<String> {
             vec![]
         }
     }
+}
+
+/// Recompute the text an edge's `EdgeType` vector id was derived from.
+///
+/// Must stay byte-identical to cognify's `edge_retrieval_text`, which builds the
+/// id via `EdgeType::new_deterministic(&text)`: prefer the nonblank `edge_text`
+/// property, else the relationship name, else empty (cognify writes no vector for
+/// an empty text, so the caller must not try to delete one).
+///
+/// `EdgeType::retrieval_text` lives in `cognee-models` precisely so the writing
+/// and deleting lanes can share this derivation instead of restating it.
+fn edge_type_retrieval_text(edge: &GraphEdge) -> String {
+    let edge_text = edge
+        .attributes
+        .as_ref()
+        .and_then(|attrs| attrs.get("edge_text"))
+        .and_then(serde_json::Value::as_str);
+    EdgeType::retrieval_text(edge_text, &edge.relationship_name)
 }
 
 fn triplet_vector_id(edge: &GraphEdge) -> Uuid {
@@ -2522,6 +2550,116 @@ mod tests {
                 .unwrap(),
             0,
             "EdgeType vector point should be removed"
+        );
+        assert_eq!(
+            vector_db.collection_size("Triplet", "text").await.unwrap(),
+            0,
+            "Triplet vector point should be removed"
+        );
+    }
+
+    /// An edge carrying a description must have its `EdgeType` vector removed.
+    ///
+    /// Cognify derives that point's id from the edge's retrieval text — the
+    /// `edge_text` property — while the delete path used to derive it from the
+    /// bare relationship name. For any described edge those are different UUIDs,
+    /// so the delete targeted a point that was never written and the real one
+    /// survived. It could never be collected later either: the orphan sweep looks
+    /// for zero-degree `EdgeType` graph nodes, and cognify writes none.
+    #[tokio::test]
+    async fn delete_dataset_cleans_edge_vector_points_for_described_edges() {
+        let (svc, storage, db, _graph_db, vector_db) = make_service_with_graph_vector().await;
+        let owner = Uuid::new_v4();
+        let (dataset_id, data_id) =
+            seed_dataset_with_data(&db, &storage, owner, "described_edge_ds").await;
+
+        let source_id = Uuid::new_v4();
+        let target_id = Uuid::new_v4();
+        let relationship_name = "worked_at";
+        // What the LLM put in `Edge.description`, carried through expansion as
+        // the `edge_text` property. This, not "worked_at", is what the EdgeType
+        // vector id was hashed from.
+        let edge_text = "Einstein worked at Princeton";
+
+        let triplet_id = Triplet::new(
+            source_id,
+            target_id,
+            relationship_name.to_string(),
+            String::new(),
+        )
+        .id;
+
+        ops::graph_storage::upsert_edges(
+            &db,
+            &[GraphEdge {
+                id: Uuid::new_v4(),
+                slug: triplet_id,
+                user_id: owner,
+                data_id,
+                dataset_id,
+                source_node_id: source_id,
+                destination_node_id: target_id,
+                relationship_name: relationship_name.to_string(),
+                label: Some(relationship_name.to_string()),
+                attributes: Some(serde_json::json!({ "edge_text": edge_text })),
+                created_at: chrono::Utc::now(),
+            }],
+        )
+        .await
+        .unwrap();
+
+        vector_db
+            .create_collection("EdgeType", "relationship_name", 3)
+            .await
+            .unwrap();
+        vector_db
+            .create_collection("Triplet", "text", 3)
+            .await
+            .unwrap();
+
+        // Seed the point at the id cognify actually writes: hashed from the
+        // retrieval text. Under the old code the delete looked for
+        // `deterministic_id("worked_at")` and this point was never touched.
+        let et_point = cognee_vector::VectorPoint::new(
+            EdgeType::deterministic_id(edge_text),
+            vec![1.0, 0.0, 0.0],
+        );
+        assert_ne!(
+            EdgeType::deterministic_id(edge_text),
+            EdgeType::deterministic_id(relationship_name),
+            "the two derivations must differ, else this test proves nothing"
+        );
+        vector_db
+            .index_points("EdgeType", "relationship_name", &[et_point])
+            .await
+            .unwrap();
+        let triplet_point = cognee_vector::VectorPoint::new(triplet_id, vec![0.0, 1.0, 0.0]);
+        vector_db
+            .index_points("Triplet", "text", &[triplet_point])
+            .await
+            .unwrap();
+
+        let result = svc
+            .execute(&DeleteRequest {
+                scope: DeleteScope::Dataset {
+                    owner_id: owner,
+                    dataset_name: "described_edge_ds".to_string(),
+                },
+                mode: DeleteMode::Soft,
+                memory_only: false,
+            })
+            .await
+            .expect("execute should succeed");
+
+        assert_eq!(result.deleted_datasets, 1);
+        assert_eq!(result.deleted_vector_points, 2);
+        assert_eq!(
+            vector_db
+                .collection_size("EdgeType", "relationship_name")
+                .await
+                .unwrap(),
+            0,
+            "the described edge's EdgeType vector should be removed"
         );
         assert_eq!(
             vector_db.collection_size("Triplet", "text").await.unwrap(),

--- a/crates/delete/src/lib.rs
+++ b/crates/delete/src/lib.rs
@@ -1806,10 +1806,15 @@ fn parse_indexed_fields(value: &serde_json::Value) -> Vec<String> {
 
 /// Recompute the text an edge's `EdgeType` vector id was derived from.
 ///
-/// Must stay byte-identical to cognify's `edge_retrieval_text`, which builds the
-/// id via `EdgeType::new_deterministic(&text)`: prefer the nonblank `edge_text`
-/// property, else the relationship name, else empty (cognify writes no vector for
-/// an empty text, so the caller must not try to delete one).
+/// Must resolve to the same text cognify's `edge_retrieval_text` produced for the
+/// edge: prefer the nonblank `edge_text` property, else the relationship name,
+/// else empty (cognify writes no vector for an empty text, so the caller must not
+/// try to delete one).
+///
+/// The text has to match byte for byte, not merely in spirit — cognify turns it
+/// into the point id with `EdgeType::new_deterministic(text, dataset_id)`, whose
+/// id half is a uuid5 hash of the text alone, so any difference yields a
+/// different UUID and the delete silently misses.
 ///
 /// `EdgeType::retrieval_text` lives in `cognee-models` precisely so the writing
 /// and deleting lanes can share this derivation instead of restating it.


### PR DESCRIPTION
Closes the remaining half of **SDK-505**. Follows #167, which did the endpoint-resolution half.

## The bug

The writer and the deleter disagree about how an `EdgeType` vector point id is computed.

**Write** — `crates/cognify/src/tasks.rs:1139`: the id comes from the edge's *retrieval text*, `edge_retrieval_text(edge_pair)`: the nonblank `edge_text` property (the trimmed LLM `Edge.description`), falling back to the relationship name only when that is blank.

**Delete** — `crates/delete/src/lib.rs:1198`: the id came from the bare `relationship_name`, always.

For an edge the model described — `worked_at` with `edge_text: "Einstein worked at Princeton"` — cognify writes `deterministic_id("Einstein worked at Princeton")` while delete looked for `deterministic_id("worked_at")`. Different UUIDs. **The delete targeted a point that was never written, and the real vector survived.**

It was never collected later either. The intended backstop, `sweep_orphan_edge_types`, queries `get_zero_degree_edge_type_nodes()` — but cognify deliberately writes no `EdgeType` *graph* nodes, so the sweep is a no-op by construction and the orphan is permanent. That is the mechanism behind the orphaned `EdgeType_relationship_name` vectors seen on the 171,888-paper corpus.

## The fix

`GraphEdge.attributes` already carries the full property map, so the delete lane can recompute the same text. It now calls `EdgeType::retrieval_text` — which lives in `cognee-models` precisely so the writing and deleting lanes share one derivation rather than restating it — and skips edges whose retrieval text is empty, matching cognify, which writes no vector for those.

## Why the existing test didn't catch it

`delete_dataset_cleans_edge_vector_points` builds its fixture with `attributes: None`. With no `edge_text`, both derivations collapse to the relationship name and agree — so the suite only ever covered the case where the bug is invisible.

The new test uses a described edge and asserts up front that the two derivations actually differ, so it cannot quietly stop testing anything if the derivation changes later.

**Verified as a genuine regression guard:** with the production change reverted and the test kept, it fails with the EdgeType vector still present (`left: 1, right: 0`).

## Verification

`cargo fmt --check`, `cargo clippy -p cognee-delete --all-targets -- -D warnings`, `cargo check --all-targets`, `cargo test -p cognee-delete --lib` (51 passed) — all clean by exit code.

## Note

One narrow corner is left alone deliberately: cognify derives the EdgeType id from the *raw* retrieval text, while `attributes` is NUL-sanitized on the way into Postgres (#149). An edge whose description contained a NUL byte would still mismatch. That is a pre-existing asymmetry in the write path rather than something this change introduces, and it wants its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KciGBA9mrYSbg6SCP53EBv
