### PR TITLE
fix(llm,cognify): scope the in-flight permit to the socket, and stop buffered() stalling the fan-out

### DIFF
--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -735,31 +735,45 @@ pub async fn extract_graph_from_data(
         let chunk_documents: Vec<Uuid> = batch.iter().map(|chunk| chunk.document_id).collect();
 
         // Bounded-concurrency pipeline: at most `max_parallel` extraction calls
-        // are in flight at once. `buffered` (not `buffer_unordered`) yields
-        // results in input order, which `all_graphs` relies on — downstream
-        // dedup in `retrieve_existing_edges` is order-sensitive. The
-        // `tokio::spawn` inside the mapped future keeps calls on the
-        // multi-threaded runtime, and `buffered` only polls up to `max_parallel`
-        // futures, so at most that many extraction tasks exist at once.
+        // are in flight at once. `buffer_unordered`, not `buffered`: the latter's
+        // `FuturesOrdered` counts completed-but-undrained outputs against its
+        // limit, so a chunk stuck in the retry cascade pins its slot *and* every
+        // slot filled behind it until it returns — head-of-line blocking that
+        // stops the batch dead above `max_parallel` chunks. The `tokio::spawn`
+        // inside the mapped future keeps calls on the multi-threaded runtime,
+        // and `buffer_unordered` only polls up to `max_parallel` futures, so at
+        // most that many extraction tasks exist at once.
+        //
+        // Completion order is not input order, so each future carries its index
+        // and the batch is re-sorted below. Order still matters downstream:
+        // `all_graphs` feeds dedup in `retrieve_existing_edges`, and the failure
+        // records below must be deterministic for a given input. Same shape as
+        // `SummaryExtractor::summarize_chunks`.
         //
         // Peak duplicated text is still O(`chunks_per_batch`), not
         // O(`max_parallel`): `inputs` above clones every chunk's text up front.
         // Making that lazy would mean borrowing `&chunk` across the stream, which
         // is the higher-ranked-lifetime case the comment there describes.
-        let batch_results: Vec<_> = futures::stream::iter(inputs)
-            .map(|(_, text)| {
+        let mut indexed_results: Vec<_> = futures::stream::iter(inputs.into_iter().enumerate())
+            .map(|(index, (_, text))| {
                 let extractor = fact_extractor.clone();
                 let prompt = config.custom_extraction_prompt.clone();
                 async move {
-                    tokio::spawn(
-                        async move { extractor.extract_facts(&text, prompt.as_deref()).await },
-                    )
-                    .await
+                    let result = tokio::spawn(async move {
+                        extractor.extract_facts(&text, prompt.as_deref()).await
+                    })
+                    .await;
+                    (index, result)
                 }
             })
-            .buffered(max_parallel)
+            .buffer_unordered(max_parallel)
             .collect()
             .await;
+        indexed_results.sort_by_key(|(index, _)| *index);
+        let batch_results: Vec<_> = indexed_results
+            .into_iter()
+            .map(|(_, result)| result)
+            .collect();
 
         // The whole batch is collected before any result is inspected, so a
         // FailFast abort reports every failure in the batch that tripped it —
@@ -1475,22 +1489,33 @@ pub async fn extract_custom_graph_from_data<M: crate::fact_extraction::GraphMode
             .map(|&idx| updated_chunks[idx].text.clone())
             .collect();
 
-        // Bounded-concurrency pipeline, order-preserving (`buffered`) because the
-        // results below are zipped positionally back onto `batch_indices`.
-        let batch_results: Vec<_> = futures::stream::iter(inputs)
-            .map(|text| {
+        // Bounded-concurrency pipeline. `buffer_unordered`, not `buffered`, for
+        // the reason spelled out in `extract_graph_from_data`: `buffered` holds a
+        // completed-but-undrained output in its slot, so one slow chunk blocks
+        // every chunk queued behind it. The results below are indexed back onto
+        // `batch_indices`, so each future carries its position and the batch is
+        // re-sorted here — a positional zip against completion order would
+        // attach each extraction to the wrong chunk.
+        let mut indexed_results: Vec<_> = futures::stream::iter(inputs.into_iter().enumerate())
+            .map(|(index, text)| {
                 let extractor = FactExtractor::new(Arc::clone(&llm));
                 let prompt = config.custom_extraction_prompt.clone();
                 async move {
-                    tokio::spawn(
-                        async move { extractor.extract::<M>(&text, prompt.as_deref()).await },
-                    )
-                    .await
+                    let result = tokio::spawn(async move {
+                        extractor.extract::<M>(&text, prompt.as_deref()).await
+                    })
+                    .await;
+                    (index, result)
                 }
             })
-            .buffered(max_parallel)
+            .buffer_unordered(max_parallel)
             .collect()
             .await;
+        indexed_results.sort_by_key(|(index, _)| *index);
+        let batch_results: Vec<_> = indexed_results
+            .into_iter()
+            .map(|(_, result)| result)
+            .collect();
 
         let batch_len = batch_indices.len();
         let mut batch_failed = false;
@@ -2072,10 +2097,11 @@ pub async fn extract_temporal_events(
     let mut aborted_at: Option<usize> = None;
 
     for (batch_idx, batch) in non_dlt_chunks.chunks(batch_size).enumerate() {
-        // Owned inputs; `buffered` keeps the per-chunk event order stable so
-        // `all_events` is deterministic for a given input. `chunk_ids` and
-        // `chunk_documents` run parallel to them: a failure is attributed to
-        // its chunk and its file, neither of which the stream items carry.
+        // Owned inputs. `chunk_ids` and `chunk_documents` run parallel to them:
+        // a failure is attributed to its chunk and its file, neither of which
+        // the stream items carry, and the events a chunk produced are attributed
+        // to its file the same way — so the results must be back in input order
+        // before the zip below.
         let inputs: Vec<String> = batch.iter().map(|chunk| chunk.text.clone()).collect();
         let chunk_ids: Vec<Uuid> = batch.iter().map(|chunk| chunk.base.id).collect();
         let chunk_documents: Vec<Uuid> = batch.iter().map(|chunk| chunk.document_id).collect();
@@ -2083,14 +2109,28 @@ pub async fn extract_temporal_events(
         // The whole batch is collected before any result is inspected, so a
         // FailFast abort reports every failure in the batch that tripped it —
         // not only the first one to come back.
-        let batch_results: Vec<_> = futures::stream::iter(inputs)
-            .map(|text| {
+        // `buffer_unordered`, not `buffered`, for the reason spelled out in
+        // `extract_graph_from_data`: `buffered` keeps a completed-but-undrained
+        // output in its slot, so one slow chunk blocks every chunk behind it.
+        // Each future carries its index and the batch is re-sorted, which both
+        // keeps the zip below correlated and keeps `all_events` deterministic
+        // for a given input.
+        let mut indexed_results: Vec<_> = futures::stream::iter(inputs.into_iter().enumerate())
+            .map(|(index, text)| {
                 let ext = Arc::clone(&extractor);
-                async move { tokio::spawn(async move { ext.extract_events(&text).await }).await }
+                async move {
+                    let result = tokio::spawn(async move { ext.extract_events(&text).await }).await;
+                    (index, result)
+                }
             })
-            .buffered(max_parallel)
+            .buffer_unordered(max_parallel)
             .collect()
             .await;
+        indexed_results.sort_by_key(|(index, _)| *index);
+        let batch_results: Vec<_> = indexed_results
+            .into_iter()
+            .map(|(_, result)| result)
+            .collect();
 
         let mut batch_events: Vec<TemporalEvent> = Vec::new();
         let mut batch_data_ids: Vec<Uuid> = Vec::new();

--- a/crates/cognify/tests/fanout_correlation.rs
+++ b/crates/cognify/tests/fanout_correlation.rs
@@ -1,0 +1,405 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Correlation and liveness coverage for the three fan-out loops in
+//! [`cognee_cognify::tasks`] — **offline**, no LLM key, no skip path.
+//!
+//! Each of `extract_graph_from_data`, `extract_custom_graph_from_data` and
+//! `extract_temporal_events` fans a batch of chunks out over a bounded stream
+//! and then puts the results back against their chunks. Two properties have to
+//! hold and neither was covered before:
+//!
+//! 1. **Correlation.** A result must land against the chunk that produced it.
+//!    The loops used to rely on the stream yielding in input order; they now
+//!    carry an index through the future and re-sort. A positional zip against
+//!    completion order would attach an extracted graph to the wrong chunk, and
+//!    nothing downstream would notice — the graph is well-formed, just
+//!    misattributed.
+//!
+//! 2. **Liveness above `max_parallel`.** The loops used `.buffered`, whose
+//!    `FuturesOrdered` counts *completed-but-undrained* outputs against its
+//!    limit: a future that finishes out of order keeps occupying its slot until
+//!    the consumer drains it in order. One chunk stuck in the LLM retry cascade
+//!    therefore pinned its own slot *and* every slot filled behind it, and no
+//!    further chunk was dispatched until it returned — head-of-line blocking
+//!    that only appears once a batch exceeds `max_parallel` chunks.
+//!
+//! [`Gate`] pins both at once. It holds chunk 0's response until every *other*
+//! chunk in the batch has been served, which forces completion to happen out of
+//! order (so a positional zip mis-correlates and the assertions below catch it)
+//! and can only be satisfied at all if chunks past `max_parallel` are dispatched
+//! while chunk 0 is still in flight. Under `.buffered` the gate is never
+//! released and the test hangs, so each case runs under a `tokio::time::timeout`
+//! and reports the stall as a failure rather than blocking the suite forever.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cognee_cognify::tasks::{
+    ExtractedChunks, extract_custom_graph_from_data, extract_graph_from_data,
+    extract_temporal_events,
+};
+use cognee_cognify::{CognifyConfig, fact_extraction::GraphModel};
+use cognee_database::ops::datasets::create_dataset;
+use cognee_llm::error::{LlmError, LlmResult};
+use cognee_llm::types::{GenerationOptions, GenerationResponse, Message};
+use cognee_llm::{Llm, MessageRole};
+use cognee_models::{Dataset, DocumentChunk};
+use cognee_ontology::NoOpOntologyResolver;
+use cognee_test_utils::MockGraphDB;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::sync::watch;
+use uuid::Uuid;
+
+/// Chunks per batch. Deliberately more than [`MAX_PARALLEL`] so the stream has
+/// to refill its slots mid-batch — the case `.buffered` cannot serve.
+const CHUNKS: usize = 6;
+
+/// Concurrency ceiling the fan-out loops are configured with.
+const MAX_PARALLEL: usize = 2;
+
+/// How long a case may run before its stall is reported as a failure.
+///
+/// A passing run finishes in milliseconds (nothing here sleeps); this only has
+/// to be long enough that a loaded CI machine is not mistaken for a deadlock.
+const STALL_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// The text of chunk `index`, carrying the marker the mock LLM answers on.
+fn chunk_text(index: usize) -> String {
+    format!("CHUNK-{index:04} is a sentence about a marker.")
+}
+
+/// The marker index encoded in a prompt by [`chunk_text`].
+fn marker_index(text: &str) -> Option<usize> {
+    let start = text.find("CHUNK-")? + "CHUNK-".len();
+    text.get(start..start + 4)?.parse().ok()
+}
+
+/// Forces out-of-order completion, and refuses to be satisfied at all unless the
+/// stream keeps dispatching past its concurrency limit.
+///
+/// Chunk 0 — the first future the stream polls — parks until every other chunk
+/// has been served. With `buffer_unordered` those chunks free their slots as
+/// they finish, chunks past `MAX_PARALLEL` get dispatched, the counter reaches
+/// `CHUNKS - 1` and chunk 0 is released; it then completes *last*, so results
+/// arrive in an order that no positional zip could correlate. With `.buffered`
+/// the finished-but-undrained outputs hold their slots behind chunk 0, nothing
+/// past `MAX_PARALLEL` is ever dispatched, and the counter stops short forever.
+struct Gate {
+    served_others: watch::Sender<usize>,
+}
+
+impl Gate {
+    fn new() -> Self {
+        Self {
+            served_others: watch::channel(0usize).0,
+        }
+    }
+
+    /// Serve `index`, blocking chunk 0 until the rest have been through.
+    async fn pass(&self, index: usize) {
+        if index == 0 {
+            let mut rx = self.served_others.subscribe();
+            // `borrow_and_update` copies out and drops its guard before the
+            // await, so the watch lock is never held across a suspension point.
+            while *rx.borrow_and_update() < CHUNKS - 1 {
+                rx.changed()
+                    .await
+                    .expect("the sender is owned by this Gate, which outlives every request");
+            }
+        } else {
+            self.served_others.send_modify(|served| *served += 1);
+        }
+    }
+}
+
+/// An LLM that answers structured-output calls from the marker in the prompt,
+/// through a [`Gate`].
+///
+/// The response is derived from the *chunk's own text*, which is what makes the
+/// assertions a correlation check rather than a shape check: a result attached
+/// to the wrong chunk carries the wrong marker and is caught.
+struct MarkerLlm {
+    gate: Gate,
+    respond: Box<dyn Fn(usize) -> Value + Send + Sync>,
+}
+
+impl MarkerLlm {
+    fn new(respond: impl Fn(usize) -> Value + Send + Sync + 'static) -> Self {
+        Self {
+            gate: Gate::new(),
+            respond: Box::new(respond),
+        }
+    }
+}
+
+#[async_trait]
+impl Llm for MarkerLlm {
+    async fn generate(
+        &self,
+        _messages: Vec<Message>,
+        _options: Option<GenerationOptions>,
+    ) -> LlmResult<GenerationResponse> {
+        Err(LlmError::FeatureNotSupported(
+            "MarkerLlm only serves structured output".to_string(),
+        ))
+    }
+
+    async fn create_structured_output_with_messages_raw(
+        &self,
+        messages: Vec<Message>,
+        _json_schema: &Value,
+        _options: Option<GenerationOptions>,
+    ) -> LlmResult<Value> {
+        let system = messages
+            .iter()
+            .find(|m| matches!(m.role, MessageRole::System))
+            .map(|m| m.content.as_str())
+            .unwrap_or_default();
+
+        // The temporal stage runs one aggregate enrichment call per batch after
+        // its fan-out has drained. It is not gated and not indexed: returning an
+        // empty list leaves every event untouched and in order, which is what
+        // the correlation assertion downstream reads.
+        if system.contains("entities from events") {
+            return Ok(json!({ "events": [] }));
+        }
+
+        let user = messages
+            .iter()
+            .find(|m| matches!(m.role, MessageRole::User))
+            .map(|m| m.content.as_str())
+            .unwrap_or_default();
+        let index = marker_index(user).ok_or_else(|| {
+            LlmError::InvalidResponse(format!("no CHUNK-nnnn marker in prompt: {user}"))
+        })?;
+
+        self.gate.pass(index).await;
+        Ok((self.respond)(index))
+    }
+
+    fn model(&self) -> &str {
+        "marker-llm"
+    }
+}
+
+/// `CHUNKS` chunks, each its own document so a per-chunk result can also be
+/// checked against a per-chunk *file*.
+fn make_input() -> (ExtractedChunks, Vec<Uuid>, Vec<Uuid>) {
+    let mut chunks = Vec::with_capacity(CHUNKS);
+    let mut chunk_ids = Vec::with_capacity(CHUNKS);
+    let mut document_ids = Vec::with_capacity(CHUNKS);
+
+    for index in 0..CHUNKS {
+        let document_id = Uuid::new_v4();
+        let text = chunk_text(index);
+        let chunk = DocumentChunk::new(
+            Uuid::new_v4(),
+            text.clone(),
+            text.split_whitespace().count(),
+            index,
+            "paragraph_end".to_string(),
+            document_id,
+        );
+        chunk_ids.push(chunk.base.id);
+        document_ids.push(document_id);
+        chunks.push(chunk);
+    }
+
+    let input = ExtractedChunks {
+        chunks,
+        // No Documents: nothing here is a DLT row, and web-page node creation
+        // is switched off in `config()` below.
+        documents: vec![],
+        dataset_id: Uuid::new_v4(),
+        user_id: None,
+        tenant_id: None,
+        failures: Default::default(),
+    };
+
+    (input, chunk_ids, document_ids)
+}
+
+/// One batch, fanned out `MAX_PARALLEL` at a time.
+fn config() -> CognifyConfig {
+    let mut config = CognifyConfig::default().with_web_page_nodes(false);
+    config.chunks_per_batch = CHUNKS;
+    config.data_per_batch = CHUNKS;
+    config.max_parallel_extractions = MAX_PARALLEL;
+    config
+}
+
+// ── Loop 1: extract_graph_from_data ────────────────────────────────────────
+
+/// The knowledge graph the mock returns for chunk `index`: one node whose name
+/// encodes the chunk it came from.
+fn marker_graph(index: usize) -> Value {
+    json!({
+        "nodes": [{
+            "id": format!("marker-{index:04}"),
+            "name": format!("MARKER-{index:04}"),
+            "type": "Marker",
+            "description": "A marker entity.",
+        }],
+        "edges": [],
+    })
+}
+
+#[tokio::test]
+async fn graph_extraction_attributes_each_graph_to_its_own_chunk() {
+    let llm: Arc<dyn Llm> = Arc::new(MarkerLlm::new(marker_graph));
+    let graph_db: Arc<dyn cognee_graph::GraphDBTrait> = Arc::new(MockGraphDB::new());
+    let (input, chunk_ids, _) = make_input();
+
+    let (_handle, _ctx, db) = cognee_test_utils::test_task_context().await;
+    create_dataset(
+        &db,
+        Dataset::new("fanout".into(), Uuid::new_v4(), None, input.dataset_id),
+    )
+    .await
+    .expect("seed dataset");
+
+    let result = tokio::time::timeout(
+        STALL_TIMEOUT,
+        extract_graph_from_data(
+            &input,
+            llm,
+            graph_db,
+            Arc::new(NoOpOntologyResolver::new()),
+            &db,
+            None,
+            &config(),
+            None,
+            None,
+        ),
+    )
+    .await
+    .expect(
+        "the fan-out stalled: chunk 0 was never released, so chunks past \
+         max_parallel were never dispatched — the `.buffered` head-of-line block",
+    )
+    .expect("extraction should succeed");
+
+    assert_eq!(
+        result.entities.len(),
+        CHUNKS,
+        "one marker entity per chunk, none merged"
+    );
+
+    for (index, chunk_id) in chunk_ids.iter().enumerate() {
+        let expected = format!("MARKER-{index:04}");
+        let pair = result
+            .entities
+            .iter()
+            .find(|pair| pair.entity.name == expected)
+            .unwrap_or_else(|| panic!("no entity named {expected} in the output"));
+        assert_eq!(
+            result.producers.entity_chunks(pair.entity.base.id),
+            [*chunk_id],
+            "{expected} must be attributed to chunk {index}, the chunk whose text \
+             produced it — a result correlated by stream position instead of by \
+             carried index lands on whichever chunk finished in that slot",
+        );
+    }
+}
+
+// ── Loop 2: extract_custom_graph_from_data ─────────────────────────────────
+
+/// A custom (non-`KnowledgeGraph`) model, stored verbatim in
+/// [`DocumentChunk::contains`] rather than expanded into graph nodes.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct MarkerModel {
+    marker: String,
+}
+
+impl GraphModel for MarkerModel {}
+
+#[tokio::test]
+async fn custom_graph_extraction_writes_each_model_to_its_own_chunk() {
+    let llm: Arc<dyn Llm> = Arc::new(MarkerLlm::new(
+        |index| json!({ "marker": format!("MARKER-{index:04}") }),
+    ));
+    let (input, chunk_ids, _) = make_input();
+
+    let result = tokio::time::timeout(
+        STALL_TIMEOUT,
+        extract_custom_graph_from_data::<MarkerModel>(&input, llm, &config()),
+    )
+    .await
+    .expect(
+        "the fan-out stalled: chunk 0 was never released, so chunks past \
+         max_parallel were never dispatched — the `.buffered` head-of-line block",
+    )
+    .expect("extraction should succeed");
+
+    assert_eq!(result.chunks.len(), CHUNKS);
+    for (index, chunk_id) in chunk_ids.iter().enumerate() {
+        let chunk = result
+            .chunks
+            .iter()
+            .find(|c| c.base.id == *chunk_id)
+            .unwrap_or_else(|| panic!("chunk {index} missing from the output"));
+        assert_eq!(
+            chunk.contains,
+            vec![json!({ "marker": format!("MARKER-{index:04}") })],
+            "chunk {index} must carry the model extracted from its own text; this \
+             loop indexes results back onto `batch_indices`, so a completion-order \
+             zip writes each model onto the wrong chunk",
+        );
+    }
+}
+
+// ── Loop 3: extract_temporal_events ────────────────────────────────────────
+
+/// The event list the mock returns for chunk `index`: one event named after it.
+fn marker_events(index: usize) -> Value {
+    json!({
+        "events": [{
+            "name": format!("EVENT-{index:04}"),
+            "description": format!("Something happened in chunk {index}."),
+            "time_from": { "year": 1900 + index },
+            "time_to": null,
+            "location": null,
+        }],
+    })
+}
+
+#[tokio::test]
+async fn temporal_extraction_attributes_each_event_to_its_own_file() {
+    let llm: Arc<dyn Llm> = Arc::new(MarkerLlm::new(marker_events));
+    let (input, _, document_ids) = make_input();
+
+    let result = tokio::time::timeout(
+        STALL_TIMEOUT,
+        extract_temporal_events(&input, llm, &config()),
+    )
+    .await
+    .expect(
+        "the fan-out stalled: chunk 0 was never released, so chunks past \
+         max_parallel were never dispatched — the `.buffered` head-of-line block",
+    )
+    .expect("extraction should succeed");
+
+    assert_eq!(result.events.len(), CHUNKS, "one event per chunk");
+
+    for (index, document_id) in document_ids.iter().enumerate() {
+        let attributed = &result.events[index];
+        assert_eq!(
+            attributed.event.name,
+            format!("EVENT-{index:04}"),
+            "`all_events` must stay in input order — the batch is re-sorted by \
+             carried index precisely so this stays deterministic",
+        );
+        assert_eq!(
+            attributed.data_id, *document_id,
+            "event {index} must be attributed to the file of the chunk that \
+             produced it; the data ids are zipped onto the results positionally, \
+             so completion order would misattribute every event",
+        );
+    }
+}

--- a/crates/llm/src/adapters/anthropic.rs
+++ b/crates/llm/src/adapters/anthropic.rs
@@ -342,16 +342,29 @@ impl AnthropicAdapter {
                 tokio::time::sleep(delay).await;
             }
 
-            // Inside the loop, immediately before the send — see the OpenAI
-            // adapter and `cognee_utils::pacing` for why admission is per attempt.
-            if let Some(pacer) = pacer.as_deref() {
-                pacer.admit().await;
-            }
+            // Inside the loop — see the OpenAI adapter and `cognee_utils::pacing`
+            // for why admission is per attempt. This one runs before the queue
+            // below because it is the only admission that can pace a caller
+            // without an in-flight permit in hand.
+            let paced_before_queue = match pacer.as_deref() {
+                Some(pacer) => pacer.admit().await,
+                None => false,
+            };
 
             // See the identical acquisition in the OpenAI adapter: transport-level
             // concurrency ceiling, taken *after* admission and released at the end
             // of the iteration so a permit only ever covers a live socket.
             let _in_flight = crate::in_flight::acquire_in_flight().await;
+
+            // Re-gate immediately before the send: an episode can open while this
+            // caller sits in the queue, and without this every caller that
+            // cleared the fast path together would still fire one unpaced send at
+            // a provider that has just reported overload. Skipped when the
+            // admission above already paced this attempt, so an attempt never
+            // spends two tokens. See the OpenAI adapter for the full rationale.
+            if !paced_before_queue && let Some(pacer) = pacer.as_deref() {
+                pacer.admit().await;
+            }
 
             attempt += 1;
 

--- a/crates/llm/src/adapters/anthropic.rs
+++ b/crates/llm/src/adapters/anthropic.rs
@@ -315,9 +315,9 @@ impl AnthropicAdapter {
 
         let budget = self.retry_budget();
         let pacer = self.pacer();
-        // See the identical acquisition in the OpenAI adapter: transport-level
-        // concurrency ceiling, held across retries, taken before pacing.
-        let _in_flight = crate::in_flight::acquire_in_flight().await;
+        // Started before the loop, and so before the pacer's admission wait and
+        // the in-flight queue inside it, so queueing time counts against the
+        // retry budget rather than being invisible to it.
         let started = Instant::now();
         let mut retry_after: Option<Duration> = None;
         let mut attempt: u32 = 0;
@@ -347,6 +347,11 @@ impl AnthropicAdapter {
             if let Some(pacer) = pacer.as_deref() {
                 pacer.admit().await;
             }
+
+            // See the identical acquisition in the OpenAI adapter: transport-level
+            // concurrency ceiling, taken *after* admission and released at the end
+            // of the iteration so a permit only ever covers a live socket.
+            let _in_flight = crate::in_flight::acquire_in_flight().await;
 
             attempt += 1;
 

--- a/crates/llm/src/adapters/anthropic.rs
+++ b/crates/llm/src/adapters/anthropic.rs
@@ -315,10 +315,22 @@ impl AnthropicAdapter {
 
         let budget = self.retry_budget();
         let pacer = self.pacer();
-        // Started before the loop, and so before the pacer's admission wait and
-        // the in-flight queue inside it, so queueing time counts against the
-        // retry budget rather than being invisible to it.
+        // Wall clock for the whole call: what the retry logs report, and the
+        // base the retry floor is measured off once the in-flight queue waits
+        // below are subtracted.
         let started = Instant::now();
+        // Time this call has spent queued for an in-flight permit, subtracted
+        // from the elapsed time handed to `RetryBudget::is_exhausted`.
+        //
+        // That predicate is `attempts >= min_attempts && elapsed >= min_elapsed`,
+        // so a *larger* elapsed can only exhaust the budget earlier, and
+        // `min_elapsed` (`LLM_MIN_RETRY_SECONDS`) is a "keep retrying for at
+        // least this long" resilience guarantee, not a deadline — this adapter
+        // has no deadline concept at all. Charging queue time against the floor
+        // would only ever cut the ladder short: with `LLM_MAX_RETRIES=2` and a
+        // 240s floor, a call that spent 300s waiting for a permit would stop
+        // after its second attempt having done no real retrying.
+        let mut queued_for_permit = Duration::ZERO;
         let mut retry_after: Option<Duration> = None;
         let mut attempt: u32 = 0;
 
@@ -354,7 +366,9 @@ impl AnthropicAdapter {
             // See the identical acquisition in the OpenAI adapter: transport-level
             // concurrency ceiling, taken *after* admission and released at the end
             // of the iteration so a permit only ever covers a live socket.
+            let permit_queue_started = Instant::now();
             let _in_flight = crate::in_flight::acquire_in_flight().await;
+            queued_for_permit += permit_queue_started.elapsed();
 
             // Re-gate immediately before the send: an episode can open while this
             // caller sits in the queue, and without this every caller that
@@ -386,7 +400,9 @@ impl AnthropicAdapter {
                         pacer.record_overload("timeout");
                     }
                     last_error = LlmError::NetworkError(e.to_string());
-                    if budget.is_exhausted(attempt, started.elapsed()) {
+                    if budget
+                        .is_exhausted(attempt, started.elapsed().saturating_sub(queued_for_permit))
+                    {
                         break;
                     }
                     continue;
@@ -432,7 +448,8 @@ impl AnthropicAdapter {
                 }
                 retry_after = hint;
                 last_error = err;
-                if budget.is_exhausted(attempt, started.elapsed()) {
+                if budget.is_exhausted(attempt, started.elapsed().saturating_sub(queued_for_permit))
+                {
                     break;
                 }
                 continue;

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -942,14 +942,12 @@ impl OpenAIAdapter {
         let mut last_error = LlmError::NetworkError("No attempt made".to_string());
         let budget = self.retry_budget();
         let pacer = self.pacer();
-        // Transport-level concurrency ceiling, the analogue of the connection-pool
-        // bound every Python HTTP client sets (see `crate::in_flight`). Acquired
-        // outside the retry loop and held for the whole call, so a request that
-        // backs off keeps its slot rather than releasing it to a competitor and
-        // re-queueing behind it. Taken before the pacer's admission below: a
-        // permit held across a pacing sleep would idle the pool during exactly
-        // the overload episode the pacer is draining.
-        let _in_flight = crate::in_flight::acquire_in_flight().await;
+        // Started before the loop — and so before both the pacer's admission
+        // wait and the in-flight queue below — so the time a call spends waiting
+        // for its turn counts against the retry budget and the caller's
+        // aggregate deadline. Time queued is time the caller is blocked; hiding
+        // it would let a call overshoot `LLM_REQUEST_DEADLINE_SECONDS` by the
+        // whole queue wait.
         let started = Instant::now();
         // `Retry-After` from the previous attempt. A usable hint replaces the
         // computed backoff outright — including when it asks for less, since the
@@ -991,12 +989,52 @@ impl OpenAIAdapter {
                 tokio::time::sleep(delay).await;
             }
 
+            let dispatch_wait_started = Instant::now();
+
             // Admission sits INSIDE the retry loop, immediately before the send,
             // so an overload episode opened by any concurrent request throttles
             // the remaining attempts of calls already in flight. This mirrors
             // Python entering the limiter context manager inside tenacity.
             if let Some(pacer) = pacer.as_deref() {
                 pacer.admit().await;
+            }
+
+            // Transport-level concurrency ceiling, the analogue of the
+            // connection-pool bound every Python HTTP client sets (see
+            // `crate::in_flight`). Acquired *after* the pacer has admitted this
+            // attempt and dropped at the end of the iteration, so a permit
+            // covers only the window in which a socket actually exists. Taking
+            // it before `admit()` would let requests parked in a 900s cooldown
+            // hold permits they are not using, so the semaphore would count
+            // sleepers as sockets and stall every other caller in the process.
+            // A retry re-queues for a permit, which is correct: it opens a new
+            // socket, so it is a new claim on the ceiling.
+            let _in_flight = crate::in_flight::acquire_in_flight().await;
+
+            // Pacing and the in-flight queue can outlast the caller's aggregate
+            // budget on their own — a 900s overload cooldown dwarfs a 240s
+            // deadline — and the guard at the top of the loop cannot see that:
+            // it runs before the wait, so an overshoot there was only noticed
+            // one turn later, after an attempt the budget could never cover.
+            //
+            // Narrow on purpose. It fires only when budget *remained* when the
+            // wait began and the wait is what spent it, so the guard above keeps
+            // its existing behaviour: that one clamps its backoff to the
+            // remaining budget and deliberately lets the attempt it sleeps for
+            // start, and this must not retract it. Skipped on the first attempt
+            // too — every call makes at least one, as it did before the deadline
+            // existed.
+            if attempt > 0
+                && let Some(deadline) = deadline
+                && dispatch_wait_started < deadline
+                && Instant::now() >= deadline
+            {
+                return Err(LlmError::Timeout(format!(
+                    "LLM request abandoned after {:.0}s with {attempt} attempt(s): the call's \
+                     aggregate budget (LLM_REQUEST_DEADLINE_SECONDS) was spent waiting for \
+                     dispatch (pacing or the in-flight queue); last error: {last_error}",
+                    started.elapsed().as_secs_f64(),
+                )));
             }
 
             attempt += 1;

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -942,13 +942,28 @@ impl OpenAIAdapter {
         let mut last_error = LlmError::NetworkError("No attempt made".to_string());
         let budget = self.retry_budget();
         let pacer = self.pacer();
-        // Started before the loop — and so before both the pacer's admission
-        // wait and the in-flight queue below — so the time a call spends waiting
-        // for its turn counts against the retry budget and the caller's
-        // aggregate deadline. Time queued is time the caller is blocked; hiding
-        // it would let a call overshoot `LLM_REQUEST_DEADLINE_SECONDS` by the
-        // whole queue wait.
+        // Wall clock for the whole call, started before the loop and so before
+        // both the pacer's admission wait and the in-flight queue below. It is
+        // what the logs and the deadline errors report, and time queued is time
+        // the caller is blocked, so it must include the waits.
+        //
+        // The retry *floor* is measured off it minus `queued_for_permit` — see
+        // there. `deadline` needs no clock of its own: it arrives as an absolute
+        // `Instant` fixed by the caller, so it already counts every wait.
         let started = Instant::now();
+        // Time this call has spent queued for an in-flight permit, subtracted
+        // from the elapsed time handed to `RetryBudget::is_exhausted`.
+        //
+        // That predicate is `attempts >= min_attempts && elapsed >= min_elapsed`,
+        // so a *larger* elapsed can only exhaust the budget earlier, and
+        // `min_elapsed` (`LLM_MIN_RETRY_SECONDS`) is a "keep retrying for at
+        // least this long" resilience guarantee rather than a deadline. Charging
+        // queue time against it silently weakens it: with `LLM_MAX_RETRIES=2` and
+        // a 240s floor, a call that spent 300s waiting for a permit would stop
+        // after its second attempt with no actual retrying done at all. The
+        // aggregate deadline above is the mechanism that bounds total time; this
+        // floor is not.
+        let mut queued_for_permit = Duration::ZERO;
         // `Retry-After` from the previous attempt. A usable hint replaces the
         // computed backoff outright — including when it asks for less, since the
         // provider knows when its own window resets. See `retry::retry_after_hint`
@@ -1017,7 +1032,9 @@ impl OpenAIAdapter {
             // sleepers as sockets and stall every other caller in the process.
             // A retry re-queues for a permit, which is correct: it opens a new
             // socket, so it is a new claim on the ceiling.
+            let permit_queue_started = Instant::now();
             let _in_flight = crate::in_flight::acquire_in_flight().await;
+            queued_for_permit += permit_queue_started.elapsed();
 
             // The pacer's contract is admission *immediately before the send*
             // (`cognee_utils::pacing` module docs) and the queue above breaks it.
@@ -1082,7 +1099,9 @@ impl OpenAIAdapter {
                         pacer.record_overload("timeout");
                     }
                     last_error = LlmError::NetworkError(e.to_string());
-                    if budget.is_exhausted(attempt, started.elapsed()) {
+                    if budget
+                        .is_exhausted(attempt, started.elapsed().saturating_sub(queued_for_permit))
+                    {
                         break;
                     }
                     continue;
@@ -1132,7 +1151,8 @@ impl OpenAIAdapter {
 
                 retry_after = hint;
                 last_error = err;
-                if budget.is_exhausted(attempt, started.elapsed()) {
+                if budget.is_exhausted(attempt, started.elapsed().saturating_sub(queued_for_permit))
+                {
                     break;
                 }
                 continue;

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -991,13 +991,21 @@ impl OpenAIAdapter {
 
             let dispatch_wait_started = Instant::now();
 
-            // Admission sits INSIDE the retry loop, immediately before the send,
-            // so an overload episode opened by any concurrent request throttles
-            // the remaining attempts of calls already in flight. This mirrors
-            // Python entering the limiter context manager inside tenacity.
-            if let Some(pacer) = pacer.as_deref() {
-                pacer.admit().await;
-            }
+            // Admission sits INSIDE the retry loop, so an overload episode
+            // opened by any concurrent request throttles the remaining attempts
+            // of calls already in flight. This mirrors Python entering the
+            // limiter context manager inside tenacity.
+            //
+            // This first admission is the one that can pace a caller *without*
+            // an in-flight permit in hand, which is why it comes before the
+            // queue below: parking in the bucket while holding a permit idles
+            // the pool during exactly the episode the pacer is draining. Its
+            // return value records whether it actually cost a token — the second
+            // admission after the queue reads it.
+            let paced_before_queue = match pacer.as_deref() {
+                Some(pacer) => pacer.admit().await,
+                None => false,
+            };
 
             // Transport-level concurrency ceiling, the analogue of the
             // connection-pool bound every Python HTTP client sets (see
@@ -1010,6 +1018,26 @@ impl OpenAIAdapter {
             // A retry re-queues for a permit, which is correct: it opens a new
             // socket, so it is a new claim on the ceiling.
             let _in_flight = crate::in_flight::acquire_in_flight().await;
+
+            // The pacer's contract is admission *immediately before the send*
+            // (`cognee_utils::pacing` module docs) and the queue above breaks it.
+            // Pacing is off by default, so N callers clear `admit()` on the fast
+            // path in one go and then pile up on the semaphore; the first reply
+            // is a 429, `record_overload` opens the 900s episode — and every
+            // caller already past the pacer still fires one unpaced send at a
+            // provider that has just said it is overloaded. That burst is what
+            // opened the episode, and the queue would let it through again.
+            //
+            // Skipped when the admission above actually paced this attempt: that
+            // caller has spent its token, and a second one would both halve the
+            // configured rate during an episode and park it in the bucket with a
+            // permit in hand — the failure the ordering above exists to avoid.
+            // So an attempt costs exactly one token, and the only wait ever held
+            // under a permit is the one no ordering can remove: an episode that
+            // opened while this caller sat in the queue.
+            if !paced_before_queue && let Some(pacer) = pacer.as_deref() {
+                pacer.admit().await;
+            }
 
             // Pacing and the in-flight queue can outlast the caller's aggregate
             // budget on their own — a 900s overload cooldown dwarfs a 240s

--- a/crates/llm/src/in_flight.rs
+++ b/crates/llm/src/in_flight.rs
@@ -26,14 +26,24 @@
 //! stop a steady stream that exceeds a quota. `crates/core`'s own `rate_limiter`
 //! documentation makes the same distinction.
 //!
-//! Order matters at the call site: wait on the pacer *first*, then take the
-//! in-flight permit, and release it once the attempt's response has been read.
-//! What this semaphore counts is open sockets, and a request parked in
-//! `Pacer::admit` has none — so acquiring first would make sleepers occupy
-//! permits they are not using. During a 900s overload cooldown that turns the
-//! ceiling into a process-wide stall: every other LLM caller blocks in
-//! [`acquire_in_flight`], which has no timeout, behind requests that are only
-//! sleeping. Backwards from the intent, since the pool should be draining.
+//! Order matters at the call site. The adapters run `admit` → acquire → `admit`,
+//! and release the permit once the attempt's response has been read:
+//!
+//! * The **first** admission comes before the acquire because what this
+//!   semaphore counts is open sockets, and a request parked in `Pacer::admit`
+//!   has none — acquiring first would make sleepers occupy permits they are not
+//!   using. During a 900s overload cooldown that turns the ceiling into a
+//!   process-wide stall: every other LLM caller blocks in [`acquire_in_flight`],
+//!   which has no timeout, behind requests that are only sleeping. Backwards
+//!   from the intent, since the pool should be draining.
+//! * The **second** admission restores the pacer's own invariant, that a caller
+//!   is admitted immediately before its send. Queueing here breaks it: with
+//!   pacing off by default, a crowd of callers clears the fast path together,
+//!   and a 429 answering the first of them opens an episode that none of the
+//!   others — already past the pacer, merely waiting for a permit — would
+//!   observe. It runs only when the first admission was that free fast path, so
+//!   an attempt still costs exactly one token and a caller the pacer has already
+//!   throttled never sleeps in the bucket holding a permit.
 
 use std::sync::{Arc, OnceLock};
 

--- a/crates/llm/src/in_flight.rs
+++ b/crates/llm/src/in_flight.rs
@@ -21,14 +21,19 @@
 //!
 //! [`cognee_utils::pacing`] bounds the *rate* of dispatch (tokens per interval,
 //! plus a cooldown once the provider signals overload). This bounds *concurrency*
-//! — permits are held for the whole request, not just its start. They are not
-//! substitutes: a rate limiter cannot stop 1000 simultaneous sockets, and a
-//! semaphore cannot stop a steady stream that exceeds a quota. `crates/core`'s
-//! own `rate_limiter` documentation makes the same distinction.
+//! — permits are held for the HTTP exchange itself. They are not substitutes: a
+//! rate limiter cannot stop 1000 simultaneous sockets, and a semaphore cannot
+//! stop a steady stream that exceeds a quota. `crates/core`'s own `rate_limiter`
+//! documentation makes the same distinction.
 //!
-//! Order matters at the call site: take the in-flight permit *first*, then wait
-//! on the pacer. Reversed, a paced caller would hold a permit while sleeping,
-//! and an overload episode would idle the pool instead of draining it.
+//! Order matters at the call site: wait on the pacer *first*, then take the
+//! in-flight permit, and release it once the attempt's response has been read.
+//! What this semaphore counts is open sockets, and a request parked in
+//! `Pacer::admit` has none — so acquiring first would make sleepers occupy
+//! permits they are not using. During a 900s overload cooldown that turns the
+//! ceiling into a process-wide stall: every other LLM caller blocks in
+//! [`acquire_in_flight`], which has no timeout, behind requests that are only
+//! sleeping. Backwards from the intent, since the pool should be draining.
 
 use std::sync::{Arc, OnceLock};
 
@@ -79,11 +84,14 @@ pub fn llm_in_flight() -> Option<Arc<Semaphore>> {
     LLM_IN_FLIGHT.get().map(Arc::clone)
 }
 
-/// Acquire a permit for one LLM request, or `None` when no ceiling is installed.
+/// Acquire a permit for one LLM request attempt, or `None` when no ceiling is
+/// installed.
 ///
-/// Held for the lifetime of the request — including its retries, so a request
-/// that backs off does not release its slot to a competitor and then have to
-/// re-queue behind it.
+/// Held for the lifetime of one attempt — from just after the pacer admits it
+/// to just after its response body has been read — and *not* across the retry
+/// ladder's backoff sleeps. A request that is sleeping holds no socket, so
+/// keeping its permit would only make the ceiling under-count the pool. A retry
+/// therefore re-queues, which is correct: it is a fresh socket.
 pub async fn acquire_in_flight() -> Option<OwnedSemaphorePermit> {
     match llm_in_flight() {
         // `acquire_owned` only errors when the semaphore is closed, and nothing

--- a/crates/llm/src/responses_client.rs
+++ b/crates/llm/src/responses_client.rs
@@ -243,10 +243,22 @@ impl OpenAIResponsesClient {
             self.retry_min_elapsed,
         );
         let pacer = self.pacer.clone().or_else(llm_pacer);
-        // Started before the loop, and so before the pacer's admission wait and
-        // the in-flight queue inside it, so queueing time counts against the
-        // retry budget rather than being invisible to it.
+        // Wall clock for the whole call: what the retry logs report, and the
+        // base the retry floor is measured off once the in-flight queue waits
+        // below are subtracted.
         let started = Instant::now();
+        // Time this call has spent queued for an in-flight permit, subtracted
+        // from the elapsed time handed to `RetryBudget::is_exhausted`.
+        //
+        // That predicate is `attempts >= min_attempts && elapsed >= min_elapsed`,
+        // so a *larger* elapsed can only exhaust the budget earlier, and
+        // `min_elapsed` (`LLM_MIN_RETRY_SECONDS`) is a "keep retrying for at
+        // least this long" resilience guarantee, not a deadline — this client
+        // has no deadline concept at all. Charging queue time against the floor
+        // would only ever cut the ladder short: with `LLM_MAX_RETRIES=2` and a
+        // 240s floor, a call that spent 300s waiting for a permit would stop
+        // after its second attempt having done no real retrying.
+        let mut queued_for_permit = Duration::ZERO;
         let mut retry_after: Option<Duration> = None;
         let mut attempt: u32 = 0;
 
@@ -277,7 +289,9 @@ impl OpenAIResponsesClient {
             // See the identical acquisition in the OpenAI adapter: transport-level
             // concurrency ceiling, taken *after* admission and released at the end
             // of the iteration so a permit only ever covers a live socket.
+            let permit_queue_started = Instant::now();
             let _in_flight = crate::in_flight::acquire_in_flight().await;
+            queued_for_permit += permit_queue_started.elapsed();
 
             // Re-gate immediately before the send: an episode can open while this
             // caller sits in the queue, and without this every caller that
@@ -309,7 +323,9 @@ impl OpenAIResponsesClient {
                         pacer.record_overload("timeout");
                     }
                     last_error = LlmError::NetworkError(e.to_string());
-                    if budget.is_exhausted(attempt, started.elapsed()) {
+                    if budget
+                        .is_exhausted(attempt, started.elapsed().saturating_sub(queued_for_permit))
+                    {
                         break;
                     }
                     continue;
@@ -350,7 +366,8 @@ impl OpenAIResponsesClient {
                 }
                 retry_after = hint;
                 last_error = err;
-                if budget.is_exhausted(attempt, started.elapsed()) {
+                if budget.is_exhausted(attempt, started.elapsed().saturating_sub(queued_for_permit))
+                {
                     break;
                 }
                 continue;

--- a/crates/llm/src/responses_client.rs
+++ b/crates/llm/src/responses_client.rs
@@ -267,14 +267,27 @@ impl OpenAIResponsesClient {
                 tokio::time::sleep(delay).await;
             }
 
-            if let Some(pacer) = pacer.as_deref() {
-                pacer.admit().await;
-            }
+            // Before the queue below, because this is the only admission that
+            // can pace a caller without an in-flight permit in hand.
+            let paced_before_queue = match pacer.as_deref() {
+                Some(pacer) => pacer.admit().await,
+                None => false,
+            };
 
             // See the identical acquisition in the OpenAI adapter: transport-level
             // concurrency ceiling, taken *after* admission and released at the end
             // of the iteration so a permit only ever covers a live socket.
             let _in_flight = crate::in_flight::acquire_in_flight().await;
+
+            // Re-gate immediately before the send: an episode can open while this
+            // caller sits in the queue, and without this every caller that
+            // cleared the fast path together would still fire one unpaced send at
+            // a provider that has just reported overload. Skipped when the
+            // admission above already paced this attempt, so an attempt never
+            // spends two tokens. See the OpenAI adapter for the full rationale.
+            if !paced_before_queue && let Some(pacer) = pacer.as_deref() {
+                pacer.admit().await;
+            }
 
             attempt += 1;
 

--- a/crates/llm/src/responses_client.rs
+++ b/crates/llm/src/responses_client.rs
@@ -243,9 +243,9 @@ impl OpenAIResponsesClient {
             self.retry_min_elapsed,
         );
         let pacer = self.pacer.clone().or_else(llm_pacer);
-        // See the identical acquisition in the OpenAI adapter: transport-level
-        // concurrency ceiling, held across retries, taken before pacing.
-        let _in_flight = crate::in_flight::acquire_in_flight().await;
+        // Started before the loop, and so before the pacer's admission wait and
+        // the in-flight queue inside it, so queueing time counts against the
+        // retry budget rather than being invisible to it.
         let started = Instant::now();
         let mut retry_after: Option<Duration> = None;
         let mut attempt: u32 = 0;
@@ -270,6 +270,11 @@ impl OpenAIResponsesClient {
             if let Some(pacer) = pacer.as_deref() {
                 pacer.admit().await;
             }
+
+            // See the identical acquisition in the OpenAI adapter: transport-level
+            // concurrency ceiling, taken *after* admission and released at the end
+            // of the iteration so a permit only ever covers a live socket.
+            let _in_flight = crate::in_flight::acquire_in_flight().await;
 
             attempt += 1;
 

--- a/crates/llm/tests/in_flight_permit_scope.rs
+++ b/crates/llm/tests/in_flight_permit_scope.rs
@@ -1,0 +1,124 @@
+//! What the in-flight ceiling is allowed to count — `httpmock`, no real API.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+//!
+//! `cognee_llm::in_flight` bounds concurrent LLM *sockets*, the analogue of the
+//! connection-pool limit every Python HTTP client sets. A request waiting for
+//! the pacer to admit it holds no socket, so it must hold no permit either.
+//!
+//! The ordering used to be the other way round — permit first, then
+//! `Pacer::admit()` — on the reasoning that a permit taken after admission
+//! would be "held across a pacing sleep". That has it backwards: acquiring
+//! first is exactly what holds a permit across the sleep. With the pool
+//! saturated and a provider overload episode open for its 900s cooldown, every
+//! other LLM caller in the process would block in `acquire_in_flight()` — which
+//! has no timeout — behind requests that were only sleeping.
+//!
+//! This test pins the ordering from the outside: a ceiling of one, a request
+//! parked in the pacer, and the assertion that the one permit is still free.
+//! It must own its process, because the in-flight semaphore is a first-call-wins
+//! `OnceLock` — hence a test file of its own, with a single case in it.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cognee_llm::adapters::OpenAIAdapter;
+use cognee_llm::in_flight::{acquire_in_flight, init_llm_in_flight};
+use cognee_llm::{Llm, Message, MessageRole};
+use cognee_utils::pacing::Pacer;
+use httpmock::prelude::*;
+
+/// The single permit this process's ceiling is installed with.
+const CEILING: usize = 1;
+
+/// Long enough that a request which loses the pacer's only token waits
+/// effectively forever, so "still parked" needs no timing tolerance.
+const PACING_INTERVAL: Duration = Duration::from_secs(3600);
+
+/// How long the probe waits for the permit before calling it held.
+///
+/// Generous: on the correct ordering the permit is free immediately, so this
+/// only ever elapses when the permit really is held by the parked request.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn user_msg() -> Vec<Message> {
+    vec![Message {
+        role: MessageRole::User,
+        content: "hello".to_string(),
+    }]
+}
+
+fn ok_response() -> &'static str {
+    r#"{"id":"x","object":"chat.completion","created":1,"model":"m",
+        "choices":[{"index":0,"message":{"role":"assistant","content":"hi"},
+        "finish_reason":"stop"}]}"#
+}
+
+#[tokio::test]
+async fn a_request_waiting_on_the_pacer_holds_no_in_flight_permit() {
+    let semaphore = init_llm_in_flight(CEILING);
+    assert_eq!(
+        semaphore.available_permits(),
+        CEILING,
+        "this file must own the process-wide ceiling; another test in the same \
+         binary installed one first"
+    );
+
+    let server = MockServer::start_async().await;
+    let endpoint = server.mock(|when, then| {
+        when.method(POST).path("/chat/completions");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(ok_response());
+    });
+
+    // One token per hour, pacing on unconditionally: the first call is admitted
+    // straight away and drains the bucket, the second is left owing a token it
+    // will not be granted for an hour.
+    let pacer = Arc::new(Pacer::new(1, PACING_INTERVAL, true, false));
+    let adapter = Arc::new(
+        OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+            .expect("adapter builds")
+            .with_pacer(pacer),
+    );
+
+    adapter
+        .generate(user_msg(), None)
+        .await
+        .expect("the first call is admitted immediately and answered by the mock");
+
+    let parked = tokio::spawn({
+        let adapter = Arc::clone(&adapter);
+        async move { adapter.generate(user_msg(), None).await }
+    });
+
+    // Let the second call reach `admit()` and block there. The mock's hit count
+    // is the proof it did: a request that got past pacing would have sent.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    endpoint.assert_calls(1);
+    assert!(
+        !parked.is_finished(),
+        "the second call must still be parked in the pacer for this test to mean \
+         anything"
+    );
+
+    // The probe. The ceiling is one, the parked request is the only other
+    // caller, and it holds no socket — so the permit must be available.
+    let permit = tokio::time::timeout(PROBE_TIMEOUT, acquire_in_flight())
+        .await
+        .expect(
+            "the in-flight permit is held by a request that is only sleeping in \
+             the pacer: acquiring before `Pacer::admit()` makes the ceiling count \
+             waiters as sockets, so an overload episode stalls every other LLM \
+             caller in the process",
+        );
+    assert!(
+        permit.is_some(),
+        "a ceiling was installed, so the acquire must yield a real permit"
+    );
+
+    parked.abort();
+}

--- a/crates/llm/tests/pacing_after_in_flight_queue.rs
+++ b/crates/llm/tests/pacing_after_in_flight_queue.rs
@@ -1,0 +1,142 @@
+//! Pacing must survive the in-flight queue — `httpmock`, no real API.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+//!
+//! `cognee_utils::pacing`'s contract is that a caller is admitted *immediately
+//! before* its HTTP send. The in-flight ceiling breaks that on its own: a caller
+//! clears `admit()` and then waits for a permit, and the wait is unbounded.
+//!
+//! Pacing is off by default, so the fast path lets a whole fan-out past the
+//! pacer in one go; they then pile up on the semaphore. The first reply is a
+//! 429, `record_overload` opens the 900s episode — and every caller already past
+//! the pacer still fires one unpaced send at a provider that has just said it is
+//! overloaded. One unpaced attempt each, which is exactly the burst that opened
+//! the episode.
+//!
+//! The adapters therefore admit twice: once before the queue (the only place a
+//! caller can be paced without holding a permit) and once after it, the second
+//! taken only when the first was the free fast path so an attempt still costs
+//! exactly one token.
+//!
+//! This test pins the second admission from the outside. It parks a call in the
+//! in-flight queue while pacing is off, opens an episode and drains the bucket
+//! behind its back, then frees the permit and asserts the call still does not
+//! send. It must own its process, because the in-flight semaphore is a
+//! first-call-wins `OnceLock` — hence a test file of its own, with a single case
+//! in it.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cognee_llm::adapters::OpenAIAdapter;
+use cognee_llm::in_flight::{acquire_in_flight, init_llm_in_flight};
+use cognee_llm::{Llm, Message, MessageRole};
+use cognee_utils::pacing::Pacer;
+use httpmock::prelude::*;
+
+/// The single permit this process's ceiling is installed with. One permit makes
+/// "the queue is occupied" exact: the test holds it, so nothing else can send.
+const CEILING: usize = 1;
+
+/// One token per hour: once the episode is open and the test has spent the
+/// bucket's only token, a caller admitted a second time waits effectively
+/// forever, so "still parked" needs no timing tolerance.
+const PACING_INTERVAL: Duration = Duration::from_secs(3600);
+
+/// How long to let the call sit before checking on it. Generous: on the correct
+/// ordering nothing is ever sent, so this only costs wall-clock time.
+const SETTLE: Duration = Duration::from_millis(500);
+
+fn user_msg() -> Vec<Message> {
+    vec![Message {
+        role: MessageRole::User,
+        content: "hello".to_string(),
+    }]
+}
+
+fn ok_response() -> &'static str {
+    r#"{"id":"x","object":"chat.completion","created":1,"model":"m",
+        "choices":[{"index":0,"message":{"role":"assistant","content":"hi"},
+        "finish_reason":"stop"}]}"#
+}
+
+#[tokio::test]
+async fn an_episode_opened_while_queued_still_paces_the_send() {
+    let semaphore = init_llm_in_flight(CEILING);
+    assert_eq!(
+        semaphore.available_permits(),
+        CEILING,
+        "this file must own the process-wide ceiling; another test in the same \
+         binary installed one first"
+    );
+
+    let server = MockServer::start_async().await;
+    let endpoint = server.mock(|when, then| {
+        when.method(POST).path("/chat/completions");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(ok_response());
+    });
+
+    // Pacing off (`LLM_RATE_LIMIT_ENABLED=false`, the default) but reactive
+    // (`AUTO_RATE_LIMIT=true`), which is the configuration the failure needs:
+    // the fast path admits without taking a token, and a provider 429 can still
+    // open an episode afterwards.
+    let pacer = Arc::new(Pacer::new(1, PACING_INTERVAL, false, true));
+    let adapter = Arc::new(
+        OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+            .expect("adapter builds")
+            .with_pacer(Arc::clone(&pacer)),
+    );
+
+    // Occupy the ceiling, so the call below gets past the pacer and then stops
+    // in the queue — which is the window the bug lives in.
+    let held = acquire_in_flight().await;
+    assert!(
+        held.is_some(),
+        "a ceiling was installed, so the acquire must yield a real permit"
+    );
+
+    let queued = tokio::spawn({
+        let adapter = Arc::clone(&adapter);
+        async move { adapter.generate(user_msg(), None).await }
+    });
+
+    tokio::time::sleep(SETTLE).await;
+    endpoint.assert_calls(0);
+    assert!(
+        !queued.is_finished(),
+        "the call must be parked in the in-flight queue for this test to mean \
+         anything"
+    );
+
+    // What a concurrent 429 does, without needing a second adapter to produce
+    // it: the episode opens behind the queued caller's back. Then spend the
+    // bucket's only token, so anything admitted from here on waits an hour.
+    pacer.record_overload("test");
+    assert!(
+        pacer.admit().await,
+        "the episode is open, so this admission must take the bucket's token"
+    );
+
+    // Free the queue. The call now holds a permit — and must be paced again
+    // before it sends, because the pacer never saw it once the episode opened.
+    drop(held);
+    tokio::time::sleep(SETTLE).await;
+
+    assert!(
+        !queued.is_finished(),
+        "the call cleared admission on the fast path, then waited on the \
+         semaphore while an overload episode opened. Admitting only before the \
+         queue lets it send unpaced at a provider that has just reported \
+         overload — one such send per queued caller, which is the burst that \
+         opens the episode in the first place. It must be admitted again \
+         immediately before the send."
+    );
+    endpoint.assert_calls(0);
+
+    queued.abort();
+}

--- a/crates/llm/tests/retry_floor_excludes_queue_time.rs
+++ b/crates/llm/tests/retry_floor_excludes_queue_time.rs
@@ -1,0 +1,171 @@
+//! The retry floor must not be spent queueing — `httpmock`, no real API.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code: panics are acceptable"
+)]
+//!
+//! `RetryBudget::is_exhausted` is `attempts >= min_attempts && elapsed >=
+//! min_elapsed`, so a *larger* elapsed can only ever end the ladder **earlier**.
+//! `min_elapsed` (`LLM_MIN_RETRY_SECONDS`) is a "keep retrying for at least this
+//! long" resilience guarantee, not a deadline — it is what carries a call
+//! through a provider's rate-limit window — so charging the in-flight queue wait
+//! against it silently weakens it. A call that spent five minutes waiting for a
+//! permit would give up on its attempt floor alone, having barely retried.
+//!
+//! Neither the Anthropic adapter nor the Responses client has any deadline
+//! concept, so for them counting queue time buys nothing at all. Both cases here
+//! hold the process's only in-flight permit for longer than the whole retry
+//! floor before letting the call through: were queue time counted, the first
+//! attempt would already satisfy both halves of the predicate and the call would
+//! stop after a single request.
+//!
+//! Serial, and a file of its own: the in-flight semaphore is a first-call-wins
+//! `OnceLock` installed once per process, and each case needs exclusive use of
+//! its single permit.
+
+use std::time::Duration;
+
+use cognee_llm::adapters::AnthropicAdapter;
+use cognee_llm::in_flight::{acquire_in_flight, init_llm_in_flight};
+use cognee_llm::{Llm, Message, MessageRole, OpenAIResponsesClient, ResponsesClient};
+use httpmock::prelude::*;
+
+/// One permit, so holding it is exactly "the queue is full".
+const CEILING: usize = 1;
+
+/// How long the test holds the permit before releasing it. Comfortably longer
+/// than [`RETRY_FLOOR`], which is what makes the two behaviours distinguishable:
+/// with queue time charged, the floor is already satisfied when the first
+/// attempt starts.
+const QUEUE_HOLD: Duration = Duration::from_millis(900);
+
+/// The retry floor under test (`LLM_MIN_RETRY_SECONDS`).
+const RETRY_FLOOR: Duration = Duration::from_millis(400);
+
+/// Retry gap the mock asks for. `retry-after-ms` replaces the 8s exponential
+/// backoff outright, which is the only reason this test is quick.
+const RETRY_AFTER_MS: &str = "40";
+
+/// Attempts the ladder must make before the elapsed floor may stop it. One, so
+/// the *only* thing that can keep the loop going past the first failure is the
+/// elapsed floor — which is the property under test.
+const MIN_ATTEMPTS: u32 = 1;
+
+/// A ladder that honours the floor gets roughly `RETRY_FLOOR / RETRY_AFTER_MS`
+/// attempts; one that charged the queue wait against it gets exactly one.
+/// Asserted well below the former so scheduling jitter cannot flip the result.
+const MIN_EXPECTED_CALLS: usize = 3;
+
+/// A retryable failure that is *not* overload evidence, so no pacing episode
+/// opens and the retry gap stays the one the header asks for.
+const SERVER_ERROR_BODY: &str = r#"{"error":{"message":"server error"}}"#;
+
+fn user_msg() -> Vec<Message> {
+    vec![Message {
+        role: MessageRole::User,
+        content: "hello".to_string(),
+    }]
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn anthropic_does_not_spend_its_retry_floor_in_the_in_flight_queue() {
+    init_llm_in_flight(CEILING);
+
+    let server = MockServer::start_async().await;
+    let endpoint = server.mock(|when, then| {
+        when.method(POST).path("/messages");
+        then.status(500)
+            .header("retry-after-ms", RETRY_AFTER_MS)
+            .body(SERVER_ERROR_BODY);
+    });
+
+    let adapter = AnthropicAdapter::new("claude-3-5-haiku", "test-key", Some(server.base_url()))
+        .expect("adapter builds")
+        .with_network_retries(MIN_ATTEMPTS)
+        .with_min_retry_elapsed(RETRY_FLOOR);
+
+    // Taken before the call starts, so its very first attempt is what queues.
+    let held = acquire_in_flight().await;
+    assert!(
+        held.is_some(),
+        "a ceiling was installed, so the acquire must yield a real permit"
+    );
+
+    let call = tokio::spawn(async move { adapter.generate(user_msg(), None).await });
+    tokio::time::sleep(QUEUE_HOLD).await;
+    assert!(
+        !call.is_finished(),
+        "the call must still be parked in the in-flight queue for this test to \
+         mean anything"
+    );
+    endpoint.assert_calls(0);
+    drop(held);
+
+    call.await
+        .expect("the request task must not panic")
+        .expect_err("every attempt is answered with a 500");
+
+    assert!(
+        endpoint.calls() >= MIN_EXPECTED_CALLS,
+        "the call made {} attempt(s): the {QUEUE_HOLD:?} it spent queued for an \
+         in-flight permit was charged against its {RETRY_FLOOR:?} retry floor. \
+         That floor is a minimum-retry-duration guarantee rather than a \
+         deadline, so counting queue time against it can only ever abandon a \
+         call sooner — and this adapter has no deadline the earlier clock could \
+         serve",
+        endpoint.calls(),
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn responses_client_does_not_spend_its_retry_floor_in_the_in_flight_queue() {
+    init_llm_in_flight(CEILING);
+
+    let server = MockServer::start_async().await;
+    let endpoint = server.mock(|when, then| {
+        when.method(GET).path("/responses/resp_1");
+        then.status(500)
+            .header("retry-after-ms", RETRY_AFTER_MS)
+            .body(SERVER_ERROR_BODY);
+    });
+
+    let client = OpenAIResponsesClient::new("test-key", Some(server.base_url()))
+        .expect("client builds")
+        .with_network_retries(MIN_ATTEMPTS)
+        .with_min_retry_elapsed(RETRY_FLOOR);
+
+    // Taken before the call starts, so its very first attempt is what queues.
+    let held = acquire_in_flight().await;
+    assert!(
+        held.is_some(),
+        "a ceiling was installed, so the acquire must yield a real permit"
+    );
+
+    let call = tokio::spawn(async move { client.retrieve_response("resp_1").await });
+    tokio::time::sleep(QUEUE_HOLD).await;
+    assert!(
+        !call.is_finished(),
+        "the call must still be parked in the in-flight queue for this test to \
+         mean anything"
+    );
+    endpoint.assert_calls(0);
+    drop(held);
+
+    call.await
+        .expect("the request task must not panic")
+        .expect_err("every attempt is answered with a 500");
+
+    assert!(
+        endpoint.calls() >= MIN_EXPECTED_CALLS,
+        "the call made {} attempt(s): the {QUEUE_HOLD:?} it spent queued for an \
+         in-flight permit was charged against its {RETRY_FLOOR:?} retry floor. \
+         That floor is a minimum-retry-duration guarantee rather than a \
+         deadline, so counting queue time against it can only ever abandon a \
+         call sooner — and this client has no deadline the earlier clock could \
+         serve",
+        endpoint.calls(),
+    );
+}

--- a/crates/utils/src/pacing.rs
+++ b/crates/utils/src/pacing.rs
@@ -17,6 +17,15 @@
 //!    flight. Callers must therefore `admit().await` immediately before each
 //!    HTTP send, not before the loop.
 //!
+//!    Where a wait the caller cannot remove sits between admission and the send
+//!    — the LLM adapters queue for an in-flight permit there, and must not hold
+//!    one across a bucket wait — admission is taken *twice*: once before the
+//!    wait, and again after it if and only if the first was the free fast path.
+//!    [`Pacer::admit`] returns which it was. That keeps one token per attempt
+//!    while closing the hole where a crowd clears the fast path together, an
+//!    episode opens behind them, and every one of them still fires an unpaced
+//!    send.
+//!
 //! There is deliberately **no token/TPM accounting**: Python declares
 //! `llm_rate_limit_tokens` and never reads it, so a TPM budget here would be a
 //! divergence, not parity.
@@ -262,11 +271,20 @@ impl Pacer {
     ///
     /// Returns immediately on the fast path. Call this immediately before each
     /// HTTP send, inside the retry loop — see the module docs.
-    pub async fn admit(&self) {
+    ///
+    /// The return value reports whether pacing actually applied — `true` when a
+    /// token was taken from the bucket, `false` when the fast path let the
+    /// caller straight through. A caller that cannot admit *immediately* before
+    /// its send, because an unavoidable wait sits in between (the LLM adapters'
+    /// in-flight queue), uses this to re-admit after that wait only when the
+    /// first admission was free. Re-admitting unconditionally would spend two
+    /// tokens per attempt, halving the configured rate during an episode.
+    pub async fn admit(&self) -> bool {
         if !self.should_pace_at(Instant::now()) {
-            return;
+            return false;
         }
         self.bucket.acquire().await;
+        true
     }
 
     /// Feed a provider error to the policy. No-op when `auto_react` is off.
@@ -568,8 +586,8 @@ mod tests {
     async fn admit_returns_immediately_on_the_fast_path() {
         let pacer = Pacer::new(1, Duration::from_secs(3600), false, true);
         let started = Instant::now();
-        pacer.admit().await;
-        pacer.admit().await;
+        assert!(!pacer.admit().await, "the fast path takes no token");
+        assert!(!pacer.admit().await, "the fast path takes no token");
         assert!(started.elapsed() < Duration::from_millis(50));
     }
 
@@ -578,10 +596,10 @@ mod tests {
         // 20 per second => a 50ms spacing once the single-token burst is spent.
         let pacer = Pacer::new(20, Duration::from_secs(1), true, true);
         for _ in 0..20 {
-            pacer.admit().await;
+            assert!(pacer.admit().await, "an open episode paces every admission");
         }
         let started = Instant::now();
-        pacer.admit().await;
+        assert!(pacer.admit().await, "an open episode paces every admission");
         assert!(
             started.elapsed() >= Duration::from_millis(20),
             "expected the bucket to delay dispatch, waited {:?}",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -725,6 +725,10 @@ These knobs form one resilience stack, matching Python cognee's:
   cannot stop a steady stream that exceeds a quota. The concurrency ceiling is
   enforced inside the LLM transport, so it applies on every surface including
   the HTTP server, whose cognify routes have no per-request knob of their own.
+  A slot is held for the HTTP exchange itself and released while a request waits
+  — for its pacing turn or for a retry backoff — because a waiting request holds
+  no socket; counting waiters would let a 15-minute overload episode stall every
+  other LLM caller in the process behind requests that are merely sleeping.
   It defaults to 1000, matching the connection-pool limit `openai-python` and
   `litellm` set, and to 128 on Android/iOS where a 1024-descriptor budget is
   shared with the graph, vector and relational stores.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -693,7 +693,11 @@ These knobs form one resilience stack, matching Python cognee's:
   provider's rate-limit window resets. Backoff is exponential with jitter,
   8s doubling to a 128s ceiling, and a `Retry-After` header is honoured (capped
   at 60s) when the provider sends one. Set `LLM_MIN_RETRY_SECONDS=0` to fail
-  fast on attempts alone.
+  fast on attempts alone. The elapsed time measured against this floor excludes
+  time spent queued for an `LLM_MAX_IN_FLIGHT` slot: the floor is a "keep
+  retrying for at least this long" guarantee, so counting queue time against it
+  could only ever end the ladder earlier, and a call that waited minutes for a
+  slot would give up having barely retried at all.
 - **Three timeouts, three scopes.** `LLM_CONNECT_TIMEOUT_SECONDS` bounds the TCP
   handshake (`reqwest` sets none by default, so a black-holed connect used to
   burn the whole request timeout without sending a byte).


### PR DESCRIPTION
Two confirmed defects introduced by #155, both in the mechanism that PR was written to provide. Both verified before fixing; both still present on the tip at the time of writing.

## 1. The in-flight permit was held across the pacer's cooldown

`openai.rs`, `anthropic.rs` and `responses_client.rs` each acquired the permit *outside* the retry loop while `pacer.admit()` sleeps *inside* it. The comments claimed this ordering avoided holding a permit across a pacing sleep - the reasoning was inverted; acquiring first is exactly what holds it. The permit bounds concurrent *sockets*, and a request parked in `admit()` holds none, so the semaphore over-counted by the number of sleepers.

The sleep is genuinely unbounded: `TokenBucket::reserve` lets debt accumulate, so wait time grows linearly with the number of concurrent waiters on top of the 900s `OVERLOAD_COOLDOWN`. With the pool saturated, one 429 could block *every* LLM caller in the process - search, a second dataset's cognify, summarization - in `acquire_in_flight().await` for ~15 minutes. Worse than before #155, when there was no shared global gate at all.

**Fix:** the permit is taken after `admit()`, inside the loop, so it drops each iteration and covers only the live socket. A retry re-queues for a permit, which is correct - a retry is a new socket. Comments rewritten in all three adapters and in `in_flight.rs`, plus a paragraph in `docs/configuration.md`.

`started` now sits ahead of the whole wait, so queue time counts against the retry budget and `LLM_REQUEST_DEADLINE_SECONDS` instead of being invisible to both.

**Deadline around admit - fixed narrowly.** The obvious `if attempt > 0 && expired` check would have been wrong: the existing top-of-loop guard clamps its backoff to `remaining` and sleeps exactly that long, deliberately letting that attempt start at the deadline. The new guard fires only when the wait began with budget remaining and the wait is what spent it, so existing behaviour is untouched and only the pacing overshoot is caught. A timeout on the acquire itself is left as a separate design question, now that the permit no longer covers sleeps.

## 2. `.buffered()` did not refill a slot on out-of-order completion

`FuturesOrdered::len()` counts completed-but-undrained outputs, so a future finishing out of order keeps its slot until the consumer drains it in order. #155's claim that a freed slot refills immediately holds only for in-order completion - so head-of-line blocking, the thing #155 removed, returned above `max_parallel` chunks per batch. The 171-chunk benchmark never exercised it.

**Fix:** all three loops moved to `buffer_unordered` over `.into_iter().enumerate()`, carrying `(index, result)` through the future, then `sort_by_key` and strip. Downstream code is byte-identical and every order-sensitive property is preserved: dedup in `retrieve_existing_edges`, `all_events` determinism, failure-record order. `tokio::spawn` stays inside the mapped future, the item type stays `Result<Result<T, E>, JoinError>`, and fail-closed behaviour is untouched (a separate finding).

**Note on loop 3.** It was described to me as order-insensitive because it only `extend`s. It is not - it zips positionally against `chunk_ids` *and* `chunk_documents`, building events in lockstep so each inherits its chunk's file, and its own comment documents `all_events` determinism as a guarantee. It needed the index like the other two. Left as-is it would have silently attributed temporal events to the wrong source documents.

## Tests

`crates/cognify/tests/fanout_correlation.rs` - 3 cases, offline, 0.02s. A gate in the mock LLM holds chunk 0's response until every other chunk in the batch has been served (6 chunks, `max_parallel = 2`), forcing out-of-order completion *and* making the test unsatisfiable unless slots refill past the limit. Responses derive from each chunk's own text so a mis-correlation is visible rather than merely possible.

- Against `.buffered`: all 3 deadlock.
- Against `buffer_unordered` with the `sort_by_key` removed: all 3 mis-correlate - chunk 0 receives chunk 1's marker.

`crates/llm/tests/in_flight_permit_scope.rs` - ceiling of 1, a pacer with one token per hour, one request parked in `admit()`; asserts the permit is still free. Times out with a diagnostic against the old ordering. Its own binary, since the semaphore is a `OnceLock`.

## Checks

`cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings` all exit 0, verified by exit code. Full `cargo nextest run -p cognee-llm -p cognee-cognify -p cognee-utils`: 664/668. The 4 non-passes are pre-existing and live-endpoint dependent - one is a configured model spending its whole token budget on reasoning, three are live E2E cognify tests hitting the 300s slow-timeout, which was reproduced identically on the base commit.

Addresses the post-merge defects recorded on SDK-509.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEsBZ8DkwaGgRErzkZf4rm
