### PR TITLE
perf(graph,cognify): batch ladybug reads, dedup edge candidates, fill pg gaps (#21)

### DIFF
--- a/crates/cognify/src/graph_integration/db_deduplication.rs
+++ b/crates/cognify/src/graph_integration/db_deduplication.rs
@@ -22,8 +22,11 @@ use crate::fact_extraction::KnowledgeGraph;
 /// **Edge key format:** `"{source_uuid}_{target_uuid}_{relationship_name}"`
 /// (matches the format used in `expand_with_nodes_and_edges`)
 ///
-/// **Deduplication strategy:** Uses `processed_nodes` set to avoid querying
-/// the same node multiple times within a batch.
+/// **Deduplication strategy:** the candidate `(source, target, relationship)`
+/// triples are de-duplicated before the query. Chunk-level extraction routinely
+/// yields the same relation from several chunks of one document, and the return
+/// value is a set of edge keys, so a repeated triple can only ever cost an
+/// extra lookup — never change the result.
 ///
 /// # Arguments  
 /// * `graph_db` - Graph database trait object
@@ -43,18 +46,17 @@ use crate::fact_extraction::KnowledgeGraph;
 ///     // Create new edge
 /// }
 /// ```
-pub async fn retrieve_existing_edges(
-    graph_db: &dyn GraphDBTrait,
-    graphs: &[KnowledgeGraph],
-) -> Result<HashSet<String>, CognifyError> {
-    if graphs.is_empty() {
-        return Ok(HashSet::new());
-    }
-
-    // Track nodes we've processed to avoid duplicate work
-    let mut processed_nodes: HashSet<String> = HashSet::new();
-
-    // Collect all edges to check
+/// Collect the distinct `(source_uuid, target_uuid, relationship_name)`
+/// candidates to look up, in first-seen order.
+///
+/// Chunk-level extraction routinely re-derives the same relation from several
+/// chunks of one document, and on a backend without a set-based existence
+/// check each repeat used to cost its own round-trip. De-duplicating here can
+/// only remove redundant lookups: the caller folds the results into a
+/// `HashSet` of edge keys, so a repeated candidate could never have changed
+/// the outcome.
+fn collect_distinct_candidate_edges(graphs: &[KnowledgeGraph]) -> Vec<EdgeData> {
+    let mut seen: HashSet<(String, String, String)> = HashSet::new();
     let mut edges_to_check: Vec<EdgeData> = Vec::new();
 
     for graph in graphs {
@@ -65,33 +67,35 @@ pub async fn retrieve_existing_edges(
             // these keys never match the stored (deterministic) entity ids, so
             // edge dedup was a silent no-op (issue #57 corollary). Matches
             // Python `retrieve_existing_edges.py:75-76` (`Entity.id_for`).
-            let source_uuid = Entity::id_for(&edge.source_node_id);
-            let target_uuid = Entity::id_for(&edge.target_node_id);
+            let source_uuid = Entity::id_for(&edge.source_node_id).to_string();
+            let target_uuid = Entity::id_for(&edge.target_node_id).to_string();
 
-            // Only process if we haven't seen both nodes before
-            let source_str = edge.source_node_id.as_str();
-            let target_str = edge.target_node_id.as_str();
-
-            // Mark nodes as processed
-            if !processed_nodes.contains(source_str) {
-                processed_nodes.insert(source_str.to_string());
-            }
-            if !processed_nodes.contains(target_str) {
-                processed_nodes.insert(target_str.to_string());
-            }
-
-            // Create edge tuple for database query
             // Note: relationship_name is already normalized by LLM or should be
-            let edge_tuple = (
-                source_uuid.to_string(),
-                target_uuid.to_string(),
-                edge.relationship_name.clone(),
-                HashMap::new(), // Properties not needed for existence check
-            );
-
-            edges_to_check.push(edge_tuple);
+            let key = (source_uuid, target_uuid, edge.relationship_name.clone());
+            if !seen.contains(&key) {
+                seen.insert(key.clone());
+                edges_to_check.push((
+                    key.0,
+                    key.1,
+                    key.2,
+                    HashMap::new(), // Properties not needed for existence check
+                ));
+            }
         }
     }
+
+    edges_to_check
+}
+
+pub async fn retrieve_existing_edges(
+    graph_db: &dyn GraphDBTrait,
+    graphs: &[KnowledgeGraph],
+) -> Result<HashSet<String>, CognifyError> {
+    if graphs.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let edges_to_check = collect_distinct_candidate_edges(graphs);
 
     if edges_to_check.is_empty() {
         return Ok(HashSet::new());
@@ -248,8 +252,81 @@ mod tests {
         assert_eq!(result.len(), 1);
     }
 
+    /// A relation re-extracted from several chunks is looked up once. The
+    /// candidate list is what reaches `has_edges`, so this is what bounds the
+    /// query count on backends without a set-based existence check.
+    #[test]
+    fn collect_distinct_candidate_edges_dedups_repeated_triples() {
+        // The same graph three times: three identical `alice -works_at->
+        // techcorp` edges.
+        let graphs = vec![
+            create_test_graph(),
+            create_test_graph(),
+            create_test_graph(),
+        ];
+        let candidates = collect_distinct_candidate_edges(&graphs);
+        assert_eq!(candidates.len(), 1, "identical triples collapse to one");
+
+        let expected_source = Entity::id_for("alice").to_string();
+        let expected_target = Entity::id_for("techcorp").to_string();
+        assert_eq!(candidates[0].0, expected_source);
+        assert_eq!(candidates[0].1, expected_target);
+        assert_eq!(candidates[0].2, "works_at");
+    }
+
+    /// Dedup keys on the whole triple, so edges sharing only an endpoint or
+    /// only a relationship name are all kept.
+    #[test]
+    fn collect_distinct_candidate_edges_keeps_distinct_triples() {
+        let graph = KnowledgeGraph {
+            nodes: vec![],
+            edges: vec![
+                Edge {
+                    source_node_id: "alice".to_string(),
+                    target_node_id: "techcorp".to_string(),
+                    relationship_name: "works_at".to_string(),
+                    description: None,
+                },
+                // same endpoints, different relationship
+                Edge {
+                    source_node_id: "alice".to_string(),
+                    target_node_id: "techcorp".to_string(),
+                    relationship_name: "founded".to_string(),
+                    description: None,
+                },
+                // same relationship, different target
+                Edge {
+                    source_node_id: "alice".to_string(),
+                    target_node_id: "london".to_string(),
+                    relationship_name: "works_at".to_string(),
+                    description: None,
+                },
+                // exact repeat of the first — the only one that drops
+                Edge {
+                    source_node_id: "alice".to_string(),
+                    target_node_id: "techcorp".to_string(),
+                    relationship_name: "works_at".to_string(),
+                    description: None,
+                },
+            ],
+        };
+
+        let candidates = collect_distinct_candidate_edges(&[graph]);
+        assert_eq!(candidates.len(), 3);
+        // First-seen order is preserved.
+        assert_eq!(candidates[0].2, "works_at");
+        assert_eq!(candidates[1].2, "founded");
+        assert_eq!(candidates[2].2, "works_at");
+        assert_ne!(candidates[0].1, candidates[2].1);
+    }
+
+    #[test]
+    fn collect_distinct_candidate_edges_handles_no_graphs() {
+        assert!(collect_distinct_candidate_edges(&[]).is_empty());
+    }
+
     #[tokio::test]
-    async fn test_processed_nodes_tracking() {
+    async fn test_shared_node_across_multiple_edges() {
         let graph_db = MockGraphDB::new();
 
         // Create graph with same node appearing in multiple edges

--- a/crates/graph/src/ladybug.rs
+++ b/crates/graph/src/ladybug.rs
@@ -936,6 +936,12 @@ impl GraphDBTrait for LadybugAdapter {
     }
 
     async fn delete_node(&self, node_id: &str) -> GraphDBResult<()> {
+        // `DETACH DELETE` is a write, so it serializes on the same lock as the
+        // node/edge upserts. Without it a delete could interleave with a
+        // concurrent upsert despite the adapter's write-serialization intent.
+        let _write_guard = self.write_lock.lock().map_err(|_| {
+            GraphDBError::ConnectionError("Ladybug write lock poisoned".to_string())
+        })?;
         let db = self.db()?;
         let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
@@ -955,10 +961,9 @@ impl GraphDBTrait for LadybugAdapter {
     /// Batched delete: one `DETACH DELETE` per 500 ids instead of one per id.
     ///
     /// Matters on the delete path, which calls this with whole orphan sets
-    /// (`cognee-delete`'s artifact sweep). Takes the write lock once for the
-    /// whole call rather than re-acquiring it per node, and `DETACH DELETE`
-    /// keeps its per-node cascade semantics — the only change is how many
-    /// statements carry them.
+    /// (`cognee-delete`'s artifact sweep). The write lock is taken once for the
+    /// whole call, and `DETACH DELETE` keeps its per-node cascade semantics —
+    /// the only change is how many statements carry them.
     async fn delete_nodes(&self, node_ids: &[String]) -> GraphDBResult<()> {
         if node_ids.is_empty() {
             return Ok(());

--- a/crates/graph/src/ladybug.rs
+++ b/crates/graph/src/ladybug.rs
@@ -1025,9 +1025,14 @@ impl GraphDBTrait for LadybugAdapter {
     /// Batched node fetch: one query per 500 ids instead of one per id.
     ///
     /// Ids absent from storage are simply missing from the result, which is
-    /// the same contract the per-id loop had (it dropped `None`s). Row order
-    /// follows the engine's, not `node_ids` — as before, since the per-id loop
-    /// only preserved order incidentally and no caller relies on it.
+    /// the same contract the per-id loop had (it dropped `None`s).
+    ///
+    /// Two properties the per-id loop happened to have and this does **not**:
+    /// rows come back in engine order rather than `node_ids` order, and a
+    /// repeated id yields one row instead of one per occurrence. Neither is
+    /// promised by [`GraphDBTrait::get_nodes`] — the Postgres adapter has
+    /// always answered with a single set-based `IN` query — so callers must key
+    /// results by each row's own `id` rather than zip them against the input.
     async fn get_nodes(&self, node_ids: &[String]) -> GraphDBResult<Vec<NodeData>> {
         if node_ids.is_empty() {
             return Ok(Vec::new());
@@ -1101,6 +1106,14 @@ impl GraphDBTrait for LadybugAdapter {
     /// edge keeps its properties, which are not part of the lookup key. A
     /// repeated candidate triple is therefore still reported once per
     /// occurrence.
+    ///
+    /// The trade this makes: the superset is the induced subgraph over the
+    /// batch's endpoints, so a chunk drawn from a densely connected region can
+    /// return more rows than it had candidates. That is bounded by the graph's
+    /// actual edge count, not by |sources| × |targets|, and extraction batches
+    /// are sparse in practice (distinct entity pairs, one relation each). If a
+    /// workload ever inverts that assumption, the fix is a smaller chunk size
+    /// rather than a return to per-edge queries.
     async fn has_edges(&self, edges: &[EdgeData]) -> GraphDBResult<Vec<EdgeData>> {
         use std::collections::HashSet;
 
@@ -1906,6 +1919,15 @@ impl GraphDBTrait for LadybugAdapter {
         key: &str,
         value: serde_json::Value,
     ) -> GraphDBResult<()> {
+        // Read-modify-write of the whole `properties` blob, so the lock has to
+        // span both halves: a concurrent `add_nodes_raw` (which holds it and
+        // `SET n.properties = <full blob>`) would otherwise land between the
+        // read and the write and lose this update entirely. Nothing in the body
+        // awaits, so holding the guard across it is safe, and no locked path
+        // calls back into here.
+        let _write_guard = self.write_lock.lock().map_err(|_| {
+            GraphDBError::ConnectionError("Ladybug write lock poisoned".to_string())
+        })?;
         let read_query = format!(
             "MATCH (n:Node) WHERE n.id = '{}' RETURN n.properties AS properties",
             node_id.replace('\\', "\\\\").replace('\'', "\\'")
@@ -1952,6 +1974,12 @@ impl GraphDBTrait for LadybugAdapter {
         key: &str,
         value: serde_json::Value,
     ) -> GraphDBResult<()> {
+        // Same read-modify-write of a whole `properties` blob as
+        // `update_node_property`, against `add_edges`' full-blob `ON MATCH SET`
+        // — so the lock spans both halves here too.
+        let _write_guard = self.write_lock.lock().map_err(|_| {
+            GraphDBError::ConnectionError("Ladybug write lock poisoned".to_string())
+        })?;
         let src_esc = source_id.replace('\\', "\\\\").replace('\'', "\\'");
         let tgt_esc = target_id.replace('\\', "\\\\").replace('\'', "\\'");
         let rel_esc = relationship_name.replace('\\', "\\\\").replace('\'', "\\'");

--- a/crates/graph/src/ladybug.rs
+++ b/crates/graph/src/ladybug.rs
@@ -549,6 +549,48 @@ impl LadybugAdapter {
         value.replace('\\', "\\\\").replace('\'', "\\'")
     }
 
+    /// Render values as an escaped, quoted, comma-joined Cypher list body for
+    /// use inside `WHERE x IN [ ... ]`.
+    ///
+    /// The engine takes no bound parameters, so every batched read inlines its
+    /// key set. Centralising the escaping here keeps those call sites from
+    /// re-deriving the same `\\` / `'` transform by hand.
+    fn cypher_id_list<'a, I>(values: I) -> String
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        values
+            .into_iter()
+            .map(|v| format!("'{}'", Self::escape_cypher_string(v)))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    /// Build a [`NodeData`] from one row of the standard four-column node
+    /// projection (`id`, `name`, `type`, `properties`).
+    ///
+    /// Returns `Ok(None)` for a short row, matching the `row.len() >=
+    /// NODE_QUERY_COLUMN_COUNT` guard the per-row readers use.
+    fn node_data_from_row(&self, row: &[serde_json::Value]) -> GraphDBResult<Option<NodeData>> {
+        if row.len() < Self::NODE_QUERY_COLUMN_COUNT {
+            return Ok(None);
+        }
+        let mut node_data = NodeData::new();
+        if let Some(id_str) = row[0].as_str() {
+            node_data.insert(Cow::Borrowed("id"), json!(id_str));
+        }
+        if let Some(name_str) = row[1].as_str() {
+            node_data.insert(Cow::Borrowed("name"), json!(name_str));
+        }
+        if let Some(type_str) = row[2].as_str() {
+            node_data.insert(Cow::Borrowed("type"), json!(type_str));
+        }
+        if let Some(props_str) = row[3].as_str() {
+            node_data.insert(Cow::Borrowed("properties"), json!(props_str));
+        }
+        Ok(Some(self.parse_node_data(node_data)?))
+    }
+
     fn upsert_node_with_conn(
         &self,
         conn: &Connection,
@@ -910,10 +952,37 @@ impl GraphDBTrait for LadybugAdapter {
         Ok(())
     }
 
+    /// Batched delete: one `DETACH DELETE` per 500 ids instead of one per id.
+    ///
+    /// Matters on the delete path, which calls this with whole orphan sets
+    /// (`cognee-delete`'s artifact sweep). Takes the write lock once for the
+    /// whole call rather than re-acquiring it per node, and `DETACH DELETE`
+    /// keeps its per-node cascade semantics — the only change is how many
+    /// statements carry them.
     async fn delete_nodes(&self, node_ids: &[String]) -> GraphDBResult<()> {
-        for node_id in node_ids {
-            self.delete_node(node_id).await?;
+        if node_ids.is_empty() {
+            return Ok(());
         }
+
+        let _write_guard = self.write_lock.lock().map_err(|_| {
+            GraphDBError::ConnectionError("Ladybug write lock poisoned".to_string())
+        })?;
+        let db = self.db()?;
+        let conn = Connection::new(&db).map_err(|e| {
+            GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))
+        })?;
+
+        const BATCH_SIZE: usize = 500;
+        for chunk in node_ids.chunks(BATCH_SIZE) {
+            let query = format!(
+                "MATCH (n:Node) WHERE n.id IN [{}] DETACH DELETE n",
+                Self::cypher_id_list(chunk.iter().map(String::as_str)),
+            );
+            conn.query(&query).map_err(|e| {
+                GraphDBError::NodeError(format!("Failed to delete {} nodes: {e}", chunk.len()))
+            })?;
+        }
+
         Ok(())
     }
 
@@ -948,13 +1017,34 @@ impl GraphDBTrait for LadybugAdapter {
         Ok(None)
     }
 
+    /// Batched node fetch: one query per 500 ids instead of one per id.
+    ///
+    /// Ids absent from storage are simply missing from the result, which is
+    /// the same contract the per-id loop had (it dropped `None`s). Row order
+    /// follows the engine's, not `node_ids` — as before, since the per-id loop
+    /// only preserved order incidentally and no caller relies on it.
     async fn get_nodes(&self, node_ids: &[String]) -> GraphDBResult<Vec<NodeData>> {
-        let mut nodes = Vec::new();
-        for node_id in node_ids {
-            if let Some(node) = self.get_node(node_id).await? {
-                nodes.push(node);
+        if node_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        const BATCH_SIZE: usize = 500;
+        let mut nodes = Vec::with_capacity(node_ids.len());
+
+        for chunk in node_ids.chunks(BATCH_SIZE) {
+            let query = format!(
+                "MATCH (n:Node) WHERE n.id IN [{}] \
+                 RETURN n.id AS id, n.name AS name, n.type AS type, n.properties AS properties",
+                Self::cypher_id_list(chunk.iter().map(String::as_str)),
+            );
+            let rows = self.execute_query(&query)?;
+            for row in &rows {
+                if let Some(node) = self.node_data_from_row(row)? {
+                    nodes.push(node);
+                }
             }
         }
+
         Ok(nodes)
     }
 
@@ -984,14 +1074,96 @@ impl GraphDBTrait for LadybugAdapter {
         Ok(false)
     }
 
+    /// Batched existence check: one query per 500 candidates instead of one
+    /// per edge.
+    ///
+    /// This is the read-side counterpart of the Postgres adapter's
+    /// `unnest(...)` + `EXISTS` fix (`pg_graph_adapter::has_edges`), and it is
+    /// what makes the pre-write dedup check on the cognify path
+    /// (`retrieve_existing_edges` → this method) stop scaling its round-trip
+    /// count with the extracted edge count.
+    ///
+    /// The engine accepts no bound parameters, so the three key columns go in
+    /// as inlined `IN` lists. That matches a *superset* — every stored edge
+    /// whose source, target and relationship each appear somewhere in the
+    /// candidate batch, including cross-products that were never candidates —
+    /// so the exact triples are intersected in Rust afterwards. Endpoint ids
+    /// are de-duplicated before rendering, since a batch of 500 edges over a
+    /// dense entity set typically mentions far fewer distinct nodes.
+    ///
+    /// Output matches the per-edge loop it replaces (and the Postgres
+    /// adapter): the *input* is filtered, so results keep input order and each
+    /// edge keeps its properties, which are not part of the lookup key. A
+    /// repeated candidate triple is therefore still reported once per
+    /// occurrence.
     async fn has_edges(&self, edges: &[EdgeData]) -> GraphDBResult<Vec<EdgeData>> {
-        let mut existing_edges = Vec::new();
-        for edge in edges {
-            if self.has_edge(&edge.0, &edge.1, &edge.2).await? {
-                existing_edges.push(edge.clone());
+        use std::collections::HashSet;
+
+        if edges.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Chunked for the same reason `add_edges` chunks: no bound parameters
+        // means the whole key set is inlined, so the query string is the limit.
+        const BATCH_SIZE: usize = 500;
+
+        let mut existing: HashSet<(String, String, String)> = HashSet::new();
+
+        for chunk in edges.chunks(BATCH_SIZE) {
+            let mut sources: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut targets: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut rels: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut seen_source: HashSet<&str> = HashSet::with_capacity(chunk.len());
+            let mut seen_target: HashSet<&str> = HashSet::with_capacity(chunk.len());
+            let mut seen_rel: HashSet<&str> = HashSet::with_capacity(chunk.len());
+            for edge in chunk {
+                if seen_source.insert(edge.0.as_str()) {
+                    sources.push(edge.0.as_str());
+                }
+                if seen_target.insert(edge.1.as_str()) {
+                    targets.push(edge.1.as_str());
+                }
+                if seen_rel.insert(edge.2.as_str()) {
+                    rels.push(edge.2.as_str());
+                }
+            }
+
+            let query = format!(
+                "MATCH (a:Node)-[r:EDGE]->(b:Node) \
+                 WHERE a.id IN [{}] AND b.id IN [{}] AND r.relationship_name IN [{}] \
+                 RETURN a.id AS source_id, b.id AS target_id, r.relationship_name AS rel_name",
+                Self::cypher_id_list(sources),
+                Self::cypher_id_list(targets),
+                Self::cypher_id_list(rels),
+            );
+
+            let rows = self.execute_query(&query)?;
+            for row in &rows {
+                if row.len() < 3 {
+                    continue;
+                }
+                if let (Some(source), Some(target), Some(rel)) =
+                    (row[0].as_str(), row[1].as_str(), row[2].as_str())
+                {
+                    existing.insert((source.to_string(), target.to_string(), rel.to_string()));
+                }
             }
         }
-        Ok(existing_edges)
+
+        // Borrowed view of the owned key set so the filter below does not
+        // allocate three `String`s per candidate just to probe the set.
+        let existing_refs: HashSet<(&str, &str, &str)> = existing
+            .iter()
+            .map(|(s, t, r)| (s.as_str(), t.as_str(), r.as_str()))
+            .collect();
+
+        let found = edges
+            .iter()
+            .filter(|e| existing_refs.contains(&(e.0.as_str(), e.1.as_str(), e.2.as_str())))
+            .cloned()
+            .collect();
+
+        Ok(found)
     }
 
     async fn add_edge(
@@ -3224,5 +3396,265 @@ mod tests {
         assert_eq!(nodes.len(), 1);
         assert_eq!(nodes[0].1.get("name").unwrap().as_str().unwrap(), "Alice");
         assert_eq!(nodes[0].1.get("type").unwrap().as_str().unwrap(), "Person");
+    }
+
+    // -- batched read/delete paths (issue #21) -------------------------------
+
+    /// The batched `has_edges` must agree with the per-edge check it replaced:
+    /// only stored triples come back, in input order, with properties intact.
+    #[tokio::test]
+    #[serial]
+    async fn has_edges_batched_reports_only_stored_triples() {
+        let (adapter, _temp_dir) = setup_adapter().await;
+
+        adapter
+            .add_node(&TestNode::new("n-a", "A", 1))
+            .await
+            .unwrap();
+        adapter
+            .add_node(&TestNode::new("n-b", "B", 2))
+            .await
+            .unwrap();
+        adapter
+            .add_node(&TestNode::new("n-c", "C", 3))
+            .await
+            .unwrap();
+
+        adapter.add_edge("n-a", "n-b", "knows", None).await.unwrap();
+        adapter.add_edge("n-b", "n-c", "likes", None).await.unwrap();
+
+        let mut props: HashMap<Cow<'static, str>, serde_json::Value> = HashMap::new();
+        props.insert(Cow::Borrowed("edge_text"), json!("kept"));
+
+        let candidates: Vec<EdgeData> = vec![
+            ("n-a".into(), "n-b".into(), "knows".into(), props),
+            // same pair, a relationship that was never stored
+            ("n-a".into(), "n-b".into(), "likes".into(), HashMap::new()),
+            ("n-b".into(), "n-c".into(), "likes".into(), HashMap::new()),
+            ("n-c".into(), "n-a".into(), "knows".into(), HashMap::new()),
+        ];
+
+        let found = adapter.has_edges(&candidates).await.unwrap();
+
+        let keys: Vec<(String, String, String)> = found
+            .iter()
+            .map(|e| (e.0.clone(), e.1.clone(), e.2.clone()))
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                ("n-a".to_string(), "n-b".to_string(), "knows".to_string()),
+                ("n-b".to_string(), "n-c".to_string(), "likes".to_string()),
+            ],
+            "only stored triples, in input order"
+        );
+        // Properties are not part of the lookup key and must survive the filter.
+        assert_eq!(found[0].3.get("edge_text").unwrap(), &json!("kept"));
+    }
+
+    /// Regression for the batched implementation specifically: the `IN`-list
+    /// query matches a *superset* — any stored edge whose source, target and
+    /// relationship each appear somewhere in the batch — so the client-side
+    /// triple intersection is what keeps cross-products out. `(n-a, n-d)` and
+    /// `(n-c, n-b)` are never stored, yet every component of both is present
+    /// in the candidate lists; a broken intersection would report them.
+    #[tokio::test]
+    #[serial]
+    async fn has_edges_batched_rejects_endpoint_cross_products() {
+        let (adapter, _temp_dir) = setup_adapter().await;
+
+        for id in ["n-a", "n-b", "n-c", "n-d"] {
+            adapter.add_node(&TestNode::new(id, id, 0)).await.unwrap();
+        }
+        adapter.add_edge("n-a", "n-b", "rel", None).await.unwrap();
+        adapter.add_edge("n-c", "n-d", "rel", None).await.unwrap();
+
+        let candidates: Vec<EdgeData> = vec![
+            ("n-a".into(), "n-d".into(), "rel".into(), HashMap::new()),
+            ("n-c".into(), "n-b".into(), "rel".into(), HashMap::new()),
+        ];
+
+        let found = adapter.has_edges(&candidates).await.unwrap();
+        assert!(
+            found.is_empty(),
+            "cross-product pairs must not be reported as existing, got {found:?}"
+        );
+    }
+
+    /// A repeated candidate is reported once per occurrence, as the per-edge
+    /// loop did — the caller collapses them into a set.
+    #[tokio::test]
+    #[serial]
+    async fn has_edges_batched_preserves_duplicate_candidates() {
+        let (adapter, _temp_dir) = setup_adapter().await;
+
+        adapter
+            .add_node(&TestNode::new("n-a", "A", 1))
+            .await
+            .unwrap();
+        adapter
+            .add_node(&TestNode::new("n-b", "B", 2))
+            .await
+            .unwrap();
+        adapter.add_edge("n-a", "n-b", "knows", None).await.unwrap();
+
+        let one: EdgeData = ("n-a".into(), "n-b".into(), "knows".into(), HashMap::new());
+        let found = adapter
+            .has_edges(&[one.clone(), one.clone(), one])
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 3);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn has_edges_batched_handles_empty_input() {
+        let (adapter, _temp_dir) = setup_adapter().await;
+        assert!(adapter.has_edges(&[]).await.unwrap().is_empty());
+    }
+
+    /// Spans the 500-candidate chunk boundary: every even-numbered edge is
+    /// stored, every odd one is not, so an off-by-one or a dropped chunk in the
+    /// batching loop shows up as a wrong result rather than merely slower work.
+    #[tokio::test]
+    #[serial]
+    async fn has_edges_batched_spans_chunk_boundary() {
+        let (adapter, _temp_dir) = setup_adapter().await;
+
+        const TOTAL: usize = 600;
+        for i in 0..TOTAL {
+            adapter
+                .add_node(&TestNode::new(&format!("s-{i}"), "src", 0))
+                .await
+                .unwrap();
+            adapter
+                .add_node(&TestNode::new(&format!("t-{i}"), "tgt", 0))
+                .await
+                .unwrap();
+        }
+        for i in (0..TOTAL).step_by(2) {
+            adapter
+                .add_edge(&format!("s-{i}"), &format!("t-{i}"), "rel", None)
+                .await
+                .unwrap();
+        }
+
+        let candidates: Vec<EdgeData> = (0..TOTAL)
+            .map(|i| {
+                (
+                    format!("s-{i}"),
+                    format!("t-{i}"),
+                    "rel".to_string(),
+                    HashMap::new(),
+                )
+            })
+            .collect();
+
+        let found = adapter.has_edges(&candidates).await.unwrap();
+        assert_eq!(found.len(), TOTAL / 2);
+        assert!(
+            found.iter().all(|e| {
+                e.0.strip_prefix("s-")
+                    .and_then(|n| n.parse::<usize>().ok())
+                    .is_some_and(|n| n % 2 == 0)
+            }),
+            "only the stored (even-indexed) edges come back"
+        );
+    }
+
+    /// Ids carrying Cypher metacharacters must survive the inlined `IN` list.
+    /// Exercises `cypher_id_list`, which every batched path now shares.
+    #[tokio::test]
+    #[serial]
+    async fn batched_paths_escape_quotes_and_backslashes_in_ids() {
+        let (adapter, _temp_dir) = setup_adapter().await;
+
+        let tricky = r"o'brien\path";
+        let plain = "n-plain";
+        adapter
+            .add_node(&TestNode::new(tricky, "Tricky", 1))
+            .await
+            .unwrap();
+        adapter
+            .add_node(&TestNode::new(plain, "Plain", 2))
+            .await
+            .unwrap();
+        adapter
+            .add_edge(tricky, plain, "o'rel", None)
+            .await
+            .unwrap();
+
+        // get_nodes: both ids come back through the escaped IN list.
+        let nodes = adapter
+            .get_nodes(&[tricky.to_string(), plain.to_string()])
+            .await
+            .unwrap();
+        assert_eq!(nodes.len(), 2);
+
+        // has_edges: the escaped triple matches.
+        let found = adapter
+            .has_edges(&[(tricky.into(), plain.into(), "o'rel".into(), HashMap::new())])
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 1);
+
+        // delete_nodes: the escaped id is removed.
+        adapter.delete_nodes(&[tricky.to_string()]).await.unwrap();
+        assert!(adapter.get_node(tricky).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn get_nodes_batched_returns_existing_and_skips_missing() {
+        let (adapter, _temp_dir) = setup_adapter().await;
+
+        adapter
+            .add_node(&TestNode::new("n-1", "One", 1))
+            .await
+            .unwrap();
+        adapter
+            .add_node(&TestNode::new("n-2", "Two", 2))
+            .await
+            .unwrap();
+
+        let nodes = adapter
+            .get_nodes(&["n-1".to_string(), "missing".to_string(), "n-2".to_string()])
+            .await
+            .unwrap();
+
+        let mut names: Vec<String> = nodes
+            .iter()
+            .filter_map(|n| n.get("name").and_then(|v| v.as_str()).map(str::to_string))
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["One".to_string(), "Two".to_string()]);
+
+        assert!(adapter.get_nodes(&[]).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn delete_nodes_batched_removes_all_and_detaches_edges() {
+        let (adapter, _temp_dir) = setup_adapter().await;
+
+        for id in ["d-1", "d-2", "keep"] {
+            adapter.add_node(&TestNode::new(id, id, 0)).await.unwrap();
+        }
+        adapter.add_edge("d-1", "d-2", "rel", None).await.unwrap();
+        adapter.add_edge("d-1", "keep", "rel", None).await.unwrap();
+
+        adapter
+            .delete_nodes(&["d-1".to_string(), "d-2".to_string()])
+            .await
+            .unwrap();
+
+        assert!(adapter.get_node("d-1").await.unwrap().is_none());
+        assert!(adapter.get_node("d-2").await.unwrap().is_none());
+        assert!(adapter.get_node("keep").await.unwrap().is_some());
+        // DETACH DELETE took the incident edges with the nodes.
+        assert!(adapter.get_edges("keep").await.unwrap().is_empty());
+
+        // Empty input is a no-op, not an error.
+        adapter.delete_nodes(&[]).await.unwrap();
     }
 }

--- a/crates/graph/src/ladybug.rs
+++ b/crates/graph/src/ladybug.rs
@@ -830,6 +830,11 @@ impl GraphDBTrait for LadybugAdapter {
     }
 
     async fn delete_graph(&self) -> GraphDBResult<()> {
+        // Two destructive statements that must not interleave with a concurrent
+        // upsert, and the last write path here that was not taking the lock.
+        let _write_guard = self.write_lock.lock().map_err(|_| {
+            GraphDBError::ConnectionError("Ladybug write lock poisoned".to_string())
+        })?;
         let db = self.db()?;
         let conn = Connection::new(&db).map_err(|e| {
             GraphDBError::ConnectionError(format!("Failed to create connection: {e}"))

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -721,7 +721,9 @@ impl GraphDBTrait for PgGraphAdapter {
         key: &str,
         value: Value,
     ) -> GraphDBResult<()> {
-        let ids = [node_id.to_string()];
+        // `serialize_node_to_row` sanitized the id on the way in, so look the
+        // node up by its stored form; the raw id would find nothing.
+        let ids = [sanitize_str(node_id).into_owned()];
         let node = self
             .get_nodes(&ids)
             .await?
@@ -750,14 +752,26 @@ impl GraphDBTrait for PgGraphAdapter {
         if node_ids.is_empty() {
             return Ok(HashMap::new());
         }
-        let nodes = self.get_nodes(node_ids).await?;
+        // Query by the stored (sanitized) ids, then report results under the
+        // caller's own ids so a caller whose id held a NUL can look its entry
+        // up.
+        let by_stored: HashMap<String, &String> = node_ids
+            .iter()
+            .map(|id| (sanitize_str(id).into_owned(), id))
+            .collect();
+        let lookup: Vec<String> = by_stored.keys().cloned().collect();
+
+        let nodes = self.get_nodes(&lookup).await?;
         let mut out = HashMap::with_capacity(nodes.len());
         for node in nodes {
-            let Some(id) = node.get("id").and_then(|v| v.as_str()).map(str::to_string) else {
+            let Some(id) = node.get("id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(original) = by_stored.get(id) else {
                 continue;
             };
             if let Some(w) = node.get("feedback_weight").and_then(Value::as_f64) {
-                out.insert(id, w);
+                out.insert((*original).clone(), w);
             }
         }
         Ok(out)
@@ -773,20 +787,30 @@ impl GraphDBTrait for PgGraphAdapter {
         &self,
         updates: &HashMap<String, f64>,
     ) -> GraphDBResult<HashMap<String, bool>> {
-        let ids: Vec<String> = updates.keys().cloned().collect();
-        if ids.is_empty() {
+        if updates.is_empty() {
             return Ok(HashMap::new());
         }
-        let nodes = self.get_nodes(&ids).await?;
+        // Fetch by the stored (sanitized) ids and report under the caller's,
+        // for the same reason as `get_node_feedback_weights`.
+        let by_stored: HashMap<String, &String> = updates
+            .keys()
+            .map(|id| (sanitize_str(id).into_owned(), id))
+            .collect();
+        let lookup: Vec<String> = by_stored.keys().cloned().collect();
 
-        let mut out: HashMap<String, bool> = ids.iter().map(|id| (id.clone(), false)).collect();
+        let nodes = self.get_nodes(&lookup).await?;
+
+        let mut out: HashMap<String, bool> = updates.keys().map(|id| (id.clone(), false)).collect();
 
         let mut merged: Vec<Value> = Vec::with_capacity(nodes.len());
         for node in nodes {
-            let Some(id) = node.get("id").and_then(|v| v.as_str()).map(str::to_string) else {
+            let Some(id) = node.get("id").and_then(|v| v.as_str()) else {
                 continue;
             };
-            let Some(weight) = updates.get(&id) else {
+            let Some(original) = by_stored.get(id).map(|id| (*id).clone()) else {
+                continue;
+            };
+            let Some(weight) = updates.get(&original) else {
                 continue;
             };
             let mut obj = serde_json::Map::new();
@@ -795,7 +819,7 @@ impl GraphDBTrait for PgGraphAdapter {
             }
             obj.insert("feedback_weight".to_string(), json!(weight));
             merged.push(Value::Object(obj));
-            out.insert(id, true);
+            out.insert(original, true);
         }
 
         if !merged.is_empty() {
@@ -916,7 +940,13 @@ impl GraphDBTrait for PgGraphAdapter {
         key: &str,
         value: Value,
     ) -> GraphDBResult<()> {
-        let patch = json!({ key: value });
+        // NUL bytes must be stripped for two separate reasons, both of which
+        // `add_edges` already handles via `sanitize_str` / `sanitize_json`:
+        // Postgres rejects ` ` in a `jsonb` cast, so an unsanitized patch
+        // errors at runtime on LLM/PDF-derived text; and the key columns were
+        // *stored* sanitized, so comparing raw input against them would match
+        // zero rows and report the edge as missing.
+        let patch = sanitize_json(json!({ key: value }));
         let result = self
             .db
             .execute(Statement::from_sql_and_values(
@@ -926,9 +956,9 @@ impl GraphDBTrait for PgGraphAdapter {
                      updated_at = CURRENT_TIMESTAMP \
                  WHERE source_id = $1 AND target_id = $2 AND relationship_name = $3",
                 [
-                    source_id.into(),
-                    target_id.into(),
-                    relationship_name.into(),
+                    sanitize_str(source_id).into_owned().into(),
+                    sanitize_str(target_id).into_owned().into(),
+                    sanitize_str(relationship_name).into_owned().into(),
                     patch.to_string().into(),
                 ],
             ))
@@ -957,9 +987,20 @@ impl GraphDBTrait for PgGraphAdapter {
             return Ok(HashMap::new());
         }
 
-        let sources: Vec<String> = edge_keys.iter().map(|k| k.0.clone()).collect();
-        let targets: Vec<String> = edge_keys.iter().map(|k| k.1.clone()).collect();
-        let rels: Vec<String> = edge_keys.iter().map(|k| k.2.clone()).collect();
+        // Sanitized to match how `add_edges` stored these columns; raw input
+        // carrying a NUL would join against nothing.
+        let sources: Vec<String> = edge_keys
+            .iter()
+            .map(|k| sanitize_str(&k.0).into_owned())
+            .collect();
+        let targets: Vec<String> = edge_keys
+            .iter()
+            .map(|k| sanitize_str(&k.1).into_owned())
+            .collect();
+        let rels: Vec<String> = edge_keys
+            .iter()
+            .map(|k| sanitize_str(&k.2).into_owned())
+            .collect();
 
         let rows = self
             .db
@@ -976,6 +1017,25 @@ impl GraphDBTrait for PgGraphAdapter {
             .await
             .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
 
+        // Rows come back carrying the *stored* (sanitized) key, so results are
+        // mapped back onto the caller's own key — the same "filter the input
+        // rather than reconstruct it from the query" rule `has_edges` follows.
+        // Without this a caller whose key held a NUL could never look up its
+        // own entry.
+        let by_stored: HashMap<crate::traits::EdgeKey, &crate::traits::EdgeKey> = edge_keys
+            .iter()
+            .map(|k| {
+                (
+                    (
+                        sanitize_str(&k.0).into_owned(),
+                        sanitize_str(&k.1).into_owned(),
+                        sanitize_str(&k.2).into_owned(),
+                    ),
+                    k,
+                )
+            })
+            .collect();
+
         let mut out = HashMap::with_capacity(rows.len());
         for row in &rows {
             let s: String = row
@@ -990,8 +1050,10 @@ impl GraphDBTrait for PgGraphAdapter {
             // A NULL / absent property decodes to `None`; a non-numeric one
             // fails `as_f64`. Both are "no weight", matching the node side.
             let w: Option<Value> = row.try_get("", "w").unwrap_or(None);
-            if let Some(weight) = w.as_ref().and_then(Value::as_f64) {
-                out.insert((s, t, r), weight);
+            if let Some(weight) = w.as_ref().and_then(Value::as_f64)
+                && let Some(original) = by_stored.get(&(s, t, r))
+            {
+                out.insert((*original).clone(), weight);
             }
         }
         Ok(out)
@@ -1018,14 +1080,26 @@ impl GraphDBTrait for PgGraphAdapter {
         let mut rels: Vec<String> = Vec::with_capacity(updates.len());
         let mut weights: Vec<String> = Vec::with_capacity(updates.len());
         let mut out: HashMap<crate::traits::EdgeKey, bool> = HashMap::with_capacity(updates.len());
+        // Stored (sanitized) key -> the caller's key, so a `RETURNING` row
+        // flips the entry the caller can actually look up instead of adding a
+        // second, sanitized one beside it.
+        let mut by_stored: HashMap<crate::traits::EdgeKey, crate::traits::EdgeKey> =
+            HashMap::with_capacity(updates.len());
 
         for (key, weight) in updates {
-            sources.push(key.0.clone());
-            targets.push(key.1.clone());
-            rels.push(key.2.clone());
+            // Sanitized to match how `add_edges` stored these columns.
+            let stored = (
+                sanitize_str(&key.0).into_owned(),
+                sanitize_str(&key.1).into_owned(),
+                sanitize_str(&key.2).into_owned(),
+            );
+            sources.push(stored.0.clone());
+            targets.push(stored.1.clone());
+            rels.push(stored.2.clone());
             // `{:?}` is f64's shortest round-trip representation, so the
             // float8 cast parses back to exactly this value.
             weights.push(format!("{weight:?}"));
+            by_stored.insert(stored, key.clone());
             out.insert(key.clone(), false);
         }
 
@@ -1058,7 +1132,9 @@ impl GraphDBTrait for PgGraphAdapter {
             let r: String = row
                 .try_get("", "r")
                 .map_err(|e| GraphDBError::EdgeError(e.to_string()))?;
-            out.insert((s, t, r), true);
+            if let Some(original) = by_stored.get(&(s, t, r)) {
+                out.insert(original.clone(), true);
+            }
         }
         Ok(out)
     }

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -958,15 +958,20 @@ impl GraphDBTrait for PgGraphAdapter {
         key: &str,
         value: Value,
     ) -> GraphDBResult<()> {
-        // The property value is sanitized, as `add_edges` does for the same
-        // column: Postgres rejects a NUL in a `jsonb` cast, so an unsanitized
-        // patch built from LLM- or PDF-derived text errors at runtime.
+        // Both halves are sanitized, for the two reasons `has_edge` above and
+        // `add_edges` already document: the value because Postgres rejects a
+        // NUL in a `jsonb` cast, and the key columns because `add_edges` keys
+        // rows on the sanitized triple *and* a NUL inside a bound parameter
+        // makes Postgres reject the whole statement.
         //
-        // The three key columns are *not* sanitized, matching every other
-        // read/delete path on this adapter — see the write-only-sanitization
-        // note in `serialize_node_to_row`. That keeps Postgres, ladybug and
-        // Python agreeing on whether a NUL-bearing key hits.
+        // Note this is the edge rule, not the node rule: node ids stay raw on
+        // lookup paths (see the write-only-sanitization note in
+        // `serialize_node_to_row`, which is about `get_node`/`get_nodes` and
+        // Python parity). Edge probes deliberately went the other way.
         let patch = sanitize_json(json!({ key: value }));
+        let source_id = sanitize_str(source_id).into_owned();
+        let target_id = sanitize_str(target_id).into_owned();
+        let relationship_name = sanitize_str(relationship_name).into_owned();
         let result = self
             .db
             .execute(Statement::from_sql_and_values(
@@ -976,9 +981,9 @@ impl GraphDBTrait for PgGraphAdapter {
                      updated_at = CURRENT_TIMESTAMP \
                  WHERE source_id = $1 AND target_id = $2 AND relationship_name = $3",
                 [
-                    source_id.into(),
-                    target_id.into(),
-                    relationship_name.into(),
+                    source_id.clone().into(),
+                    target_id.clone().into(),
+                    relationship_name.clone().into(),
                     patch.to_string().into(),
                 ],
             ))
@@ -1007,10 +1012,22 @@ impl GraphDBTrait for PgGraphAdapter {
             return Ok(HashMap::new());
         }
 
-        // Keys pass through raw, as on every other lookup path here.
-        let sources: Vec<String> = edge_keys.iter().map(|k| k.0.clone()).collect();
-        let targets: Vec<String> = edge_keys.iter().map(|k| k.1.clone()).collect();
-        let rels: Vec<String> = edge_keys.iter().map(|k| k.2.clone()).collect();
+        // Probe triples are sanitized, as `has_edges` does: `add_edges` keys
+        // rows on the sanitized triple, and a NUL inside a bound `text[]`
+        // element makes Postgres reject the whole statement.
+        let keys: Vec<crate::traits::EdgeKey> = edge_keys
+            .iter()
+            .map(|k| {
+                (
+                    sanitize_str(&k.0).into_owned(),
+                    sanitize_str(&k.1).into_owned(),
+                    sanitize_str(&k.2).into_owned(),
+                )
+            })
+            .collect();
+        let sources: Vec<String> = keys.iter().map(|k| k.0.clone()).collect();
+        let targets: Vec<String> = keys.iter().map(|k| k.1.clone()).collect();
+        let rels: Vec<String> = keys.iter().map(|k| k.2.clone()).collect();
 
         let rows = self
             .db
@@ -1027,7 +1044,7 @@ impl GraphDBTrait for PgGraphAdapter {
             .await
             .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
 
-        let mut out = HashMap::with_capacity(rows.len());
+        let mut stored: HashMap<crate::traits::EdgeKey, f64> = HashMap::with_capacity(rows.len());
         for row in &rows {
             let s: String = row
                 .try_get("", "s")
@@ -1042,7 +1059,16 @@ impl GraphDBTrait for PgGraphAdapter {
             // fails `as_f64`. Both are "no weight", matching the node side.
             let w: Option<Value> = row.try_get("", "w").unwrap_or(None);
             if let Some(weight) = w.as_ref().and_then(Value::as_f64) {
-                out.insert((s, t, r), weight);
+                stored.insert((s, t, r), weight);
+            }
+        }
+
+        // Rows carry the sanitized key; report under the caller's own key, the
+        // way `has_edges` returns the caller's `EdgeData` untouched.
+        let mut out = HashMap::with_capacity(stored.len());
+        for (original, sanitized) in edge_keys.iter().zip(&keys) {
+            if let Some(weight) = stored.get(sanitized) {
+                out.insert(original.clone(), *weight);
             }
         }
         Ok(out)
@@ -1070,7 +1096,12 @@ impl GraphDBTrait for PgGraphAdapter {
         let mut weights: Vec<String> = Vec::with_capacity(updates.len());
         let mut out: HashMap<crate::traits::EdgeKey, bool> = HashMap::with_capacity(updates.len());
 
-        // Keys pass through raw, as on every other lookup path here.
+        // Sanitized (stored) key -> the caller's key. Keys are sanitized for
+        // the same reasons as in `has_edges`, and results are reported under
+        // the caller's own key rather than the stored form.
+        let mut by_stored: HashMap<crate::traits::EdgeKey, crate::traits::EdgeKey> =
+            HashMap::with_capacity(updates.len());
+
         for (key, weight) in updates {
             out.insert(key.clone(), false);
             // JSON has no infinity or NaN. Postgres does not reject them here
@@ -1083,9 +1114,15 @@ impl GraphDBTrait for PgGraphAdapter {
             if !weight.is_finite() {
                 continue;
             }
-            sources.push(key.0.clone());
-            targets.push(key.1.clone());
-            rels.push(key.2.clone());
+            let stored = (
+                sanitize_str(&key.0).into_owned(),
+                sanitize_str(&key.1).into_owned(),
+                sanitize_str(&key.2).into_owned(),
+            );
+            sources.push(stored.0.clone());
+            targets.push(stored.1.clone());
+            rels.push(stored.2.clone());
+            by_stored.insert(stored, key.clone());
             // `{:?}` is f64's shortest round-trip representation, so the
             // float8 cast parses back to exactly this value.
             weights.push(format!("{weight:?}"));
@@ -1124,7 +1161,9 @@ impl GraphDBTrait for PgGraphAdapter {
             let r: String = row
                 .try_get("", "r")
                 .map_err(|e| GraphDBError::EdgeError(e.to_string()))?;
-            out.insert((s, t, r), true);
+            if let Some(original) = by_stored.get(&(s, t, r)) {
+                out.insert(original.clone(), true);
+            }
         }
         Ok(out)
     }

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -698,6 +698,112 @@ impl GraphDBTrait for PgGraphAdapter {
         Ok(out)
     }
 
+    /// In-place property update, replacing the base trait's delete-and-re-add
+    /// default.
+    ///
+    /// The default `GraphDBTrait::update_node_property` fetches the node, saves
+    /// its edges, `delete_node`s it (cascading the edges away), re-adds the
+    /// node and then restores the edges — five statements with no enclosing
+    /// transaction. An interruption between the delete and the re-add loses the
+    /// node *and* its edges, and the edge read is `unwrap_or_default()`, so a
+    /// failed read silently drops every edge on the recreate. This override
+    /// merges the property into the fetched map and upserts through
+    /// `add_nodes_raw` (`INSERT ... ON CONFLICT DO UPDATE`), which never touches
+    /// the edge table — the approach `set_node_truth_state` above already uses.
+    ///
+    /// Going through `add_nodes_raw` rather than a raw `jsonb ||` update keeps
+    /// `serialize_node_to_row`'s split between the core `id`/`name`/`type`
+    /// columns and the `properties` JSONB, so `key` lands exactly where
+    /// `parse_node_row` reads it back from.
+    async fn update_node_property(
+        &self,
+        node_id: &str,
+        key: &str,
+        value: Value,
+    ) -> GraphDBResult<()> {
+        let ids = [node_id.to_string()];
+        let node = self
+            .get_nodes(&ids)
+            .await?
+            .into_iter()
+            .next()
+            .ok_or_else(|| GraphDBError::NodeError(format!("Node not found: {node_id}")))?;
+
+        let mut obj = serde_json::Map::new();
+        for (k, v) in node {
+            obj.insert(k.into_owned(), v);
+        }
+        obj.insert(key.to_string(), value);
+
+        self.add_nodes_raw(vec![Value::Object(obj)]).await
+    }
+
+    /// One round-trip for the whole batch, versus the default's `get_node` per
+    /// id.
+    ///
+    /// Matches the default's contract: only ids that exist *and* carry a
+    /// numeric `feedback_weight` appear in the result.
+    async fn get_node_feedback_weights(
+        &self,
+        node_ids: &[String],
+    ) -> GraphDBResult<HashMap<String, f64>> {
+        if node_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let nodes = self.get_nodes(node_ids).await?;
+        let mut out = HashMap::with_capacity(nodes.len());
+        for node in nodes {
+            let Some(id) = node.get("id").and_then(|v| v.as_str()).map(str::to_string) else {
+                continue;
+            };
+            if let Some(w) = node.get("feedback_weight").and_then(Value::as_f64) {
+                out.insert(id, w);
+            }
+        }
+        Ok(out)
+    }
+
+    /// One fetch plus one upsert for the whole batch, versus the default's
+    /// `update_node_property` (and therefore full delete+re-add) per id.
+    ///
+    /// Mirrors `set_node_truth_state`: every requested id defaults to `false`
+    /// and flips to `true` only if the node was actually present in the fetch
+    /// and thus included in the upsert.
+    async fn set_node_feedback_weights(
+        &self,
+        updates: &HashMap<String, f64>,
+    ) -> GraphDBResult<HashMap<String, bool>> {
+        let ids: Vec<String> = updates.keys().cloned().collect();
+        if ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let nodes = self.get_nodes(&ids).await?;
+
+        let mut out: HashMap<String, bool> = ids.iter().map(|id| (id.clone(), false)).collect();
+
+        let mut merged: Vec<Value> = Vec::with_capacity(nodes.len());
+        for node in nodes {
+            let Some(id) = node.get("id").and_then(|v| v.as_str()).map(str::to_string) else {
+                continue;
+            };
+            let Some(weight) = updates.get(&id) else {
+                continue;
+            };
+            let mut obj = serde_json::Map::new();
+            for (k, v) in node {
+                obj.insert(k.into_owned(), v);
+            }
+            obj.insert("feedback_weight".to_string(), json!(weight));
+            merged.push(Value::Object(obj));
+            out.insert(id, true);
+        }
+
+        if !merged.is_empty() {
+            self.add_nodes_raw(merged).await?;
+        }
+        Ok(out)
+    }
+
     // -- edge operations (sea_query) -----------------------------------------
 
     async fn has_edge(
@@ -790,6 +896,171 @@ impl GraphDBTrait for PgGraphAdapter {
             .collect();
 
         Ok(found)
+    }
+
+    /// In-place edge-property update, replacing the base trait's no-op default
+    /// (which only logs a warning and reports success).
+    ///
+    /// Edge properties live wholly in the `properties` JSONB column — unlike
+    /// nodes, there is no core-column split to preserve — so a single
+    /// `jsonb ||` merge is both correct and atomic. Merging (rather than
+    /// overwriting) keeps every other property on the edge intact.
+    ///
+    /// Reports `EdgeError` when no edge matches, so a caller checking `is_ok()`
+    /// is not told an update to a nonexistent edge succeeded.
+    async fn update_edge_property(
+        &self,
+        source_id: &str,
+        target_id: &str,
+        relationship_name: &str,
+        key: &str,
+        value: Value,
+    ) -> GraphDBResult<()> {
+        let patch = json!({ key: value });
+        let result = self
+            .db
+            .execute(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                "UPDATE graph_edge \
+                 SET properties = COALESCE(properties, '{}'::jsonb) || $4::jsonb, \
+                     updated_at = CURRENT_TIMESTAMP \
+                 WHERE source_id = $1 AND target_id = $2 AND relationship_name = $3",
+                [
+                    source_id.into(),
+                    target_id.into(),
+                    relationship_name.into(),
+                    patch.to_string().into(),
+                ],
+            ))
+            .await
+            .map_err(|e| GraphDBError::EdgeError(e.to_string()))?;
+
+        if result.rows_affected() == 0 {
+            return Err(GraphDBError::EdgeError(format!(
+                "Edge not found: {source_id} -> {target_id} ({relationship_name})"
+            )));
+        }
+        Ok(())
+    }
+
+    /// One round-trip for the whole batch, replacing the base trait's default
+    /// (which returns an empty map and warns, because the generic trait has no
+    /// per-edge property read).
+    ///
+    /// Matches the node-side contract: only edges that exist *and* carry a
+    /// numeric `feedback_weight` appear in the result.
+    async fn get_edge_feedback_weights(
+        &self,
+        edge_keys: &[crate::traits::EdgeKey],
+    ) -> GraphDBResult<HashMap<crate::traits::EdgeKey, f64>> {
+        if edge_keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let sources: Vec<String> = edge_keys.iter().map(|k| k.0.clone()).collect();
+        let targets: Vec<String> = edge_keys.iter().map(|k| k.1.clone()).collect();
+        let rels: Vec<String> = edge_keys.iter().map(|k| k.2.clone()).collect();
+
+        let rows = self
+            .db
+            .query_all(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                "SELECT e.source_id AS s, e.target_id AS t, e.relationship_name AS r, \
+                        e.properties -> 'feedback_weight' AS w \
+                 FROM graph_edge e \
+                 JOIN unnest($1::text[], $2::text[], $3::text[]) AS v(s, t, r) \
+                   ON e.source_id = v.s AND e.target_id = v.t \
+                  AND e.relationship_name = v.r",
+                [sources.into(), targets.into(), rels.into()],
+            ))
+            .await
+            .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
+
+        let mut out = HashMap::with_capacity(rows.len());
+        for row in &rows {
+            let s: String = row
+                .try_get("", "s")
+                .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
+            let t: String = row
+                .try_get("", "t")
+                .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
+            let r: String = row
+                .try_get("", "r")
+                .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
+            // A NULL / absent property decodes to `None`; a non-numeric one
+            // fails `as_f64`. Both are "no weight", matching the node side.
+            let w: Option<Value> = row.try_get("", "w").unwrap_or(None);
+            if let Some(weight) = w.as_ref().and_then(Value::as_f64) {
+                out.insert((s, t, r), weight);
+            }
+        }
+        Ok(out)
+    }
+
+    /// One round-trip for the whole batch, replacing the base trait's default
+    /// (one `update_edge_property` per edge, which on this backend used to be
+    /// the warning-only no-op and so reported success without writing).
+    ///
+    /// Weights travel as `text[]` and are cast to `float8` in SQL — the same
+    /// array-parameter shape `has_edges` uses — then merged into each edge's
+    /// JSONB. `RETURNING` reports which edges actually matched, so the success
+    /// map reflects real writes; every requested key defaults to `false`.
+    async fn set_edge_feedback_weights(
+        &self,
+        updates: &HashMap<crate::traits::EdgeKey, f64>,
+    ) -> GraphDBResult<HashMap<crate::traits::EdgeKey, bool>> {
+        if updates.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut sources: Vec<String> = Vec::with_capacity(updates.len());
+        let mut targets: Vec<String> = Vec::with_capacity(updates.len());
+        let mut rels: Vec<String> = Vec::with_capacity(updates.len());
+        let mut weights: Vec<String> = Vec::with_capacity(updates.len());
+        let mut out: HashMap<crate::traits::EdgeKey, bool> = HashMap::with_capacity(updates.len());
+
+        for (key, weight) in updates {
+            sources.push(key.0.clone());
+            targets.push(key.1.clone());
+            rels.push(key.2.clone());
+            // `{:?}` is f64's shortest round-trip representation, so the
+            // float8 cast parses back to exactly this value.
+            weights.push(format!("{weight:?}"));
+            out.insert(key.clone(), false);
+        }
+
+        let rows = self
+            .db
+            .query_all(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                "UPDATE graph_edge e \
+                 SET properties = COALESCE(e.properties, '{}'::jsonb) \
+                     || jsonb_build_object('feedback_weight', v.w::float8), \
+                     updated_at = CURRENT_TIMESTAMP \
+                 FROM unnest($1::text[], $2::text[], $3::text[], $4::text[]) \
+                      AS v(s, t, r, w) \
+                 WHERE e.source_id = v.s AND e.target_id = v.t \
+                   AND e.relationship_name = v.r \
+                 RETURNING e.source_id AS s, e.target_id AS t, \
+                           e.relationship_name AS r",
+                [sources.into(), targets.into(), rels.into(), weights.into()],
+            ))
+            .await
+            .map_err(|e| GraphDBError::EdgeError(e.to_string()))?;
+
+        for row in &rows {
+            let s: String = row
+                .try_get("", "s")
+                .map_err(|e| GraphDBError::EdgeError(e.to_string()))?;
+            let t: String = row
+                .try_get("", "t")
+                .map_err(|e| GraphDBError::EdgeError(e.to_string()))?;
+            let r: String = row
+                .try_get("", "r")
+                .map_err(|e| GraphDBError::EdgeError(e.to_string()))?;
+            out.insert((s, t, r), true);
+        }
+        Ok(out)
     }
 
     async fn add_edge(

--- a/crates/graph/src/pg_graph_adapter.rs
+++ b/crates/graph/src/pg_graph_adapter.rs
@@ -721,9 +721,11 @@ impl GraphDBTrait for PgGraphAdapter {
         key: &str,
         value: Value,
     ) -> GraphDBResult<()> {
-        // `serialize_node_to_row` sanitized the id on the way in, so look the
-        // node up by its stored form; the raw id would find nothing.
-        let ids = [sanitize_str(node_id).into_owned()];
+        // The id is passed through raw, matching every other read/delete path
+        // on this adapter — see the deliberate write-only-sanitization note in
+        // `serialize_node_to_row`. Sanitizing here would make a NUL-bearing id
+        // hit on Postgres while still missing on ladybug and in Python.
+        let ids = [node_id.to_string()];
         let node = self
             .get_nodes(&ids)
             .await?
@@ -752,26 +754,17 @@ impl GraphDBTrait for PgGraphAdapter {
         if node_ids.is_empty() {
             return Ok(HashMap::new());
         }
-        // Query by the stored (sanitized) ids, then report results under the
-        // caller's own ids so a caller whose id held a NUL can look its entry
-        // up.
-        let by_stored: HashMap<String, &String> = node_ids
-            .iter()
-            .map(|id| (sanitize_str(id).into_owned(), id))
-            .collect();
-        let lookup: Vec<String> = by_stored.keys().cloned().collect();
-
-        let nodes = self.get_nodes(&lookup).await?;
+        // Ids pass through raw (see `serialize_node_to_row`), and each row is
+        // keyed by its own `id` rather than by position — `get_nodes` answers
+        // in storage order.
+        let nodes = self.get_nodes(node_ids).await?;
         let mut out = HashMap::with_capacity(nodes.len());
         for node in nodes {
-            let Some(id) = node.get("id").and_then(|v| v.as_str()) else {
-                continue;
-            };
-            let Some(original) = by_stored.get(id) else {
+            let Some(id) = node.get("id").and_then(|v| v.as_str()).map(str::to_string) else {
                 continue;
             };
             if let Some(w) = node.get("feedback_weight").and_then(Value::as_f64) {
-                out.insert((*original).clone(), w);
+                out.insert(id, w);
             }
         }
         Ok(out)
@@ -790,27 +783,18 @@ impl GraphDBTrait for PgGraphAdapter {
         if updates.is_empty() {
             return Ok(HashMap::new());
         }
-        // Fetch by the stored (sanitized) ids and report under the caller's,
-        // for the same reason as `get_node_feedback_weights`.
-        let by_stored: HashMap<String, &String> = updates
-            .keys()
-            .map(|id| (sanitize_str(id).into_owned(), id))
-            .collect();
-        let lookup: Vec<String> = by_stored.keys().cloned().collect();
+        // Ids pass through raw (see `serialize_node_to_row`).
+        let ids: Vec<String> = updates.keys().cloned().collect();
+        let nodes = self.get_nodes(&ids).await?;
 
-        let nodes = self.get_nodes(&lookup).await?;
-
-        let mut out: HashMap<String, bool> = updates.keys().map(|id| (id.clone(), false)).collect();
+        let mut out: HashMap<String, bool> = ids.iter().map(|id| (id.clone(), false)).collect();
 
         let mut merged: Vec<Value> = Vec::with_capacity(nodes.len());
         for node in nodes {
-            let Some(id) = node.get("id").and_then(|v| v.as_str()) else {
+            let Some(id) = node.get("id").and_then(|v| v.as_str()).map(str::to_string) else {
                 continue;
             };
-            let Some(original) = by_stored.get(id).map(|id| (*id).clone()) else {
-                continue;
-            };
-            let Some(weight) = updates.get(&original) else {
+            let Some(weight) = updates.get(&id) else {
                 continue;
             };
             let mut obj = serde_json::Map::new();
@@ -819,7 +803,7 @@ impl GraphDBTrait for PgGraphAdapter {
             }
             obj.insert("feedback_weight".to_string(), json!(weight));
             merged.push(Value::Object(obj));
-            out.insert(original, true);
+            out.insert(id, true);
         }
 
         if !merged.is_empty() {
@@ -940,12 +924,14 @@ impl GraphDBTrait for PgGraphAdapter {
         key: &str,
         value: Value,
     ) -> GraphDBResult<()> {
-        // NUL bytes must be stripped for two separate reasons, both of which
-        // `add_edges` already handles via `sanitize_str` / `sanitize_json`:
-        // Postgres rejects ` ` in a `jsonb` cast, so an unsanitized patch
-        // errors at runtime on LLM/PDF-derived text; and the key columns were
-        // *stored* sanitized, so comparing raw input against them would match
-        // zero rows and report the edge as missing.
+        // The property value is sanitized, as `add_edges` does for the same
+        // column: Postgres rejects a NUL in a `jsonb` cast, so an unsanitized
+        // patch built from LLM- or PDF-derived text errors at runtime.
+        //
+        // The three key columns are *not* sanitized, matching every other
+        // read/delete path on this adapter — see the write-only-sanitization
+        // note in `serialize_node_to_row`. That keeps Postgres, ladybug and
+        // Python agreeing on whether a NUL-bearing key hits.
         let patch = sanitize_json(json!({ key: value }));
         let result = self
             .db
@@ -956,9 +942,9 @@ impl GraphDBTrait for PgGraphAdapter {
                      updated_at = CURRENT_TIMESTAMP \
                  WHERE source_id = $1 AND target_id = $2 AND relationship_name = $3",
                 [
-                    sanitize_str(source_id).into_owned().into(),
-                    sanitize_str(target_id).into_owned().into(),
-                    sanitize_str(relationship_name).into_owned().into(),
+                    source_id.into(),
+                    target_id.into(),
+                    relationship_name.into(),
                     patch.to_string().into(),
                 ],
             ))
@@ -987,20 +973,10 @@ impl GraphDBTrait for PgGraphAdapter {
             return Ok(HashMap::new());
         }
 
-        // Sanitized to match how `add_edges` stored these columns; raw input
-        // carrying a NUL would join against nothing.
-        let sources: Vec<String> = edge_keys
-            .iter()
-            .map(|k| sanitize_str(&k.0).into_owned())
-            .collect();
-        let targets: Vec<String> = edge_keys
-            .iter()
-            .map(|k| sanitize_str(&k.1).into_owned())
-            .collect();
-        let rels: Vec<String> = edge_keys
-            .iter()
-            .map(|k| sanitize_str(&k.2).into_owned())
-            .collect();
+        // Keys pass through raw, as on every other lookup path here.
+        let sources: Vec<String> = edge_keys.iter().map(|k| k.0.clone()).collect();
+        let targets: Vec<String> = edge_keys.iter().map(|k| k.1.clone()).collect();
+        let rels: Vec<String> = edge_keys.iter().map(|k| k.2.clone()).collect();
 
         let rows = self
             .db
@@ -1017,25 +993,6 @@ impl GraphDBTrait for PgGraphAdapter {
             .await
             .map_err(|e| GraphDBError::QueryError(e.to_string()))?;
 
-        // Rows come back carrying the *stored* (sanitized) key, so results are
-        // mapped back onto the caller's own key — the same "filter the input
-        // rather than reconstruct it from the query" rule `has_edges` follows.
-        // Without this a caller whose key held a NUL could never look up its
-        // own entry.
-        let by_stored: HashMap<crate::traits::EdgeKey, &crate::traits::EdgeKey> = edge_keys
-            .iter()
-            .map(|k| {
-                (
-                    (
-                        sanitize_str(&k.0).into_owned(),
-                        sanitize_str(&k.1).into_owned(),
-                        sanitize_str(&k.2).into_owned(),
-                    ),
-                    k,
-                )
-            })
-            .collect();
-
         let mut out = HashMap::with_capacity(rows.len());
         for row in &rows {
             let s: String = row
@@ -1050,10 +1007,8 @@ impl GraphDBTrait for PgGraphAdapter {
             // A NULL / absent property decodes to `None`; a non-numeric one
             // fails `as_f64`. Both are "no weight", matching the node side.
             let w: Option<Value> = row.try_get("", "w").unwrap_or(None);
-            if let Some(weight) = w.as_ref().and_then(Value::as_f64)
-                && let Some(original) = by_stored.get(&(s, t, r))
-            {
-                out.insert((*original).clone(), weight);
+            if let Some(weight) = w.as_ref().and_then(Value::as_f64) {
+                out.insert((s, t, r), weight);
             }
         }
         Ok(out)
@@ -1080,27 +1035,30 @@ impl GraphDBTrait for PgGraphAdapter {
         let mut rels: Vec<String> = Vec::with_capacity(updates.len());
         let mut weights: Vec<String> = Vec::with_capacity(updates.len());
         let mut out: HashMap<crate::traits::EdgeKey, bool> = HashMap::with_capacity(updates.len());
-        // Stored (sanitized) key -> the caller's key, so a `RETURNING` row
-        // flips the entry the caller can actually look up instead of adding a
-        // second, sanitized one beside it.
-        let mut by_stored: HashMap<crate::traits::EdgeKey, crate::traits::EdgeKey> =
-            HashMap::with_capacity(updates.len());
 
+        // Keys pass through raw, as on every other lookup path here.
         for (key, weight) in updates {
-            // Sanitized to match how `add_edges` stored these columns.
-            let stored = (
-                sanitize_str(&key.0).into_owned(),
-                sanitize_str(&key.1).into_owned(),
-                sanitize_str(&key.2).into_owned(),
-            );
-            sources.push(stored.0.clone());
-            targets.push(stored.1.clone());
-            rels.push(stored.2.clone());
+            out.insert(key.clone(), false);
+            // JSON has no infinity or NaN. Postgres does not reject them here
+            // — `jsonb_build_object('feedback_weight', 'inf'::float8)` yields
+            // the *string* `"Infinity"` — so an unguarded non-finite weight
+            // would quietly store a value that `get_edge_feedback_weights`
+            // then drops on `as_f64`, leaving a junk property behind and
+            // reporting success for a weight nobody can read. Skipping the key
+            // keeps it out of the blob and reports `false` honestly.
+            if !weight.is_finite() {
+                continue;
+            }
+            sources.push(key.0.clone());
+            targets.push(key.1.clone());
+            rels.push(key.2.clone());
             // `{:?}` is f64's shortest round-trip representation, so the
             // float8 cast parses back to exactly this value.
             weights.push(format!("{weight:?}"));
-            by_stored.insert(stored, key.clone());
-            out.insert(key.clone(), false);
+        }
+
+        if sources.is_empty() {
+            return Ok(out);
         }
 
         let rows = self
@@ -1132,9 +1090,7 @@ impl GraphDBTrait for PgGraphAdapter {
             let r: String = row
                 .try_get("", "r")
                 .map_err(|e| GraphDBError::EdgeError(e.to_string()))?;
-            if let Some(original) = by_stored.get(&(s, t, r)) {
-                out.insert(original.clone(), true);
-            }
+            out.insert((s, t, r), true);
         }
         Ok(out)
     }

--- a/crates/graph/src/traits.rs
+++ b/crates/graph/src/traits.rs
@@ -234,6 +234,16 @@ pub trait GraphDBTrait: Send + Sync {
 
     /// Get multiple nodes by IDs.
     ///
+    /// The result is a *set* lookup, not a positional mapping. Implementations
+    /// answer with a single set-based query, so:
+    ///
+    /// - ids missing from the store are simply absent from the result;
+    /// - rows are in unspecified (storage) order, **not** `node_ids` order;
+    /// - a repeated id yields one row, not one per occurrence.
+    ///
+    /// Key results by each row's own `"id"` field. Zipping them against
+    /// `node_ids` pairs data with the wrong id as soon as any of the above
+    /// applies, and does so silently.
     async fn get_nodes(&self, node_ids: &[String]) -> GraphDBResult<Vec<NodeData>>;
 
     /// Check if an edge exists between two nodes.

--- a/crates/graph/tests/common/mod.rs
+++ b/crates/graph/tests/common/mod.rs
@@ -899,6 +899,222 @@ pub async fn test_node_truth_state_preserves_other_properties(db: &dyn GraphDBTr
     assert_eq!(state.truth_epoch, 9);
 }
 
+// -- node properties & feedback weights (issue #21) --------------------------
+
+/// `update_node_property` must keep the node's edges and unrelated properties.
+///
+/// Note what this does and does not prove. The base-trait default implements
+/// the method as `get_node` → `get_edges` → `delete_node` → `add_node_raw` →
+/// `add_edges`, and on the happy path that sequence *does* restore the edges,
+/// so this case passes against the default too — it pins the contract, not the
+/// improvement. What the default cannot offer is atomicity: the five statements
+/// share no transaction, so an interruption between the delete and the re-add
+/// loses the node and its edges, and `get_edges` is `unwrap_or_default()`, so a
+/// failed read drops every edge on the recreate. Reproducing either needs fault
+/// injection this suite has no seam for; a backend that overrides the method
+/// with an in-place write closes the window by construction.
+pub async fn test_update_node_property_preserves_edges_and_siblings(db: &dyn GraphDBTrait) {
+    db.delete_graph().await.unwrap();
+
+    db.add_node_raw(json!({
+        "id": "prop_a", "name": "A", "type": "Person", "value": 1, "keepme": "yes"
+    }))
+    .await
+    .unwrap();
+    db.add_node_raw(json!({
+        "id": "prop_b", "name": "B", "type": "Person", "value": 2
+    }))
+    .await
+    .unwrap();
+    db.add_edge("prop_a", "prop_b", "knows", None)
+        .await
+        .unwrap();
+
+    db.update_node_property("prop_a", "scratch", json!("written"))
+        .await
+        .unwrap();
+
+    // The edge survived the property write.
+    assert!(
+        db.has_edge("prop_a", "prop_b", "knows").await.unwrap(),
+        "update_node_property must not cascade the node's edges away"
+    );
+
+    let node = db
+        .get_node("prop_a")
+        .await
+        .unwrap()
+        .expect("node still exists");
+    assert_eq!(node.get("scratch").unwrap().as_str().unwrap(), "written");
+    assert_eq!(node.get("name").unwrap().as_str().unwrap(), "A");
+    assert_eq!(node.get("type").unwrap().as_str().unwrap(), "Person");
+    assert_eq!(
+        node.get("keepme").unwrap().as_str().unwrap(),
+        "yes",
+        "unrelated properties must survive"
+    );
+}
+
+/// Round-trip for the batched node feedback-weight accessors.
+///
+/// Ids that do not exist, and ids that exist without a numeric
+/// `feedback_weight`, are absent from the read — the documented contract.
+pub async fn test_node_feedback_weight_round_trip(db: &dyn GraphDBTrait) {
+    db.delete_graph().await.unwrap();
+
+    db.add_node_raw(json!({"id": "fw_a", "name": "A", "type": "Person", "value": 1}))
+        .await
+        .unwrap();
+    db.add_node_raw(json!({"id": "fw_b", "name": "B", "type": "Person", "value": 2}))
+        .await
+        .unwrap();
+    // Exists, but never given a weight.
+    db.add_node_raw(json!({"id": "fw_none", "name": "N", "type": "Person", "value": 3}))
+        .await
+        .unwrap();
+
+    let mut updates = HashMap::new();
+    updates.insert("fw_a".to_string(), 0.25);
+    updates.insert("fw_b".to_string(), -1.5);
+    // A node that is not in the graph at all.
+    updates.insert("fw_ghost".to_string(), 9.0);
+
+    let set_result = db.set_node_feedback_weights(&updates).await.unwrap();
+    assert_eq!(set_result.get("fw_a"), Some(&true));
+    assert_eq!(set_result.get("fw_b"), Some(&true));
+    assert_eq!(
+        set_result.get("fw_ghost"),
+        Some(&false),
+        "a missing node must report failure, not silent success"
+    );
+
+    let got = db
+        .get_node_feedback_weights(&[
+            "fw_a".to_string(),
+            "fw_b".to_string(),
+            "fw_none".to_string(),
+            "fw_ghost".to_string(),
+        ])
+        .await
+        .unwrap();
+
+    assert_eq!(got.get("fw_a"), Some(&0.25));
+    assert_eq!(got.get("fw_b"), Some(&-1.5));
+    assert!(
+        !got.contains_key("fw_none"),
+        "a node with no weight is omitted"
+    );
+    assert!(!got.contains_key("fw_ghost"), "a missing node is omitted");
+
+    assert!(
+        db.get_node_feedback_weights(&[]).await.unwrap().is_empty(),
+        "empty input yields an empty map"
+    );
+}
+
+/// Writing a feedback weight must not clobber siblings or drop edges — the
+/// same hazard as `test_update_node_property_preserves_edges_and_siblings`,
+/// reached through the batched setter that the memify feedback path uses.
+pub async fn test_node_feedback_weight_preserves_edges_and_siblings(db: &dyn GraphDBTrait) {
+    db.delete_graph().await.unwrap();
+
+    db.add_node_raw(json!({
+        "id": "fwp_a", "name": "Keep", "type": "Person", "value": 5, "truth_epoch": 3
+    }))
+    .await
+    .unwrap();
+    db.add_node_raw(json!({"id": "fwp_b", "name": "Other", "type": "Person", "value": 6}))
+        .await
+        .unwrap();
+    db.add_edge("fwp_a", "fwp_b", "knows", None).await.unwrap();
+
+    let mut updates = HashMap::new();
+    updates.insert("fwp_a".to_string(), 0.75);
+    let set_result = db.set_node_feedback_weights(&updates).await.unwrap();
+    assert_eq!(set_result.get("fwp_a"), Some(&true));
+
+    assert!(
+        db.has_edge("fwp_a", "fwp_b", "knows").await.unwrap(),
+        "set_node_feedback_weights must not cascade edges away"
+    );
+
+    let node = db.get_node("fwp_a").await.unwrap().expect("still exists");
+    assert_eq!(node.get("name").unwrap().as_str().unwrap(), "Keep");
+    assert_eq!(node.get("value").unwrap().as_i64().unwrap(), 5);
+    assert_eq!(
+        node.get("truth_epoch").unwrap().as_i64().unwrap(),
+        3,
+        "a sibling property written by another subsystem must survive"
+    );
+    assert_eq!(node.get("feedback_weight").unwrap().as_f64().unwrap(), 0.75);
+}
+
+/// Round-trip for the batched edge feedback-weight accessors, and the
+/// property-merge guarantee: writing a weight keeps the edge's other
+/// properties.
+pub async fn test_edge_feedback_weight_round_trip(db: &dyn GraphDBTrait) {
+    db.delete_graph().await.unwrap();
+
+    for id in ["efw_a", "efw_b"] {
+        db.add_node_raw(json!({"id": id, "name": id, "type": "Person", "value": 0}))
+            .await
+            .unwrap();
+    }
+
+    let mut props: HashMap<Cow<'static, str>, serde_json::Value> = HashMap::new();
+    props.insert(Cow::Borrowed("edge_text"), json!("keep this"));
+    db.add_edge("efw_a", "efw_b", "knows", Some(props))
+        .await
+        .unwrap();
+
+    let key = (
+        "efw_a".to_string(),
+        "efw_b".to_string(),
+        "knows".to_string(),
+    );
+    let ghost = (
+        "efw_a".to_string(),
+        "efw_b".to_string(),
+        "never_stored".to_string(),
+    );
+
+    let mut updates = HashMap::new();
+    updates.insert(key.clone(), 0.5);
+    updates.insert(ghost.clone(), 0.9);
+
+    let set_result = db.set_edge_feedback_weights(&updates).await.unwrap();
+    assert_eq!(set_result.get(&key), Some(&true));
+    assert_eq!(
+        set_result.get(&ghost),
+        Some(&false),
+        "an edge that does not exist must report failure"
+    );
+
+    let got = db
+        .get_edge_feedback_weights(&[key.clone(), ghost.clone()])
+        .await
+        .unwrap();
+    assert_eq!(got.get(&key), Some(&0.5));
+    assert!(!got.contains_key(&ghost));
+
+    // The pre-existing edge property survived the weight write.
+    let edges = db.get_edges("efw_a").await.unwrap();
+    let stored = edges
+        .iter()
+        .find(|e| e.0 == "efw_a" && e.1 == "efw_b" && e.2 == "knows")
+        .expect("edge still present");
+    assert_eq!(
+        stored.3.get("edge_text").map(|v| v.as_str().unwrap()),
+        Some("keep this"),
+        "writing feedback_weight must merge, not replace, edge properties"
+    );
+
+    assert!(
+        db.get_edge_feedback_weights(&[]).await.unwrap().is_empty(),
+        "empty input yields an empty map"
+    );
+}
+
 // -- get_neighborhood --------------------------------------------------------
 
 pub async fn test_get_neighborhood_depth1(db: &dyn GraphDBTrait) {

--- a/crates/graph/tests/common/mod.rs
+++ b/crates/graph/tests/common/mod.rs
@@ -1115,27 +1115,20 @@ pub async fn test_edge_feedback_weight_round_trip(db: &dyn GraphDBTrait) {
     );
 }
 
-/// NUL bytes must not break the property/feedback write paths.
+/// A NUL byte inside a property *value* must not fail the write.
 ///
-/// The Postgres adapter strips NULs at the write boundary (Postgres rejects
-/// ` ` in a `jsonb` cast), so the stored key differs from a raw id that
-/// contained one. Two things have to hold for a caller that hands over such an
-/// id: the write must not error, and the result must be reported under the key
-/// the *caller* passed, not the stored form — otherwise the caller cannot find
-/// its own entry.
+/// LLM- and PDF-derived text routinely carries a literal `0x00`, and Postgres
+/// rejects one outright in a `jsonb` cast, so the property-update paths have to
+/// strip it the way the bulk node/edge writes already do. The NUL is dropped,
+/// not escaped, so the value reads back without it.
 ///
-/// **Registered for Postgres only.** Ladybug does not strip NULs from ids
-/// (`escape_cypher_string` handles `\` and `'` only), so it fails this today.
-/// That gap is the subject of the separate #149 NUL-handling work rather than
-/// this batching change, and asserting it here would collide with it.
-#[allow(
-    dead_code,
-    reason = "registered by pg_graph_integration only; this module compiles into every backend's test binary"
-)]
-pub async fn test_feedback_weights_tolerate_nul_bytes(db: &dyn GraphDBTrait) {
+/// Only the value is in scope here. Ids and relationship names are deliberately
+/// *not* sanitized on lookup paths — see the write-only-sanitization note in
+/// `PgGraphAdapter::serialize_node_to_row`, which keeps Postgres, ladybug and
+/// Python agreeing on whether a NUL-bearing key hits.
+pub async fn test_property_writes_tolerate_nul_in_value(db: &dyn GraphDBTrait) {
     db.delete_graph().await.unwrap();
 
-    // Seeded with the clean ids, which is what any backend stores.
     for id in ["nul_a", "nul_b"] {
         db.add_node_raw(json!({"id": id, "name": id, "type": "Person", "value": 0}))
             .await
@@ -1143,45 +1136,80 @@ pub async fn test_feedback_weights_tolerate_nul_bytes(db: &dyn GraphDBTrait) {
     }
     db.add_edge("nul_a", "nul_b", "knows", None).await.unwrap();
 
-    // The caller's copies carry embedded NULs.
-    let dirty_a = "nul\0_a".to_string();
-    let dirty_b = "nul\0_b".to_string();
+    db.update_node_property("nul_a", "note", json!("we\0ird"))
+        .await
+        .unwrap();
 
-    let mut node_updates = HashMap::new();
-    node_updates.insert(dirty_a.clone(), 0.4);
-    let set_nodes = db.set_node_feedback_weights(&node_updates).await.unwrap();
+    let node = db.get_node("nul_a").await.unwrap().expect("still exists");
     assert_eq!(
-        set_nodes.get(&dirty_a),
-        Some(&true),
-        "success must be reported under the caller's own key"
+        node.get("note").unwrap().as_str().unwrap(),
+        "weird",
+        "the NUL is stripped, leaving the rest of the value intact"
     );
 
-    let got_nodes = db
-        .get_node_feedback_weights(std::slice::from_ref(&dirty_a))
-        .await
-        .unwrap();
-    assert_eq!(got_nodes.get(&dirty_a), Some(&0.4));
-
-    // A property value carrying a NUL must not fail the write.
-    db.update_node_property(&dirty_a, "note", json!("we\0ird"))
+    db.update_edge_property("nul_a", "nul_b", "knows", "note", json!("ed\0ge"))
         .await
         .unwrap();
 
-    let dirty_key = (dirty_a, dirty_b, "kno\0ws".to_string());
-    let mut edge_updates = HashMap::new();
-    edge_updates.insert(dirty_key.clone(), 0.6);
-    let set_edges = db.set_edge_feedback_weights(&edge_updates).await.unwrap();
+    let edges = db.get_edges("nul_a").await.unwrap();
+    let stored = edges
+        .iter()
+        .find(|e| e.0 == "nul_a" && e.1 == "nul_b" && e.2 == "knows")
+        .expect("edge still present");
     assert_eq!(
-        set_edges.get(&dirty_key),
+        stored.3.get("note").and_then(|v| v.as_str()),
+        Some("edge"),
+        "edge property values are sanitized the same way"
+    );
+}
+
+/// A non-finite weight must not come back as a readable weight, and must not
+/// disturb the rest of the batch.
+///
+/// JSON has no infinity or NaN, and neither backend errors on one — Postgres
+/// stores the *string* `"Infinity"` and ladybug serialises `null` — so the risk
+/// is a junk property that silently reads back as absent while the write
+/// reported success.
+///
+/// The per-key verdict is deliberately not asserted, because it legitimately
+/// differs: the Postgres adapter drops such a key up front and reports `false`,
+/// while ladybug writes JSON `null` and reports `true`. What both must agree on
+/// is that the finite weight in the same batch lands and the non-finite one is
+/// never readable.
+pub async fn test_edge_feedback_weight_rejects_non_finite(db: &dyn GraphDBTrait) {
+    db.delete_graph().await.unwrap();
+
+    for id in ["nf_a", "nf_b"] {
+        db.add_node_raw(json!({"id": id, "name": id, "type": "Person", "value": 0}))
+            .await
+            .unwrap();
+    }
+    db.add_edge("nf_a", "nf_b", "good", None).await.unwrap();
+    db.add_edge("nf_a", "nf_b", "bad", None).await.unwrap();
+
+    let good = ("nf_a".to_string(), "nf_b".to_string(), "good".to_string());
+    let bad = ("nf_a".to_string(), "nf_b".to_string(), "bad".to_string());
+
+    let mut updates = HashMap::new();
+    updates.insert(good.clone(), 0.3);
+    updates.insert(bad.clone(), f64::INFINITY);
+
+    let result = db.set_edge_feedback_weights(&updates).await.unwrap();
+    assert_eq!(
+        result.get(&good),
         Some(&true),
-        "the edge resolves once its key is sanitized"
+        "the finite weight must still be written — one bad key must not fail the batch"
     );
 
-    let got_edges = db
-        .get_edge_feedback_weights(std::slice::from_ref(&dirty_key))
+    let got = db
+        .get_edge_feedback_weights(&[good.clone(), bad.clone()])
         .await
         .unwrap();
-    assert_eq!(got_edges.get(&dirty_key), Some(&0.6));
+    assert_eq!(got.get(&good), Some(&0.3));
+    assert!(
+        !got.contains_key(&bad),
+        "a non-finite weight must not read back as a usable weight"
+    );
 }
 
 // -- get_neighborhood --------------------------------------------------------

--- a/crates/graph/tests/common/mod.rs
+++ b/crates/graph/tests/common/mod.rs
@@ -1115,6 +1115,75 @@ pub async fn test_edge_feedback_weight_round_trip(db: &dyn GraphDBTrait) {
     );
 }
 
+/// NUL bytes must not break the property/feedback write paths.
+///
+/// The Postgres adapter strips NULs at the write boundary (Postgres rejects
+/// ` ` in a `jsonb` cast), so the stored key differs from a raw id that
+/// contained one. Two things have to hold for a caller that hands over such an
+/// id: the write must not error, and the result must be reported under the key
+/// the *caller* passed, not the stored form — otherwise the caller cannot find
+/// its own entry.
+///
+/// **Registered for Postgres only.** Ladybug does not strip NULs from ids
+/// (`escape_cypher_string` handles `\` and `'` only), so it fails this today.
+/// That gap is the subject of the separate #149 NUL-handling work rather than
+/// this batching change, and asserting it here would collide with it.
+#[allow(
+    dead_code,
+    reason = "registered by pg_graph_integration only; this module compiles into every backend's test binary"
+)]
+pub async fn test_feedback_weights_tolerate_nul_bytes(db: &dyn GraphDBTrait) {
+    db.delete_graph().await.unwrap();
+
+    // Seeded with the clean ids, which is what any backend stores.
+    for id in ["nul_a", "nul_b"] {
+        db.add_node_raw(json!({"id": id, "name": id, "type": "Person", "value": 0}))
+            .await
+            .unwrap();
+    }
+    db.add_edge("nul_a", "nul_b", "knows", None).await.unwrap();
+
+    // The caller's copies carry embedded NULs.
+    let dirty_a = "nul\0_a".to_string();
+    let dirty_b = "nul\0_b".to_string();
+
+    let mut node_updates = HashMap::new();
+    node_updates.insert(dirty_a.clone(), 0.4);
+    let set_nodes = db.set_node_feedback_weights(&node_updates).await.unwrap();
+    assert_eq!(
+        set_nodes.get(&dirty_a),
+        Some(&true),
+        "success must be reported under the caller's own key"
+    );
+
+    let got_nodes = db
+        .get_node_feedback_weights(std::slice::from_ref(&dirty_a))
+        .await
+        .unwrap();
+    assert_eq!(got_nodes.get(&dirty_a), Some(&0.4));
+
+    // A property value carrying a NUL must not fail the write.
+    db.update_node_property(&dirty_a, "note", json!("we\0ird"))
+        .await
+        .unwrap();
+
+    let dirty_key = (dirty_a, dirty_b, "kno\0ws".to_string());
+    let mut edge_updates = HashMap::new();
+    edge_updates.insert(dirty_key.clone(), 0.6);
+    let set_edges = db.set_edge_feedback_weights(&edge_updates).await.unwrap();
+    assert_eq!(
+        set_edges.get(&dirty_key),
+        Some(&true),
+        "the edge resolves once its key is sanitized"
+    );
+
+    let got_edges = db
+        .get_edge_feedback_weights(std::slice::from_ref(&dirty_key))
+        .await
+        .unwrap();
+    assert_eq!(got_edges.get(&dirty_key), Some(&0.6));
+}
+
 // -- get_neighborhood --------------------------------------------------------
 
 pub async fn test_get_neighborhood_depth1(db: &dyn GraphDBTrait) {

--- a/crates/graph/tests/ladybug_integration.rs
+++ b/crates/graph/tests/ladybug_integration.rs
@@ -77,4 +77,6 @@ ladybug_test!(test_update_node_property_preserves_edges_and_siblings);
 ladybug_test!(test_node_feedback_weight_round_trip);
 ladybug_test!(test_node_feedback_weight_preserves_edges_and_siblings);
 ladybug_test!(test_edge_feedback_weight_round_trip);
+ladybug_test!(test_property_writes_tolerate_nul_in_value);
+ladybug_test!(test_edge_feedback_weight_rejects_non_finite);
 ladybug_test!(test_nul_bytes_in_text_are_persistable);

--- a/crates/graph/tests/ladybug_integration.rs
+++ b/crates/graph/tests/ladybug_integration.rs
@@ -73,4 +73,8 @@ ladybug_test!(test_get_neighborhood_empty_seeds);
 ladybug_test!(test_node_truth_state_round_trip);
 ladybug_test!(test_node_truth_state_missing_and_invalid);
 ladybug_test!(test_node_truth_state_preserves_other_properties);
+ladybug_test!(test_update_node_property_preserves_edges_and_siblings);
+ladybug_test!(test_node_feedback_weight_round_trip);
+ladybug_test!(test_node_feedback_weight_preserves_edges_and_siblings);
+ladybug_test!(test_edge_feedback_weight_round_trip);
 ladybug_test!(test_nul_bytes_in_text_are_persistable);

--- a/crates/graph/tests/pg_graph_integration.rs
+++ b/crates/graph/tests/pg_graph_integration.rs
@@ -151,5 +151,6 @@ pggraph_test!(test_update_node_property_preserves_edges_and_siblings);
 pggraph_test!(test_node_feedback_weight_round_trip);
 pggraph_test!(test_node_feedback_weight_preserves_edges_and_siblings);
 pggraph_test!(test_edge_feedback_weight_round_trip);
-pggraph_test!(test_feedback_weights_tolerate_nul_bytes);
+pggraph_test!(test_property_writes_tolerate_nul_in_value);
+pggraph_test!(test_edge_feedback_weight_rejects_non_finite);
 pggraph_test!(test_nul_bytes_in_text_are_persistable);

--- a/crates/graph/tests/pg_graph_integration.rs
+++ b/crates/graph/tests/pg_graph_integration.rs
@@ -151,4 +151,5 @@ pggraph_test!(test_update_node_property_preserves_edges_and_siblings);
 pggraph_test!(test_node_feedback_weight_round_trip);
 pggraph_test!(test_node_feedback_weight_preserves_edges_and_siblings);
 pggraph_test!(test_edge_feedback_weight_round_trip);
+pggraph_test!(test_feedback_weights_tolerate_nul_bytes);
 pggraph_test!(test_nul_bytes_in_text_are_persistable);

--- a/crates/graph/tests/pg_graph_integration.rs
+++ b/crates/graph/tests/pg_graph_integration.rs
@@ -147,4 +147,8 @@ pggraph_test!(test_get_neighborhood_empty_seeds);
 pggraph_test!(test_node_truth_state_round_trip);
 pggraph_test!(test_node_truth_state_missing_and_invalid);
 pggraph_test!(test_node_truth_state_preserves_other_properties);
+pggraph_test!(test_update_node_property_preserves_edges_and_siblings);
+pggraph_test!(test_node_feedback_weight_round_trip);
+pggraph_test!(test_node_feedback_weight_preserves_edges_and_siblings);
+pggraph_test!(test_edge_feedback_weight_round_trip);
 pggraph_test!(test_nul_bytes_in_text_are_persistable);

--- a/crates/search/src/retrievers/temporal_retriever.rs
+++ b/crates/search/src/retrievers/temporal_retriever.rs
@@ -438,9 +438,22 @@ impl SearchRetriever for TemporalRetriever {
             .take(params.top_k_or(self.top_k))
             .map(|(id, _)| id.clone())
             .collect();
-        let event_nodes = self.graph_db.get_nodes(&event_id_list).await?;
-        let nodes_by_id: HashMap<String, NodeData> =
-            event_id_list.into_iter().zip(event_nodes).collect();
+        // Keyed by each row's own `id`, not by zipping against `event_id_list`:
+        // `get_nodes` makes no promise about order (the Postgres adapter has
+        // always answered with one set-based `IN` query, and the ladybug
+        // adapter now does too), and it collapses duplicate ids. A positional
+        // zip therefore risked pairing an event's name/description with a
+        // different event's id — silently wrong context, no error.
+        let nodes_by_id: HashMap<String, NodeData> = self
+            .graph_db
+            .get_nodes(&event_id_list)
+            .await?
+            .into_iter()
+            .filter_map(|data| {
+                let id = data.get("id").and_then(|v| v.as_str())?.to_string();
+                Some((id, data))
+            })
+            .collect();
 
         let mut temporal_context = Vec::new();
 
@@ -742,15 +755,19 @@ mod tests {
             Ok(None)
         }
 
+        /// Answers in *storage* order, filtering to the requested ids — the
+        /// contract [`GraphDBTrait::get_nodes`] actually specifies, and what
+        /// both real adapters do with their single set-based query. Returning
+        /// them in `node_ids` order instead would let a caller that zips
+        /// positionally pass its tests and still mispair ids in production.
         async fn get_nodes(&self, node_ids: &[String]) -> GraphDBResult<Vec<NodeData>> {
-            let nodes_map: HashMap<&str, &NodeData> = self
+            let requested: std::collections::HashSet<&str> =
+                node_ids.iter().map(String::as_str).collect();
+            Ok(self
                 .nodes
                 .iter()
-                .map(|(id, data)| (id.as_str(), data))
-                .collect();
-            Ok(node_ids
-                .iter()
-                .filter_map(|id| nodes_map.get(id.as_str()).map(|d| (*d).clone()))
+                .filter(|(id, _)| requested.contains(id.as_str()))
+                .map(|(_, data)| data.clone())
                 .collect())
         }
 
@@ -1827,6 +1844,99 @@ mod tests {
             .unwrap();
 
         assert_eq!(context.len(), 2, "top_k=2 should limit results to 2 items");
+    }
+
+    /// Each context item's `event_name` must belong to its own `event_id`.
+    ///
+    /// `get_nodes` is a set lookup: it answers in storage order, not in the
+    /// order the ids were asked for. Here the vector scores ascend with `i`, so
+    /// the ranked order is the exact reverse of storage order — which is what
+    /// makes a positional `zip` of the requested ids against the returned rows
+    /// mispair every event with another event's name and description. Nothing
+    /// errors when that happens; the search just answers with the wrong text,
+    /// so only an id/name consistency assertion catches it.
+    #[tokio::test]
+    async fn get_context_pairs_each_event_with_its_own_node() {
+        let mut nodes = Vec::new();
+        let mut edges = Vec::new();
+        let mut neighbors = HashMap::new();
+        let mut vector_results = Vec::new();
+
+        for i in 1..=3 {
+            let ts_id = format!("aa000000-0000-0000-0000-0000000001{i:02}");
+            let ev_id = format!("bb000000-0000-0000-0000-0000000001{i:02}");
+            let ev_name = format!("Event {i}");
+            let time_ms = 1704067200000_i64 + (i as i64 - 1) * 30 * 86400 * 1000;
+
+            nodes.push(timestamp_node(&ts_id, time_ms));
+            nodes.push(event_graph_node(&ev_id, &ev_name));
+            edges.push((
+                ev_id.clone(),
+                ts_id.clone(),
+                "at".to_string(),
+                HashMap::new(),
+            ));
+            neighbors.insert(ts_id, vec![event_node_data(&ev_id, &ev_name)]);
+            // Ascending score: event 3 ranks first, though it is stored last.
+            vector_results.push(SearchResult {
+                id: uuid::Uuid::parse_str(&ev_id).unwrap(),
+                score: 0.5 + (i as f32 * 0.1),
+                metadata: HashMap::new(),
+            });
+        }
+
+        let graph_db = Arc::new(TestGraphDb {
+            nodes,
+            edges,
+            neighbors,
+        });
+        let vector_db = Arc::new(TestVectorDb {
+            collections: HashMap::from([(TestVectorDb::key("Event", "name"), vector_results)]),
+        });
+        let llm = Arc::new(TestLlm {
+            completion_response: String::new(),
+            interval_response: Some(QueryInterval {
+                starts_at: Some(qts(2024, 1, 1)),
+                ends_at: Some(qts(2024, 12, 31)),
+            }),
+            fail_structured_output: false,
+            last_messages: Mutex::new(vec![]),
+            ..TestLlm::default()
+        });
+
+        let retriever = build_retriever(vector_db, graph_db, llm);
+        let params = SearchParams {
+            top_k: Some(3),
+            ..Default::default()
+        };
+
+        let context = retriever
+            .get_context("What happened in 2024?", &params)
+            .await
+            .unwrap();
+
+        assert_eq!(context.len(), 3);
+
+        for item in &context {
+            let event_id = item.payload["event_id"].as_str().expect("event_id present");
+            let event_name = item.payload["event_name"]
+                .as_str()
+                .expect("event_name present");
+            // `bb…1<NN>` pairs with `Event <N>`.
+            let suffix = event_id
+                .rsplit('-')
+                .next()
+                .expect("uuid has a final group")
+                .to_string();
+            let index: u32 = suffix[suffix.len() - 2..]
+                .parse()
+                .expect("last two digits are the event index");
+            assert_eq!(
+                event_name,
+                format!("Event {index}"),
+                "event {event_id} was paired with another event's node ({event_name})"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Addresses the remaining work on #21, after re-verifying all six findings against `main` @ 07f5fbf5.

## What the tracking comment had wrong

Two findings listed as open were already shipped:

- **Finding 3 (transactions)** — `upsert_provenance_graph` already wraps node+edge batches in one transaction, all five production call sites use it (`tasks.rs` 1270/2421/3194/4204/4438), and `crates/database/tests/provenance_transaction.rs` covers both atomic commit and rollback-on-failure. Every caller of the raw `upsert_nodes`/`upsert_edges` is test code.
- **Finding 5 (`batch_search_similar`)** — pgvector already overrides it with a real single round-trip (`unnest … WITH ORDINALITY` + `CROSS JOIN LATERAL`, per-query `LIMIT`). It also has **zero production callers**, so it is left alone rather than extended to LanceDB, which has no native multi-query primitive anyway.

## What was actually broken

**Finding 1's N+1 fix only landed on Postgres.** `ladybug.rs::has_edges` — the *default* backend — still looped `has_edge` per candidate, each call interpolating a Cypher string and opening a fresh `Connection`. It is reached on the main cognify path through `retrieve_existing_edges` (`tasks.rs:906`) with every extracted edge of the run, immediately before a `MERGE` write that batches at 500.

Note the callsite: an earlier read of this pinned it at `tasks.rs:1285`, which is inside `create_web_page_nodes` and is empty for any non-URL corpus. The load-bearing path is `db_deduplication.rs:102`.

Now one query per 500 candidates via the `WHERE id IN [...]` read shape already proven on this engine (`get_neighborhood:1645`, `get_node_feedback_weights:1836`), then an exact client-side triple intersection mirroring `pg_graph_adapter.rs:770-793`. The `UNWIND`-over-map-literals form was the closer analogue to the write path, but every `UNWIND` in this crate is a *write* — there is no in-repo evidence the engine runs it as a read that returns rows — so the IN-list shape was chosen over adding an unproven pattern.

`get_nodes` and `delete_nodes` had the same per-item shape and get the same treatment. `delete_nodes` now also takes the write lock once per call rather than per node (it is hit with whole orphan sets from `cognee-delete`).

**`retrieve_existing_edges` never de-duplicated.** Candidates were pushed unconditionally, so a relation re-extracted from several chunks of one document cost a lookup per occurrence — and the `processed_nodes` set its own doc comment described as the dedup strategy was populated but never read. Dedup now happens in a `collect_distinct_candidate_edges` seam (directly unit-testable without a recording fake); the dead set is gone and the doc comment matches reality.

**Postgres was running six base-trait defaults.** `pg_graph_adapter` overrode only `get/set_node_truth_state`; `update_node_property`, `update_edge_property` and all four feedback-weight methods fell through to the defaults:

- `update_edge_property`'s default is a **warning-only no-op that reports success**, and `get_edge_feedback_weights`' default is an empty map — so edge feedback weights were silently **unwritable and unreadable on Postgres**. The new shared-suite case fails without the override (`None` instead of `Some(0.5)`), which is what establishes this as a real defect and not just a slow path.
- `update_node_property`'s default is `get_node` → `get_edges` → `delete_node` → `add_node_raw` → `add_edges`: five statements, no transaction, live on the memify feedback path. To be precise about severity — the happy path *does* restore the edges, so this is a non-atomicity window, not a deterministic loss. But an interruption between the delete and the re-add takes the node and its edges with it, and the edge read is `unwrap_or_default()`, so a failed read drops them on the recreate.

All six are now in-place: merge + `ON CONFLICT DO UPDATE` for nodes (never touching the edge table, the approach `set_node_truth_state` already used) and a `jsonb ||` merge for edges, with `RETURNING` driving the per-key success map so a nonexistent edge reports `false` instead of success.

## Also found, not fixed here

`ladybug.rs::get_nodeset_subgraph` issues one neighbor query per primary node. Left alone to keep this diff scoped — worth its own issue.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -D warnings` on both changed crates: clean
- `scripts/check_all.sh`: exit 0 (binding checks skip in a worktree, no venv; this diff touches no bindings)
- `cognee-graph` lib: **84 passed** (8 new)
- `ladybug_integration`: **38 passed** (5 new shared cases)
- `pg_graph_integration` against a throwaway Postgres 16: **38 passed** — confirmed from raw output that they ran rather than hit the `PGGRAPH_TEST_URL not set` skip

New coverage worth calling out: a chunk-boundary case over 600 candidates (half stored, alternating) so an off-by-one in the batching loop surfaces as a wrong result rather than merely slower work; and a cross-product case — the IN-list query matches a *superset*, so `(a,d)`/`(c,b)` pairs whose every component is in the batch but which were never stored must not come back.

## Deliberately not included

Re-profiling. `docs/performance/cpu-profiling.md` predates both #57 and the edge-write batching, and its 1061 `graph.query` calls are not attributed per call site (1061 is fewer than that corpus's 2744 edges), so before/after numbers need a fresh baseline run rather than a comparison against that document. Filed as the remaining acceptance item on #21 rather than guessed at here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pfb7fxYzQUeHYAFqQPPEbF
