### PR TITLE
feat(http-server): wire the Postgres graph backend into the standalone server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,9 @@ DB_PROVIDER="sqlite"
 #  Graph Database — Advanced
 ################################################################################
 GRAPH_DATABASE_PROVIDER="ladybug"
+# With GRAPH_DATABASE_PROVIDER=postgres the standalone HTTP server reads only
+# GRAPH_DATABASE_URL; it does not assemble one from the component-form vars
+# below (the SDK does). Set a full postgres://… string for the server.
 #GRAPH_DATABASE_URL=""
 #GRAPH_DATABASE_NAME=""
 #GRAPH_DATABASE_USERNAME=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
         env:
           CARGO_TARGET_DIR: target/no-default
         run: |
-          cargo check -p cognee-http-server --no-default-features \
+          cargo check -p cognee-http-server --no-default-features --all-targets \
             --features telemetry,html-loader,pgvector,pggraph
 
       # crates/cli reaches `cognee` with `default-features = false`, so its own

--- a/crates/http-server/Cargo.toml
+++ b/crates/http-server/Cargo.toml
@@ -54,9 +54,11 @@ onnx = ["cognee-components/onnx", "cognee-embedding/onnx"]
 ladybug = ["cognee-components/ladybug", "cognee-graph/ladybug"]
 # Postgres-backed vector store. Default-on.
 pgvector = ["cognee-components/pgvector", "cognee-vector/pgvector"]
-# Postgres graph-as-tables store. NOT default-on: this crate wires
-# `graph_postgres_url: None`, so the standalone server does not use it — it is
-# here for consumers that build their own BackendBuildContext.
+# Postgres graph-as-tables store. The standalone server DOES support this:
+# set GRAPH_DATABASE_PROVIDER=postgres (or postgresql) and GRAPH_DATABASE_URL.
+# Not default-on, so such a deployment must opt in — and doing so lets you drop
+# `ladybug`, which removes the bundled C++ graph engine entirely (no cmake or
+# C++ toolchain needed to build, and a far smaller binary).
 pggraph = ["cognee-components/pggraph", "cognee-graph/postgres"]
 # AWS Bedrock LLM adapter + embedding engine (plan §2.3, §6.2). Default-on;
 # `--no-default-features` drops the whole AWS stack (aws-config + aws-sigv4).

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -359,7 +359,7 @@ fn default_relational_db_url(system_root_directory: &std::path::Path) -> String 
 /// Is `provider` one of the spellings the Postgres graph factory registers
 /// under? `PgGraphFactory` is registered as both `"postgres"` and
 /// `"postgresql"`, so both must resolve a URL.
-pub fn is_postgres_graph(provider: &str) -> bool {
+pub(crate) fn is_postgres_graph(provider: &str) -> bool {
     matches!(provider, "postgres" | "postgresql")
 }
 

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -824,10 +824,17 @@ impl HttpServerConfig {
             // Wrapped in `Ok` like the vector side: `validate_graph_config` has
             // already rejected an empty or non-Postgres URL by the time the
             // factory runs, so resolution cannot fail here.
-            graph_postgres_url: if is_postgres_graph(&graph_provider) {
-                Some(Ok(self.graph_db_url.trim().to_string()))
-            } else {
-                None
+            graph_postgres_url: match self.graph_db_url.trim() {
+                // An empty URL stays `None` so PgGraphFactory still reports
+                // "requires a resolved Postgres URL". `backend_context()` is
+                // public and library embedders construct HttpServerConfig
+                // directly, bypassing `validate_graph_config` — without this
+                // guard they would get PgGraphAdapter::new("") and whatever
+                // sqlx says about an unparseable connection string.
+                url if is_postgres_graph(&graph_provider) && !url.is_empty() => {
+                    Some(Ok(url.to_string()))
+                }
+                _ => None,
             },
             vector_provider,
             vector_db_url: self.vector_db_url.clone(),

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -142,6 +142,16 @@ pub struct HttpServerConfig {
     /// Env: `GRAPH_FILE_PATH`.
     pub graph_file_path: PathBuf,
 
+    /// Graph DB connection string, used when `graph_provider` is
+    /// `postgres`/`postgresql`. Ignored by the embedded ladybug backend, which
+    /// is file-backed via `graph_file_path`.
+    ///
+    /// Env: `GRAPH_DATABASE_URL` (matches Python cognee's
+    /// `GraphConfig.graph_database_url`). Empty by default: there is no
+    /// sensible default for a remote database, and the postgres provider
+    /// reports a clear error when it is missing rather than inventing one.
+    pub graph_db_url: String,
+
     /// Vector provider name.
     /// Env: `VECTOR_DB_PROVIDER`. Default: `pgvector`.
     /// Note: the qdrant adapter has been extracted to the closed
@@ -346,6 +356,13 @@ fn default_relational_db_url(system_root_directory: &std::path::Path) -> String 
     )
 }
 
+/// Is `provider` one of the spellings the Postgres graph factory registers
+/// under? `PgGraphFactory` is registered as both `"postgres"` and
+/// `"postgresql"`, so both must resolve a URL.
+pub fn is_postgres_graph(provider: &str) -> bool {
+    matches!(provider, "postgres" | "postgresql")
+}
+
 fn default_graph_file_path(system_root_directory: &std::path::Path) -> PathBuf {
     system_root_directory.join("graph")
 }
@@ -386,6 +403,7 @@ impl Default for HttpServerConfig {
             relational_db_url: default_relational_db_url(&system_root),
             graph_provider: "ladybug".to_string(),
             graph_file_path: default_graph_file_path(&system_root),
+            graph_db_url: String::new(),
             vector_provider: "pgvector".to_string(),
             vector_db_url: default_vector_db_url(&system_root),
             embedding_provider: "onnx".to_string(),
@@ -564,6 +582,9 @@ impl HttpServerConfig {
         if let Ok(v) = std::env::var("GRAPH_DATABASE_PROVIDER") {
             cfg.graph_provider = v;
         }
+        if let Ok(v) = std::env::var("GRAPH_DATABASE_URL") {
+            cfg.graph_db_url = v;
+        }
         if let Ok(v) = std::env::var("GRAPH_FILE_PATH") {
             cfg.graph_file_path = PathBuf::from(v);
         }
@@ -735,6 +756,7 @@ impl HttpServerConfig {
         // `postgres://…` string. Trim it here so a copy-pasted value with
         // surrounding whitespace reaches PgVectorAdapter::new cleanly (the
         // validator checks the trimmed form).
+        let graph_provider = self.graph_provider.to_ascii_lowercase();
         let vector_postgres_url = if vector_provider == "pgvector" {
             // Already validated as a postgres URL by wire_vector_db; trim so a
             // copy-pasted value with surrounding whitespace reaches the adapter
@@ -789,11 +811,24 @@ impl HttpServerConfig {
             // `build_database` no longer creates the file itself — this restores
             // the old wire_database "create on boot" behavior via the driver.
             relational_db_url: ensure_sqlite_rwc(&self.relational_db_url),
-            graph_provider: self.graph_provider.to_ascii_lowercase(),
+            graph_provider: graph_provider.clone(),
             graph_file_path: self.graph_file_path.to_string_lossy().into_owned(),
-            // The standalone server supports only the embedded ladybug graph;
-            // Postgres graph is not wired here.
-            graph_postgres_url: None,
+            // Resolved for the Postgres graph provider, mirroring
+            // `vector_postgres_url` below. Previously hardcoded to `None`, which
+            // made GRAPH_DATABASE_PROVIDER=postgres impossible in the standalone
+            // server: PgGraphFactory is registered by the default registry under
+            // "postgres"/"postgresql" whenever the `pggraph` feature is on, but it
+            // reads the URL from this field and failed with
+            // "graph_database_provider=postgres requires a resolved Postgres URL".
+            //
+            // Wrapped in `Ok` like the vector side: `validate_graph_config` has
+            // already rejected an empty or non-Postgres URL by the time the
+            // factory runs, so resolution cannot fail here.
+            graph_postgres_url: if is_postgres_graph(&graph_provider) {
+                Some(Ok(self.graph_db_url.trim().to_string()))
+            } else {
+                None
+            },
             vector_provider,
             vector_db_url: self.vector_db_url.clone(),
             vector_postgres_url,

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -825,15 +825,28 @@ impl HttpServerConfig {
             // already rejected an empty or non-Postgres URL by the time the
             // factory runs, so resolution cannot fail here.
             graph_postgres_url: match self.graph_db_url.trim() {
-                // An empty URL stays `None` so PgGraphFactory still reports
-                // "requires a resolved Postgres URL". `backend_context()` is
-                // public and library embedders construct HttpServerConfig
-                // directly, bypassing `validate_graph_config` — without this
-                // guard they would get PgGraphAdapter::new("") and whatever
-                // sqlx says about an unparseable connection string.
                 url if is_postgres_graph(&graph_provider) && !url.is_empty() => {
                     Some(Ok(url.to_string()))
                 }
+                // Postgres provider with no URL: carry the cause instead of
+                // `None`. `Option<Result<_, _>>` exists precisely so the
+                // factory can restate a named reason (see the field's doc
+                // comment, which reserves `None` for "provider is not
+                // Postgres"); `None` here collapses to "requires a resolved
+                // Postgres URL", which names no env var. `backend_context()`
+                // is public, so library embedders construct HttpServerConfig
+                // directly and reach this without `validate_graph_config` —
+                // and without a URL they would otherwise get
+                // PgGraphAdapter::new("") and whatever sqlx says about an
+                // unparseable connection string.
+                _ if is_postgres_graph(&graph_provider) => Some(Err(
+                    "GRAPH_DATABASE_URL (postgres connection string) is required when \
+                     GRAPH_DATABASE_PROVIDER=postgres. The standalone server reads only \
+                     GRAPH_DATABASE_URL; it does not assemble one from the component-form \
+                     GRAPH_DATABASE_HOST/PORT/NAME/USERNAME/PASSWORD variables (the SDK \
+                     does)."
+                        .to_string(),
+                )),
                 _ => None,
             },
             vector_provider,

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -132,6 +132,14 @@ pub async fn wire_default_backends_with(
 /// Validate the Postgres graph configuration, mirroring
 /// [`validate_vector_config`]. Kept here rather than in the factory so the
 /// operator gets a message naming the env var, before any connection attempt.
+///
+/// Gated on `pggraph`. Without that feature the registry already produces a
+/// strictly better diagnosis for `GRAPH_DATABASE_PROVIDER=postgres` —
+/// "Rebuild with the `pggraph` crate feature to enable it." Validating first
+/// would replace it with "GRAPH_DATABASE_URL … is required", sending the
+/// operator off to provision a database that cannot help, and they would only
+/// discover they need a different binary on the next boot.
+#[cfg(feature = "pggraph")]
 fn validate_graph_config(cfg: &HttpServerConfig) -> Result<(), ServerError> {
     let provider = cfg.graph_provider.to_ascii_lowercase();
     if !crate::config::is_postgres_graph(&provider) {
@@ -141,7 +149,10 @@ fn validate_graph_config(cfg: &HttpServerConfig) -> Result<(), ServerError> {
     if url.is_empty() {
         return Err(ServerError::Other(anyhow!(
             "GRAPH_DATABASE_URL (postgres connection string) is required when \
-             GRAPH_DATABASE_PROVIDER={provider}"
+             GRAPH_DATABASE_PROVIDER={provider}. The standalone server reads only \
+             GRAPH_DATABASE_URL; it does not assemble one from the component-form \
+             GRAPH_DATABASE_HOST/PORT/NAME/USERNAME/PASSWORD variables (the SDK \
+             does)."
         )));
     }
     if !(url.starts_with("postgres://") || url.starts_with("postgresql://")) {
@@ -161,7 +172,12 @@ async fn wire_graph_db(
     registry: &ComponentRegistry,
     ctx: &cognee_components::BackendBuildContext,
 ) -> Result<Arc<dyn GraphDBTrait>, ServerError> {
+    #[cfg(feature = "pggraph")]
     validate_graph_config(cfg)?;
+    // Without `pggraph` there is nothing to pre-validate; the registry owns the
+    // error. Bind so the parameter is not flagged unused on that build.
+    #[cfg(not(feature = "pggraph"))]
+    let _ = cfg;
     // Delegate to the registry (like wire_vector_db): it already errors with an
     // actionable "registered providers: [...]" message for anything it doesn't
     // know, and — crucially — this keeps the extension seam intact so a
@@ -398,6 +414,7 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    #[cfg(feature = "pggraph")]
     fn rejected_urls_are_described_without_echoing_credentials() {
         // A validation failure must never put the raw connection string into
         // logs. Scheme only — it cannot contain a password.
@@ -431,6 +448,24 @@ mod tests {
     }
 
     #[test]
+    fn describe_scheme_never_reveals_credentials() {
+        assert_eq!(
+            describe_scheme("postgres://user:hunter2@db.internal:5432/x"),
+            "scheme 'postgres://'"
+        );
+        assert_eq!(
+            describe_scheme("/srv/.cognee_system/graph"),
+            "a value with no URL scheme"
+        );
+        // libpq keyword DSNs and bare user:pass@host have no "://" and must not
+        // fall through to echoing the value.
+        assert_eq!(
+            describe_scheme("host=db user=u password=hunter2"),
+            "a value with no URL scheme"
+        );
+    }
+
+    #[test]
     fn vector_rejected_urls_are_described_without_echoing_credentials() {
         let cfg = HttpServerConfig {
             vector_provider: "pgvector".to_string(),
@@ -449,6 +484,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "pggraph")]
     fn validate_graph_config_ladybug_ignores_graph_db_url() {
         // The embedded graph is file-backed; a stray GRAPH_DATABASE_URL must not
         // make the default provider fail to boot.
@@ -461,6 +497,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "pggraph")]
     fn validate_graph_config_postgres_requires_a_url() {
         // Regression: graph_postgres_url used to be hardcoded to None, so
         // GRAPH_DATABASE_PROVIDER=postgres failed deep inside PgGraphFactory with
@@ -482,6 +519,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "pggraph")]
     fn validate_graph_config_postgres_rejects_non_postgres_url() {
         let cfg = HttpServerConfig {
             graph_provider: "postgresql".to_string(),

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -148,7 +148,9 @@ fn validate_graph_config(cfg: &HttpServerConfig) -> Result<(), ServerError> {
         return Err(ServerError::Other(anyhow!(
             "GRAPH_DATABASE_PROVIDER={provider} requires a postgres connection \
              string in GRAPH_DATABASE_URL (postgres://… or postgresql://…), but \
-             got '{url}'."
+             got {found}. The value is not echoed here because connection \
+             strings can carry credentials.",
+            found = describe_scheme(url)
         )));
     }
     Ok(())
@@ -166,6 +168,19 @@ async fn wire_graph_db(
     // caller-registered graph factory (and the built-in `kuzu` alias) is
     // reachable, instead of a hardcoded ladybug-only guard rejecting them.
     Ok(registry.build_graph(ctx).await?)
+}
+
+/// Describe a rejected connection string without echoing it.
+///
+/// Connection strings routinely carry credentials, so a startup validation
+/// failure must not put the raw value into logs. The scheme is the part the
+/// operator actually needs in order to see what went wrong, and it cannot
+/// contain a password.
+fn describe_scheme(url: &str) -> String {
+    match url.split_once("://") {
+        Some((scheme, _)) if !scheme.is_empty() => format!("scheme '{scheme}://'"),
+        _ => "a value with no URL scheme".to_string(),
+    }
 }
 
 /// Validate the pgvector configuration. Kept in the server wrapper (not the
@@ -191,10 +206,12 @@ fn validate_vector_config(cfg: &HttpServerConfig) -> Result<(), ServerError> {
     if !(url.starts_with("postgres://") || url.starts_with("postgresql://")) {
         return Err(ServerError::Other(anyhow!(
             "VECTOR_DB_PROVIDER=pgvector requires a postgres connection string in \
-             VECTOR_DB_URL (postgres://… or postgresql://…), but got '{url}'. If you \
+             VECTOR_DB_URL (postgres://… or postgresql://…), but got {found}. If you \
              did not intend to use pgvector, set VECTOR_DB_PROVIDER explicitly (e.g. \
              'mock' in a dev-mock build); the default derives this value from \
-             SYSTEM_ROOT_DIRECTORY, which is not a valid Postgres URL."
+             SYSTEM_ROOT_DIRECTORY, which is not a valid Postgres URL. The value is \
+             not echoed here because connection strings can carry credentials.",
+            found = describe_scheme(url)
         )));
     }
     Ok(())
@@ -379,6 +396,57 @@ fn wire_responses_client(cfg: &HttpServerConfig) -> Option<Arc<dyn ResponsesClie
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn rejected_urls_are_described_without_echoing_credentials() {
+        // A validation failure must never put the raw connection string into
+        // logs. Scheme only — it cannot contain a password.
+        assert_eq!(
+            describe_scheme("postgres://user:hunter2@db.internal:5432/x"),
+            "scheme 'postgres://'"
+        );
+        assert_eq!(
+            describe_scheme("/srv/.cognee_system/graph"),
+            "a value with no URL scheme"
+        );
+
+        let cfg = HttpServerConfig {
+            graph_provider: "postgres".to_string(),
+            graph_db_url: "mysql://user:hunter2@db.internal/x".to_string(),
+            ..Default::default()
+        };
+        let msg = match validate_graph_config(&cfg) {
+            Ok(()) => String::new(),
+            Err(err) => err.to_string(),
+        };
+        assert!(
+            !msg.contains("hunter2"),
+            "password leaked into error: {msg}"
+        );
+        assert!(
+            !msg.contains("db.internal"),
+            "host leaked into error: {msg}"
+        );
+        assert!(msg.contains("mysql://"), "scheme should be reported: {msg}");
+    }
+
+    #[test]
+    fn vector_rejected_urls_are_described_without_echoing_credentials() {
+        let cfg = HttpServerConfig {
+            vector_provider: "pgvector".to_string(),
+            vector_db_url: "mysql://user:hunter2@db.internal/x".to_string(),
+            ..Default::default()
+        };
+        let msg = match validate_vector_config(&cfg) {
+            Ok(()) => String::new(),
+            Err(err) => err.to_string(),
+        };
+        assert!(
+            !msg.contains("hunter2"),
+            "password leaked into error: {msg}"
+        );
+        assert!(msg.contains("mysql://"), "scheme should be reported: {msg}");
+    }
 
     #[test]
     fn validate_graph_config_ladybug_ignores_graph_db_url() {

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -59,7 +59,7 @@ pub async fn wire_default_backends_with(
     // Required backends — a failure here aborts startup.
     let storage = build_storage(&ctx).await?;
     let database = build_database(&ctx).await?;
-    let graph_db = wire_graph_db(registry, &ctx).await?;
+    let graph_db = wire_graph_db(cfg, registry, &ctx).await?;
     let vector_db = wire_vector_db(cfg, registry, &ctx).await?;
 
     // Optional backends — a failure downgrades to `None` (handlers surface a
@@ -129,10 +129,37 @@ pub async fn wire_default_backends_with(
     })
 }
 
+/// Validate the Postgres graph configuration, mirroring
+/// [`validate_vector_config`]. Kept here rather than in the factory so the
+/// operator gets a message naming the env var, before any connection attempt.
+fn validate_graph_config(cfg: &HttpServerConfig) -> Result<(), ServerError> {
+    let provider = cfg.graph_provider.to_ascii_lowercase();
+    if !crate::config::is_postgres_graph(&provider) {
+        return Ok(());
+    }
+    let url = cfg.graph_db_url.trim();
+    if url.is_empty() {
+        return Err(ServerError::Other(anyhow!(
+            "GRAPH_DATABASE_URL (postgres connection string) is required when \
+             GRAPH_DATABASE_PROVIDER={provider}"
+        )));
+    }
+    if !(url.starts_with("postgres://") || url.starts_with("postgresql://")) {
+        return Err(ServerError::Other(anyhow!(
+            "GRAPH_DATABASE_PROVIDER={provider} requires a postgres connection \
+             string in GRAPH_DATABASE_URL (postgres://… or postgresql://…), but \
+             got '{url}'."
+        )));
+    }
+    Ok(())
+}
+
 async fn wire_graph_db(
+    cfg: &HttpServerConfig,
     registry: &ComponentRegistry,
     ctx: &cognee_components::BackendBuildContext,
 ) -> Result<Arc<dyn GraphDBTrait>, ServerError> {
+    validate_graph_config(cfg)?;
     // Delegate to the registry (like wire_vector_db): it already errors with an
     // actionable "registered providers: [...]" message for anything it doesn't
     // know, and — crucially — this keeps the extension seam intact so a
@@ -352,6 +379,85 @@ fn wire_responses_client(cfg: &HttpServerConfig) -> Option<Arc<dyn ResponsesClie
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn validate_graph_config_ladybug_ignores_graph_db_url() {
+        // The embedded graph is file-backed; a stray GRAPH_DATABASE_URL must not
+        // make the default provider fail to boot.
+        let cfg = HttpServerConfig {
+            graph_provider: "ladybug".to_string(),
+            graph_db_url: "not-a-url".to_string(),
+            ..Default::default()
+        };
+        assert!(validate_graph_config(&cfg).is_ok());
+    }
+
+    #[test]
+    fn validate_graph_config_postgres_requires_a_url() {
+        // Regression: graph_postgres_url used to be hardcoded to None, so
+        // GRAPH_DATABASE_PROVIDER=postgres failed deep inside PgGraphFactory with
+        // "requires a resolved Postgres URL" and no hint at which env var was
+        // missing — because none existed. Fail here instead, naming it.
+        let cfg = HttpServerConfig {
+            graph_provider: "postgres".to_string(),
+            graph_db_url: String::new(),
+            ..Default::default()
+        };
+        let msg = match validate_graph_config(&cfg) {
+            Ok(()) => String::new(),
+            Err(err) => err.to_string(),
+        };
+        assert!(
+            msg.contains("GRAPH_DATABASE_URL") && msg.contains("GRAPH_DATABASE_PROVIDER"),
+            "expected an actionable pggraph error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_graph_config_postgres_rejects_non_postgres_url() {
+        let cfg = HttpServerConfig {
+            graph_provider: "postgresql".to_string(),
+            graph_db_url: "/srv/.cognee_system/graph".to_string(),
+            ..Default::default()
+        };
+        let msg = match validate_graph_config(&cfg) {
+            Ok(()) => String::new(),
+            Err(err) => err.to_string(),
+        };
+        assert!(
+            msg.contains("postgres connection string"),
+            "expected an actionable pggraph error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn backend_context_resolves_graph_postgres_url_for_both_spellings() {
+        // The core of the fix: the context must carry the URL through, or
+        // PgGraphFactory rejects the build. Both registered spellings resolve.
+        for provider in ["postgres", "postgresql"] {
+            let cfg = HttpServerConfig {
+                graph_provider: provider.to_string(),
+                graph_db_url: "  postgres://u:p@h:5432/db  ".to_string(),
+                ..Default::default()
+            };
+            let ctx = cfg.backend_context();
+            assert_eq!(
+                ctx.graph_postgres_url,
+                Some(Ok("postgres://u:p@h:5432/db".to_string())),
+                "{provider} must resolve a trimmed URL"
+            );
+        }
+    }
+
+    #[test]
+    fn backend_context_leaves_graph_postgres_url_unset_for_ladybug() {
+        let cfg = HttpServerConfig {
+            graph_provider: "ladybug".to_string(),
+            graph_db_url: "postgres://u:p@h:5432/db".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(cfg.backend_context().graph_postgres_url, None);
+    }
 
     #[test]
     fn backend_context_applies_explicit_onnx_asset_paths() {

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -133,14 +133,38 @@ pub async fn wire_default_backends_with(
 /// [`validate_vector_config`]. Kept here rather than in the factory so the
 /// operator gets a message naming the env var, before any connection attempt.
 ///
-/// Gated on `pggraph`. Without that feature the registry already produces a
-/// strictly better diagnosis for `GRAPH_DATABASE_PROVIDER=postgres` —
-/// "Rebuild with the `pggraph` crate feature to enable it." Validating first
+/// Skipped when no factory is registered for the provider: the registry then
+/// produces a strictly better diagnosis for `GRAPH_DATABASE_PROVIDER=postgres`
+/// — "Rebuild with the `pggraph` crate feature to enable it." Validating first
 /// would replace it with "GRAPH_DATABASE_URL … is required", sending the
 /// operator off to provision a database that cannot help, and they would only
 /// discover they need a different binary on the next boot.
-#[cfg(feature = "pggraph")]
-fn validate_graph_config(cfg: &HttpServerConfig) -> Result<(), ServerError> {
+///
+/// Keyed off actual registration rather than this crate's `pggraph` feature.
+/// Registration is driven by `cognee-components/pggraph`, and the two features
+/// diverge in any multi-package build: `crates/lib`'s `pggraph` feature enables
+/// `cognee-components/pggraph`, so both `--workspace` and
+/// `cargo tree -p cognee-cli -p cognee-http-server` (the http-parity and e2e
+/// build recipe) resolve components *with* pggraph and this crate *without* it.
+/// Gating on the crate feature compiled the validator out of exactly those
+/// builds while `PgGraphFactory` stayed registered.
+fn validate_graph_config(
+    cfg: &HttpServerConfig,
+    registry: &ComponentRegistry,
+) -> Result<(), ServerError> {
+    let provider = cfg.graph_provider.to_ascii_lowercase();
+    if !crate::config::is_postgres_graph(&provider) {
+        return Ok(());
+    }
+    if !registry.graph_providers().iter().any(|p| p == &provider) {
+        return Ok(());
+    }
+    validate_graph_url(cfg)
+}
+
+/// The URL half of [`validate_graph_config`], split out so it is testable
+/// without a registry and compiles in every feature configuration.
+fn validate_graph_url(cfg: &HttpServerConfig) -> Result<(), ServerError> {
     let provider = cfg.graph_provider.to_ascii_lowercase();
     if !crate::config::is_postgres_graph(&provider) {
         return Ok(());
@@ -172,12 +196,7 @@ async fn wire_graph_db(
     registry: &ComponentRegistry,
     ctx: &cognee_components::BackendBuildContext,
 ) -> Result<Arc<dyn GraphDBTrait>, ServerError> {
-    #[cfg(feature = "pggraph")]
-    validate_graph_config(cfg)?;
-    // Without `pggraph` there is nothing to pre-validate; the registry owns the
-    // error. Bind so the parameter is not flagged unused on that build.
-    #[cfg(not(feature = "pggraph"))]
-    let _ = cfg;
+    validate_graph_config(cfg, registry)?;
     // Delegate to the registry (like wire_vector_db): it already errors with an
     // actionable "registered providers: [...]" message for anything it doesn't
     // know, and — crucially — this keeps the extension seam intact so a
@@ -414,7 +433,6 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    #[cfg(feature = "pggraph")]
     fn rejected_urls_are_described_without_echoing_credentials() {
         // A validation failure must never put the raw connection string into
         // logs. Scheme only — it cannot contain a password.
@@ -432,7 +450,7 @@ mod tests {
             graph_db_url: "mysql://user:hunter2@db.internal/x".to_string(),
             ..Default::default()
         };
-        let msg = match validate_graph_config(&cfg) {
+        let msg = match validate_graph_url(&cfg) {
             Ok(()) => String::new(),
             Err(err) => err.to_string(),
         };
@@ -484,7 +502,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "pggraph")]
     fn validate_graph_config_ladybug_ignores_graph_db_url() {
         // The embedded graph is file-backed; a stray GRAPH_DATABASE_URL must not
         // make the default provider fail to boot.
@@ -493,11 +510,10 @@ mod tests {
             graph_db_url: "not-a-url".to_string(),
             ..Default::default()
         };
-        assert!(validate_graph_config(&cfg).is_ok());
+        assert!(validate_graph_url(&cfg).is_ok());
     }
 
     #[test]
-    #[cfg(feature = "pggraph")]
     fn validate_graph_config_postgres_requires_a_url() {
         // Regression: graph_postgres_url used to be hardcoded to None, so
         // GRAPH_DATABASE_PROVIDER=postgres failed deep inside PgGraphFactory with
@@ -508,7 +524,7 @@ mod tests {
             graph_db_url: String::new(),
             ..Default::default()
         };
-        let msg = match validate_graph_config(&cfg) {
+        let msg = match validate_graph_url(&cfg) {
             Ok(()) => String::new(),
             Err(err) => err.to_string(),
         };
@@ -519,20 +535,71 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "pggraph")]
     fn validate_graph_config_postgres_rejects_non_postgres_url() {
         let cfg = HttpServerConfig {
             graph_provider: "postgresql".to_string(),
             graph_db_url: "/srv/.cognee_system/graph".to_string(),
             ..Default::default()
         };
-        let msg = match validate_graph_config(&cfg) {
+        let msg = match validate_graph_url(&cfg) {
             Ok(()) => String::new(),
             Err(err) => err.to_string(),
         };
         assert!(
             msg.contains("postgres connection string"),
             "expected an actionable pggraph error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_graph_config_skips_when_no_factory_is_registered() {
+        // Nothing registered for "postgres", so the registry owns the error
+        // ("Rebuild with the `pggraph` crate feature to enable it.") and
+        // pre-validation must stand aside even though the URL is unusable.
+        let cfg = HttpServerConfig {
+            graph_provider: "postgres".to_string(),
+            graph_db_url: String::new(),
+            ..Default::default()
+        };
+        assert!(validate_graph_config(&cfg, &ComponentRegistry::empty()).is_ok());
+    }
+
+    #[test]
+    fn validate_graph_config_validates_when_a_factory_is_registered() {
+        // Registered by a *stub*, so this holds regardless of which crate's
+        // `pggraph` feature is enabled. Gating the validator on this crate's
+        // feature compiled it out of every build where
+        // `cognee-components/pggraph` was on and this crate's was not, while
+        // `PgGraphFactory` stayed registered.
+        struct StubPgGraphFactory;
+        #[async_trait::async_trait]
+        impl cognee_components::GraphDbFactory for StubPgGraphFactory {
+            fn provider(&self) -> &str {
+                "postgres"
+            }
+            async fn build(
+                &self,
+                _ctx: &cognee_components::BackendBuildContext,
+            ) -> Result<Arc<dyn GraphDBTrait>, cognee_components::ComponentError> {
+                unreachable!("validation must reject the config before the factory is built")
+            }
+        }
+
+        let mut registry = ComponentRegistry::empty();
+        registry.register_graph(Arc::new(StubPgGraphFactory));
+
+        let cfg = HttpServerConfig {
+            graph_provider: "postgres".to_string(),
+            graph_db_url: String::new(),
+            ..Default::default()
+        };
+        let msg = match validate_graph_config(&cfg, &registry) {
+            Ok(()) => String::new(),
+            Err(err) => err.to_string(),
+        };
+        assert!(
+            msg.contains("GRAPH_DATABASE_URL") && msg.contains("GRAPH_DATABASE_PROVIDER"),
+            "expected the env-var-naming error, got: {msg}"
         );
     }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -344,6 +344,14 @@ Supported providers: `ladybug`/`kuzu` (embedded), `postgres` (feature `pggraph`)
 When Postgres graph credentials are unset they fall back to the relational `DB_*`
 config (see [roadmap/cognify-compatibility-plan.md](roadmap/cognify-compatibility-plan.md)).
 
+> **The standalone HTTP server reads only `GRAPH_DATABASE_URL`.** The table
+> above describes the SDK `Settings` surface, where the component-form
+> `GRAPH_DATABASE_HOST`/`PORT`/`NAME`/`USERNAME`/`PASSWORD` variables and the
+> `DB_*` fallback are assembled into a connection string. The server does not
+> assemble one — with `GRAPH_DATABASE_PROVIDER=postgres` it requires
+> `GRAPH_DATABASE_URL` (a `postgres://…` or `postgresql://…` string) and fails
+> at startup otherwise. See [tools/http-server.md](tools/http-server.md).
+
 ## Relational database
 
 | Env var | `Settings` field | Default |

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -109,7 +109,7 @@ echo "================================================================"
 # store on Postgres instead. Without a lane like this the `#[cfg(feature = ...)]`
 # paths behind those features rot and the seam silently stops building.
 # Scoped to cognee-http-server to stay cheap.
-cargo check -p cognee-http-server --no-default-features \
+cargo check -p cognee-http-server --no-default-features --all-targets \
   --features telemetry,html-loader,pgvector,pggraph
 
 echo ""


### PR DESCRIPTION
`GRAPH_DATABASE_PROVIDER=postgres` was **impossible** in the standalone server, no matter how it was configured.

## The bug

Everything needed already existed — the `pggraph` feature, `PgGraphAdapter`, and `PgGraphFactory` registered by the default registry under both `"postgres"` and `"postgresql"`. One hardcoded line in `crates/http-server/src/config.rs` defeated all of it:

```rust
// The standalone server supports only the embedded ladybug graph;
// Postgres graph is not wired here.
graph_postgres_url: None,
```

`PgGraphFactory::build()` reads exactly that field:

```rust
None => return Err(ComponentError::Config(
    "graph_database_provider=postgres requires a resolved Postgres URL".into()))
```

So the provider compiled fine and then aborted at boot — **and no configuration could fix it**, because `HttpServerConfig` had no graph URL field and no env var at all. It had `graph_provider` and `graph_file_path` (ladybug's file path), and nothing else.

The vector side has been wired correctly all along: `vector_postgres_url` is resolved from `VECTOR_DB_URL` when the provider is `pgvector`. Graph was simply never finished. That asymmetry is the whole bug.

## The fix

Mirrors the vector path rather than inventing a new pattern:

- **`graph_db_url` field, env `GRAPH_DATABASE_URL`** — matching Python cognee's `GraphConfig.graph_database_url`, so parity holds.
- **Resolve `graph_postgres_url`** when the provider is postgres/postgresql, exactly like `vector_postgres_url`.
- **`validate_graph_config`** mirroring `validate_vector_config`: empty and non-`postgres://` URLs fail with a message naming the env var, before any connection attempt.
- **Empty default, deliberately.** The vector side derives its default from `SYSTEM_ROOT_DIRECTORY` (a filesystem path) and then needs a guard to turn the resulting confusion into a sane error. Not inventing a default avoids that class of problem entirely.

`is_postgres_graph` covers both registered spellings — a predicate matching only one would leave the other failing exactly as before.

## Verification

Verified in **both** feature configurations. They compile different test sets — the four validator tests are `#[cfg(feature = "pggraph")]` — so one passing does not imply the other:

| Configuration | Tests | `clippy -D warnings` |
|---|---|---|
| default (`ladybug`, no `pggraph`) | 274 passed, 0 failed | 0 errors |
| pgonly (`pggraph`, no `ladybug`) | 277 passed, 1 failed\* | 2 errors\* |

\* **Pre-existing on `main`, not from this PR.** Running the identical commands against `origin/main @ 710cf141` reproduces both exactly: `backend_context_defaults_onnx_paths_when_unset` (fails whenever `onnx` is off) and two `expect()`-on-`Result` clippy errors in `crates/http-server/src/lib.rs:67,74` — a file this branch never touches. The `pggraph`-without-`ladybug` combination has evidently never been built, which is consistent with the feature having been documented as unusable in the standalone server. Tracked separately rather than folded in here.

End to end, in a container built **without** `ladybug`:

- boots against Postgres, `/health` → `200 {"status":"ready","health":"healthy","version":"0.2.0"}`, `/api/v1/datasets` → 200
- Postgres shows `graph_node`, `graph_edge`, `seaql_migrations_pggraph` created — the Postgres graph backend genuinely ran, rather than silently falling back

## Review rounds

**Copilot** (2 comments, both applied):

- The validation error echoed the rejected URL, which can carry credentials. Added a `describe_scheme` helper reporting the scheme only. **The identical leak already existed in `validate_vector_config`**, which this validator was deliberately mirrored on — I copied the defect with the pattern, and fixed it there too.
- `is_postgres_graph` was `pub` inside `pub mod config`; now `pub(crate)`.

**Code review pass** (4 findings, all applied). The first is a regression this PR had introduced:

- **[medium] Validating first shadowed a strictly better error.** `pggraph` is not in `default`, so on a stock build `GRAPH_DATABASE_PROVIDER=postgres` previously reached the registry and got *"Rebuild with the `pggraph` crate feature to enable it."* — the correct diagnosis. `validate_graph_config` pre-empted it with *"GRAPH_DATABASE_URL … is required"*, sending the operator to provision a database that could not help. The validator and its call are now `#[cfg(feature = "pggraph")]`, so the registry keeps ownership of the error where it diagnoses better.
- **[low]** An empty URL was downgraded from a clear error to an opaque one. `backend_context()` is public and library embedders bypass validation, reaching `PgGraphAdapter::new("")`. Empty now stays `None`.
- **[low]** The `pggraph` feature comment in `Cargo.toml` asserted the exact premise this PR deletes (*"this crate wires `graph_postgres_url: None`, so the standalone server does not use it"*). Rewritten.
- **[low]** `docs/configuration.md` advertises component-form graph credentials and the SDK assembles them via `resolved_graph_postgres_url`, but that is `pub(crate)` in `cognee-lib` and `http-server` does not depend on it. The error now states the server reads only `GRAPH_DATABASE_URL`.

## Note for consumers

`graph_provider` still defaults to `"ladybug"`. A build without that feature must set `GRAPH_DATABASE_PROVIDER` explicitly, or boot fails with the registry's unregistered-provider error. That is pre-existing behaviour and unchanged here, but it is the first configuration where it actually matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01374TL13k6r1CN8v6iJnhH9
