### PR TITLE
fix(http-server): repair the non-default feature builds (onnx-off test, shutdown panic)

### DIFF
--- a/crates/http-server/src/lib.rs
+++ b/crates/http-server/src/lib.rs
@@ -59,22 +59,47 @@ use std::net::SocketAddr;
 ///
 /// Only compiled when the `bin` feature is enabled so the library does not
 /// require `tokio/signal`.
+///
+/// **Never panics.** Installing a signal handler is an OS call that can fail,
+/// and this future is the argument to `with_graceful_shutdown` — an unwind out
+/// of it aborts the serve task *before* [`serve_with_shutdown`] reaches
+/// `lifecycle::on_shutdown`, i.e. it re-introduces exactly the leak that
+/// topoteretes/cognee-rs#132 fixed. A handler that cannot be installed is also
+/// no reason to refuse to serve: the signal just keeps its OS default
+/// disposition, so the process still dies on SIGINT/SIGTERM, only without
+/// draining first. A failed registration is therefore logged and that arm parks
+/// forever, leaving the other signal — and the teardown path behind it —
+/// working.
 #[cfg(feature = "bin")]
 async fn shutdown_signal() {
     use tokio::signal;
 
     let ctrl_c = async {
-        signal::ctrl_c()
-            .await
-            .expect("failed to install Ctrl+C handler");
+        if let Err(error) = signal::ctrl_c().await {
+            tracing::error!(
+                %error,
+                "failed to install the Ctrl+C handler; SIGINT will terminate the process \
+                 without draining in-flight requests"
+            );
+            std::future::pending::<()>().await;
+        }
     };
 
     #[cfg(unix)]
     let terminate = async {
-        signal::unix::signal(signal::unix::SignalKind::terminate())
-            .expect("failed to install SIGTERM handler")
-            .recv()
-            .await;
+        match signal::unix::signal(signal::unix::SignalKind::terminate()) {
+            Ok(mut sigterm) => {
+                sigterm.recv().await;
+            }
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    "failed to install the SIGTERM handler; SIGTERM will terminate the process \
+                     without draining in-flight requests"
+                );
+                std::future::pending::<()>().await;
+            }
+        }
     };
 
     #[cfg(not(unix))]

--- a/crates/http-server/src/wiring.rs
+++ b/crates/http-server/src/wiring.rs
@@ -381,6 +381,18 @@ mod tests {
         );
     }
 
+    // Gated on `onnx` because the fallback asserted below only exists in an
+    // `onnx` build. `cognee_components::onnx_asset_defaults()` reads
+    // `cognee_embedding::OnnxEmbeddingConfig::default()` under
+    // `cognee-components`'s own `onnx` cfg and returns inert (empty) paths
+    // otherwise — deliberately, because `build_embedding_config` populates
+    // `EmbeddingConfig::onnx` under that same cfg and so never reads them. The
+    // `./target/models` default is therefore unobservable *and* unused without
+    // `onnx`, which makes this a test of ONNX-build behaviour, not a bug.
+    // This crate's `onnx` forwards to `cognee-components/onnx`, so the gate is
+    // sufficient: under feature unification it can only skip the test (when our
+    // `onnx` is off but the dependency's is unified on), never fail it.
+    #[cfg(feature = "onnx")]
     #[test]
     fn backend_context_defaults_onnx_paths_when_unset() {
         let cfg = HttpServerConfig {


### PR DESCRIPTION
Two pre-existing bugs that make `cognee-http-server` fail to build or test in any non-default feature configuration. Surfaced while working on #179 (which enables `pggraph` without `ladybug`); neither is caused by that PR.

Both reproduce on `main` @ `710cf141`:

```
cargo test   -p cognee-http-server --lib      --no-default-features --features "bin,pggraph,pgvector,telemetry,html-loader"
cargo clippy -p cognee-http-server --all-targets --no-default-features --features "bin,pggraph,pgvector,telemetry,html-loader" -- -D warnings
```

---

## 1. `backend_context_defaults_onnx_paths_when_unset` fails whenever `onnx` is off — `9083fa8a`

`backend_context()` resolves the unset-path fallback through `cognee_components::onnx_asset_defaults()`, which is cfg'd on **`cognee-components`' own `onnx` feature**: with it on, the `./target/models` BGE-Small paths; with it off, `PathBuf::new()`. The test asserts the former unconditionally, so it panics with an empty `got `.

**Gated the test on `onnx`; no assertion changed** (+12/−0, comment + `#[cfg]`).

That is the correct call rather than the convenient one. The only reader of `onnx_model_path`/`onnx_tokenizer_path` anywhere in the workspace is `build_embedding_config`, which populates `EmbeddingConfig::onnx` under the *same* cfg — so without `onnx` the empty paths are provably never read. `onnx_asset_defaults`' own doc comment says as much: the inert branch is *"provably unread rather than merely intended to be."* "Fixing production" would mean duplicating the `./target/models` literal outside the crate that owns the default, which that comment explicitly rejects.

The gate is safe under feature unification too: this crate's `onnx` forwards to `cognee-components/onnx`, so the implication runs one way — the gate can only skip the test, never fail it.

## 2. `shutdown_signal()` panics if a signal handler cannot install — `dcb5145f`

Two `clippy::expect_used` errors at `lib.rs:67,74`. The lint is the symptom; the panic is the bug.

`shutdown_signal()` is passed to `with_graceful_shutdown` inside `serve_with_shutdown`, which is deliberately ordered so teardown runs **after** serving returns:

```rust
let served = axum::serve(listener, app)
    .with_graceful_shutdown(shutdown)
    .await;

// Draining is complete here — or the accept loop failed. Either way the
// resources are still open, so tear down before propagating.
lifecycle::on_shutdown(&state).await;
```

An unwind out of the shutdown future aborts before `on_shutdown` is ever reached — silently re-opening **#132**, whose fix exists precisely because *"dropping them is not closing them"* (that comment is already in this file).

`expect()` was also indefensible on its own terms: installing a signal handler is an OS call returning `io::Error`, so there is no invariant to assert, and the project convention asks `expect` messages to explain why something *cannot* fail — these stated only what did.

Failing fast at startup would be wrong too: a handler that will not install costs the graceful *drain*, not the ability to serve. And on non-Unix `signal::ctrl_c()` has no separable registration step to hoist before `bind()`, so it would not even be uniformly a startup failure.

**Chosen: log at `error` and park that arm with `future::pending()`.** What makes this bounded rather than a silent swallow — if registration fails the signal keeps its **OS default disposition**, so SIGINT/SIGTERM still terminate the process, just without draining. The other arm keeps working, teardown stays reachable, and call sites are unchanged.

---

## Why these went unnoticed: the binary is never linted

Every clippy invocation in the repo runs default features only:

| Location | Command |
|---|---|
| `.github/workflows/ci.yml:206` | `cargo clippy --all-targets -- -D warnings` |
| `.github/workflows/ci.yml:224` | `cargo clippy --all-targets --features telemetry -- -D warnings` |
| `.github/workflows/community.yml:104` | `cargo clippy --all-targets -- -D warnings` |
| `scripts/check_all.sh:79` | `cargo clippy --all-targets -- -D warnings` |

`bin` is not in `default`, and `[[bin]]` carries `required-features = ["bin"]`, so even `--all-targets` skips it. `shutdown_signal` is `#[cfg(feature = "bin")]` and is never type-checked. The `--features telemetry` step exists as a cfg-gated-lint mirror, but `telemetry` is already default-on for this crate, so it adds nothing.

Nor can feature unification close it: `cargo metadata` confirms **no** workspace crate depends on `cognee-http-server`, so nothing pulls `bin` in transitively. The result is that `main.rs`, the clap arg parsing, `dotenv` and `shutdown_signal` are linted by **no** CI job and by no local gate.

A step such as `cargo clippy -p cognee-http-server --all-targets --features bin -- -D warnings` would close it. **Deliberately not included here** — this PR fixes today's instances; the blind spot is a separate decision.

## Verification

| Gate | Result |
|---|---|
| `clippy` pgonly `-D warnings` | clean (was 2 errors) |
| `clippy` default `-D warnings` | clean |
| tests pgonly | **269 passed**, 0 failed (was 1 failed) |
| tests default | **270 passed**, 0 failed |
| `cargo fmt --check` | clean |

The gated test was re-run by exact name under default features to confirm it still executes rather than silently vanishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01374TL13k6r1CN8v6iJnhH9