### PR TITLE
fix(deps): pin aws-smithy-runtime-api-macros to =1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ aws-sigv4 = "=1.4.5"
 aws-smithy-runtime-api = "=1.12.3"
 # aws-smithy-runtime-api 1.12.3 depends on this as `^1.0.0`, so an unpinned
 # resolve takes 1.1.0 — which raised its MSRV to 1.94.1 and fails this
-# workspace's rust-version = 1.91. 1.0.0 declares 1.91.0 and is compatible.
+# workspace's rust-version = 1.91.1. 1.0.0 declares 1.91.0 and is compatible.
 aws-smithy-runtime-api-macros = "=1.0.0"
 # Transitive smithy crates, pinned for the same reason. They are not imported
 # directly; they are declared so the pin exists at all. Cargo.lock is

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,10 @@ aws-config = "=1.8.18"
 aws-credential-types = "=1.2.14"
 aws-sigv4 = "=1.4.5"
 aws-smithy-runtime-api = "=1.12.3"
+# aws-smithy-runtime-api 1.12.3 depends on this as `^1.0.0`, so an unpinned
+# resolve takes 1.1.0 — which raised its MSRV to 1.94.1 and fails this
+# workspace's rust-version = 1.91. 1.0.0 declares 1.91.0 and is compatible.
+aws-smithy-runtime-api-macros = "=1.0.0"
 # Transitive smithy crates, pinned for the same reason. They are not imported
 # directly; they are declared so the pin exists at all. Cargo.lock is
 # .gitignore'd in this repo, so every clone and every CI run resolves from

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -26,8 +26,10 @@ bedrock = [
     "dep:aws-credential-types",
     "dep:aws-sigv4",
     "dep:aws-smithy-runtime-api",
-    # Not imported by this crate — declared only to hold the MSRV pin on two
-    # transitive smithy crates. See the workspace manifest.
+    # Not imported by this crate — declared only to hold the MSRV pin on three
+    # transitive smithy crates. See the workspace manifest. Add to this list
+    # whenever a new transitive smithy crate needs pinning; a pin in
+    # [workspace.dependencies] is inert until some crate references it.
     "dep:aws-smithy-async",
     "dep:aws-smithy-types",
     "dep:aws-smithy-runtime-api-macros",

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -30,6 +30,7 @@ bedrock = [
     # transitive smithy crates. See the workspace manifest.
     "dep:aws-smithy-async",
     "dep:aws-smithy-types",
+    "dep:aws-smithy-runtime-api-macros",
 ]
 
 [dependencies]
@@ -71,6 +72,7 @@ aws-credential-types = { workspace = true, optional = true }
 aws-sigv4 = { workspace = true, optional = true }
 aws-smithy-async = { workspace = true, optional = true }
 aws-smithy-runtime-api = { workspace = true, optional = true }
+aws-smithy-runtime-api-macros = { workspace = true, optional = true }
 aws-smithy-types = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
`aws-smithy-runtime-api = "=1.12.3"` depends on `aws-smithy-runtime-api-macros` as `^1.0.0`. Only three versions exist:

| version | `rust-version` | published |
|---|---|---|
| 1.1.0 | **1.94.1** | 2026-07-07 |
| **1.0.0** | **1.91.0** | 2026-04-16 |
| 0.0.1 | – | 2026-04-15 |

A resolve that is free to take 1.1.0 lands on an MSRV above this workspace's `rust-version = "1.91"`, and the build dies before compiling anything:

```
error: rustc 1.93.0 is not supported by the following package:
  aws-smithy-runtime-api-macros@1.1.0 requires rustc 1.94.1
```

## 1.0.0 is not a downgrade to an untried version

It is what every tree that **successfully built** was already using:

```
cognee-rust-oss/Cargo.lock                    runtime-api=1.12.3  macros=1.0.0   builds
cognee-cloud-rs/cognee-rust-oss/Cargo.lock    runtime-api=1.12.3  macros=1.0.0   builds
cognee-cloud-rs/Cargo.lock                    runtime-api=1.12.3  macros=1.1.0   failed
```

The 1.1.0 entry came from a lockfile written during a resolve that then failed on MSRV — it never corresponded to a working build. 1.0.0 is also the newest version the declared `rust-version` permits; taking 1.1.0 would mean raising the MSRV of both this workspace and its consumers.

## Where it was observed, and where it wasn't

The failure surfaced in the **closed consumer workspace** (`topoteretes/cognee-cloud-rs`), which path-deps into this tree and enables `bedrock`.

Building *this* repo standalone currently resolves correctly on its own — cargo reports `Locking 993 packages to latest Rust 1.91.1 compatible versions` and declines `aws-config 1.11.0` unprompted. So this is not a claim that MSRV-aware resolution is broken. The pin makes the constraint **explicit** rather than dependent on resolver behaviour, on a consumer's resolver settings, or on whatever a consumer's existing lockfile already contains — which is precisely what went wrong.

## In-convention, not a new technique

This manifest already pins `aws-smithy-async` and `aws-smithy-types` the same way, and `cognee-llm` already declares them as unused optional deps purely so the pins exist. The existing comment explains why:

> Transitive smithy crates, pinned for the same reason. They are not imported directly; they are declared so the pin exists at all. `Cargo.lock` is `.gitignore`'d in this repo, so every clone and every CI run resolves from scratch…

`aws-smithy-runtime-api-macros` is a third crate joining that list — it escaped the existing net when AWS published 1.1.0 in July.

## Verification

| Check | Result |
|---|---|
| `cargo check -p cognee-llm --features bedrock` on rustc 1.91.1 | ✅ clean, 23.68s |
| Full closed workspace (10 crates + this tree) with the pin | ✅ 0 errors, 4m17s |

## Worth considering separately

This is the third transitive AWS crate needing a manual pin, and it will keep recurring as AWS publishes new ones. Committing `Cargo.lock` would fix the class of problem rather than each instance — standard practice for a repo shipping binaries. Deliberately not bundled here, since it changes a repo-wide convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01374TL13k6r1CN8v6iJnhH9