### PR TITLE
perf(cognify): stop copying the corpus payload four extra times (SDK-507)

### DIFF
--- a/crates/cognify/src/graph_integration/db_deduplication.rs
+++ b/crates/cognify/src/graph_integration/db_deduplication.rs
@@ -55,7 +55,9 @@ use crate::fact_extraction::KnowledgeGraph;
 /// only remove redundant lookups: the caller folds the results into a
 /// `HashSet` of edge keys, so a repeated candidate could never have changed
 /// the outcome.
-fn collect_distinct_candidate_edges(graphs: &[KnowledgeGraph]) -> Vec<EdgeData> {
+fn collect_distinct_candidate_edges<'a>(
+    graphs: impl IntoIterator<Item = &'a KnowledgeGraph>,
+) -> Vec<EdgeData> {
     let mut seen: HashSet<(String, String, String)> = HashSet::new();
     let mut edges_to_check: Vec<EdgeData> = Vec::new();
 
@@ -87,14 +89,14 @@ fn collect_distinct_candidate_edges(graphs: &[KnowledgeGraph]) -> Vec<EdgeData> 
     edges_to_check
 }
 
-pub async fn retrieve_existing_edges(
+/// Takes any iterator of borrowed graphs rather than a slice, so a caller
+/// holding `Vec<(Uuid, KnowledgeGraph)>` can project out the graphs without
+/// deep-cloning every one of them just to change the element type. Only three
+/// `&str` fields per edge are ever read, so nothing here needs ownership.
+pub async fn retrieve_existing_edges<'a>(
     graph_db: &dyn GraphDBTrait,
-    graphs: &[KnowledgeGraph],
+    graphs: impl IntoIterator<Item = &'a KnowledgeGraph>,
 ) -> Result<HashSet<String>, CognifyError> {
-    if graphs.is_empty() {
-        return Ok(HashSet::new());
-    }
-
     let edges_to_check = collect_distinct_candidate_edges(graphs);
 
     if edges_to_check.is_empty() {

--- a/crates/cognify/src/graph_integration/db_deduplication.rs
+++ b/crates/cognify/src/graph_integration/db_deduplication.rs
@@ -11,41 +11,6 @@ use cognee_models::Entity;
 use crate::error::CognifyError;
 use crate::fact_extraction::KnowledgeGraph;
 
-/// Retrieve existing edges from the graph database.
-///
-/// This function:
-/// 1. Collects all edges from the knowledge graphs
-/// 2. Generates deterministic UUIDs for entity nodes using `Entity::id_for()`
-/// 3. Batch queries the graph database to check which edges already exist
-/// 4. Returns a set of existing edge keys
-///
-/// **Edge key format:** `"{source_uuid}_{target_uuid}_{relationship_name}"`
-/// (matches the format used in `expand_with_nodes_and_edges`)
-///
-/// **Deduplication strategy:** the candidate `(source, target, relationship)`
-/// triples are de-duplicated before the query. Chunk-level extraction routinely
-/// yields the same relation from several chunks of one document, and the return
-/// value is a set of edge keys, so a repeated triple can only ever cost an
-/// extra lookup — never change the result.
-///
-/// # Arguments  
-/// * `graph_db` - Graph database trait object
-/// * `graphs` - Knowledge graphs extracted from text chunks
-///
-/// # Returns
-/// HashSet containing edge identifiers that already exist in the database
-///
-/// # Example
-/// ```ignore
-/// let graphs = vec![knowledge_graph1, knowledge_graph2];
-/// let existing_edges = retrieve_existing_edges(&graph_db, &graphs).await?;
-///
-/// // Check if edge exists before creating
-/// let edge_key = format!("{}_{}_{}",  source_id, target_id, "works_at");
-/// if !existing_edges.contains(&edge_key) {
-///     // Create new edge
-/// }
-/// ```
 /// Collect the distinct `(source_uuid, target_uuid, relationship_name)`
 /// candidates to look up, in first-seen order.
 ///
@@ -74,8 +39,10 @@ fn collect_distinct_candidate_edges<'a>(
 
             // Note: relationship_name is already normalized by LLM or should be
             let key = (source_uuid, target_uuid, edge.relationship_name.clone());
-            if !seen.contains(&key) {
-                seen.insert(key.clone());
+            // `insert` reports novelty, so this hashes the three-String tuple
+            // once instead of twice (`contains` then `insert`). The clone is
+            // needed either way, to keep `key` for the push below.
+            if seen.insert(key.clone()) {
                 edges_to_check.push((
                     key.0,
                     key.1,
@@ -89,10 +56,45 @@ fn collect_distinct_candidate_edges<'a>(
     edges_to_check
 }
 
-/// Takes any iterator of borrowed graphs rather than a slice, so a caller
-/// holding `Vec<(Uuid, KnowledgeGraph)>` can project out the graphs without
-/// deep-cloning every one of them just to change the element type. Only three
-/// `&str` fields per edge are ever read, so nothing here needs ownership.
+/// Retrieve existing edges from the graph database.
+///
+/// This function:
+/// 1. Collects all edges from the knowledge graphs
+/// 2. Generates deterministic UUIDs for entity nodes using `Entity::id_for()`
+/// 3. Batch queries the graph database to check which edges already exist
+/// 4. Returns a set of existing edge keys
+///
+/// **Edge key format:** `"{source_uuid}_{target_uuid}_{relationship_name}"`
+/// (matches the format used in `expand_with_nodes_and_edges`)
+///
+/// **Deduplication strategy:** the candidate `(source, target, relationship)`
+/// triples are de-duplicated before the query. Chunk-level extraction routinely
+/// yields the same relation from several chunks of one document, and the return
+/// value is a set of edge keys, so a repeated triple can only ever cost an
+/// extra lookup — never change the result.
+///
+/// # Arguments
+/// * `graph_db` - Graph database trait object
+/// * `graphs` - Any iterator of borrowed knowledge graphs extracted from text
+///   chunks. Deliberately not a slice: a caller holding
+///   `Vec<(Uuid, KnowledgeGraph)>` can project the graphs out without
+///   deep-cloning every one of them to change the element type, and only three
+///   `&str` fields per edge are ever read, so nothing here needs ownership.
+///
+/// # Returns
+/// HashSet containing edge identifiers that already exist in the database
+///
+/// # Example
+/// ```ignore
+/// let graphs = vec![knowledge_graph1, knowledge_graph2];
+/// let existing_edges = retrieve_existing_edges(&graph_db, &graphs).await?;
+///
+/// // Check if edge exists before creating
+/// let edge_key = format!("{}_{}_{}", source_id, target_id, "works_at");
+/// if !existing_edges.contains(&edge_key) {
+///     // Create new edge
+/// }
+/// ```
 pub async fn retrieve_existing_edges<'a>(
     graph_db: &dyn GraphDBTrait,
     graphs: impl IntoIterator<Item = &'a KnowledgeGraph>,

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -915,9 +915,13 @@ pub async fn extract_graph_from_data(
             }
         };
 
-    // Database deduplication — query for existing edges
-    let graphs_only: Vec<KnowledgeGraph> = all_graphs.iter().map(|(_, g)| g.clone()).collect();
-    let existing_edges_set = retrieve_existing_edges(graph_db.as_ref(), &graphs_only).await?;
+    // Database deduplication — query for existing edges.
+    //
+    // Borrow the graphs out of `all_graphs` rather than deep-cloning every one
+    // of them (SDK-507): the callee only reads three `&str` fields per edge, so
+    // a second full copy of every extracted graph bought nothing.
+    let existing_edges_set =
+        retrieve_existing_edges(graph_db.as_ref(), all_graphs.iter().map(|(_, g)| g)).await?;
 
     // Merge and deduplicate graphs (with DB awareness).
     //
@@ -3884,13 +3888,28 @@ pub(crate) fn unwrap_execution_error(e: cognee_core::pipeline::ExecutionError) -
 /// `CognifyResult`. Mirrors `cognee_ingestion::pipeline::extract_data_outputs`
 /// (LIB-06-01) and `cognee_cognify::memify::extract_memify_outputs` (LIB-06-02).
 fn extract_cognify_outputs(outputs: Vec<Arc<dyn Value>>) -> Result<CognifyResult, CognifyError> {
-    let first = outputs
+    let mut first = outputs
         .into_iter()
         .next()
         .ok_or(CognifyError::OutputTypeMismatch {
             expected: "CognifyResult",
             actual: "empty",
         })?;
+
+    // Move the result out of the `Arc` when this is the last handle to it —
+    // the executor drops its own before returning — instead of deep-cloning
+    // the entire corpus payload (chunks, entities, edges, summaries and every
+    // embedding) one more time on the way out (SDK-507). `CognifyResult::empty`
+    // is the natural vacated value; it allocates nothing.
+    //
+    // Falls through to the clone below when the `Arc` is still shared, so the
+    // observable result is the same either way.
+    if let Some(value) = Arc::get_mut(&mut first)
+        && let Some(result) = value.as_any_mut().downcast_mut::<CognifyResult>()
+    {
+        return Ok(std::mem::replace(result, CognifyResult::empty()));
+    }
+
     // Explicit deref through `Arc` to reach the inner `dyn Value`, then call
     // `as_any` via vtable dispatch — without this, method resolution would
     // pick the blanket `<Arc<dyn Value> as Value>::as_any()` which downcasts
@@ -4566,7 +4585,7 @@ async fn generate_embeddings(
 /// parallel slices.
 async fn reuse_or_embed(
     engine: &Arc<dyn EmbeddingEngine>,
-    precomputed: &std::collections::HashMap<Uuid, Vec<f32>>,
+    precomputed: &std::collections::HashMap<Uuid, &[f32]>,
     ids: &[Uuid],
     texts: &[&str],
 ) -> Result<Vec<Vec<f32>>, CognifyError> {
@@ -4590,7 +4609,10 @@ async fn reuse_or_embed(
     let mut fresh = fresh.into_iter();
     ids.iter()
         .map(|id| match precomputed.get(id) {
-            Some(vector) => Ok(vector.clone()),
+            // Copy once, here, at the point the owned vector is actually
+            // needed — the map itself borrows from `precomputed_embeddings`
+            // rather than holding a second copy of every vector (SDK-507).
+            Some(vector) => Ok(vector.to_vec()),
             None => fresh
                 .next()
                 .ok_or_else(|| CognifyError::EmbeddingError("missing fresh embedding".into())),
@@ -4621,9 +4643,13 @@ async fn index_data_points(
     // Vectors already produced by `generate_embeddings`, keyed by data point id,
     // so the chunk/entity/summary collections below reuse them rather than
     // re-embedding the same text.
-    let precomputed: std::collections::HashMap<Uuid, Vec<f32>> = precomputed_embeddings
+    // Borrowed, not cloned (SDK-507): this map used to hold a second full copy
+    // of every chunk, entity and summary vector for the whole of
+    // `index_data_points` — ~1 GB at 1536 dimensions on a 170k-chunk corpus,
+    // live alongside the retained originals and the per-collection copies.
+    let precomputed: std::collections::HashMap<Uuid, &[f32]> = precomputed_embeddings
         .iter()
-        .map(|e| (e.data_point_id, e.vector.clone()))
+        .map(|e| (e.data_point_id, e.vector.as_slice()))
         .collect();
 
     // 1. Index DocumentChunk.text field
@@ -4658,7 +4684,11 @@ async fn index_data_points(
                 // 2. Context-specific keys not present on the DataPoint.
                 point = point
                     .with_metadata("field", json!("text"))
-                    .with_metadata("text", json!(chunk.text.clone()))
+                    // `json!(expr)` routes a non-literal through `to_value`,
+                    // which serialises the clone into a *second* String before
+                    // dropping the first. Constructing the node directly moves
+                    // the one copy we have to make (SDK-507).
+                    .with_metadata("text", serde_json::Value::String(chunk.text.clone()))
                     .with_metadata("dataset_id", json!(dataset_id.to_string()))
                     .with_metadata("document_id", json!(chunk.document_id.to_string()))
                     .with_metadata("chunk_index", json!(chunk.chunk_index));
@@ -4829,7 +4859,8 @@ async fn index_data_points(
                 // 2. Context-specific keys not present on the DataPoint.
                 point = point
                     .with_metadata("field", json!("text"))
-                    .with_metadata("text", json!(summary.text.clone()))
+                    // See the chunk-text note above — one copy, not two.
+                    .with_metadata("text", serde_json::Value::String(summary.text.clone()))
                     .with_metadata("dataset_id", json!(dataset_id.to_string()));
                 if let Some(made_from) = summary.made_from {
                     point = point.with_metadata("chunk_id", json!(made_from.to_string()));
@@ -10570,5 +10601,66 @@ mod tests {
                     && row.data_id == Uuid::nil()),
             "the schema-level FK edge spans data items"
         );
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod extract_cognify_outputs_tests {
+    use super::*;
+
+    fn sample_result() -> CognifyResult {
+        let mut result = CognifyResult::empty();
+        result.pipeline_run_id = Some(Uuid::from_u128(7));
+        result.already_completed = true;
+        result
+    }
+
+    /// The sole handle is moved out of the `Arc`, not deep-cloned (SDK-507).
+    #[test]
+    fn takes_the_result_when_the_arc_is_unique() {
+        let outputs: Vec<Arc<dyn Value>> = vec![Arc::new(sample_result())];
+
+        let extracted = extract_cognify_outputs(outputs).expect("downcast succeeds");
+
+        assert_eq!(extracted.pipeline_run_id, Some(Uuid::from_u128(7)));
+        assert!(extracted.already_completed);
+    }
+
+    /// A still-shared `Arc` falls back to the clone, so the payload is intact
+    /// *and* the other handle never observes the vacated value.
+    #[test]
+    fn clones_the_result_when_the_arc_is_shared() {
+        let shared: Arc<dyn Value> = Arc::new(sample_result());
+        let retained = Arc::clone(&shared);
+
+        let extracted = extract_cognify_outputs(vec![shared]).expect("downcast succeeds");
+        assert_eq!(extracted.pipeline_run_id, Some(Uuid::from_u128(7)));
+
+        let still_there = (*retained)
+            .as_any()
+            .downcast_ref::<CognifyResult>()
+            .expect("the retained handle still holds a CognifyResult");
+        assert_eq!(
+            still_there.pipeline_run_id,
+            Some(Uuid::from_u128(7)),
+            "the shared path must not empty the value the other handle sees"
+        );
+    }
+
+    #[test]
+    fn reports_a_type_mismatch_for_an_empty_output_list() {
+        let err = extract_cognify_outputs(vec![]).expect_err("no outputs is an error");
+        assert!(matches!(
+            err,
+            CognifyError::OutputTypeMismatch {
+                actual: "empty",
+                ..
+            }
+        ));
     }
 }

--- a/crates/cognify/src/tasks.rs
+++ b/crates/cognify/src/tasks.rs
@@ -10613,33 +10613,60 @@ mod tests {
 mod extract_cognify_outputs_tests {
     use super::*;
 
+    /// Carries a **non-empty** heap-backed field on purpose. Whether the
+    /// result was moved or cloned is otherwise unobservable — both produce
+    /// equal values — but a move preserves the `Vec`'s allocation while a
+    /// clone must allocate a fresh one, so `as_ptr()` discriminates. An empty
+    /// `Vec` would not: its pointer is dangling and shared between instances.
     fn sample_result() -> CognifyResult {
         let mut result = CognifyResult::empty();
         result.pipeline_run_id = Some(Uuid::from_u128(7));
         result.already_completed = true;
+        result.edge_types = vec![EdgeType::new_deterministic("works_at", None)];
         result
     }
 
     /// The sole handle is moved out of the `Arc`, not deep-cloned (SDK-507).
+    ///
+    /// The pointer assertion is what gives this test teeth: delete the
+    /// `Arc::get_mut` fast path and the value assertions below still pass,
+    /// because the clone fallback produces an equal result. Only the retained
+    /// allocation proves the move actually happened.
     #[test]
     fn takes_the_result_when_the_arc_is_unique() {
-        let outputs: Vec<Arc<dyn Value>> = vec![Arc::new(sample_result())];
+        let result = sample_result();
+        let heap_before = result.edge_types.as_ptr();
+        let outputs: Vec<Arc<dyn Value>> = vec![Arc::new(result)];
 
         let extracted = extract_cognify_outputs(outputs).expect("downcast succeeds");
 
         assert_eq!(extracted.pipeline_run_id, Some(Uuid::from_u128(7)));
         assert!(extracted.already_completed);
+        assert_eq!(extracted.edge_types.len(), 1);
+        assert!(
+            std::ptr::eq(extracted.edge_types.as_ptr(), heap_before),
+            "a unique Arc must be moved out, not deep-cloned: the payload's \
+             allocation should survive extraction untouched"
+        );
     }
 
-    /// A still-shared `Arc` falls back to the clone, so the payload is intact
-    /// *and* the other handle never observes the vacated value.
+    /// A still-shared `Arc` falls back to the clone, so the payload is intact,
+    /// the other handle never observes the vacated value, and the extracted
+    /// result genuinely is a copy rather than a steal.
     #[test]
     fn clones_the_result_when_the_arc_is_shared() {
-        let shared: Arc<dyn Value> = Arc::new(sample_result());
+        let result = sample_result();
+        let heap_before = result.edge_types.as_ptr();
+        let shared: Arc<dyn Value> = Arc::new(result);
         let retained = Arc::clone(&shared);
 
         let extracted = extract_cognify_outputs(vec![shared]).expect("downcast succeeds");
         assert_eq!(extracted.pipeline_run_id, Some(Uuid::from_u128(7)));
+        assert!(
+            !std::ptr::eq(extracted.edge_types.as_ptr(), heap_before),
+            "a shared Arc must be cloned, so the extracted payload owns a \
+             fresh allocation"
+        );
 
         let still_there = (*retained)
             .as_any()
@@ -10649,6 +10676,11 @@ mod extract_cognify_outputs_tests {
             still_there.pipeline_run_id,
             Some(Uuid::from_u128(7)),
             "the shared path must not empty the value the other handle sees"
+        );
+        assert_eq!(
+            still_there.edge_types.len(),
+            1,
+            "the retained handle keeps its own payload intact"
         );
     }
 


### PR DESCRIPTION
Tier 1 of **SDK-507**. Removes four whole-corpus copies from a cognify run without changing what any stage computes.

Every copy removed here was already redundant, so there is no behavioural change and no parity change. The structural work — bounding residency properly — is tiers 2 and 3, and is deliberately **not** in this PR.

## What changed

| Site | Was | Now |
|---|---|---|
| `tasks.rs` edge dedup | Deep-cloned every extracted graph out of `Vec<(Uuid, KnowledgeGraph)>` purely to drop the `Uuid` from the tuple | `retrieve_existing_edges` takes any iterator of borrowed graphs; it reads three `&str` fields per edge and never needed ownership |
| `index_data_points` `precomputed` | A second full copy of every chunk, entity and summary vector, live for the whole function | Borrows out of `precomputed_embeddings`; the one copy that is genuinely needed happens in `reuse_or_embed`, where an owned vector is returned |
| Chunk / summary vector metadata | `json!(text.clone())` — `json!` routes a non-literal through `to_value`, which serialises the clone into a *second* `String` before the first drops | `Value::String(text.clone())` — one copy, not two |
| `extract_cognify_outputs` | Deep-cloned the entire `CognifyResult` out of the `Arc` on the way out | Moves it when it is the last handle (the executor drops its own before returning); falls back to the clone when still shared |

The `precomputed` one is the largest: on the order of a gigabyte at 1536 dimensions on a 170k-chunk corpus, held alongside the retained originals and the per-collection copies.

## Adversarial review changed the ticket

SDK-507 went through a pre-implementation pass instructed to refute it, the same treatment that retired SDK-510 and rescoped SDK-517. Verdict: **confirmed but rescoped.**

- All four anchors survive on current `main` — #155 reshaped the extraction loop but removed no clone.
- The ticket's headline sentence is wrong: it is one copy *between* stages, two *during*, three at each stage's tail. But it **understates** the real peak — in `add_data_points` a chunk's text exists in roughly 6–8 independent allocations.
- The 3.3 GB scale figure is unsupported. "19 KB/chunk" came from a War-and-Peace benchmark and is inconsistent with "one chunk per document" unless the documents are themselves ~19 KB.
- **Parity argues *for* this work**, unusually. Python runs the task chain per data item with `data_per_batch=20`, so its residency is bounded by ~20 documents in flight while Rust holds the whole dataset. Tier 3 is essentially Python's execution model.

## One tier-1 item deliberately dropped

The ticket lists "replace `CognifyResult::embeddings` with a count; every non-test consumer only calls `.len()`". That is true of the four production consumers — but `crates/cognify/tests/integration_embeddings.rs` reads the vectors themselves in **nine places across five tests**. Removing the field would delete the only coverage of embedding generation, on top of being a public-API break on a re-exported type.

If reclaiming those retained vectors is worth it, it should be a config-gated retention flag as its own change, so the test can opt in.

## Still open

Tiers 2 and 3 are gated on measuring the bytes-per-document slope, and no instrumentation in the repo can produce that today. The cheapest settling measurement is to cognify a 1% sample under `/usr/bin/time -l` and scale max RSS. **Until that exists, the "Urgent" priority on SDK-507 is not backed by evidence** — no OOM was ever observed; the corpus run that prompted the finding died on NUL bytes (#149).

## Verification

- `cargo check --workspace --all-targets` — exit 0
- `cargo clippy -p cognee-cognify --all-targets -- -D warnings` — exit 0
- `cargo fmt --check` — exit 0
- `cargo test -p cognee-cognify --lib` — 325 passed, 0 failed (322 before, plus 3 new)

The three new tests pin `extract_cognify_outputs`: the unique-`Arc` move path, the shared-`Arc` clone fallback (asserting the other handle does not observe the vacated value), and the empty-output error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194nijjRDrwHFRHGmtSGYwg
