### PR TITLE
fix(embedding): make MOCK_EMBEDDING=true deterministic, not zero vectors

### DIFF
--- a/capi/README.md
+++ b/capi/README.md
@@ -218,7 +218,7 @@ Tested on Linux x86_64 (CI) and Android aarch64 (slim build, ONNX local embeddin
 | `EMBEDDING_DIMENSIONS` | Embedding vector dimensions. |
 | `EMBEDDING_ENDPOINT` | Embedding API base URL (falls back to `OPENAI_URL`). |
 | `EMBEDDING_API_KEY` | Embedding API key (falls back to `OPENAI_TOKEN`). |
-| `MOCK_EMBEDDING` | Set `true` to use zero-vector mock embeddings (no model download). |
+| `MOCK_EMBEDDING` | Set `true` to use deterministic SHA-256-derived mock embeddings (no model download); `zero` gives all-zero vectors instead. |
 | `RUST_LOG`, `LOG_LEVEL` | `tracing-subscriber` env-filter level overrides. |
 | `COGNEE_LOG_*`, `LOG_FILE_NAME` | Consumed by `cognee_setup_logging()` — see docs/configuration.md (Logging section). |
 | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_*` | Consumed by `cognee_init_otlp()`. |

--- a/crates/cli/tests/cli_memify.rs
+++ b/crates/cli/tests/cli_memify.rs
@@ -31,7 +31,7 @@ fn test_memify_help() {
 // These follow the `cognify_live_smoke` pattern from cli_e2e.rs:
 // - Isolated TempDir per test with its own COGNEE_CONFIG_HOME and workdir.
 // - `config_set` writes settings via the `cognee-cli config set` subcommand.
-// - `MOCK_EMBEDDING=true` forces zero-vector embeddings (no network for the
+// - `MOCK_EMBEDDING=true` forces deterministic mock embeddings (no network for the
 //   embedding path). Memify itself never calls the LLM.
 // - LLM-gated tests short-circuit with a printed skip message when
 //   OPENAI_TOKEN / OPENAI_URL / OPENAI_MODEL are not all set, matching the

--- a/crates/cognify/src/memify/distill_sessions.rs
+++ b/crates/cognify/src/memify/distill_sessions.rs
@@ -1010,10 +1010,11 @@ mod tests {
     use cognee_embedding::MockEmbeddingEngine;
     use cognee_vector::{MockVectorDB, VectorPoint};
 
-    /// Sixteen-element vector matching `MockEmbeddingEngine::new(16)`. The engine
-    /// defaults to zero vectors, so every stored point scores identically and
-    /// `search_similar`'s stable sort returns them in insertion order — making
-    /// dedup/limit assertions deterministic.
+    /// Sixteen-element vector matching `MockEmbeddingEngine::new(16)`. Every
+    /// stored point carries this same vector, so whatever the (deterministic)
+    /// query vector is, they all score identically and `search_similar`'s stable
+    /// sort returns them in insertion order — making dedup/limit assertions
+    /// deterministic.
     fn v16() -> Vec<f32> {
         vec![0.25_f32; 16]
     }

--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -122,7 +122,7 @@ mod tests {
                 rate_limit_requests: 60,
                 rate_limit_interval: 60,
                 mock: true,
-                mock_deterministic: false,
+                mock_mode: Default::default(),
                 api_version: None,
                 huggingface_tokenizer: None,
                 max_completion_tokens: 8191,

--- a/crates/components/src/builtins/embedding.rs
+++ b/crates/components/src/builtins/embedding.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use cognee_embedding::{EmbeddingConfig, EmbeddingEngine, EmbeddingProvider, MockVectorMode};
+use cognee_embedding::{EmbeddingConfig, EmbeddingEngine, EmbeddingProvider};
 
 use crate::context::{BackendBuildContext, EmbeddingInputs};
 use crate::error::ComponentError;
@@ -82,7 +82,7 @@ fn parse_embedding_provider(provider: &str) -> Option<EmbeddingProvider> {
 /// non-empty unrecognized values separately (see [`DefaultEmbeddingFactory`]) so
 /// a typo surfaces as an error rather than a silent ONNX fallback.
 /// `MOCK_EMBEDDING` handling is expressed through [`EmbeddingInputs::mock`] /
-/// [`EmbeddingInputs::mock_deterministic`], which the caller populates.
+/// [`EmbeddingInputs::mock_mode`], which the caller populates.
 #[allow(
     clippy::field_reassign_with_default,
     reason = "the `onnx` field is cfg-gated on the embedding crate's own feature \
@@ -94,12 +94,6 @@ pub fn build_embedding_config(inputs: &EmbeddingInputs) -> EmbeddingConfig {
         EmbeddingProvider::Mock
     } else {
         parse_embedding_provider(&inputs.provider).unwrap_or(EmbeddingProvider::Onnx)
-    };
-
-    let mock_mode = if inputs.mock_deterministic {
-        MockVectorMode::Deterministic
-    } else {
-        MockVectorMode::Zero
     };
 
     // Start from the embedding crate's own defaults and override the fields we
@@ -119,7 +113,7 @@ pub fn build_embedding_config(inputs: &EmbeddingInputs) -> EmbeddingConfig {
     config.max_completion_tokens = inputs.max_completion_tokens;
     config.batch_size = inputs.batch_size;
     config.mock = inputs.mock;
-    config.mock_mode = mock_mode;
+    config.mock_mode = inputs.mock_mode;
     config.huggingface_tokenizer = inputs.huggingface_tokenizer.clone();
     // Same feature-unification caveat as `onnx` above, with a benign
     // degradation: when `cognee-embedding/bedrock` is unified on while *this*
@@ -234,7 +228,7 @@ mod tests {
             rate_limit_requests: 60,
             rate_limit_interval: 60,
             mock,
-            mock_deterministic: false,
+            mock_mode: Default::default(),
             api_version: None,
             huggingface_tokenizer: None,
             max_completion_tokens: 8191,

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -12,6 +12,8 @@
 use std::fmt;
 use std::path::PathBuf;
 
+use cognee_embedding::MockVectorMode;
+
 /// Resolved inputs consumed by [`crate::ComponentRegistry`] and the free
 /// `build_storage` / `build_database` constructors.
 #[derive(Clone)]
@@ -84,8 +86,10 @@ pub struct EmbeddingInputs {
     pub rate_limit_interval: u32,
     /// `MOCK_EMBEDDING` opt-in — overrides `provider` to the mock engine.
     pub mock: bool,
-    /// When `mock` is set, selects SHA-256-derived vectors instead of zeros.
-    pub mock_deterministic: bool,
+    /// When `mock` is set, how the mock engine fills vectors. Defaults to
+    /// SHA-256-derived content-stable vectors; `MOCK_EMBEDDING=zero` selects
+    /// all-zero vectors (which cosine KNN backends never retrieve).
+    pub mock_mode: MockVectorMode,
     /// Forward-compat fields historically read from the environment.
     pub api_version: Option<String>,
     pub huggingface_tokenizer: Option<String>,

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -733,7 +733,7 @@ mod tests {
                 rate_limit_requests: 60,
                 rate_limit_interval: 60,
                 mock: false,
-                mock_deterministic: false,
+                mock_mode: Default::default(),
                 api_version: None,
                 huggingface_tokenizer: None,
                 max_completion_tokens: 8191,

--- a/crates/embedding/README.md
+++ b/crates/embedding/README.md
@@ -20,7 +20,8 @@ Selected via `EmbeddingProvider` (or the `EMBEDDING_PROVIDER` env var):
   (`cohere.embed-*`; batched). Output is always L2-normalised — Titan v2
   server-side, the rest client-side. Shares the AWS plumbing (region/endpoint
   chains, credential ladder, SigV4) with `cognee-llm`'s Bedrock adapter
-- **`MockEmbeddingEngine`** — zero vectors for testing (`MOCK_EMBEDDING=true`)
+- **`MockEmbeddingEngine`** — deterministic SHA-256-derived vectors for testing
+  (`MOCK_EMBEDDING=true`); `MOCK_EMBEDDING=zero` gives all-zero vectors
 
 The default provider is **OpenAI `text-embedding-3-small`** (1536-d) on host
 platforms and local **ONNX** on Android (when the `onnx` feature is enabled).

--- a/crates/embedding/src/config.rs
+++ b/crates/embedding/src/config.rs
@@ -178,7 +178,8 @@ impl OnnxEmbeddingConfig {
 ///
 /// Environment variables (match Python SDK names):
 /// - `EMBEDDING_PROVIDER` — backend selection (default: `openai`; `onnx` on Android)
-/// - `MOCK_EMBEDDING` — set to `true`/`1`/`yes` to force mock mode
+/// - `MOCK_EMBEDDING` — `true`/`1`/`yes`/`deterministic` force the mock engine
+///   with SHA-256-derived vectors; `zero` forces it with all-zero vectors
 /// - `EMBEDDING_MODEL` — model identifier
 /// - `EMBEDDING_DIMENSIONS` — vector size
 /// - `EMBEDDING_ENDPOINT` — API endpoint URL
@@ -226,8 +227,10 @@ pub struct EmbeddingConfig {
     pub mock: bool,
 
     /// How the mock engine generates vectors when `provider` is `Mock`.
-    /// Defaults to [`MockVectorMode::Zero`]. Set via `MOCK_EMBEDDING=deterministic`
-    /// to derive content-stable vectors from `sha256(text)`.
+    /// Defaults to [`MockVectorMode::Deterministic`] (content-stable vectors
+    /// from `sha256(text)`, selected by any truthy `MOCK_EMBEDDING` value).
+    /// `MOCK_EMBEDDING=zero` opts into [`MockVectorMode::Zero`], under which
+    /// cosine KNN retrieval is vacuously empty.
     #[serde(default)]
     pub mock_mode: MockVectorMode,
 
@@ -304,7 +307,7 @@ impl Default for EmbeddingConfig {
             max_completion_tokens: 8191,
             batch_size: 36,
             mock: false,
-            mock_mode: MockVectorMode::Zero,
+            mock_mode: MockVectorMode::default(),
             #[cfg(feature = "onnx")]
             onnx: OnnxEmbeddingConfig::default(),
             huggingface_tokenizer: None,
@@ -323,20 +326,23 @@ impl EmbeddingConfig {
         let mut config = Self::default();
 
         // Parse MOCK_EMBEDDING first — it overrides everything else if set.
-        // `deterministic` (or `hash`) selects the SHA-256-derived deterministic
-        // mode; other truthy values keep the legacy zero-vector mode.
+        // Every truthy spelling (`true`/`1`/`yes`, plus the explicit
+        // `deterministic`/`hash`) selects the SHA-256-derived mode; `zero` is
+        // the only way to get the legacy all-zero vectors, which cosine KNN
+        // backends drop (NaN distance) and therefore never retrieve.
         if let Ok(val) = std::env::var("MOCK_EMBEDDING") {
             let val = val.trim().to_lowercase();
-            if val == "deterministic" || val == "hash" {
+            let mode = match val.as_str() {
+                "zero" => Some(MockVectorMode::Zero),
+                "true" | "1" | "yes" | "deterministic" | "hash" => {
+                    Some(MockVectorMode::Deterministic)
+                }
+                _ => None,
+            };
+            if let Some(mode) = mode {
                 config.mock = true;
                 config.provider = EmbeddingProvider::Mock;
-                config.mock_mode = MockVectorMode::Deterministic;
-                return config;
-            }
-            if val == "true" || val == "1" || val == "yes" {
-                config.mock = true;
-                config.provider = EmbeddingProvider::Mock;
-                config.mock_mode = MockVectorMode::Zero;
+                config.mock_mode = mode;
                 return config;
             }
         }
@@ -644,7 +650,19 @@ mod tests {
         let config = EmbeddingConfig::from_env();
         unsafe { std::env::remove_var("MOCK_EMBEDDING") };
         assert!(config.mock);
-        // Legacy truthy values keep the zero-vector mode.
+        // Truthy spellings select the deterministic mode, not zero vectors.
+        assert_eq!(config.mock_mode, MockVectorMode::Deterministic);
+    }
+
+    #[test]
+    #[serial]
+    fn test_from_env_mock_embedding_zero_opt_in() {
+        // SAFETY: see test_from_env_mock_embedding_true
+        unsafe { std::env::set_var("MOCK_EMBEDDING", "zero") };
+        let config = EmbeddingConfig::from_env();
+        unsafe { std::env::remove_var("MOCK_EMBEDDING") };
+        assert!(config.mock);
+        assert_eq!(config.effective_provider(), EmbeddingProvider::Mock);
         assert_eq!(config.mock_mode, MockVectorMode::Zero);
     }
 

--- a/crates/embedding/src/mock.rs
+++ b/crates/embedding/src/mock.rs
@@ -16,21 +16,28 @@ use crate::error::{EmbeddingError, EmbeddingResult};
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MockVectorMode {
-    /// Every component is `0.0` (default; preserves legacy test behavior).
-    #[default]
+    /// Every component is `0.0`. Opt-in only (`MOCK_EMBEDDING=zero`,
+    /// [`MockEmbeddingEngine::zero`], or [`MockEmbeddingEngine::with_mode`]).
+    ///
+    /// Cosine-distance KNN backends (LanceDB in particular) cannot score an
+    /// all-zero vector — the distance is NaN and the row is silently dropped —
+    /// so retrieval under this mode is vacuously empty. It is kept for tests
+    /// that deliberately want every point to score identically.
     Zero,
     /// Components are derived deterministically from `sha256(text)`, mirroring
     /// the Python benchmark mock so that the same text always yields the same
-    /// vector and similar text yields stable neighbors.
+    /// vector and similar text yields stable neighbors. This is the default so
+    /// that `MOCK_EMBEDDING=true` exercises real (if arbitrary) KNN retrieval.
+    #[default]
     Deterministic,
 }
 
 /// A mock embedding engine.
 ///
 /// Useful for testing pipeline stages that depend on an `EmbeddingEngine`
-/// without requiring a real model or network connection. By default it returns
-/// zero vectors ([`MockVectorMode::Zero`]); in [`MockVectorMode::Deterministic`]
-/// it derives content-stable vectors from `sha256(text)`.
+/// without requiring a real model or network connection. By default it derives
+/// content-stable vectors from `sha256(text)` ([`MockVectorMode::Deterministic`]);
+/// [`MockVectorMode::Zero`] returns all-zero vectors on explicit request.
 pub struct MockEmbeddingEngine {
     dimensions: usize,
     batch_size: usize,
@@ -48,12 +55,12 @@ pub struct MockEmbeddingEngine {
 impl MockEmbeddingEngine {
     /// Create a mock engine with the given output dimensionality and a default batch size of 100.
     ///
-    /// Defaults to [`MockVectorMode::Zero`].
+    /// Defaults to [`MockVectorMode::Deterministic`].
     pub fn new(dimensions: usize) -> Self {
         Self {
             dimensions,
             batch_size: 100,
-            mode: MockVectorMode::Zero,
+            mode: MockVectorMode::default(),
             failure_after: Arc::new(Mutex::new(None)),
             call_count: Arc::new(Mutex::new(0)),
             text_count: Arc::new(Mutex::new(0)),
@@ -62,12 +69,12 @@ impl MockEmbeddingEngine {
 
     /// Create a mock engine with explicit dimensionality and batch size.
     ///
-    /// Defaults to [`MockVectorMode::Zero`].
+    /// Defaults to [`MockVectorMode::Deterministic`].
     pub fn with_batch_size(dimensions: usize, batch_size: usize) -> Self {
         Self {
             dimensions,
             batch_size,
-            mode: MockVectorMode::Zero,
+            mode: MockVectorMode::default(),
             failure_after: Arc::new(Mutex::new(None)),
             call_count: Arc::new(Mutex::new(0)),
             text_count: Arc::new(Mutex::new(0)),
@@ -76,15 +83,17 @@ impl MockEmbeddingEngine {
 
     /// Create a mock engine that produces deterministic, content-stable vectors
     /// derived from `sha256(text)` (see [`MockVectorMode::Deterministic`]).
+    ///
+    /// Equivalent to [`MockEmbeddingEngine::new`]; kept so call sites can spell
+    /// out that they depend on content-stable vectors.
     pub fn deterministic(dimensions: usize) -> Self {
-        Self {
-            dimensions,
-            batch_size: 100,
-            mode: MockVectorMode::Deterministic,
-            failure_after: Arc::new(Mutex::new(None)),
-            call_count: Arc::new(Mutex::new(0)),
-            text_count: Arc::new(Mutex::new(0)),
-        }
+        Self::new(dimensions).with_mode(MockVectorMode::Deterministic)
+    }
+
+    /// Create a mock engine that returns all-zero vectors
+    /// (see [`MockVectorMode::Zero`] for why retrieval is empty under it).
+    pub fn zero(dimensions: usize) -> Self {
+        Self::new(dimensions).with_mode(MockVectorMode::Zero)
     }
 
     /// Override the vector-generation mode, consuming and returning `self`.
@@ -216,7 +225,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_embed_returns_zero_vectors() {
-        let engine = MockEmbeddingEngine::new(128);
+        // `Zero` is opt-in: the escape hatch must still produce all-zero output.
+        let engine = MockEmbeddingEngine::new(128).with_mode(MockVectorMode::Zero);
         let texts = vec!["a", "b"];
         let embeddings = engine
             .embed(&texts)
@@ -329,9 +339,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_zero_mode_still_returns_zeros() {
-        // Regression guard: default mode must remain zero vectors.
-        let engine = MockEmbeddingEngine::new(128);
+    async fn test_zero_constructor_returns_zeros() {
+        let engine = MockEmbeddingEngine::zero(128);
         let out = engine
             .embed(&["a", "b"])
             .await
@@ -341,5 +350,31 @@ mod tests {
                 assert_eq!(val, 0.0_f32);
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_default_mode_is_deterministic() {
+        // Regression guard: `new` must NOT hand out zero vectors any more —
+        // cosine KNN drops them, which made retrieval under MOCK_EMBEDDING=true
+        // vacuously empty. The default must match `deterministic()` exactly.
+        assert_eq!(MockVectorMode::default(), MockVectorMode::Deterministic);
+        let default_engine = MockEmbeddingEngine::new(128);
+        let explicit = MockEmbeddingEngine::deterministic(128);
+        let a = default_engine
+            .embed(&["a", "b"])
+            .await
+            .expect("embed must not fail for mock engine");
+        let b = explicit
+            .embed(&["a", "b"])
+            .await
+            .expect("embed must not fail for mock engine");
+        assert_eq!(a, b);
+        for vec in &a {
+            assert!(
+                vec.iter().any(|&v| v != 0.0),
+                "default vector must be non-zero"
+            );
+        }
+        assert_ne!(a[0], a[1], "distinct texts must map to distinct vectors");
     }
 }

--- a/crates/embedding/src/provider.rs
+++ b/crates/embedding/src/provider.rs
@@ -30,6 +30,7 @@ pub enum EmbeddingProvider {
     /// litellm's Bedrock embedding handler; in Rust we use a direct-HTTP engine over the
     /// same wire shapes. Requires the `bedrock` crate feature.
     Bedrock,
-    /// Zero vectors; for testing. Activated by EMBEDDING_PROVIDER=mock or MOCK_EMBEDDING=true.
+    /// Deterministic SHA-256-derived vectors (or zeros with `MOCK_EMBEDDING=zero`); for
+    /// testing. Activated by EMBEDDING_PROVIDER=mock or MOCK_EMBEDDING=true.
     Mock,
 }

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -866,7 +866,7 @@ impl HttpServerConfig {
                 rate_limit_requests: 60,
                 rate_limit_interval: 60,
                 mock: false,
-                mock_deterministic: false,
+                mock_mode: Default::default(),
                 api_version: None,
                 huggingface_tokenizer: None,
                 max_completion_tokens: emb_defaults.max_completion_tokens,

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -900,15 +900,25 @@ impl Settings {
             .cloned();
         let api_key = api_key_sources.into_iter().find(|v| !v.is_empty()).cloned();
 
-        // MOCK_EMBEDDING: `deterministic`/`hash` selects SHA-256-derived
-        // vectors; other truthy values keep the legacy zero-vector mode.
-        let mock_mode = std::env::var("MOCK_EMBEDDING")
+        // MOCK_EMBEDDING: every truthy spelling (`true`/`1`/`yes`, plus the
+        // explicit `deterministic`/`hash`) selects SHA-256-derived vectors;
+        // `zero` is the only way to get the legacy all-zero vectors, which
+        // cosine KNN backends drop (NaN distance) and therefore never retrieve.
+        // Mirrors `cognee_embedding::EmbeddingConfig::from_env`.
+        let mock_raw = std::env::var("MOCK_EMBEDDING")
             .ok()
             .map(|v| v.trim().to_lowercase());
-        let mock_deterministic =
-            matches!(mock_mode.as_deref(), Some("deterministic") | Some("hash"));
-        let mock = mock_deterministic
-            || matches!(mock_mode.as_deref(), Some("true") | Some("1") | Some("yes"));
+        let mock_zero = matches!(mock_raw.as_deref(), Some("zero"));
+        let mock = mock_zero
+            || matches!(
+                mock_raw.as_deref(),
+                Some("true") | Some("1") | Some("yes") | Some("deterministic") | Some("hash")
+            );
+        let mock_mode = if mock_zero {
+            cognee_embedding::MockVectorMode::Zero
+        } else {
+            cognee_embedding::MockVectorMode::Deterministic
+        };
 
         // Forward-compat env fields not yet on Settings.
         let api_version = std::env::var("EMBEDDING_API_VERSION")
@@ -946,7 +956,7 @@ impl Settings {
                 rate_limit_requests: self.embedding_rate_limit_requests,
                 rate_limit_interval: self.embedding_rate_limit_interval,
                 mock,
-                mock_deterministic,
+                mock_mode,
                 api_version,
                 huggingface_tokenizer,
                 max_completion_tokens,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,7 +271,7 @@ Read by `EmbeddingConfig::from_env()` ([`crates/embedding/src/config.rs`](../cra
 | `EMBEDDING_MAX_SEQUENCE_LENGTH` | `embedding_max_sequence_length` | `512` |
 | `EMBEDDING_BATCH_SIZE` | `embedding_batch_size` | `36` (texts per embedding request; raise for providers that allow larger batches. The OpenAI-compatible engine also dispatches up to 8 sub-batches concurrently) |
 | `EMBEDDING_ONNX_BATCH_SIZE` | `embedding_onnx_batch_size` | `32` (ONNX inference batch size; independent of `EMBEDDING_BATCH_SIZE`. Lower it under memory pressure on edge devices) |
-| `MOCK_EMBEDDING` | _(provider override)_ | `false` (also accepts `deterministic`) |
+| `MOCK_EMBEDDING` | _(provider override)_ | `false`. `true`/`1`/`yes`/`deterministic` select the mock engine with deterministic SHA-256-derived vectors; `zero` selects all-zero vectors (cosine KNN then returns nothing) |
 
 Provider values: `onnx`, `fastembed`, `openai`, `openai_compatible`, `ollama`,
 `bedrock`, `mock`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,6 +276,16 @@ Read by `EmbeddingConfig::from_env()` ([`crates/embedding/src/config.rs`](../cra
 Provider values: `onnx`, `fastembed`, `openai`, `openai_compatible`, `ollama`,
 `bedrock`, `mock`.
 
+**`MOCK_EMBEDDING` diverges from the Python SDK, deliberately.** Python cognee's
+embedding engines all return `[0.0] * dimensions` under a truthy `MOCK_EMBEDDING`
+and have no deterministic mode. Rust defaults to SHA-256-derived vectors instead,
+because zero vectors are silently discarded by cosine-distance KNN — the distance
+is `NaN`, and LanceDB filters `NaN` rows out — so retrieval under zero vectors is
+vacuously empty *and* unobservable, which is how a test or smoke check can search
+under the mock engine and assert nothing at all. The mock engine is test-only and
+no workflow enables it, so this does not affect production or cross-SDK parity.
+Set `MOCK_EMBEDDING=zero` to reproduce Python's behaviour where a test wants it.
+
 `EMBEDDING_PROVIDER=bedrock` uses Amazon Bedrock's **InvokeModel** API
 (`POST {endpoint}/model/{modelId}/invoke`) — Converse is the chat API and is
 never used here. Two model families are supported, selected from the normalised

--- a/python/README.md
+++ b/python/README.md
@@ -168,7 +168,7 @@ print(cfg)
 | `EMBEDDING_DIMENSIONS` | Embedding vector dimensions. |
 | `EMBEDDING_ENDPOINT` | Embedding API base URL (falls back to `OPENAI_URL`). |
 | `EMBEDDING_API_KEY` | Embedding API key (falls back to `OPENAI_TOKEN`). |
-| `MOCK_EMBEDDING` | Set `true` to use zero-vector mock embeddings (no model download). |
+| `MOCK_EMBEDDING` | Set `true` to use deterministic SHA-256-derived mock embeddings (no model download); `zero` gives all-zero vectors instead. |
 | `COGNEE_BINDING_SUPPRESS_LOGS` | Suppress the auto-installed `pyo3-log` bridge. |
 | `COGNEE_HOST_SDK` | Set by an upstream/host `cognee` SDK to suppress this binding's analytics emission (avoids double-counting). |
 | `RUST_LOG`, `LOG_LEVEL` | Standard `tracing-subscriber` env-filter level overrides. |

--- a/ts/README.md
+++ b/ts/README.md
@@ -409,7 +409,7 @@ auto-installed stderr subscriber if your host manages the logging pipeline.
 | `EMBEDDING_DIMENSIONS` | Embedding vector dimensions. |
 | `EMBEDDING_ENDPOINT` | Embedding API base URL (falls back to `OPENAI_URL`). |
 | `EMBEDDING_API_KEY` | Embedding API key (falls back to `OPENAI_TOKEN`). |
-| `MOCK_EMBEDDING` | Set `true` to use zero-vector mock embeddings (no model download). |
+| `MOCK_EMBEDDING` | Set `true` to use deterministic SHA-256-derived mock embeddings (no model download); `zero` gives all-zero vectors instead. |
 | `COGNEE_BINDING_SUPPRESS_LOGS` | Suppress the auto-installed stderr fmt subscriber. |
 | `COGNEE_HOST_SDK` | Suppress binding-armed analytics when the host is an embedding SDK. |
 | `TELEMETRY_DISABLED`, `ENV` | Standard analytics opt-outs for `setupTelemetryAnalytics()`. |


### PR DESCRIPTION
## Why

`MockVectorMode::Zero` was the default for `MOCK_EMBEDDING=true`, which made mock-embedded retrieval vacuously empty and — worse — **unobservable**.

LanceDB scores by cosine distance, `1 - xy/(|x|·|y|)`. An all-zero vector has zero norm, so the distance is `NaN`, and `KNNVectorDistanceExec` filters `NaN` rows out of the result set (`lance/src/io/exec/knn.rs`, `!v.is_nan()`). A zero-vector row is read from storage and then silently discarded one plan node later.

Measured directly against a real LanceDB table:

| stored rows | query | rows returned |
|---|---|---|
| 3 non-zero | non-zero | 3 |
| 3 non-zero | all-zeros | **0** |
| 3 zero | zeros (= `MOCK_EMBEDDING=true`) | **0** |
| 3 non-zero + 3 zero | non-zero | 3 (zero rows dropped) |

`analyze_plan` shows it exactly: `LanceRead output_rows=3` → `KNNVectorDistance output_rows=0`.

The practical consequence is that any test or smoke check searching under `MOCK_EMBEDDING=true` could not observe retrieval at all — it asserted against a permanently empty result set. `capi/scripts/check.sh`'s `sdk_retrieval_smoke` is one such caller.

## What changed

`MockVectorMode::Deterministic` already existed, deriving content-stable vectors from `sha256(text)`, so this only flips which mode is the default.

`Zero` stays reachable on purpose — `MOCK_EMBEDDING=zero`, `MockEmbeddingEngine::zero()`, or `with_mode` — for tests that deliberately want every point to score identically. `test_embed_returns_zero_vectors` is retargeted at it explicitly rather than deleted.

## Deliberate divergence from Python

Python cognee's four embedding engines all return `[0.0] * dimensions` under a truthy `MOCK_EMBEDDING` and have no deterministic mode, so this puts Rust ahead of upstream rather than aligned with it.

Accepted as fine: the mock engine is test-only, and **no workflow sets `MOCK_EMBEDDING`** (not `ci.yml`, `community.yml` or `http-parity.yml`) — the only hardcoded use is `e2e-cross-sdk/failure-parity/py_probe.py`, which is the Python half of a manual instrument. `MOCK_EMBEDDING=zero` reproduces Python's behaviour for any test that wants it. Recorded in `docs/configuration.md` so the next reader does not mistake it for drift.

## Verification

Locally green: `cargo fmt --check`, `cargo check --all-targets` (2m22s), `cognee-embedding` (92 passed), `cognee-cognify --lib` (322 passed).

**Not completed locally:** the full workspace suite and `check_all.sh` — both were interrupted, so this PR is leaning on CI for the broad run. Note the Java lane self-skips locally (`mvn` not installed). Reviewers: the interesting failure class to watch for is any test that was asserting *empty* search results under mock embeddings, since those were passing on the bug.

## Provenance

Found while investigating #91, where a reporter used `MOCK_EMBEDDING=true` as a control to rule embeddings out and it inverted their diagnosis instead.

Two follow-ups this does **not** fix, to be filed separately:
- Zero-norm vectors are accepted and silently dropped with no warning anywhere in `crates/vector/` — a `warn!` at insert/query would have made all of this visible from a log.
- Nothing in CI asserts that search returns rows (`cli_e2e::search_live_smoke` skips on unset model paths and only checks `.success()`; `test_search_parity.py::test_search_returns_nonempty_in_both_sdks` is selected by no workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Yfx7RicVvMYCicT6WPy4H
