### PR TITLE
feat(llm): let an operator pin the structured-output mode (SDK-508)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,10 @@ LLM_API_KEY="your_api_key"
 #LLM_REASONING="auto"            # auto | always | never — override OpenAI reasoning-model (o1/o3/o4/gpt-5)
                                  # parameter detection; use "never" for a remote gateway that serves a
                                  # reasoning-named model but only accepts legacy max_tokens+temperature
+#LLM_STRUCTURED_OUTPUT_MODE="auto"  # auto | tools | functions | json — pin the structured-output request
+                                 # shape instead of cascading tools -> functions -> json. Set "json" for a
+                                 # vLLM/gateway deployment with no --tool-call-parser: the cascade would
+                                 # otherwise pay all three modes before finding the one that works.
 #LLM_TEMPERATURE=0.0
 #LLM_MAX_RETRIES=2
 # Minimum seconds a transient LLM failure is retried for. Paired with

--- a/crates/components/src/builtins/database.rs
+++ b/crates/components/src/builtins/database.rs
@@ -159,6 +159,7 @@ mod tests {
                 llm_args: serde_json::Map::new(),
                 api_version: String::new(),
                 reasoning_override: None,
+                structured_output_mode: cognee_llm::StructuredOutputMode::Auto,
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),

--- a/crates/components/src/builtins/llm.rs
+++ b/crates/components/src/builtins/llm.rs
@@ -133,6 +133,7 @@ impl LlmFactory for OpenAiCompatibleLlmFactory {
         .with_extra_args(ctx.llm.llm_args.clone())
         .with_default_max_tokens(Some(ctx.llm.max_completion_tokens))
         .with_reasoning_override(ctx.llm.reasoning_override)
+        .with_structured_output_mode(ctx.llm.structured_output_mode)
         .with_request_deadline(request_deadline(ctx));
         let (request_timeout, connect_timeout) = http_timeouts(ctx);
         let adapter = adapter.with_http_timeouts(request_timeout, connect_timeout);
@@ -279,6 +280,7 @@ impl LlmFactory for AzureLlmFactory {
         // Azure deployments with a smaller output cap 400 on every such call.
         .with_default_max_tokens(Some(ctx.llm.max_completion_tokens))
         .with_reasoning_override(ctx.llm.reasoning_override)
+        .with_structured_output_mode(ctx.llm.structured_output_mode)
         .with_request_deadline(request_deadline(ctx));
         let (request_timeout, connect_timeout) = http_timeouts(ctx);
         let adapter = adapter.with_http_timeouts(request_timeout, connect_timeout);

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -429,10 +429,12 @@ pub fn parse_reasoning_override(value: &str) -> Option<bool> {
 /// try them.
 ///
 /// An unrecognised token falls back to the cascade rather than failing, matching
-/// [`parse_reasoning_override`]. That does mean a typo reads as `auto`: the
-/// counter-argument is that a hard failure here would take down a process over a
-/// misspelled optional knob, and the cascade is the safe default in a way that
-/// no particular pin is.
+/// [`parse_reasoning_override`]: a hard failure here would take down a process
+/// over a misspelled optional knob, and the cascade is the safe default in a way
+/// that no particular pin is. It does **warn**, though — not hard-failing is not
+/// a reason to be silent, and a silently-ignored pin is otherwise invisible,
+/// since the operator sees the cascade they were trying to turn off and no
+/// pinned-exhaustion error ever fires.
 ///
 /// Lives here — the shared config→[`LlmInputs`] boundary — so the SDK `Settings`
 /// and the standalone HTTP server resolve the knob identically.
@@ -441,7 +443,15 @@ pub fn parse_structured_output_mode(value: &str) -> StructuredOutputMode {
         "tools" | "tool" | "tool_calls" => StructuredOutputMode::Tools,
         "functions" | "function" | "function_call" | "legacy" => StructuredOutputMode::Functions,
         "json" | "json_object" | "json_mode" => StructuredOutputMode::Json,
-        _ => StructuredOutputMode::Auto,
+        "auto" | "" => StructuredOutputMode::Auto,
+        other => {
+            tracing::warn!(
+                value = other,
+                "LLM_STRUCTURED_OUTPUT_MODE is not one of auto|tools|functions|json; \
+                 ignoring it and using the full structured-output cascade",
+            );
+            StructuredOutputMode::Auto
+        }
     }
 }
 

--- a/crates/components/src/context.rs
+++ b/crates/components/src/context.rs
@@ -13,6 +13,7 @@ use std::fmt;
 use std::path::PathBuf;
 
 use cognee_embedding::MockVectorMode;
+use cognee_llm::StructuredOutputMode;
 
 /// Resolved inputs consumed by [`crate::ComponentRegistry`] and the free
 /// `build_storage` / `build_database` constructors.
@@ -189,6 +190,13 @@ pub struct LlmInputs {
     /// nature the model name mis-signals. Applied via
     /// `OpenAIAdapter::with_reasoning_override`.
     pub reasoning_override: Option<bool>,
+    /// Which structured-output request shape the OpenAI-compatible adapter may
+    /// send, from `LLM_STRUCTURED_OUTPUT_MODE` (`auto` | `tools` | `functions` |
+    /// `json`). [`StructuredOutputMode::Auto`] keeps the three-mode cascade; any
+    /// other value pins that one shape and never sends the others. The
+    /// counterpart of Python's `llm_instructor_mode`. Applied via
+    /// `OpenAIAdapter::with_structured_output_mode`.
+    pub structured_output_mode: StructuredOutputMode,
     /// Replaces the provider adapter with a cassette replay mock.
     pub mock: bool,
     /// Cassette path for the replay mock (consumed only under `mock-llm`).
@@ -408,9 +416,41 @@ pub fn parse_reasoning_override(value: &str) -> Option<bool> {
     }
 }
 
+/// Parse the `LLM_STRUCTURED_OUTPUT_MODE` knob into a
+/// [`StructuredOutputMode`] for [`LlmInputs::structured_output_mode`].
+/// `tools`, `functions` and `json` each pin that one request shape; everything
+/// else — including the default `auto`, an empty value, or an unrecognised
+/// token — leaves the three-mode cascade in place. Case- and
+/// whitespace-insensitive.
+///
+/// `function_call` and `legacy` are accepted as aliases of `functions`, and
+/// `json_object` of `json`, because those are the names the wire protocol and
+/// the adapter's own log lines use — an operator reading either will reasonably
+/// try them.
+///
+/// An unrecognised token falls back to the cascade rather than failing, matching
+/// [`parse_reasoning_override`]. That does mean a typo reads as `auto`: the
+/// counter-argument is that a hard failure here would take down a process over a
+/// misspelled optional knob, and the cascade is the safe default in a way that
+/// no particular pin is.
+///
+/// Lives here — the shared config→[`LlmInputs`] boundary — so the SDK `Settings`
+/// and the standalone HTTP server resolve the knob identically.
+pub fn parse_structured_output_mode(value: &str) -> StructuredOutputMode {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "tools" | "tool" | "tool_calls" => StructuredOutputMode::Tools,
+        "functions" | "function" | "function_call" | "legacy" => StructuredOutputMode::Functions,
+        "json" | "json_object" | "json_mode" => StructuredOutputMode::Json,
+        _ => StructuredOutputMode::Auto,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{AwsInputs, aws_inputs_from, parse_reasoning_override};
+    use super::{
+        AwsInputs, StructuredOutputMode, aws_inputs_from, parse_reasoning_override,
+        parse_structured_output_mode,
+    };
 
     #[test]
     fn parse_reasoning_override_maps_known_tokens() {
@@ -423,6 +463,60 @@ mod tests {
         // Default, empty, and unrecognised tokens fall through to auto (None).
         for auto in ["auto", "", "   ", "maybe", "yes"] {
             assert_eq!(parse_reasoning_override(auto), None, "{auto:?}");
+        }
+    }
+
+    #[test]
+    fn parse_structured_output_mode_maps_known_tokens() {
+        for tools in ["tools", "tool", "tool_calls", "  TOOLS  ", "Tool"] {
+            assert_eq!(
+                parse_structured_output_mode(tools),
+                StructuredOutputMode::Tools,
+                "{tools:?}"
+            );
+        }
+        for functions in ["functions", "function", "function_call", "legacy", "LEGACY"] {
+            assert_eq!(
+                parse_structured_output_mode(functions),
+                StructuredOutputMode::Functions,
+                "{functions:?}"
+            );
+        }
+        for json in ["json", "json_object", "json_mode", " Json "] {
+            assert_eq!(
+                parse_structured_output_mode(json),
+                StructuredOutputMode::Json,
+                "{json:?}"
+            );
+        }
+        // The default, empty, and unrecognised tokens all leave the cascade in
+        // place — a misspelled pin must not silently disable every mode.
+        for auto in ["auto", "", "   ", "cascade", "tolls", "yes"] {
+            assert_eq!(
+                parse_structured_output_mode(auto),
+                StructuredOutputMode::Auto,
+                "{auto:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn only_auto_permits_every_mode() {
+        let auto = StructuredOutputMode::Auto;
+        assert!(auto.allows_tools() && auto.allows_functions() && auto.allows_json());
+        assert!(!auto.is_pinned());
+
+        // Each pin permits exactly itself, so a pinned adapter can never send a
+        // shape the operator did not ask for.
+        for (mode, tools, functions, json) in [
+            (StructuredOutputMode::Tools, true, false, false),
+            (StructuredOutputMode::Functions, false, true, false),
+            (StructuredOutputMode::Json, false, false, true),
+        ] {
+            assert_eq!(mode.allows_tools(), tools, "{mode:?} tools");
+            assert_eq!(mode.allows_functions(), functions, "{mode:?} functions");
+            assert_eq!(mode.allows_json(), json, "{mode:?} json");
+            assert!(mode.is_pinned(), "{mode:?} is a pin");
         }
     }
 

--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -37,7 +37,7 @@ pub use builtins::embedding::{OnnxAssetDefaults, onnx_asset_defaults};
 pub use builtins::{build_database, build_embedding_config, build_storage};
 pub use context::{
     AwsInputs, BackendBuildContext, EmbeddingInputs, LlmInputs, anthropic_base_url_from_env,
-    aws_inputs_from_env, parse_reasoning_override,
+    aws_inputs_from_env, parse_reasoning_override, parse_structured_output_mode,
 };
 pub use error::ComponentError;
 pub use registry::ComponentRegistry;

--- a/crates/components/src/registry.rs
+++ b/crates/components/src/registry.rs
@@ -770,6 +770,7 @@ mod tests {
                 llm_args: serde_json::Map::new(),
                 api_version: String::new(),
                 reasoning_override: None,
+                structured_output_mode: cognee_llm::StructuredOutputMode::Auto,
                 mock: false,
                 cassette: String::new(),
                 record_path: String::new(),

--- a/crates/http-server/src/config.rs
+++ b/crates/http-server/src/config.rs
@@ -216,6 +216,11 @@ pub struct HttpServerConfig {
     /// Env: `LLM_REASONING`.
     pub llm_reasoning: String,
 
+    /// Structured-output request shape: `auto` (default, cascade), or `tools` /
+    /// `functions` / `json` to pin one shape and never send the others.
+    /// Env: `LLM_STRUCTURED_OUTPUT_MODE`.
+    pub llm_structured_output_mode: String,
+
     /// LLM retry count for both structured-output and network retries.
     /// Env: `LLM_MAX_RETRIES`.
     pub llm_max_retries: u32,
@@ -419,6 +424,7 @@ impl Default for HttpServerConfig {
             llm_endpoint: String::new(),
             llm_api_version: String::new(),
             llm_reasoning: "auto".to_string(),
+            llm_structured_output_mode: "auto".to_string(),
             // Matches `Settings::llm_max_retries` and the value
             // `docs/configuration.md` documents. This was 3 — an undocumented
             // divergence that nothing here justified, and one that made the
@@ -638,6 +644,9 @@ impl HttpServerConfig {
         }
         if let Ok(v) = std::env::var("LLM_REASONING") {
             cfg.llm_reasoning = v;
+        }
+        if let Ok(v) = std::env::var("LLM_STRUCTURED_OUTPUT_MODE") {
+            cfg.llm_structured_output_mode = v;
         }
         if let Ok(v) = std::env::var("LLM_MAX_RETRIES") {
             cfg.llm_max_retries = v
@@ -906,6 +915,9 @@ impl HttpServerConfig {
                 api_version: self.llm_api_version.clone(),
                 reasoning_override: cognee_components::parse_reasoning_override(
                     &self.llm_reasoning,
+                ),
+                structured_output_mode: cognee_components::parse_structured_output_mode(
+                    &self.llm_structured_output_mode,
                 ),
                 mock: false,
                 cassette: String::new(),

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -138,6 +138,16 @@ pub struct Settings {
     /// or `never` (force the legacy `max_tokens`+sampling shape). Lets an operator
     /// correct an endpoint whose model name mis-signals its reasoning nature.
     pub llm_reasoning: String,
+    /// Structured-output request shape (`LLM_STRUCTURED_OUTPUT_MODE`): `auto`
+    /// (default, try native `tools` then legacy `functions` then JSON mode),
+    /// or `tools` / `functions` / `json` to pin one shape and never send the
+    /// others. The counterpart of Python's `llm_instructor_mode`.
+    ///
+    /// Worth pinning on an endpoint whose shape is known — a vLLM deployment
+    /// started without `--enable-auto-tool-choice --tool-call-parser` answers no
+    /// tool call at all, and the adapter's miss probe has to rediscover that in
+    /// every fresh process. An unrecognised value leaves the cascade in place.
+    pub llm_structured_output_mode: String,
     pub llm_temperature: f64,
     pub llm_streaming: bool,
     pub llm_max_completion_tokens: u32,
@@ -427,6 +437,9 @@ impl Settings {
         }
         if let Some(v) = str_var("LLM_REASONING") {
             self.llm_reasoning = v;
+        }
+        if let Some(v) = str_var("LLM_STRUCTURED_OUTPUT_MODE") {
+            self.llm_structured_output_mode = v;
         }
         if let Some(v) = str_var("LLM_TEMPERATURE")
             && let Ok(f) = v.parse::<f64>()
@@ -990,6 +1003,9 @@ impl Settings {
                 reasoning_override: cognee_components::parse_reasoning_override(
                     &self.llm_reasoning,
                 ),
+                structured_output_mode: cognee_components::parse_structured_output_mode(
+                    &self.llm_structured_output_mode,
+                ),
                 mock: self.llm_mock,
                 cassette: self.llm_cassette.clone(),
                 record_path: self.llm_record_path.clone(),
@@ -1218,6 +1234,7 @@ impl Default for Settings {
             llm_endpoint: String::new(),
             llm_api_version: String::new(),
             llm_reasoning: "auto".to_string(),
+            llm_structured_output_mode: "auto".to_string(),
             llm_temperature: 0.0,
             llm_streaming: false,
             // Single-sourced with the adapter/http-server default so lowering
@@ -1825,6 +1842,15 @@ impl ConfigManager {
         self.bump_version();
     }
 
+    /// Set the structured-output request shape (`auto` | `tools` | `functions` |
+    /// `json`); see [`Settings::llm_structured_output_mode`].
+    pub fn set_llm_structured_output_mode(&self, mode: &str) {
+        let mut s = self.inner.write().expect("lock poison is unrecoverable"); // lock poison is unrecoverable
+        s.llm_structured_output_mode = mode.to_string();
+        drop(s);
+        self.bump_version();
+    }
+
     pub fn set_llm_temperature(&self, temperature: f64) {
         let mut s = self.inner.write().expect("lock poison is unrecoverable"); // lock poison is unrecoverable
         s.llm_temperature = temperature;
@@ -2035,6 +2061,10 @@ impl ConfigManager {
             Value::String(s.llm_reasoning.clone()),
         );
         m.insert(
+            "llm_structured_output_mode".into(),
+            Value::String(s.llm_structured_output_mode.clone()),
+        );
+        m.insert(
             "llm_temperature".into(),
             Value::Number(
                 serde_json::Number::from_f64(s.llm_temperature)
@@ -2212,6 +2242,9 @@ impl ConfigManager {
                 "llm_endpoint" => s.llm_endpoint = as_string(key, value)?,
                 "llm_api_version" => s.llm_api_version = as_string(key, value)?,
                 "llm_reasoning" => s.llm_reasoning = as_string(key, value)?,
+                "llm_structured_output_mode" => {
+                    s.llm_structured_output_mode = as_string(key, value)?
+                }
                 "llm_temperature" => s.llm_temperature = as_f64(key, value)?,
                 "llm_max_completion_tokens" => s.llm_max_completion_tokens = as_u32(key, value)?,
                 "llm_streaming" => s.llm_streaming = as_bool(key, value)?,
@@ -2325,6 +2358,9 @@ impl ConfigManager {
             // LLM tuning
             "llm_api_version" => self.set_llm_api_version(as_string(key, &value)?.as_str()),
             "llm_reasoning" => self.set_llm_reasoning(as_string(key, &value)?.as_str()),
+            "llm_structured_output_mode" => {
+                self.set_llm_structured_output_mode(as_string(key, &value)?.as_str())
+            }
             "llm_temperature" => self.set_llm_temperature(as_f64(key, &value)?),
             "llm_streaming" => self.set_llm_streaming(as_bool(key, &value)?),
             "llm_max_completion_tokens" => {

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -1862,9 +1862,11 @@ impl OpenAIAdapter {
         // `NoUsableOutput`, the validation check is a no-op, and control falls
         // straight through to legacy mode. See [`CascadeProbe`].
         //
-        // An operator pin overrides the probe in both directions, and never
-        // touches its counters: the probe exists to *discover* an endpoint's
-        // shape, and there is nothing to discover once it has been declared.
+        // An operator pin overrides the probe in both directions: the probe
+        // exists to *discover* an endpoint's shape, and there is nothing to
+        // discover once it has been declared. A pin neither consults the
+        // counters nor records misses into them (see the `record_useless` call
+        // sites); a success still resets them, which is inert either way.
         //
         // Note the pinned arm is unconditionally `true` rather than deferring to
         // the probe. The probe's purpose is to stop paying for a mode when other
@@ -2077,6 +2079,15 @@ impl OpenAIAdapter {
                     // loops re-issue the request and surface any real API error
                     // via `?`. Crucially we do NOT return a stale validation/parse
                     // error here [#5]; we discard the prior miss and fall through.
+                    //
+                    // Under a pin there is nothing to fall through *to*, and the
+                    // generic pinned-exhaustion error at the end of this function
+                    // would replace the one fact the operator needs — typically
+                    // an HTTP 400 naming tool calling as unsupported, which is
+                    // exactly the mis-pin this knob can cause. Surface it.
+                    if mode_pin.is_pinned() {
+                        return Err(e);
+                    }
                     warn!(error = %e, "tool-call request failed; falling back to legacy function/JSON mode");
                     outcome = ToolOutcome::NoUsableOutput;
                     break;
@@ -2095,7 +2106,14 @@ impl OpenAIAdapter {
         // One such call still proves little on its own — the model may simply
         // have answered badly — so this only accumulates suspicion, and
         // `MISS_THRESHOLD` consecutive ones are needed before mode 1 is skipped.
-        if try_tools && !native_tool_call && tools_lacked_native_payload {
+        //
+        // Skipped entirely under a pin. The counters only exist to decide whether
+        // to keep sending a mode, and a pin has already decided; recording into
+        // them would make the threshold `warn!` below announce that tool-calling
+        // mode is being skipped "from now on" while a pinned adapter goes on
+        // sending it on every single call — telling an operator debugging a bad
+        // pin the opposite of what is happening.
+        if try_tools && !mode_pin.is_pinned() && !native_tool_call && tools_lacked_native_payload {
             let misses = self.cascade_probe.tools.record_useless();
             if misses == ModeProbe::MISS_THRESHOLD {
                 warn!(
@@ -2124,8 +2142,15 @@ impl OpenAIAdapter {
         // identical request is answered by JSON mode. Three failures then a
         // success, for byte-identical input, is worse than either outcome
         // consistently.
+        // The `native_tool_call` gate is also satisfied by a pin: its purpose is
+        // to leave a fall-through available when JSON mode might answer the same
+        // request, and under a pin JSON mode never runs. Without this, a
+        // parser-less endpoint echoing an incomplete object in `content` reports
+        // "without a parseable response" about a response that parsed perfectly
+        // and failed validation — the one error naming the missing field is the
+        // useful one.
         if let ToolOutcome::ValidationMiss { reason, raw } = outcome
-            && native_tool_call
+            && (native_tool_call || mode_pin.is_pinned())
         {
             return Err(LlmError::DeserializationError(format!(
                 "Tool-call arguments failed schema validation after {} attempt(s): {reason}. Raw: {raw}",
@@ -2312,7 +2337,8 @@ impl OpenAIAdapter {
         // reach here at all — but the flag is still what gates this, so the rule
         // reads the same way as tool calling above: a response arrived, and it
         // carried no usable native payload.
-        if try_legacy && legacy_lacked_native_payload {
+        // Skipped under a pin, for the reason given at the tool-calling counter.
+        if try_legacy && !mode_pin.is_pinned() && legacy_lacked_native_payload {
             let misses = self.cascade_probe.legacy.record_useless();
             if misses == ModeProbe::MISS_THRESHOLD {
                 debug!(

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -22,7 +22,9 @@ use cognee_utils::tracing_keys::{COGNEE_LLM_MODEL, COGNEE_LLM_PROVIDER};
 use crate::error::{LlmError, LlmResult};
 use crate::llm_trait::{Llm, StructuredOutputValidator};
 use crate::transcriber::{Transcriber, TranscriptionOutput, validate_audio_format};
-use crate::types::{GenerationOptions, GenerationResponse, Message, MessageRole, TokenUsage};
+use crate::types::{
+    GenerationOptions, GenerationResponse, Message, MessageRole, StructuredOutputMode, TokenUsage,
+};
 
 /// OpenAI API adapter.
 ///
@@ -298,6 +300,19 @@ pub struct OpenAIAdapter {
     /// particular handle on it. See [`CascadeProbe`] for why the cascade needs
     /// this at all.
     cascade_probe: Arc<CascadeProbe>,
+    /// Which structured-output shapes this endpoint is allowed to be sent.
+    ///
+    /// [`StructuredOutputMode::Auto`] — the default — runs the full cascade and
+    /// leans on [`cascade_probe`](Self::cascade_probe) to stop paying for a mode
+    /// that never answers. Any other value pins one mode: the others are never
+    /// sent at all, and exhausting the pinned one is terminal.
+    ///
+    /// The probe and the pin solve the same problem from opposite ends. The
+    /// probe *learns* an endpoint's shape at the cost of a miss threshold per
+    /// process and a periodic re-probe forever; the pin is told, so it costs
+    /// nothing and never re-probes. Both are kept because only the probe helps
+    /// an operator who does not know what their gateway speaks.
+    structured_output_mode: StructuredOutputMode,
 }
 
 /// Whether `model` is an OpenAI reasoning family (`gpt-5*`, `o1*`, `o3*`, `o4*`)
@@ -518,6 +533,9 @@ impl OpenAIAdapter {
             // unbounded behaviour. The component factory opts in from settings.
             request_deadline: None,
             cascade_probe: Arc::new(CascadeProbe::new()),
+            // Cascade by default, so an adapter built without config behaves
+            // exactly as it did before this knob existed.
+            structured_output_mode: StructuredOutputMode::default(),
         })
     }
 
@@ -563,6 +581,22 @@ impl OpenAIAdapter {
         if let Some(force) = force {
             self.reasoning_model = force;
         }
+        self
+    }
+
+    /// Pin the structured-output request shape, disabling the cascade.
+    ///
+    /// Wired from `LLM_STRUCTURED_OUTPUT_MODE` (`auto` | `tools` | `functions` |
+    /// `json`), the counterpart of Python's `llm_instructor_mode`. See
+    /// [`StructuredOutputMode`] for what each value sends and
+    /// [`structured_output_mode`](Self::structured_output_mode) for why this
+    /// exists alongside the miss probe.
+    ///
+    /// The default, [`StructuredOutputMode::Auto`], is the pre-existing cascade,
+    /// so this is opt-in: an endpoint whose shape the operator does not know
+    /// keeps the behaviour that discovers it.
+    pub fn with_structured_output_mode(mut self, mode: StructuredOutputMode) -> Self {
+        self.structured_output_mode = mode;
         self
     }
 
@@ -1827,12 +1861,36 @@ impl OpenAIAdapter {
         // keep their existing shape: with no attempts the outcome stays
         // `NoUsableOutput`, the validation check is a no-op, and control falls
         // straight through to legacy mode. See [`CascadeProbe`].
-        let try_tools = self.cascade_probe.tools.should_try();
+        //
+        // An operator pin overrides the probe in both directions, and never
+        // touches its counters: the probe exists to *discover* an endpoint's
+        // shape, and there is nothing to discover once it has been declared.
+        //
+        // Note the pinned arm is unconditionally `true` rather than deferring to
+        // the probe. The probe's purpose is to stop paying for a mode when other
+        // modes could answer instead; under a pin there are no others, so a
+        // tripped probe would mean sending *nothing* and failing every call
+        // without a request until the re-probe interval elapsed. Trying the one
+        // mode the operator asked for is strictly better, and its failure is
+        // reported against the pin. See [`StructuredOutputMode`].
+        let mode_pin = self.structured_output_mode;
+        let try_tools = if mode_pin.is_pinned() {
+            mode_pin.allows_tools()
+        } else {
+            self.cascade_probe.tools.should_try()
+        };
         if !try_tools {
-            debug!(
-                consecutive_misses = self.cascade_probe.tools.misses(),
-                "tool-calling mode has produced nothing usable on this endpoint; skipping it",
-            );
+            if mode_pin.is_pinned() {
+                debug!(
+                    structured_output_mode = mode_pin.as_str(),
+                    "tool-calling mode is disabled by configuration; skipping it",
+                );
+            } else {
+                debug!(
+                    consecutive_misses = self.cascade_probe.tools.misses(),
+                    "tool-calling mode has produced nothing usable on this endpoint; skipping it",
+                );
+            }
         }
         // Whether the endpoint answered with a *native* tool call (`tool_calls`
         // or a legacy `function_call`), as opposed to JSON echoed in `content`.
@@ -2112,13 +2170,25 @@ impl OpenAIAdapter {
         // the cascade exists precisely because a server may accept one shape and
         // not the other — a shared counter would skip legacy mode on a server
         // that supports only legacy.
-        let try_legacy = self.cascade_probe.legacy.should_try();
+        // A pin bypasses the probe, for the reason given at `try_tools`.
+        let try_legacy = if mode_pin.is_pinned() {
+            mode_pin.allows_functions()
+        } else {
+            self.cascade_probe.legacy.should_try()
+        };
         if !try_legacy {
-            debug!(
-                consecutive_misses = self.cascade_probe.legacy.misses(),
-                "legacy function-call mode has produced nothing usable on this endpoint; \
-                 skipping it",
-            );
+            if mode_pin.is_pinned() {
+                debug!(
+                    structured_output_mode = mode_pin.as_str(),
+                    "legacy function-call mode is disabled by configuration; skipping it",
+                );
+            } else {
+                debug!(
+                    consecutive_misses = self.cascade_probe.legacy.misses(),
+                    "legacy function-call mode has produced nothing usable on this endpoint; \
+                     skipping it",
+                );
+            }
         }
         // Same distinction as tool calling above: only a response that actually
         // arrived carrying no usable `function_call` is evidence against the
@@ -2253,7 +2323,19 @@ impl OpenAIAdapter {
             }
         }
 
-        // Fallback to JSON mode (works with Ollama and other providers)
+        // Fallback to JSON mode (works with Ollama and other providers).
+        //
+        // Unlike the two modes above this has no miss probe — it is the cascade's
+        // terminal fallback, so under `auto` it always runs. Only an operator pin
+        // can take it away, and then the same zero-length-attempt-range idiom is
+        // used, leaving the loop body and the exhaustion handling below untouched.
+        let try_json = mode_pin.allows_json();
+        if !try_json {
+            debug!(
+                structured_output_mode = mode_pin.as_str(),
+                "JSON mode is disabled by configuration; skipping it",
+            );
+        }
         let mut json_messages = Self::convert_messages(&messages);
 
         let example = Self::schema_to_example(&schema);
@@ -2289,7 +2371,12 @@ impl OpenAIAdapter {
             json_request["reasoning"] = json!({"effort": "none"});
         }
 
-        for attempt in 0..self.structured_output_retries {
+        let json_attempts = if try_json {
+            self.structured_output_retries
+        } else {
+            0
+        };
+        for attempt in 0..json_attempts {
             // Aggregate budget check. Placed at the head of the attempt rather
             // than only between modes so a long retry ladder inside one mode
             // cannot run past the budget either.
@@ -2380,6 +2467,19 @@ impl OpenAIAdapter {
             return Err(LlmError::InvalidResponse(format!(
                 "Structured output retries exhausted after a truncated response: {reason}. The \
                  answer does not fit the available output budget"
+            )));
+        }
+        // Name the pin when there was one. Otherwise the message implies three
+        // modes were tried and all failed, which sends the reader hunting for a
+        // provider fault when the actual cause is a one-line config choice —
+        // including the case where the pinned mode is one this endpoint cannot
+        // speak at all.
+        if mode_pin.is_pinned() {
+            return Err(LlmError::InvalidResponse(format!(
+                "Structured output retries exhausted without a parseable response in \
+                 {mode} mode. LLM_STRUCTURED_OUTPUT_MODE pins this endpoint to that mode, so \
+                 the other request shapes were not tried; unset it to restore the full cascade",
+                mode = mode_pin.as_str(),
             )));
         }
         Err(LlmError::InvalidResponse(

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -81,5 +81,5 @@ pub use schema::{
 pub use transcriber::{Transcriber, TranscriptionOutput, validate_audio_format};
 pub use types::{
     DEFAULT_MAX_COMPLETION_TOKENS, GenerationOptions, GenerationResponse, Message, MessageRole,
-    TokenUsage,
+    StructuredOutputMode, TokenUsage,
 };

--- a/crates/llm/src/types.rs
+++ b/crates/llm/src/types.rs
@@ -112,3 +112,76 @@ pub struct TokenUsage {
     pub completion_tokens: u32,
     pub total_tokens: u32,
 }
+
+/// Which structured-output request shape the OpenAI-compatible adapter may send.
+///
+/// The adapter's default behaviour is a three-mode cascade — native `tools`,
+/// then legacy `functions`, then `response_format: {"type": "json_object"}` —
+/// because an OpenAI-compatible endpoint may accept any one of the three and
+/// reject the others, and nothing in the protocol advertises which. The cascade
+/// is a Rust-only mechanism: Python pins one instructor mode per provider from a
+/// static table (`instructor_modes.py`) and exposes `llm_instructor_mode` to
+/// override it. This knob is the counterpart of that override.
+///
+/// [`Self::Auto`] keeps the cascade, bounded per mode by the adapter's own miss
+/// probe. Every other variant **pins** one shape: the other two are never sent,
+/// and exhausting the pinned mode is terminal rather than falling through.
+///
+/// Pinning is the cheaper answer whenever the operator already knows what the
+/// endpoint speaks. A vLLM deployment started without
+/// `--enable-auto-tool-choice --tool-call-parser` answers no tool call at all,
+/// and the miss probe still has to spend its threshold rediscovering that in
+/// every fresh process — while a pin costs nothing and is exact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StructuredOutputMode {
+    /// Try each mode in cascade order, skipping any the miss probe has tripped.
+    /// The default, and the behaviour before this knob existed.
+    #[default]
+    Auto,
+    /// Only native `tools`.
+    Tools,
+    /// Only the legacy `functions` / `function_call` pair.
+    Functions,
+    /// Only `response_format: {"type": "json_object"}`.
+    Json,
+}
+
+impl StructuredOutputMode {
+    /// Whether native tool-calling may be sent.
+    pub fn allows_tools(self) -> bool {
+        matches!(self, Self::Auto | Self::Tools)
+    }
+
+    /// Whether the legacy `functions` shape may be sent.
+    pub fn allows_functions(self) -> bool {
+        matches!(self, Self::Auto | Self::Functions)
+    }
+
+    /// Whether JSON mode may be sent.
+    ///
+    /// Under [`Self::Auto`] this is always true: JSON mode is the cascade's
+    /// terminal fallback and the one mode with no miss probe.
+    pub fn allows_json(self) -> bool {
+        matches!(self, Self::Auto | Self::Json)
+    }
+
+    /// Whether a single mode is pinned, i.e. the cascade is disabled.
+    ///
+    /// Used to phrase an exhaustion error honestly: under a pin there is no
+    /// further mode to fall through to, so the message should name the pinned
+    /// mode rather than implying the whole cascade ran.
+    pub fn is_pinned(self) -> bool {
+        !matches!(self, Self::Auto)
+    }
+
+    /// The knob spelling, for log and error messages.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Tools => "tools",
+            Self::Functions => "functions",
+            Self::Json => "json",
+        }
+    }
+}

--- a/crates/llm/tests/openai_structured_output_mode.rs
+++ b/crates/llm/tests/openai_structured_output_mode.rs
@@ -1,0 +1,259 @@
+//! `LLM_STRUCTURED_OUTPUT_MODE` — pinning the structured-output request shape.
+//!
+//! The adapter's default is a three-mode cascade (native `tools` → legacy
+//! `functions` → `response_format: json_object`) because nothing in the
+//! OpenAI-compatible protocol says which shape a server understands. On an
+//! endpoint that answers none of them — a vLLM deployment started without
+//! `--enable-auto-tool-choice --tool-call-parser` — every call pays all three.
+//!
+//! These tests pin down what a pin actually does:
+//!
+//! - only the pinned shape reaches the wire, and the other two are never sent;
+//! - a pin bypasses the miss probe, so the one permitted mode is still attempted
+//!   after the probe would have tripped (otherwise a pinned adapter would stop
+//!   sending anything at all);
+//! - exhausting a pinned mode fails naming the pin, rather than reporting a
+//!   generic cascade exhaustion that sends the reader hunting a provider fault;
+//! - `auto` is untouched — the cascade still cascades.
+//!
+//! Mock discrimination follows `openai_structured_output.rs`:
+//! `body_includes("\"tools\"")` + `body_excludes` for the other two shapes
+//! identifies mode 1, `body_includes("\"functions\"")` mode 2, and
+//! `body_includes("json_object")` mode 3.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test code — panics are acceptable"
+)]
+
+use cognee_llm::{Llm, OpenAIAdapter, StructuredOutputMode};
+use httpmock::prelude::*;
+use serde_json::json;
+
+/// Prose in `content`, no `tool_calls` — what a parser-less server returns.
+const PROSE: &str = r#"{"id":"x","object":"chat.completion","created":1,"model":"m",
+    "choices":[{"index":0,"message":{"role":"assistant",
+        "content":"Sure! Here is the node you asked for."},
+      "finish_reason":"stop"}]}"#;
+
+/// A parseable payload echoed in `content`. Accepted by the tool-calling and
+/// JSON modes, which both fall back to `content`.
+const USABLE: &str = r#"{"id":"x","object":"chat.completion","created":1,"model":"m",
+    "choices":[{"index":0,"message":{"role":"assistant",
+        "content":"{\"foo\":\"bar\"}"},
+      "finish_reason":"stop"}]}"#;
+
+/// A payload the legacy mode accepts. Unlike the tool-calling path, legacy
+/// `functions` requires a *native* `function_call` — JSON echoed in `content`
+/// does not satisfy it — so a legacy-answering server needs its own fixture.
+const USABLE_LEGACY: &str = r#"{"id":"x","object":"chat.completion","created":1,"model":"m",
+    "choices":[{"index":0,"message":{"role":"assistant",
+        "function_call":{"name":"extract","arguments":"{\"foo\":\"bar\"}"}},
+      "finish_reason":"function_call"}]}"#;
+
+fn schema() -> serde_json::Value {
+    json!({"type":"object","properties":{"foo":{"type":"string"}}})
+}
+
+/// The three per-mode mocks, each answering `body`.
+async fn mocks<'a>(
+    server: &'a MockServer,
+    tools_body: &str,
+    legacy_body: &str,
+    json_body: &str,
+) -> (httpmock::Mock<'a>, httpmock::Mock<'a>, httpmock::Mock<'a>) {
+    let tools = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes("\"tools\"")
+                .body_excludes("\"functions\"")
+                .body_excludes("json_object");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(tools_body);
+        })
+        .await;
+    let legacy = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes("\"functions\"")
+                .body_excludes("json_object");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(legacy_body);
+        })
+        .await;
+    let json_mode = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes("json_object");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(json_body);
+        })
+        .await;
+    (tools, legacy, json_mode)
+}
+
+fn adapter(server: &MockServer, mode: StructuredOutputMode) -> OpenAIAdapter {
+    OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(1)
+        .with_structured_output_mode(mode)
+}
+
+#[tokio::test]
+async fn json_pin_sends_only_json_mode() {
+    let server = MockServer::start_async().await;
+    // Both other modes would answer usefully if they were sent. The point is
+    // that they are not: a pin is not a fallback order, it is an exclusion.
+    let (tools, legacy, json_mode) = mocks(&server, USABLE, USABLE, USABLE).await;
+
+    let result = adapter(&server, StructuredOutputMode::Json)
+        .create_structured_output_raw("input text", "system prompt", &schema(), None)
+        .await;
+
+    assert!(result.is_ok(), "json mode answers: {result:?}");
+    assert_eq!(tools.calls_async().await, 0, "tool-calling must not be sent");
+    assert_eq!(legacy.calls_async().await, 0, "legacy must not be sent");
+    assert_eq!(
+        json_mode.calls_async().await,
+        1,
+        "json mode is the only send"
+    );
+}
+
+#[tokio::test]
+async fn tools_pin_sends_only_tool_calling() {
+    let server = MockServer::start_async().await;
+    let (tools, legacy, json_mode) = mocks(&server, USABLE, USABLE, USABLE).await;
+
+    let result = adapter(&server, StructuredOutputMode::Tools)
+        .create_structured_output_raw("input text", "system prompt", &schema(), None)
+        .await;
+
+    assert!(result.is_ok(), "tool mode answers: {result:?}");
+    assert_eq!(tools.calls_async().await, 1, "tool-calling is the only send");
+    assert_eq!(legacy.calls_async().await, 0, "legacy must not be sent");
+    assert_eq!(
+        json_mode.calls_async().await,
+        0,
+        "json mode must not be sent"
+    );
+}
+
+#[tokio::test]
+async fn functions_pin_sends_only_legacy() {
+    let server = MockServer::start_async().await;
+    let (tools, legacy, json_mode) = mocks(&server, USABLE, USABLE_LEGACY, USABLE).await;
+
+    let result = adapter(&server, StructuredOutputMode::Functions)
+        .create_structured_output_raw("input text", "system prompt", &schema(), None)
+        .await;
+
+    assert!(result.is_ok(), "legacy mode answers: {result:?}");
+    assert_eq!(tools.calls_async().await, 0, "tool-calling must not be sent");
+    assert_eq!(legacy.calls_async().await, 1, "legacy is the only send");
+    assert_eq!(
+        json_mode.calls_async().await,
+        0,
+        "json mode must not be sent"
+    );
+}
+
+#[tokio::test]
+async fn an_exhausted_pin_names_the_pin_and_never_falls_through() {
+    let server = MockServer::start_async().await;
+    // Tool calling is unanswerable; JSON mode *would* work. Under `auto` the
+    // call would succeed via the cascade — under a pin it must fail instead,
+    // and say why, or the operator has no way to tell a misconfigured pin from
+    // a broken provider.
+    let (tools, legacy, json_mode) = mocks(&server, PROSE, USABLE, USABLE).await;
+
+    let err = adapter(&server, StructuredOutputMode::Tools)
+        .create_structured_output_raw("input text", "system prompt", &schema(), None)
+        .await
+        .expect_err("a pinned mode that cannot answer must fail, not fall through");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("tools") && msg.contains("LLM_STRUCTURED_OUTPUT_MODE"),
+        "the error must name the pin and the knob that set it, got: {msg}"
+    );
+    assert!(
+        tools.calls_async().await >= 1,
+        "the pinned mode was attempted"
+    );
+    assert_eq!(legacy.calls_async().await, 0, "no fall-through to legacy");
+    assert_eq!(json_mode.calls_async().await, 0, "no fall-through to json");
+}
+
+#[tokio::test]
+async fn a_pin_keeps_sending_after_the_probe_would_have_tripped() {
+    let server = MockServer::start_async().await;
+    // Tool calling never answers, which is exactly what trips the miss probe
+    // under `auto`. Pinned, the probe must not apply: skipping the only
+    // permitted mode would mean sending no request at all and failing every
+    // later call without ever contacting the provider.
+    let (tools, legacy, json_mode) = mocks(&server, PROSE, USABLE, USABLE).await;
+    let pinned = adapter(&server, StructuredOutputMode::Tools);
+
+    // Well past ModeProbe::MISS_THRESHOLD (3).
+    for i in 0..6 {
+        let _ = pinned
+            .create_structured_output_raw("input text", "system prompt", &schema(), None)
+            .await;
+        assert_eq!(
+            tools.calls_async().await,
+            i + 1,
+            "call {i} must still send the pinned mode",
+        );
+    }
+    assert_eq!(legacy.calls_async().await, 0, "still no legacy");
+    assert_eq!(json_mode.calls_async().await, 0, "still no json");
+}
+
+#[tokio::test]
+async fn auto_still_cascades() {
+    let server = MockServer::start_async().await;
+    // Regression guard on the default: this knob must be opt-in, so an adapter
+    // left at `auto` behaves exactly as it did before the knob existed —
+    // tool calling attempted, then fall-through until something answers.
+    let (tools, legacy, json_mode) = mocks(&server, PROSE, PROSE, USABLE).await;
+
+    let result = adapter(&server, StructuredOutputMode::Auto)
+        .create_structured_output_raw("input text", "system prompt", &schema(), None)
+        .await;
+
+    assert!(result.is_ok(), "the cascade reaches json mode: {result:?}");
+    assert!(tools.calls_async().await >= 1, "tool calling was attempted");
+    assert!(legacy.calls_async().await >= 1, "legacy was attempted");
+    assert!(json_mode.calls_async().await >= 1, "json mode answered");
+}
+
+#[tokio::test]
+async fn the_default_adapter_is_auto() {
+    let server = MockServer::start_async().await;
+    // `with_structured_output_mode` is never called here: an adapter built
+    // directly — tests, embedders, downstream users of the crate — must keep
+    // the cascade rather than silently pinning anything.
+    let (tools, _legacy, json_mode) = mocks(&server, PROSE, PROSE, USABLE).await;
+
+    let result = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(1)
+        .create_structured_output_raw("input text", "system prompt", &schema(), None)
+        .await;
+
+    assert!(result.is_ok(), "default cascades to json mode: {result:?}");
+    assert!(
+        tools.calls_async().await >= 1,
+        "the default must still try tool calling first"
+    );
+    assert!(json_mode.calls_async().await >= 1, "and reach json mode");
+}

--- a/crates/llm/tests/openai_structured_output_mode.rs
+++ b/crates/llm/tests/openai_structured_output_mode.rs
@@ -14,6 +14,9 @@
 //!   sending anything at all);
 //! - exhausting a pinned mode fails naming the pin, rather than reporting a
 //!   generic cascade exhaustion that sends the reader hunting a provider fault;
+//! - but a pin does **not** swallow a specific failure it has one for: an API
+//!   error and a schema-validation miss both survive, where the cascade would
+//!   have surfaced them by falling through to a mode that reports them;
 //! - `auto` is untouched — the cascade still cascades.
 //!
 //! Mock discrimination follows `openai_structured_output.rs`:
@@ -26,9 +29,16 @@
     reason = "integration test code — panics are acceptable"
 )]
 
-use cognee_llm::{Llm, OpenAIAdapter, StructuredOutputMode};
+use cognee_llm::{Llm, LlmExt, OpenAIAdapter, StructuredOutputMode};
 use httpmock::prelude::*;
 use serde_json::json;
+
+/// A target with two required fields, for the typed-validation case.
+#[derive(Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+struct Node {
+    name: String,
+    r#type: String,
+}
 
 /// Prose in `content`, no `tool_calls` — what a parser-less server returns.
 const PROSE: &str = r#"{"id":"x","object":"chat.completion","created":1,"model":"m",
@@ -118,7 +128,11 @@ async fn json_pin_sends_only_json_mode() {
         .await;
 
     assert!(result.is_ok(), "json mode answers: {result:?}");
-    assert_eq!(tools.calls_async().await, 0, "tool-calling must not be sent");
+    assert_eq!(
+        tools.calls_async().await,
+        0,
+        "tool-calling must not be sent"
+    );
     assert_eq!(legacy.calls_async().await, 0, "legacy must not be sent");
     assert_eq!(
         json_mode.calls_async().await,
@@ -137,7 +151,11 @@ async fn tools_pin_sends_only_tool_calling() {
         .await;
 
     assert!(result.is_ok(), "tool mode answers: {result:?}");
-    assert_eq!(tools.calls_async().await, 1, "tool-calling is the only send");
+    assert_eq!(
+        tools.calls_async().await,
+        1,
+        "tool-calling is the only send"
+    );
     assert_eq!(legacy.calls_async().await, 0, "legacy must not be sent");
     assert_eq!(
         json_mode.calls_async().await,
@@ -156,7 +174,11 @@ async fn functions_pin_sends_only_legacy() {
         .await;
 
     assert!(result.is_ok(), "legacy mode answers: {result:?}");
-    assert_eq!(tools.calls_async().await, 0, "tool-calling must not be sent");
+    assert_eq!(
+        tools.calls_async().await,
+        0,
+        "tool-calling must not be sent"
+    );
     assert_eq!(legacy.calls_async().await, 1, "legacy is the only send");
     assert_eq!(
         json_mode.calls_async().await,
@@ -215,6 +237,79 @@ async fn a_pin_keeps_sending_after_the_probe_would_have_tripped() {
     }
     assert_eq!(legacy.calls_async().await, 0, "still no legacy");
     assert_eq!(json_mode.calls_async().await, 0, "still no json");
+}
+
+// A pin must not swallow the reason the call failed. Both cases below produce a
+// specific, actionable error under `auto` (by falling through to a mode that
+// reports it) and were being replaced by the generic pinned-exhaustion message —
+// losing exactly the diagnostic a mis-pinned endpoint needs.
+
+#[tokio::test]
+async fn a_pinned_mode_surfaces_the_api_error_not_the_pin_message() {
+    let server = MockServer::start_async().await;
+    // What a server without a tool parser returns when it rejects the request
+    // outright rather than ignoring it.
+    let tools = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes("\"tools\"");
+            then.status(400)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"error":{"message":"tool_choice unsupported: start vLLM with --enable-auto-tool-choice","type":"invalid_request_error"}}"#,
+                );
+        })
+        .await;
+
+    let err = adapter(&server, StructuredOutputMode::Tools)
+        .create_structured_output_raw("input text", "system prompt", &schema(), None)
+        .await
+        .expect_err("a 400 must fail the call");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("enable-auto-tool-choice"),
+        "the provider's own explanation must survive the pin, got: {msg}"
+    );
+    assert!(tools.calls_async().await >= 1, "the request was sent");
+}
+
+#[tokio::test]
+async fn a_pinned_mode_surfaces_a_validation_failure() {
+    let server = MockServer::start_async().await;
+    // A parser-less endpoint echoing well-formed JSON in `content` that omits a
+    // required field: the payload parses, and fails validation. Reporting
+    // "without a parseable response" about it sends the reader looking in
+    // entirely the wrong place.
+    let tools = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes("\"tools\"");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"id":"x","object":"chat.completion","created":1,"model":"m",
+                        "choices":[{"index":0,"message":{"role":"assistant",
+                            "content":"{\"name\":\"Ada\"}"},
+                          "finish_reason":"stop"}]}"#,
+                );
+        })
+        .await;
+
+    let result: Result<Node, _> = adapter(&server, StructuredOutputMode::Tools)
+        .create_structured_output("input text", "extract a node", None)
+        .await;
+
+    let msg = result
+        .expect_err("a missing required field must fail")
+        .to_string();
+    assert!(
+        msg.contains("type"),
+        "the error must name the missing field rather than claim nothing parsed, got: {msg}"
+    );
+    assert!(tools.calls_async().await >= 1, "the request was sent");
 }
 
 #[tokio::test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ for retries and the `cognee-llm` rustdoc for the adapter.
 | `LLM_ENDPOINT` / `OPENAI_URL` | `llm_endpoint` | _(empty)_ |
 | `LLM_API_VERSION` | `llm_api_version` | _(empty)_ |
 | `LLM_REASONING` | `llm_reasoning` | `auto` |
+| `LLM_STRUCTURED_OUTPUT_MODE` | `llm_structured_output_mode` | `auto` |
 | `LLM_TEMPERATURE` | `llm_temperature` | `0.0` |
 | `LLM_STREAMING` | `llm_streaming` | `false` |
 | `LLM_MAX_COMPLETION_TOKENS` / `LLM_MAX_TOKENS` | `llm_max_completion_tokens` | `16384` |
@@ -248,6 +249,37 @@ shape). `LLM_REASONING` overrides that detection:
 - `never` — force the legacy `max_tokens`+`temperature` shape (e.g. a remote
   OpenAI-compatible gateway serving a reasoning-*named* model that only accepts
   the legacy parameters).
+
+### Structured-output request shape (`LLM_STRUCTURED_OUTPUT_MODE`)
+
+Nothing in the OpenAI-compatible protocol advertises which structured-output
+shape a server understands, so by default the adapter cascades: native `tools`,
+then legacy `functions`, then `response_format: {"type": "json_object"}`. The
+first shape that yields a parseable payload wins.
+
+That cascade costs nothing on an endpoint that answers the first shape, and a
+great deal on one that answers none of them. A vLLM deployment started without
+`--enable-auto-tool-choice --tool-call-parser` returns no tool call at all: every
+call then pays all three modes. The adapter keeps a per-mode miss counter and
+stops sending a mode that has produced nothing three calls running (re-probing
+occasionally, so a redeploy that gains a parser recovers on its own) — but that
+still spends the threshold in every fresh process.
+
+`LLM_STRUCTURED_OUTPUT_MODE` skips the discovery when you already know the
+answer:
+
+- `auto` (default) — cascade as above, bounded by the miss counter.
+- `tools` — only native tool-calling.
+- `functions` — only the legacy `functions`/`function_call` pair.
+- `json` — only JSON mode. The right choice for a server with no tool parser.
+
+Pinning a mode means the other two are **never sent**, and exhausting the pinned
+mode fails the call rather than falling through — the error names the pin, so a
+mode the endpoint cannot actually speak is diagnosable rather than silent. An
+unrecognised value falls back to `auto`.
+
+This is the counterpart of Python cognee's `llm_instructor_mode`; Python picks
+one mode per provider from a static table and has no cascade to bound.
 
 > **Ollama embeddings:** set `EMBEDDING_ENDPOINT` explicitly when using
 > `EMBEDDING_PROVIDER=ollama`. The Ollama embedder needs the `/api/embed` route, and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,7 +271,15 @@ answer:
 - `auto` (default) — cascade as above, bounded by the miss counter.
 - `tools` — only native tool-calling.
 - `functions` — only the legacy `functions`/`function_call` pair.
-- `json` — only JSON mode. The right choice for a server with no tool parser.
+- `json` — only JSON mode.
+
+Pick `json` when the server **rejects** `tools`/`functions` outright. If it
+merely *ignores* them — accepting the request and echoing JSON in `content` —
+leave it on `auto`: tool-calling mode already succeeds there in one request, and
+it is the only mode that puts the real JSON schema on the wire. JSON mode sends a
+prose example derived from the schema instead, so pinning it trades one wasted
+request for permanently weaker schema pressure, which shows up as more missing
+fields and more corrective retries.
 
 Pinning a mode means the other two are **never sent**, and exhausting the pinned
 mode fails the call rather than falling through — the error names the pin, so a


### PR DESCRIPTION
Closes the remaining half of **SDK-508**.

The ticket asked for two things. #178 shipped the second (a sticky negative cache, so a mode an endpoint never answers stops being re-probed). This ships the first: an explicit operator override.

## Why both

They solve the same problem from opposite ends. The probe **learns** an endpoint's shape — at the cost of spending its miss threshold in every fresh process, and re-probing periodically forever. The pin is simply **told**, so it costs nothing and never re-probes.

An operator running vLLM without `--enable-auto-tool-choice --tool-call-parser` already knows the answer. The case that motivated the ticket saw **0 tool calls in 11,890 responses**, with 72.5% of calls and 71% of cost producing nothing. The probe bounds that; a pin avoids it entirely.

Keeping the probe matters too — it is the only thing that helps an operator who *doesn't* know what their gateway speaks.

## Parity

Python has no cascade at all: it picks one instructor mode per provider from a static table (`instructor_modes.py`) and exposes `llm_instructor_mode` to override it. So this knob closes a parity gap rather than opening one. The cascade remains the Rust default because it is a Rust-only mechanism and removing it would be the divergence.

## Behaviour

| Value | Sends |
|---|---|
| `auto` (default) | cascade: `tools` → `functions` → `json`, probe-bounded |
| `tools` | native tool-calling only |
| `functions` | legacy `functions`/`function_call` only |
| `json` | `response_format: {"type": "json_object"}` only |

- **`auto` is byte-for-byte the previous behaviour.** The change is opt-in: an adapter built without config — tests, embedders, downstream users of the published crate — keeps the cascade. Two regression tests guard this.
- **A pin excludes, it does not reorder.** The other two shapes never reach the wire.
- **A pin bypasses the miss probe** rather than composing with it. Composing would let a tripped probe disable the *only* permitted mode, at which point calls send no request at all and fail until the re-probe interval elapses. Attempting the one mode the operator asked for is strictly better. This was the one real design decision here.
- **Exhausting a pinned mode names the pin** and the env var, rather than reporting generic cascade exhaustion — otherwise a mode the endpoint cannot speak reads as a provider fault.
- **An unrecognised value falls back to `auto`**, matching `parse_reasoning_override`. A hard failure over a misspelled optional knob would be worse, and the cascade is the safe default in a way that no particular pin is.

## Wiring

Follows the sibling `LLM_REASONING` knob exactly: `Settings` field, env read, `ConfigManager` setter plus string-keyed get/set, lowered by a new `parse_structured_output_mode` into `LlmInputs`, applied by both OpenAI-compatible factories. The standalone HTTP server reads the env var on its own path too. Documented in `docs/configuration.md` and `.env.example`.

## Tests

7 new cases in `crates/llm/tests/openai_structured_output_mode.rs` — each pin in isolation, no fall-through on exhaustion, the probe bypass held across six consecutive calls, and the two `auto` regression guards. Plus unit coverage of token parsing (including alias and typo handling) and the per-mode predicates.

`cargo fmt`, `cargo clippy -D warnings` and the `cognee-llm` / `cognee-components` / `cognee` / `cognee-http-server` suites are clean. Two pre-existing failures in this environment are unrelated and confirmed against pristine `origin/main`: `integration_openai::test_simple_text_generation` (a live model spends all 10 `max_tokens` on reasoning and returns empty content) and `test_cognify_blocking` (HTTP 401 `invalid_api_key` on an embedding call).

## Incidental finding

Encoded in the fixtures: legacy `functions` mode requires a **native** `function_call` and will not accept JSON echoed in `content`, which the tool-calling path does accept. Worth knowing if anyone writes mocks against that mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cf5zk52eebyLhd24Hxu5u4
