### PR TITLE
fix(vector): surface zero-norm vectors, and make CI assert search returns rows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,6 +584,42 @@ jobs:
       - name: Test
         run: bash scripts/run_tests_with_openai.sh
 
+      # Retrieval coverage. `search_live_smoke` is the only case in the repo that
+      # asserts search returns any rows, and it spent its whole life skipping:
+      # it gated on COGNEE_E2E_EMBED_MODEL_PATH / _TOKENIZER_PATH, which no job
+      # downloads, while still reporting `ok` — the same silent-green shape the
+      # `pgvector-spans` lane shipped with. Those two paths are optional now
+      # (embeddings fall back to the LLM account, as in `pg_full_stack_e2e`), and
+      # the guard below fails this lane if the case ever skips again.
+      #
+      # Run as its own step rather than asserting over the workspace log above:
+      # that run legitimately skips other backend-gated suites, whose skip markers
+      # the guard would — correctly, for its own purposes — treat as failures.
+      #
+      # Keyed, and deliberately absent from the community.yml mirror rather than
+      # allowed to skip there: a skip prints the marker the guard fails on, and
+      # "the key is missing" and "retrieval returned nothing" must not look alike.
+      #
+      # Cost, stated plainly: now that the ONNX gate is gone the case also runs
+      # inside the workspace step above, so each CI run performs two live
+      # add+cognify+search cycles rather than one. The duplicate is accepted
+      # because the guard needs a log containing only this suite, and because
+      # one extra gpt-4o-mini round-trip on a one-sentence corpus is cheap. If
+      # that stops being true, filter it out of the workspace run rather than
+      # dropping the guard — an unguarded assertion is what this step exists to
+      # prevent.
+      - name: Run retrieval smoke test (LLM)
+        run: |
+          set -o pipefail
+          cargo test -p cognee-cli --test cli_e2e search_live_smoke \
+            -- --nocapture 2>&1 | tee retrieval-smoke.log
+
+      - name: Assert the retrieval smoke test really ran
+        run: |
+          bash scripts/ci/assert_pg_suite_ran.sh --label "CLI retrieval" \
+            --log retrieval-smoke.log --min-tests 1 \
+            --require-test search_live_smoke
+
   # ── Stage 2.5: Docs + feature-variant lanes (depends on lint, parallel with `test`) ──
   # Moved out of the `test` job so they run concurrently with it instead of
   # serially after the workspace test run. Together these were ~14 min of the

--- a/crates/cli/tests/cli_e2e.rs
+++ b/crates/cli/tests/cli_e2e.rs
@@ -113,49 +113,64 @@ fn config_value(config_home: &TempDir, key: &str) -> serde_json::Value {
         .unwrap_or(serde_json::Value::Null)
 }
 
-fn live_cli_env(test_name: &str) -> Option<(String, String, String, String, String)> {
-    let api_key = std::env::var("OPENAI_TOKEN").ok();
-    let api_url = std::env::var("OPENAI_URL").ok();
-    let llm_model = std::env::var("OPENAI_MODEL").ok();
-    let embedding_model_path = std::env::var("COGNEE_E2E_EMBED_MODEL_PATH").ok();
-    let embedding_tokenizer_path = std::env::var("COGNEE_E2E_TOKENIZER_PATH").ok();
+/// Live-CLI environment for the LLM-backed smoke tests.
+///
+/// Only `api_key`, `api_url` and `llm_model` are required; the two embedding
+/// paths are optional. A named struct rather than a tuple both for
+/// `clippy::type_complexity` and to match `LlmEnv` in `cli_memify.rs`.
+struct LiveCliEnv {
+    api_key: String,
+    api_url: String,
+    llm_model: String,
+    /// Local BGE-Small ONNX model, when one has been fetched.
+    embedding_model_path: Option<String>,
+    /// Local BGE-Small tokenizer.json, when one has been fetched.
+    embedding_tokenizer_path: Option<String>,
+}
 
-    match (
+/// Resolve the live-CLI environment, or `None` (with a skip line) if the
+/// required variables are absent.
+///
+/// The two ONNX paths are **optional**, mirroring `pg_full_stack_e2e`: no CI job
+/// downloads BGE-Small, and requiring them is exactly what kept these tests
+/// unrunnable in CI. When they are absent the embedding endpoint and key fall
+/// back to `llm_*` via `Settings::resolve_embedding_inputs`, so embeddings come
+/// from the same OpenAI-compatible account as the LLM. Nothing here depends on
+/// which embedding backend produced the vectors.
+///
+/// The skip line deliberately reads `<VAR> not set — skipping <test>` so that
+/// `scripts/ci/assert_pg_suite_ran.sh` (whose marker pattern is
+/// `[A-Z_]+ not set .* skipping`) fails a lane where these silently no-op. A
+/// skipped test still prints `ok`, so the exit status alone proves nothing.
+fn live_cli_env(test_name: &str) -> Option<LiveCliEnv> {
+    let required = [
+        ("OPENAI_TOKEN", std::env::var("OPENAI_TOKEN").ok()),
+        ("OPENAI_URL", std::env::var("OPENAI_URL").ok()),
+        ("OPENAI_MODEL", std::env::var("OPENAI_MODEL").ok()),
+    ];
+    if let Some((name, _)) = required
+        .iter()
+        .find(|(_, v)| v.as_deref().unwrap_or("").is_empty())
+    {
+        eprintln!("[{test_name}] {name} not set — skipping {test_name}");
+        return None;
+    }
+    let mut vals = required
+        .into_iter()
+        .map(|(_, v)| v.expect("the is_empty scan above returns early on any absent required var"));
+    let api_key = vals.next().expect("three required vars were collected");
+    let api_url = vals.next().expect("three required vars were collected");
+    let llm_model = vals.next().expect("three required vars were collected");
+
+    // Optional: present only when a local BGE-Small model has been fetched.
+    let non_empty = |k: &str| std::env::var(k).ok().filter(|v| !v.is_empty());
+    Some(LiveCliEnv {
         api_key,
         api_url,
         llm_model,
-        embedding_model_path,
-        embedding_tokenizer_path,
-    ) {
-        (
-            Some(api_key),
-            Some(api_url),
-            Some(llm_model),
-            Some(embedding_model_path),
-            Some(embedding_tokenizer_path),
-        ) if !api_key.is_empty()
-            && !api_url.is_empty()
-            && !llm_model.is_empty()
-            && !embedding_model_path.is_empty()
-            && !embedding_tokenizer_path.is_empty() =>
-        {
-            Some((
-                api_key,
-                api_url,
-                llm_model,
-                embedding_model_path,
-                embedding_tokenizer_path,
-            ))
-        }
-        _ => {
-            eprintln!(
-                "[{test_name}] skipping: live CLI env not configured \
-                 (set OPENAI_TOKEN, OPENAI_URL, OPENAI_MODEL, \
-                 COGNEE_E2E_EMBED_MODEL_PATH, COGNEE_E2E_TOKENIZER_PATH to run)"
-            );
-            None
-        }
-    }
+        embedding_model_path: non_empty("COGNEE_E2E_EMBED_MODEL_PATH"),
+        embedding_tokenizer_path: non_empty("COGNEE_E2E_TOKENIZER_PATH"),
+    })
 }
 
 #[test]
@@ -528,8 +543,13 @@ fn cognify_without_datasets_fails_with_explicit_message() {
 
 #[test]
 fn cognify_live_smoke() {
-    let Some((api_key, api_url, llm_model, embedding_model_path, embedding_tokenizer_path)) =
-        live_cli_env("cognify_live_smoke")
+    let Some(LiveCliEnv {
+        api_key,
+        api_url,
+        llm_model,
+        embedding_model_path,
+        embedding_tokenizer_path,
+    }) = live_cli_env("cognify_live_smoke")
     else {
         return;
     };
@@ -589,18 +609,24 @@ fn cognify_live_smoke() {
         "llm_api_key",
         &format!("\"{api_key}\""),
     );
-    config_set(
-        &config_home,
-        workdir.path(),
-        "embedding_model_path",
-        &format!("\"{embedding_model_path}\""),
-    );
-    config_set(
-        &config_home,
-        workdir.path(),
-        "embedding_tokenizer_path",
-        &format!("\"{embedding_tokenizer_path}\""),
-    );
+    // Only pin a local ONNX embedding model when one was provided; otherwise
+    // embeddings fall back to the same account as the LLM (see `live_cli_env`).
+    if let Some(path) = embedding_model_path.as_deref() {
+        config_set(
+            &config_home,
+            workdir.path(),
+            "embedding_model_path",
+            &format!("\"{path}\""),
+        );
+    }
+    if let Some(path) = embedding_tokenizer_path.as_deref() {
+        config_set(
+            &config_home,
+            workdir.path(),
+            "embedding_tokenizer_path",
+            &format!("\"{path}\""),
+        );
+    }
 
     make_cmd_in(&config_home, workdir.path())
         .args([
@@ -621,8 +647,13 @@ fn cognify_live_smoke() {
 
 #[test]
 fn search_live_smoke() {
-    let Some((api_key, api_url, llm_model, embedding_model_path, embedding_tokenizer_path)) =
-        live_cli_env("search_live_smoke")
+    let Some(LiveCliEnv {
+        api_key,
+        api_url,
+        llm_model,
+        embedding_model_path,
+        embedding_tokenizer_path,
+    }) = live_cli_env("search_live_smoke")
     else {
         return;
     };
@@ -682,18 +713,24 @@ fn search_live_smoke() {
         "llm_api_key",
         &format!("\"{api_key}\""),
     );
-    config_set(
-        &config_home,
-        workdir.path(),
-        "embedding_model_path",
-        &format!("\"{embedding_model_path}\""),
-    );
-    config_set(
-        &config_home,
-        workdir.path(),
-        "embedding_tokenizer_path",
-        &format!("\"{embedding_tokenizer_path}\""),
-    );
+    // Only pin a local ONNX embedding model when one was provided; otherwise
+    // embeddings fall back to the same account as the LLM (see `live_cli_env`).
+    if let Some(path) = embedding_model_path.as_deref() {
+        config_set(
+            &config_home,
+            workdir.path(),
+            "embedding_model_path",
+            &format!("\"{path}\""),
+        );
+    }
+    if let Some(path) = embedding_tokenizer_path.as_deref() {
+        config_set(
+            &config_home,
+            workdir.path(),
+            "embedding_tokenizer_path",
+            &format!("\"{path}\""),
+        );
+    }
 
     make_cmd_in(&config_home, workdir.path())
         .args([
@@ -710,7 +747,12 @@ fn search_live_smoke() {
         .assert()
         .success();
 
-    make_cmd_in(&config_home, workdir.path())
+    // The point of this test. `.success()` alone passed for the whole life of
+    // this file while retrieval returned nothing: an empty result set is a
+    // successful exit, so the only assertion that means anything here is a row
+    // count. Zero rows is what a broken embedding or vector path looks like —
+    // see `cognee_vector::zero_norm` for the case where it is silent.
+    let out = make_cmd_in(&config_home, workdir.path())
         .args([
             "search",
             "What is this dataset about?",
@@ -722,7 +764,47 @@ fn search_live_smoke() {
             "json",
         ])
         .assert()
-        .success();
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(out).expect("search --output-format json emits UTF-8");
+
+    // `--output-format json` does not give clean stdout: the logger writes to it
+    // too, so the payload is preceded by timestamped lines. Parsing the whole
+    // buffer reads the `2026` of a timestamp as a JSON number and then fails on
+    // "trailing characters". Slice from the first line that starts a JSON object
+    // and take a single value off a streaming deserializer, so anything the
+    // logger emits before or after the payload is tolerated.
+    let json_start = if stdout.starts_with('{') {
+        Some(0)
+    } else {
+        stdout.find("\n{").map(|i| i + 1)
+    }
+    .unwrap_or_else(|| panic!("no JSON object in search stdout:\n{stdout}"));
+    let parsed: serde_json::Value = serde_json::Deserializer::from_str(&stdout[json_start..])
+        .into_iter::<serde_json::Value>()
+        .next()
+        .unwrap_or_else(|| panic!("no JSON value in search stdout:\n{stdout}"))
+        .unwrap_or_else(|e| panic!("search JSON parse failed: {e}\n{stdout}"));
+
+    // Shape is `{"search_type": .., "result": {"kind": "Items", "data": [..]}}`.
+    // Read it defensively so a shape change fails with the payload in hand
+    // rather than a bare unwrap panic.
+    let rows = parsed
+        .pointer("/result/data")
+        .and_then(|d| d.as_array())
+        .unwrap_or_else(|| panic!("no /result/data array in search output:\n{stdout}"));
+    assert!(
+        !rows.is_empty(),
+        "CHUNKS search returned 0 rows after add + cognify — retrieval is broken, \
+         not merely unpopulated:\n{stdout}"
+    );
+    // Positive marker: proves the test did real work rather than skipping.
+    eprintln!(
+        "[search_live_smoke] CHUNKS returned {} row(s) after add + cognify",
+        rows.len()
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/vector/src/brute_force_vector_db.rs
+++ b/crates/vector/src/brute_force_vector_db.rs
@@ -31,6 +31,7 @@ use crate::error::{VectorDBError, VectorDBResult};
 use crate::models::{SearchResult, VectorPoint};
 use crate::node_filter::metadata_matches_node_filter;
 use crate::vector_db_trait::VectorDB;
+use crate::zero_norm::{warn_zero_norm_points, warn_zero_norm_query};
 
 #[derive(Debug)]
 struct Collection {
@@ -134,6 +135,11 @@ impl VectorDB for BruteForceVectorDB {
             }
         }
 
+        // Unlike LanceDB/pgvector this backend keeps the row — the denominator
+        // is clamped with `max(f32::EPSILON)` — but it scores 0.0 and so ranks
+        // below every real match. Degenerate either way, worth the same signal.
+        warn_zero_norm_points("brute-force", &key, points);
+
         // Upsert by id: replace existing, otherwise append. On replace, union
         // dataset membership so a content-addressed point indexed under several
         // datasets stays retrievable for all of them (cross-dataset dedup).
@@ -160,6 +166,9 @@ impl VectorDB for BruteForceVectorDB {
             return Ok(());
         }
         let key = Self::key(data_type, field_name);
+        // Raw upsert writes system-owned collections (TruthCentroid_vector and
+        // friends); a zero-norm centroid stored here is unsearchable too.
+        warn_zero_norm_points("brute-force", &key, points);
         let mut g = self.collections.write().await;
 
         // Self-create the collection when absent, sized from the first vector
@@ -190,6 +199,7 @@ impl VectorDB for BruteForceVectorDB {
         top_k: usize,
     ) -> VectorDBResult<Vec<SearchResult>> {
         let key = Self::key(data_type, field_name);
+        warn_zero_norm_query("brute-force", &key, query_vector);
         // Score under the read guard, then drop it before sorting + result
         // construction so we never hold the lock across the (synchronous,
         // but still post-await) sort/truncate step.
@@ -249,6 +259,7 @@ impl VectorDB for BruteForceVectorDB {
             _ => None,
         };
         let key = Self::key(data_type, field_name);
+        warn_zero_norm_query("brute-force", &key, query_vector);
         // Score (and filter) under the read guard, then drop it before the
         // sort/truncate, mirroring `search_similar`.
         let mut scored: Vec<(Uuid, f32, HashMap<String, serde_json::Value>)> = {

--- a/crates/vector/src/lancedb_adapter.rs
+++ b/crates/vector/src/lancedb_adapter.rs
@@ -39,6 +39,7 @@ use uuid::Uuid;
 use crate::error::{VectorDBError, VectorDBResult};
 use crate::models::{SearchResult, VectorPoint};
 use crate::vector_db_trait::VectorDB;
+use crate::zero_norm::{warn_zero_norm_points, warn_zero_norm_query};
 
 fn collection_name(data_type: &str, field_name: &str) -> String {
     format!("{data_type}_{field_name}")
@@ -86,6 +87,11 @@ fn points_to_batch(
             actual: p.vector.len(),
         });
     }
+
+    // A zero-norm vector is accepted by the writer and then dropped by the
+    // reader: lance scores it NaN and `KNNVectorDistanceExec` filters NaN rows
+    // out, so the row exists on disk and never appears in a result.
+    warn_zero_norm_points("lancedb", collection, points);
 
     let id_array = FixedSizeBinaryArray::try_from_iter(points.iter().map(|p| *p.id.as_bytes()))
         .map_err(|e| VectorDBError::StorageError(format!("id column build: {e}")))?;
@@ -435,6 +441,7 @@ impl VectorDB for LanceDbAdapter {
         top_k: usize,
     ) -> VectorDBResult<Vec<SearchResult>> {
         let name = collection_name(data_type, field_name);
+        warn_zero_norm_query("lancedb", &name, query_vector);
         let table = self
             .connection
             .open_table(&name)
@@ -754,6 +761,60 @@ mod tests {
             .await
             .unwrap();
         assert!(results.iter().all(|r| r.id != drop));
+    }
+
+    /// Pins the hazard the zero-norm warnings exist for: LanceDB accepts a
+    /// zero-norm vector and then never returns it.
+    ///
+    /// Cosine distance is `1 - xy/(|x|.|y|)`, so a zero-norm operand yields
+    /// NaN, and lance's `KNNVectorDistanceExec` masks NaN rows out. The row is
+    /// therefore on disk (`collection_size` counts it) and absent from every
+    /// result — no error, no signal. If this test ever goes red because the
+    /// zero row *is* returned, lance changed its NaN handling and the warning
+    /// text in `crate::zero_norm` needs revisiting.
+    #[tokio::test]
+    async fn zero_norm_points_are_stored_but_never_returned() {
+        let (adapter, _dir) = fresh_adapter().await;
+        adapter.create_collection("Chunk", "text", 2).await.unwrap();
+        let real = Uuid::new_v4();
+        let zero = Uuid::new_v4();
+        adapter
+            .index_points(
+                "Chunk",
+                "text",
+                &[
+                    point(real, vec![1.0, 0.0], "real"),
+                    point(zero, vec![0.0, 0.0], "zero"),
+                ],
+            )
+            .await
+            .unwrap();
+
+        // Both rows are persisted.
+        assert_eq!(adapter.collection_size("Chunk", "text").await.unwrap(), 2);
+
+        // A generous top_k cannot surface the zero-norm row.
+        let results = adapter
+            .search_similar("Chunk", "text", &[1.0, 0.0], 100)
+            .await
+            .unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "expected only the non-zero point, got {results:?}"
+        );
+        assert_eq!(results[0].id, real);
+
+        // And a zero-norm *query* cannot rank anything at all, even though the
+        // collection holds a perfectly good point.
+        let none = adapter
+            .search_similar("Chunk", "text", &[0.0, 0.0], 100)
+            .await
+            .unwrap();
+        assert!(
+            none.is_empty(),
+            "a zero-norm query should match nothing, got {none:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/vector/src/lib.rs
+++ b/crates/vector/src/lib.rs
@@ -12,6 +12,9 @@ pub mod models;
 mod node_filter;
 /// Vector database trait definition.
 pub mod vector_db_trait;
+/// Zero-norm (all-zero) embedding vector detection, and the warnings that
+/// make an otherwise-silent unsearchable write or query visible.
+mod zero_norm;
 
 #[cfg(feature = "pgvector")]
 pub mod pgvector_adapter;

--- a/crates/vector/src/mock_vector_db.rs
+++ b/crates/vector/src/mock_vector_db.rs
@@ -17,6 +17,7 @@ use crate::error::{VectorDBError, VectorDBResult};
 use crate::models::{SearchResult, VectorPoint};
 use crate::node_filter::metadata_matches_node_filter;
 use crate::vector_db_trait::VectorDB;
+use crate::zero_norm::{warn_zero_norm_points, warn_zero_norm_query};
 
 /// Mock vector database for testing
 ///
@@ -208,6 +209,7 @@ impl VectorDB for MockVectorDB {
                 });
             }
         }
+        warn_zero_norm_points("mock", &key, points);
 
         // Upsert points (replace if ID exists, otherwise append). On replace,
         // union dataset membership so a content-addressed point indexed under
@@ -241,6 +243,7 @@ impl VectorDB for MockVectorDB {
         if points.is_empty() {
             return Ok(());
         }
+        warn_zero_norm_points("mock", &Self::collection_key(data_type, field_name), points);
 
         let key = Self::collection_key(data_type, field_name);
         let mut collections = self.collections.lock().unwrap(); // lock poison is unrecoverable
@@ -274,6 +277,7 @@ impl VectorDB for MockVectorDB {
         top_k: usize,
     ) -> VectorDBResult<Vec<SearchResult>> {
         let key = Self::collection_key(data_type, field_name);
+        warn_zero_norm_query("mock", &key, query_vector);
         let collections = self.collections.lock().unwrap(); // lock poison is unrecoverable
 
         let collection = collections
@@ -330,6 +334,7 @@ impl VectorDB for MockVectorDB {
             _ => None,
         };
         let key = Self::collection_key(data_type, field_name);
+        warn_zero_norm_query("mock", &key, query_vector);
         let collections = self.collections.lock().unwrap(); // lock poison is unrecoverable
 
         let collection = collections

--- a/crates/vector/src/pgvector_adapter.rs
+++ b/crates/vector/src/pgvector_adapter.rs
@@ -23,6 +23,7 @@ use cognee_utils::tracing_keys::{
 use crate::error::{VectorDBError, VectorDBResult};
 use crate::models::{SearchResult, VectorPoint};
 use crate::vector_db_trait::VectorDB;
+use crate::zero_norm::{warn_zero_norm_points, warn_zero_norm_query, warn_zero_norm_query_batch};
 
 /// Max points per INSERT batch (300 params = 100 rows × 3 columns).
 const BATCH_SIZE: usize = 100;
@@ -519,6 +520,10 @@ impl VectorDB for PgVectorAdapter {
             }
         }
 
+        // `vector <=> $1` is NaN when either operand has zero norm, so these
+        // rows score and sort unusably once written.
+        warn_zero_norm_points("pgvector", &coll, points);
+
         // Batch upsert in chunks to stay within parameter limits.
         for chunk in points.chunks(BATCH_SIZE) {
             // Point IDs are content-addressed, so the same point is re-indexed
@@ -612,6 +617,9 @@ impl VectorDB for PgVectorAdapter {
 
         let coll = Self::collection_name(data_type, field_name)?;
         Span::current().record(COGNEE_VECTOR_COLLECTION, coll.as_str());
+        // Raw upsert writes system-owned collections (TruthCentroid_vector and
+        // friends); a zero-norm centroid stored here is unsearchable too.
+        warn_zero_norm_points("pgvector", &coll, points);
 
         // Dimension check across the batch.
         let expected_dim = points[0].vector.len();
@@ -702,6 +710,7 @@ impl VectorDB for PgVectorAdapter {
     ) -> VectorDBResult<Vec<SearchResult>> {
         let coll = Self::collection_name(data_type, field_name)?;
         Span::current().record(COGNEE_VECTOR_COLLECTION, coll.as_str());
+        warn_zero_norm_query("pgvector", &coll, query_vector);
 
         let vec_str = Self::format_vector(query_vector);
 
@@ -765,6 +774,7 @@ impl VectorDB for PgVectorAdapter {
 
         let coll = Self::collection_name(data_type, field_name)?;
         Span::current().record(COGNEE_VECTOR_COLLECTION, coll.as_str());
+        warn_zero_norm_query("pgvector", &coll, query_vector);
 
         let vec_str = Self::format_vector(query_vector);
         // $1 = query vector, $2 = top_k, $3.. = requested node names. Pushing the
@@ -889,6 +899,9 @@ impl VectorDB for PgVectorAdapter {
         }
         let coll = Self::collection_name(data_type, field_name)?;
         Span::current().record(COGNEE_VECTOR_COLLECTION, coll.as_str());
+        // This override never routes through `search_similar`, so the
+        // single-query warning would otherwise never fire on this path.
+        warn_zero_norm_query_batch("pgvector", &coll, query_vectors);
 
         // One round-trip for the whole batch instead of the default's one query
         // per vector: unnest the query vectors with ordinality and run the ANN

--- a/crates/vector/src/zero_norm.rs
+++ b/crates/vector/src/zero_norm.rs
@@ -1,0 +1,183 @@
+//! Zero-norm (all-zero) embedding vector detection.
+//!
+//! A zero vector has no direction, so cosine similarity against it is
+//! mathematically undefined — and every backend here scores by cosine. The
+//! four backends then disagree about what happens, none of them loudly:
+//!
+//! | backend       | zero-norm row                                   |
+//! |---------------|-------------------------------------------------|
+//! | LanceDB       | distance is `NaN`; `KNNVectorDistanceExec` filters `NaN` rows out, so the row is read from storage and silently discarded |
+//! | pgvector      | `vector <=> $1` yields `NaN` for a zero operand, so the row sorts and scores unusably |
+//! | brute-force   | `cosine_similarity` clamps the denominator with `max(f32::EPSILON)`, so the row survives with score `0.0` and ranks last |
+//! | MockVectorDB  | returns `0.0` when either magnitude is zero — same last-place ranking as brute-force |
+//!
+//! The mock is included deliberately despite being `cfg(feature = "testing")`:
+//! it is the backend most suites actually run against, and it is where the
+//! `MOCK_EMBEDDING` zero-vector problem hid in the first place. A diagnostic
+//! that goes quiet in tests is quiet exactly where it would be read.
+//!
+//! In every case the point is not retrievable as the caller intended, and in
+//! the LanceDB case — the OSS default — it is not retrievable at all. Nothing
+//! errors, so a zero-norm write is indistinguishable from a successful one.
+//!
+//! Two things produce zero vectors in practice:
+//!
+//! 1. `MOCK_EMBEDDING=zero`, which asks for them deliberately.
+//! 2. Empty or whitespace-only input text with a real provider. The cloud
+//!    embedding adapters substitute `"."` before the API call and then
+//!    overwrite that slot with a zero vector (see `handle_embedding_response`
+//!    in `cognee-embedding`), so a blank chunk, entity name, or summary is
+//!    stored as an unsearchable row.
+//!
+//! These helpers do not reject anything — they only make the condition visible
+//! in logs, which is what was missing when both cases went unnoticed.
+
+use crate::models::VectorPoint;
+
+/// Returns `true` if every component is exactly zero.
+///
+/// Testing components rather than a computed norm is deliberate: it is exact,
+/// needs no square root, and it catches the two cases that actually occur —
+/// `MOCK_EMBEDDING=zero`, and the deliberate zeroing of empty-text slots in
+/// `handle_embedding_response`. Both write literal zeros.
+///
+/// This is **not** equivalent to "the computed `f32` norm is zero", and the
+/// difference is a known blind spot rather than an invariant. Squares of very
+/// small components underflow: for `[f32::MIN_POSITIVE, 0.0]` the sum of
+/// squares rounds to `0.0`, so the norm is `0.0` and cosine is every bit as
+/// undefined as for an all-zero vector — yet this returns `false` and no
+/// warning fires. Accepted because no embedding model emits components near
+/// `1e-38`, and because an epsilon on the norm would start warning about
+/// legitimate small-magnitude vectors. If that assumption ever breaks, the fix
+/// is an explicit norm-underflow check here, not a tolerance.
+pub(crate) fn is_zero_norm(vector: &[f32]) -> bool {
+    !vector.is_empty() && vector.iter().all(|v| *v == 0.0)
+}
+
+/// Warn once per batch if any point carries a zero-norm vector.
+///
+/// Emits a single record with a count rather than one per point, so a corpus
+/// with many blank fields cannot flood the log.
+pub(crate) fn warn_zero_norm_points(backend: &str, collection: &str, points: &[VectorPoint]) {
+    let zero_norm = points
+        .iter()
+        .filter(|p| is_zero_norm(&p.vector))
+        .collect::<Vec<_>>();
+    if zero_norm.is_empty() {
+        return;
+    }
+    // A few ids are enough to chase the source data; the full list would be
+    // unbounded.
+    let sample: Vec<String> = zero_norm.iter().take(3).map(|p| p.id.to_string()).collect();
+    tracing::warn!(
+        backend,
+        collection,
+        zero_norm_points = zero_norm.len(),
+        total_points = points.len(),
+        sample_ids = %sample.join(", "),
+        "indexing zero-norm embedding vectors — cosine similarity is undefined for these, so \
+         they are dropped from KNN results on LanceDB/pgvector and ranked last on brute-force; \
+         usual cause is empty or whitespace-only input text, or MOCK_EMBEDDING=zero"
+    );
+}
+
+/// Warn if a query vector is zero-norm.
+///
+/// A zero-norm query cannot rank anything, so the search returns nothing
+/// useful regardless of what the collection holds — the single most confusing
+/// version of this failure, because the data is fine and the query is at fault.
+pub(crate) fn warn_zero_norm_query(backend: &str, collection: &str, query_vector: &[f32]) {
+    if !is_zero_norm(query_vector) {
+        return;
+    }
+    tracing::warn!(
+        backend,
+        collection,
+        "zero-norm query vector — cosine similarity is undefined, so this search cannot rank \
+         any row and will return nothing (LanceDB/pgvector) or an arbitrary order (brute-force); \
+         usual cause is an empty or whitespace-only query string, or MOCK_EMBEDDING=zero"
+    );
+}
+
+/// Warn once if any query vector in a batch is zero-norm.
+///
+/// `batch_search_similar` overrides exist that never route through
+/// `search_similar` (pgvector builds one `unnest ... LATERAL` round-trip), so
+/// the single-query helper never runs for them. Counts rather than warning per
+/// vector, so a large batch of blanks cannot flood the log.
+pub(crate) fn warn_zero_norm_query_batch(
+    backend: &str,
+    collection: &str,
+    query_vectors: &[Vec<f32>],
+) {
+    let zero_norm = query_vectors.iter().filter(|v| is_zero_norm(v)).count();
+    if zero_norm == 0 {
+        return;
+    }
+    tracing::warn!(
+        backend,
+        collection,
+        zero_norm_queries = zero_norm,
+        total_queries = query_vectors.len(),
+        "zero-norm query vectors in a batch search — cosine similarity is undefined, so these \
+         queries cannot rank any row; usual cause is empty or whitespace-only query text, or \
+         MOCK_EMBEDDING=zero"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn all_zero_is_zero_norm() {
+        assert!(is_zero_norm(&[0.0, 0.0, 0.0]));
+        assert!(is_zero_norm(&[0.0]));
+    }
+
+    #[test]
+    fn negative_zero_is_still_zero_norm() {
+        // -0.0 == 0.0 in IEEE 754, and its square is +0.0, so the norm is zero.
+        assert!(is_zero_norm(&[-0.0, 0.0, -0.0]));
+    }
+
+    #[test]
+    fn any_nonzero_component_is_not_zero_norm() {
+        assert!(!is_zero_norm(&[0.0, 0.0, 1.0]));
+        assert!(!is_zero_norm(&[-1.0, 0.0]));
+    }
+
+    /// Documents the blind spot named in `is_zero_norm`'s doc comment, so the
+    /// gap is pinned behaviour rather than a surprise. This vector's *computed*
+    /// f32 norm underflows to zero, making it as unsearchable as an all-zero
+    /// one, but the component test does not flag it.
+    #[test]
+    fn underflowing_norm_is_a_known_blind_spot() {
+        let tiny = [f32::MIN_POSITIVE, 0.0];
+        // The square underflows, so the norm really is 0.0 ...
+        let sum_sq: f32 = tiny.iter().map(|v| v * v).sum();
+        assert_eq!(
+            sum_sq, 0.0,
+            "expected the square of MIN_POSITIVE to underflow"
+        );
+        // ... yet no component is zero, so this returns false and stays silent.
+        assert!(!is_zero_norm(&tiny));
+    }
+
+    #[test]
+    fn empty_vector_is_not_reported() {
+        // An empty vector is a dimension error, caught elsewhere with a precise
+        // message. Reporting it as zero-norm would misattribute the cause.
+        assert!(!is_zero_norm(&[]));
+    }
+
+    #[test]
+    fn warn_helpers_tolerate_empty_and_clean_input() {
+        // No panics and no work when there is nothing to report.
+        warn_zero_norm_points("test", "T_f", &[]);
+        warn_zero_norm_query("test", "T_f", &[1.0, 0.0]);
+        let clean = vec![VectorPoint::new(Uuid::new_v4(), vec![1.0, 2.0])];
+        warn_zero_norm_points("test", "T_f", &clean);
+    }
+}

--- a/scripts/ci/assert_pg_suite_ran.sh
+++ b/scripts/ci/assert_pg_suite_ran.sh
@@ -15,7 +15,14 @@
 #
 # Called by the `pgvector-postgres`, `pggraph-postgres` and
 # `pg-single-db-postgres` lanes in .github/workflows/ci.yml and their mirrors in
-# .github/workflows/community.yml. It lives here rather than inline in six YAML
+# .github/workflows/community.yml.
+#
+# Also called by the `test` job's retrieval step, which is not Postgres-gated at
+# all — `search_live_smoke` gates on an LLM key and (formerly) a local ONNX
+# model. Nothing here is Postgres-specific: the skip-marker pattern is
+# variable-agnostic by design, and both the test-count floor and the required
+# test names are parameters. The name is kept for its three original callers
+# rather than churning six YAML references. It lives here rather than inline in six YAML
 # blocks so the copies cannot drift, and so it can be tested against captured
 # logs without a CI round-trip.
 #
@@ -208,4 +215,4 @@ for test_name in ${REQUIRE_TESTS[@]+"${REQUIRE_TESTS[@]}"}; do
     fail "required test $test_name did not run (or did not pass) in any of: ${LOGS[*]}."
 done
 
-echo "$LABEL suite verified: $total_passed tests passed against a live Postgres across ${#LOGS[@]} log(s), ${#REQUIRE_TESTS[@]} named case(s) confirmed, no skip markers."
+echo "$LABEL suite verified: $total_passed tests passed against a live backend across ${#LOGS[@]} log(s), ${#REQUIRE_TESTS[@]} named case(s) confirmed, no skip markers."


### PR DESCRIPTION
Two independent changes to the same failure mode: a zero-norm embedding vector is accepted by every backend and then behaves as if it were never written, and nothing in CI noticed that search returned nothing. One commit each.

## 1. `fix(vector)` — warn on zero-norm vectors instead of dropping them silently

The four cosine backends do not agree on how a zero-norm vector fails, and none of them says anything:

| backend | zero-norm row |
|---|---|
| LanceDB (OSS default) | distance is `NaN`; `KNNVectorDistanceExec` filters `NaN` rows out — the row is on disk and absent from every result |
| pgvector | `vector <=> $1` is `NaN` for a zero operand, so it scores and sorts unusably |
| brute-force | `cosine_similarity` clamps with `max(f32::EPSILON)`, so it survives at score `0.0` and ranks last |
| MockVectorDB | returns `0.0` when either magnitude is zero — same last place |

Two things produce them in practice. `MOCK_EMBEDDING=zero` asks for them. More importantly, so does **empty or whitespace-only input text with a real provider**: the cloud adapters substitute `"."` before the API call and then overwrite that slot with zeros in `handle_embedding_response`, so a blank chunk, entity name or summary is stored unsearchable. Neither was visible from a log.

New `crate::zero_norm` has one shared detector and three warning helpers, wired into the insert and query paths of all four backends — including `batch_search_similar`, which overrides the default and so never routes through `search_similar`, and `upsert_raw_vectors`, which writes system-owned collections like `TruthCentroid_vector`. Nothing is rejected; the condition just becomes observable.

`zero_norm_points_are_stored_but_never_returned` pins the LanceDB behaviour: both rows persist, `collection_size` counts 2, and `top_k = 100` returns only the non-zero one. If lance changes its `NaN` handling that goes red rather than the warning text quietly becoming wrong.

Known blind spot, documented rather than papered over: `is_zero_norm` tests components for exact zero, which is **not** the same as "the computed `f32` norm is zero". `[f32::MIN_POSITIVE, 0.0]` underflows to a zero norm and is equally undefined, yet returns `false`. Accepted because no embedding model emits components near `1e-38` and an epsilon would warn on legitimate small vectors; `underflowing_norm_is_a_known_blind_spot` pins it.

## 2. `test(cli)` — assert search actually returns rows, and fail CI if it skips

Nothing in CI verified that retrieval returns anything. `search_live_smoke` was the only candidate and was inert twice over:

1. It ended on a bare `.assert().success()`. **An empty result set is a successful exit**, so the assertion held whatever search returned.
2. It gated on `COGNEE_E2E_EMBED_MODEL_PATH` / `_TOKENIZER_PATH`, which no CI job downloads — so it skipped every run while printing `ok`, in 0.00s.

Both had to be fixed for either to matter. It now asserts a non-empty `/result/data` with the payload in the panic message, and the two ONNX paths are optional exactly as `pg_full_stack_e2e` already made them: absent, the embedding endpoint and key fall back to `llm_*`. Verified against live credentials on that path — `output_rows=1`, one chunk, score 0.167.

A keyed CI step runs the case into its own log behind `assert_pg_suite_ran.sh`. Three details worth knowing:

- **`--require-test` alone cannot catch this**, because a skipped test still prints `ok`. The skip line was reworded to `<VAR> not set — skipping <test>` so the guard's marker pattern sees it.
- **The guard needs a dedicated log.** Pointed at the workspace run it would trip on other backend-gated suites that legitimately skip.
- **Kept out of `community.yml`** for the reason `pg_full_stack_e2e` documents: a skip prints the marker the guard fails on, and a missing key must not look like broken retrieval.

Both directions verified locally: the real run passes the guard, and a run with `OPENAI_TOKEN` unset reports `ok. 1 passed` in 0.00s and is correctly failed.

## Provenance and cost

Both fall out of investigating #91, where `MOCK_EMBEDDING=true` returning zero vectors made retrieval vacuously empty. #184 fixed the mock; this makes the underlying condition visible and pins the coverage gap that let #91 go seven weeks without a green check anyone could point at.

One cost, stated plainly: with the ONNX gate gone the case also runs inside the workspace step, so each CI run now performs two live `add`+`cognify`+`search` cycles instead of one. Accepted and commented in `ci.yml` — if it stops being acceptable, filter it out of the workspace run rather than dropping the guard.

## Verification

`cargo fmt --check`, `cargo check --all-targets`, `clippy -D warnings` (vector + cli, incl. `pgvector`), and 54 `cognee-vector` lib tests all pass. Full workspace suite and `check_all.sh` were not run locally — CI covers those.

A code review pass over this branch found no high-severity bug; its five findings (three uncovered code paths, the `f32` invariant above, and the duplicate-run cost) are all addressed in the two commits.

## Follow-up found in passing, not fixed here

`cognee-cli search --output-format json` writes logger output to **stdout** ahead of the payload, so a consumer piping it into a parser gets `trailing characters at line 1 column 5` — the new test hits exactly that and works around it. The logger already writes to a file, so the stdout copy looks unintended for a machine-readable format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmwWAiTW184ZDFDdhW58Ki
