### PR TITLE
fix(llm): tell a chosen output budget from the library default (SDK-581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+- **`GenerationOptions::default()` no longer carries a `max_tokens`.** It set
+  `Some(16384)`; it now leaves `None`. The field had to stop carrying a value so
+  that `Some(n)` means "a caller chose n" — the OpenAI adapter refuses to raise a
+  caller's own output budget when a structured-output answer is truncated, and it
+  could not tell a deliberate 16384 from the one the `Default` supplied. A caller
+  writing `GenerationOptions { temperature: Some(0.1), ..Default::default() }`
+  therefore had a budget it never picked treated as a constraint, and the call
+  failed terminally naming that number.
+
+  Both option-less paths are unchanged: `generate` with no options still gets the
+  configured `llm_max_completion_tokens`, and option-less structured output still
+  gets 16384 (now named at that call site rather than inherited from `Default`).
+
+  What changes is one spelling — options built with `..Default::default()` that
+  never set `max_tokens`. Such a caller now expresses "no budget of my own", and
+  each path resolves that its own way:
+
+  1. **OpenAI `generate` sends no cap**, so the provider's default applies rather
+     than 16384. Note this path does *not* substitute the configured ceiling for
+     an explicit `None`, by long-standing design ("an explicit `max_tokens`,
+     including `None` = no cap, always wins over config"). If you relied on the
+     old default to bound completion length, set `max_tokens` explicitly.
+  2. **Anthropic and Bedrock chat take the configured ceiling**
+     (`llm_max_completion_tokens`), clamped to the model cap — where they
+     previously clamped such callers to 16384 even if the operator had configured
+     more. This is what their docs already claimed to do.
+  3. **`transcribe_image` on Anthropic and Bedrock uses its 300-token vision
+     default** instead of 16384. Pass an explicit `max_tokens` for longer image
+     descriptions.
+
+  Python parity: `acreate_structured_output` passes no output cap either.
+
 - **Teardown now closes every backend, not just the relational pool — and a
   closed graph/vector store rejects later operations.** `ComponentManager::close`
   (reached by every binding's handle teardown and by the CLI on exit) used to

--- a/crates/llm/src/adapters/anthropic.rs
+++ b/crates/llm/src/adapters/anthropic.rs
@@ -882,8 +882,9 @@ mod tests {
         // Claude 3.5 Sonnet caps output at 8192.
         let sonnet = AnthropicAdapter::new("claude-3-5-sonnet-20241022", "k", None).unwrap();
 
-        // GenerationOptions::default() sets Some(16384); it must clamp to 8192
-        // (the model cap), not send 16384 (which 400s) nor a hard 4096.
+        // Default options carry no budget since SDK-581, so this resolves to the
+        // configured ceiling (16384) and must then clamp to 8192 (the model cap),
+        // not send 16384 (which 400s) nor a hard 4096.
         assert_eq!(
             sonnet.effective_max_tokens(&GenerationOptions::default()),
             8192
@@ -933,8 +934,9 @@ mod tests {
             .with_max_completion_tokens(2000);
         assert_eq!(capped.effective_max_tokens(&unset), 2000);
         // ...and it is an upper bound on the default-options path too, not only
-        // when the caller passes None: GenerationOptions::default() carries
-        // Some(16384), which must not bypass a lower configured ceiling.
+        // when the caller passes None. Since SDK-581
+        // GenerationOptions::default() carries no budget either, so both
+        // spellings take the configured ceiling and neither can bypass it.
         assert_eq!(
             capped.effective_max_tokens(&GenerationOptions::default()),
             2000

--- a/crates/llm/src/adapters/anthropic.rs
+++ b/crates/llm/src/adapters/anthropic.rs
@@ -237,13 +237,19 @@ impl AnthropicAdapter {
     /// The `max_tokens` to send: `min(caller value, configured ceiling, model cap)`.
     ///
     /// The configured ceiling (`llm_max_completion_tokens`) is an upper bound on
-    /// *every* path, not only when the caller passes `None`:
-    /// `GenerationOptions::default()` sets `Some(16384)`, so a default-options
-    /// caller would otherwise silently bypass a lower operator-configured ceiling
-    /// (an operator setting 4096 to cap cost would still get 8192). Python treats
+    /// *every* path, not only when the caller passes `None`, so a caller cannot
+    /// silently bypass a lower operator-configured ceiling (an operator setting
+    /// 4096 to cap cost must not still get 8192). Python treats
     /// `llm_max_completion_tokens` as the effective ceiling on all paths. The
     /// model cap is applied last so Anthropic never 400s on
     /// `max_tokens > model limit`.
+    ///
+    /// A caller who passes no budget of their own — `None`, which is also what
+    /// `GenerationOptions::default()` now leaves in `max_tokens` (SDK-581) —
+    /// takes the configured ceiling directly. Before SDK-581 the default carried
+    /// `Some(16384)`, which clamped such callers to 16384 even when the operator
+    /// had configured something larger; taking the ceiling is what this doc
+    /// already claimed to do.
     fn effective_max_tokens(&self, opts: &GenerationOptions) -> u32 {
         let requested = opts.max_tokens.map_or(self.max_completion_tokens, |v| {
             v.min(self.max_completion_tokens)
@@ -759,10 +765,10 @@ impl Llm for AnthropicAdapter {
         }
         let b64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
         // Clamp to the model's documented output cap, like the chat path's
-        // `effective_max_tokens`. A caller supplying GenerationOptions with the
-        // default max_tokens (16384) on a model whose cap is lower (e.g. Claude
-        // 3.5 at 8192) would otherwise 400 the vision request. Floored at 1 so a
-        // zero never 400s either.
+        // `effective_max_tokens`. A caller supplying a large max_tokens (16384,
+        // say) on a model whose cap is lower (e.g. Claude 3.5 at 8192) would
+        // otherwise 400 the vision request. Floored at 1 so a zero never 400s
+        // either. A caller who sets nothing keeps the 300-token vision default.
         let max_tokens = options
             .as_ref()
             .and_then(|o| o.max_tokens)

--- a/crates/llm/src/adapters/bedrock/mod.rs
+++ b/crates/llm/src/adapters/bedrock/mod.rs
@@ -234,10 +234,15 @@ impl BedrockAdapter {
     /// ceiling, model cap)`, floored at 1 (plan §1.0).
     ///
     /// The configured ceiling bounds **every** path, not only the
-    /// `max_tokens: None` one: `GenerationOptions::default()` carries
-    /// `Some(16384)`, so a default-options caller would otherwise silently
-    /// bypass a lower operator-configured ceiling. The model cap is applied last
-    /// so Bedrock never 400s on `maxTokens > model limit`.
+    /// `max_tokens: None` one, so a caller cannot silently bypass a lower
+    /// operator-configured ceiling. The model cap is applied last so Bedrock
+    /// never 400s on `maxTokens > model limit`.
+    ///
+    /// A caller who passes no budget of their own — `None`, which is also what
+    /// `GenerationOptions::default()` leaves in `max_tokens` since SDK-581 —
+    /// takes the configured ceiling. Before then the default carried
+    /// `Some(16384)`, which clamped such callers to 16384 even where the
+    /// operator had configured more.
     fn effective_max_tokens(&self, opts: &GenerationOptions) -> u32 {
         let requested = opts.max_tokens.map_or(self.max_completion_tokens, |value| {
             value.min(self.max_completion_tokens)
@@ -644,11 +649,20 @@ impl Llm for BedrockAdapter {
         let encoded = base64::engine::general_purpose::STANDARD.encode(image_bytes);
         // Clamp to the same effective budget as the chat path — the lesser of
         // the model's documented output cap and the configured
-        // `llm_max_completion_tokens` ceiling. A caller passing
-        // GenerationOptions with the default max_tokens (16384) against a model
-        // that caps lower would otherwise 400, and would slip past an operator
-        // ceiling that bounds every other path. Floored at 1 so a zero never
-        // 400s either.
+        // `llm_max_completion_tokens` ceiling. A caller passing a large
+        // max_tokens against a model that caps lower would otherwise 400, and
+        // would slip past an operator ceiling that bounds every other path.
+        // Floored at 1 so a zero never 400s either.
+        //
+        // A caller who sets nothing keeps the 300-token vision default. Note the
+        // asymmetry with the chat path above, which substitutes the *ceiling* for
+        // an unset budget: 300 is a deliberate vision-specific floor, not the
+        // configured ceiling. Since SDK-581 that also covers
+        // `GenerationOptions::default()`, which no longer carries 16384 — so a
+        // published-crate caller passing default options gets 300 here where it
+        // used to get 16384. The only in-tree caller
+        // (`cognee-ingestion`'s image loader) passes `None` and always took this
+        // path.
         let max_tokens = options
             .as_ref()
             .and_then(|o| o.max_tokens)
@@ -720,7 +734,10 @@ mod tests {
             16_384
         );
         // A configured ceiling below the cap wins, on the default-options path
-        // too (GenerationOptions::default() carries Some(16384)).
+        // too. Since SDK-581 `GenerationOptions::default()` carries no budget,
+        // so this now asserts that an unset budget resolves *to* the ceiling
+        // rather than that a defaulted 16384 is clamped down to it. Same
+        // expected value, different guarantee.
         let capped = adapter("eu.anthropic.claude-sonnet-4-5-20250929-v1:0")
             .await
             .with_max_completion_tokens(2_000);

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -985,10 +985,28 @@ impl OpenAIAdapter {
     ///   route forwards client-supplied budgets straight into structured output,
     ///   so a client requesting 200 tokens could be re-issued at the ceiling.
     ///   A deliberate budget is treated as a constraint, not a suggestion.
-    /// - **The budget is already at or above the ceiling.** Raising is impossible
-    ///   and falling through to another request *mode* cannot help, because the
-    ///   legacy and JSON-mode requests carry the same budget and truncate
-    ///   identically.
+    /// - **The ceiling is no higher than the budget that just truncated.** Raising
+    ///   is impossible and falling through to another request *mode* cannot help,
+    ///   because the legacy and JSON-mode requests carry the same budget and
+    ///   truncate identically.
+    ///
+    /// `observed_completion_tokens` is `usage.completion_tokens` from the
+    /// truncated response, and it is what makes the second test sound when the
+    /// request carried no cap of its own (SDK-581). There,
+    /// [`effective_output_budget`](Self::effective_output_budget) reports `0`
+    /// meaning "unknown, the provider's own default applied" — and `0` is not
+    /// smaller than the ceiling in any useful sense. Comparing the ceiling against
+    /// `0` therefore always looked like headroom, so the response to a truncation
+    /// was to write the ceiling over a provider default that may well have been
+    /// *larger*, shrinking the budget and re-truncating, while the reason string
+    /// still announced a raise. The tokens the provider actually spent before
+    /// cutting the answer off are a lower bound on the budget it applied, so they
+    /// stand in for the unknown.
+    ///
+    /// When the provider reports no usage the bound is unavailable and the old
+    /// behaviour stands — write the ceiling and try — but the reason string then
+    /// says only what was sent, because there is nothing to claim an increase
+    /// against.
     ///
     /// Mirrors the Anthropic adapter, which has rejected a `stop_reason ==
     /// "max_tokens"` response since it shipped, with one deliberate difference:
@@ -998,6 +1016,7 @@ impl OpenAIAdapter {
         body: &mut Value,
         mode: &str,
         caller_requested: Option<u32>,
+        observed_completion_tokens: Option<u32>,
     ) -> LlmResult<(String, u32)> {
         let current = self.effective_output_budget(body);
         let ceiling = self.max_completion_tokens().max(1);
@@ -1010,40 +1029,57 @@ impl OpenAIAdapter {
             )));
         }
 
-        if current >= ceiling {
+        // The budget that actually truncated, as far as it can be known: the cap
+        // on the request if it carried one, otherwise the tokens the provider
+        // spent before cutting off. `0` means neither is available.
+        let truncated_at = current.max(observed_completion_tokens.unwrap_or(0));
+
+        if ceiling <= truncated_at {
             // Name the budget that actually truncated, not the ceiling — they
-            // differ whenever an option-less call sends the GenerationOptions
+            // differ whenever an option-less call sends the structured-output
             // default while a lower ceiling is configured, and pointing at the
             // ceiling there sends the operator to raise a setting that changes
             // nothing.
-            let what = if current == 0 {
-                "its output budget".to_string()
-            } else {
+            let what = if current > 0 {
                 format!("its {current}-token output budget")
+            } else {
+                // No cap of our own: `truncated_at` came from the response, so it
+                // describes the provider's default rather than a configured value.
+                format!("the provider's default output budget, after {truncated_at} tokens")
             };
             return Err(LlmError::InvalidResponse(format!(
                 "{mode} structured output was truncated at {what} before the JSON object was \
                  complete, and the configured ceiling (llm_max_completion_tokens = {ceiling}) \
                  is no higher, so the budget cannot be raised automatically. Raise \
-                 LLM_MAX_COMPLETION_TOKENS above {current}, or set a larger cap with \
+                 LLM_MAX_COMPLETION_TOKENS above {truncated_at}, or set a larger cap with \
                  LLM_ARGS='{{\"max_tokens\": N}}' (CLI and SDK only — the HTTP server does not \
                  read LLM_ARGS)"
             )));
         }
 
         self.write_max_tokens(body, Some(ceiling));
-        let previous = if current == 0 {
-            "provider-default".to_string()
-        } else {
-            format!("{current}-token")
-        };
-        Ok((
+        // Only claim a raise against a budget that is actually known. On the
+        // no-cap path with no usage reported, `truncated_at` is 0 and the previous
+        // budget is whatever the provider chose — asserting an increase over it
+        // would be unverifiable, and the number quoted was never the budget that
+        // truncated. Say what was sent instead.
+        let reason = if truncated_at > 0 {
+            let previous = if current > 0 {
+                format!("{current}-token")
+            } else {
+                format!("{truncated_at}-token provider-default")
+            };
             format!(
                 "the previous answer was cut off at the {previous} output budget before the \
                  JSON object was complete; the budget has been raised to {ceiling}"
-            ),
-            ceiling,
-        ))
+            )
+        } else {
+            format!(
+                "the previous answer was cut off at the provider's default output budget \
+                 before the JSON object was complete; this attempt asks for {ceiling}"
+            )
+        };
+        Ok((reason, ceiling))
     }
 
     /// Call the OpenAI chat completions API, retrying on transient network/server errors.
@@ -1749,21 +1785,32 @@ impl OpenAIAdapter {
         let validation_error =
             |parsed: &Value| -> Option<String> { validator.and_then(|v| v(parsed).err()) };
 
+        // A budget the caller *chose*. Only this is a deliberate constraint that
+        // must not be raised on truncation.
+        //
+        // `GenerationOptions::default()` leaves `max_tokens` as `None` precisely
+        // so this stays unambiguous (SDK-581): while the default carried
+        // `Some(16384)`, a caller writing `..Default::default()` was
+        // indistinguishable from one who had picked 16384 deliberately, and the
+        // recovery path below refused to raise a number nobody chose.
+        let caller_max_tokens = options.as_ref().and_then(|o| o.max_tokens);
+
         // Structured extraction intentionally does NOT inherit the config
         // `default_max_tokens` (the global completion ceiling applied to
-        // `generate`): it keeps the historical `GenerationOptions::default()`
-        // cap (16384) for option-less calls. Applying the *configured* ceiling
-        // here risks truncating the tool-call JSON mid-object, so a user
-        // lowering the answer ceiling never silently breaks internal structured
-        // calls (e.g. feedback detection). Callers that want NO cap at all pass
-        // explicit `max_tokens: None` (as cognify's extraction paths do).
-        // A budget the caller *chose*, as distinct from the one
-        // `GenerationOptions::default()` supplies when no options were passed at
-        // all. Only the former is a deliberate constraint that must not be raised
-        // on truncation; the default's 16384 is a library value and carries no
-        // caller intent.
-        let caller_max_tokens = options.as_ref().and_then(|o| o.max_tokens);
-        let opts = options.unwrap_or_default();
+        // `generate`): an option-less call keeps the historical 16384. Applying
+        // the *configured* ceiling here risks truncating the tool-call JSON
+        // mid-object, so a user lowering the answer ceiling never silently breaks
+        // internal structured calls (e.g. feedback detection). Callers that want
+        // NO cap at all pass explicit `max_tokens: None` (as cognify's extraction
+        // paths do).
+        //
+        // Spelled out rather than left to `unwrap_or_default()`, which supplied
+        // this same 16384 only as a side effect of the old `Default`. The cap is
+        // wanted here and not in `Default`, so it belongs here.
+        let opts = options.unwrap_or(GenerationOptions {
+            max_tokens: Some(Self::DEFAULT_MAX_COMPLETION_TOKENS),
+            ..GenerationOptions::default()
+        });
         // Align the advertised `required` array with what instructor sends on its
         // default TOOLS path (every non-default property is required). See
         // `recompute_top_level_required`. This is the shallow, Baseten-safe
@@ -1952,6 +1999,7 @@ impl OpenAIAdapter {
                             &mut tools_request,
                             "Tool-call",
                             caller_max_tokens,
+                            tools_response.usage.as_ref().map(|u| u.completion_tokens),
                         )?;
                         raised_budget = Some(budget);
                         truncation_seen = Some(reason.clone());
@@ -2258,6 +2306,7 @@ impl OpenAIAdapter {
                     &mut request_body,
                     "Function-call",
                     caller_max_tokens,
+                    response.usage.as_ref().map(|u| u.completion_tokens),
                 )?;
                 raised_budget = Some(budget);
                 truncation_seen = Some(reason.clone());
@@ -2445,6 +2494,7 @@ impl OpenAIAdapter {
                     &mut json_request,
                     "JSON-mode",
                     caller_max_tokens,
+                    json_response.usage.as_ref().map(|u| u.completion_tokens),
                 )?;
                 let _ = budget; // JSON mode is last; nothing downstream inherits it.
                 truncation_seen = Some(reason.clone());

--- a/crates/llm/src/adapters/openai.rs
+++ b/crates/llm/src/adapters/openai.rs
@@ -251,12 +251,16 @@ pub struct OpenAIAdapter {
     ///   control of `max_tokens` (including `None` = no cap), so the config
     ///   default never overrides an explicit choice.
     /// - Structured-output extraction (`structured_output_impl`) deliberately
-    ///   ignores this *configured* default and keeps the historical
-    ///   [`GenerationOptions::default`] cap (16384) for option-less calls: a
-    ///   lower cap there would truncate tool-call JSON mid-object, so lowering
-    ///   the completion ceiling never silently breaks internal structured calls
+    ///   ignores this *configured* default and substitutes
+    ///   [`Self::DEFAULT_MAX_COMPLETION_TOKENS`] for option-less calls: a lower
+    ///   cap there would truncate tool-call JSON mid-object, so lowering the
+    ///   completion ceiling never silently breaks internal structured calls
     ///   (e.g. feedback detection). Callers wanting NO cap pass explicit
     ///   `max_tokens: None` (as cognify's extraction paths do).
+    ///
+    ///   That cap used to arrive from [`GenerationOptions::default`] via
+    ///   `unwrap_or_default()`; since SDK-581 the default leaves `max_tokens` as
+    ///   `None` and the value is named here instead.
     ///
     /// `None` means "send no default cap". Defaults to
     /// [`Some(DEFAULT_MAX_COMPLETION_TOKENS)`](Self::DEFAULT_MAX_COMPLETION_TOKENS),
@@ -444,11 +448,17 @@ impl OpenAIAdapter {
     /// rate-limit window resets; the time floor is what actually carries a call
     /// through an overload episode.
     pub const DEFAULT_MIN_RETRY_ELAPSED: Duration = Duration::from_secs(240);
-    /// Default output-token cap applied to option-less calls, mirroring the
-    /// historical [`GenerationOptions::default`] cap and Python cognee's
+    /// Default output-token cap applied to option-less calls, and the cap the
+    /// structured-output path substitutes for them. Mirrors Python cognee's
     /// `llm_max_completion_tokens` default (`config.py`). Overridden per-adapter
     /// via [`with_default_max_tokens`](Self::with_default_max_tokens).
-    pub const DEFAULT_MAX_COMPLETION_TOKENS: u32 = 16384;
+    ///
+    /// Aliases the crate-wide [`crate::DEFAULT_MAX_COMPLETION_TOKENS`] so it
+    /// moves in lockstep with the Anthropic and Bedrock adapters, which already
+    /// do. It was a bare `16384` literal until SDK-581, which is a drift the
+    /// crate-wide doc claimed could not happen: raising the shared constant moved
+    /// those two adapters and left the OpenAI structured-output cap behind.
+    pub const DEFAULT_MAX_COMPLETION_TOKENS: u32 = crate::DEFAULT_MAX_COMPLETION_TOKENS;
     /// Default per-HTTP-request timeout. Unchanged from the value that used to be
     /// hardcoded in `new`, so an adapter built without config behaves as before.
     pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(600);
@@ -1007,6 +1017,16 @@ impl OpenAIAdapter {
     /// behaviour stands — write the ceiling and try — but the reason string then
     /// says only what was sent, because there is nothing to claim an increase
     /// against.
+    ///
+    /// **Known gap.** That fallback is the unfixed case: with no cap on the
+    /// request and no usage in the response, nothing here can tell whether the
+    /// ceiling is larger than the provider default it is about to overwrite, so
+    /// the shrink-and-re-truncate is still reachable. `usage` is optional in the
+    /// response because OpenAI-compatible servers (llama.cpp, older Ollama, some
+    /// gateways) omit it, so which behaviour applies is chosen by the provider
+    /// rather than by configuration. Closing it needs a budget the request can
+    /// state rather than infer — see SDK-538, which changes which layer supplies
+    /// the cap this reads.
     ///
     /// Mirrors the Anthropic adapter, which has rejected a `stop_reason ==
     /// "max_tokens"` response since it shipped, with one deliberate difference:

--- a/crates/llm/src/types.rs
+++ b/crates/llm/src/types.rs
@@ -42,10 +42,16 @@ impl Message {
 }
 
 /// Default output-token ceiling (`llm_max_completion_tokens`) shared across the
-/// SDK: `GenerationOptions::default`, the config defaults in `cognee-lib` and
-/// `cognee-http-server`, and the Anthropic adapter's fallback. Kept in one place
-/// so all of them move in lockstep. The per-request value is still clamped to
-/// each model's documented cap (see `AnthropicAdapter::effective_max_tokens`).
+/// SDK: the config defaults in `cognee-lib` and `cognee-http-server`, the
+/// Anthropic adapter's fallback, and the cap the OpenAI adapter substitutes on
+/// *option-less* structured-output calls. Kept in one place so all of them move
+/// in lockstep. The per-request value is still clamped to each model's
+/// documented cap (see `AnthropicAdapter::effective_max_tokens`).
+///
+/// Deliberately *not* the value of [`GenerationOptions::default`]'s
+/// `max_tokens`: a default sitting in that field is indistinguishable from a
+/// budget the caller chose, and the truncation-recovery path has to tell those
+/// apart. See that impl.
 pub const DEFAULT_MAX_COMPLETION_TOKENS: u32 = 16384;
 
 /// Options for LLM generation.
@@ -77,10 +83,31 @@ pub struct GenerationOptions {
 }
 
 impl Default for GenerationOptions {
+    /// `max_tokens` defaults to `None` — "no budget of my own".
+    ///
+    /// It carried `Some(DEFAULT_MAX_COMPLETION_TOKENS)` until SDK-581, which made
+    /// `Some(_)` ambiguous. `GenerationOptions { temperature: Some(0.1),
+    /// ..Default::default() }` handed the adapter a 16384 the caller never
+    /// picked, and the OpenAI truncation-recovery path — which refuses to raise a
+    /// budget the caller *chose* — read that as a deliberate constraint and
+    /// failed the call terminally, naming a number nobody had asked for.
+    ///
+    /// With `None` here, `Some(n)` is only ever a value a caller wrote, so the
+    /// adapter carries intent instead of inferring it from `Option`. Both
+    /// option-less paths still apply a cap of their own and are unchanged:
+    /// `OpenAIAdapter::resolve_options` substitutes the configured
+    /// `default_max_tokens` for `generate`, and the structured-output path
+    /// substitutes [`DEFAULT_MAX_COMPLETION_TOKENS`].
+    ///
+    /// This does change behaviour for one spelling: a caller who builds options
+    /// with `..Default::default()` and never sets `max_tokens` now sends no cap,
+    /// so the provider's own default applies rather than 16384. That is the
+    /// documented meaning of an explicit `max_tokens: None`, and it matches
+    /// Python parity — `acreate_structured_output` passes no cap either.
     fn default() -> Self {
         Self {
             temperature: Some(0.0),
-            max_tokens: Some(DEFAULT_MAX_COMPLETION_TOKENS),
+            max_tokens: None,
             top_p: None,
             frequency_penalty: None,
             presence_penalty: None,

--- a/crates/llm/tests/openai_truncation_retry.rs
+++ b/crates/llm/tests/openai_truncation_retry.rs
@@ -61,6 +61,24 @@ fn truncated_tool_call(finish_reason: &str) -> String {
     )
 }
 
+/// A truncated tool call that also reports what it spent, the way a real
+/// provider does. `usage.completion_tokens` is the only evidence of the budget
+/// the provider applied when the request carried no cap of its own.
+fn truncated_tool_call_with_usage(completion_tokens: u32) -> String {
+    let cut_off = serde_json::to_string(r#"{"name": "Alexander Gra"#).expect("string escapes");
+    format!(
+        r#"{{"id":"x","object":"chat.completion","created":1,"model":"m",
+            "choices":[{{"index":0,"message":{{"role":"assistant","tool_calls":[
+                {{"id":"c1","type":"function","function":{{
+                    "name":"extract_structured_data","arguments":{cut_off}
+                }}}}
+            ]}},"finish_reason":"length"}}],
+            "usage":{{"prompt_tokens":10,"completion_tokens":{completion_tokens},
+                      "total_tokens":{total}}}}}"#,
+        total = completion_tokens + 10
+    )
+}
+
 /// A complete, parseable tool call.
 fn complete_tool_call() -> String {
     let payload =
@@ -455,4 +473,248 @@ async fn gateway_max_tokens_finish_reason_is_treated_as_truncation() {
 
     assert!(err.to_string().contains("truncated"), "got: {err}");
     tools.assert_calls_async(1).await;
+}
+
+// ---------------------------------------------------------------------------
+// SDK-581: a library default is not a caller's choice, and a "raise" must not
+// be able to lower the budget.
+// ---------------------------------------------------------------------------
+
+/// The latent half of SDK-581. `..Default::default()` without setting
+/// `max_tokens` is the idiomatic spelling, and it used to hand the adapter a
+/// 16384 the caller never picked — which the recovery path then read as a
+/// deliberate constraint, refused to raise, and reported as
+/// "the caller-requested 16384-token output budget".
+///
+/// Such a caller has expressed no budget, so the truncation must be recovered
+/// exactly as it is for `max_tokens: None`.
+#[tokio::test]
+async fn a_defaulted_budget_is_not_treated_as_a_caller_choice() {
+    let server = MockServer::start_async().await;
+
+    // No cap on the wire: the default must not put one there.
+    let uncapped = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions").is_true(|req| {
+                let body = req.body_string();
+                body.contains(r#""tools""#) && !body.contains("max_tokens")
+            });
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(truncated_tool_call("length"));
+        })
+        .await;
+
+    let completed = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(format!(
+                    r#""max_tokens":{}"#,
+                    OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS
+                ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(complete_tool_call());
+        })
+        .await;
+
+    let value = adapter(server.base_url())
+        .create_structured_output_with_messages_raw(
+            user_msg(),
+            &schema(),
+            // The spelling that used to fail: temperature set, max_tokens absent.
+            Some(GenerationOptions {
+                temperature: Some(0.1),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("a defaulted budget carries no caller intent and must be raised");
+
+    assert_eq!(value["name"], "Alexander Graham Bell");
+    uncapped.assert_calls_async(1).await;
+    completed.assert_calls_async(1).await;
+}
+
+/// The live half of SDK-581. With no cap on the request, the budget in force is
+/// the provider's own default and the request body says nothing about it.
+/// Writing the configured ceiling over it is only a *raise* if the ceiling is
+/// larger — and when it is not, the old code wrote it anyway, shrinking the
+/// budget and re-truncating while announcing an increase.
+///
+/// `usage.completion_tokens` is the evidence: the provider spent 8000 tokens
+/// before cutting off, so its budget is at least that, and a 4096 ceiling cannot
+/// help. That must be terminal, and the cascade must not run.
+#[tokio::test]
+async fn a_ceiling_below_the_provider_default_is_not_written_as_a_raise() {
+    let server = MockServer::start_async().await;
+
+    let uncapped = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions").is_true(|req| {
+                let body = req.body_string();
+                body.contains(r#""tools""#) && !body.contains("max_tokens")
+            });
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(truncated_tool_call_with_usage(8000));
+        })
+        .await;
+
+    // Any request carrying the lowered ceiling is the bug: it would shrink the
+    // budget that just truncated.
+    let shrunk = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(r#""max_tokens":4096"#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(complete_tool_call());
+        })
+        .await;
+
+    let err = OpenAIAdapter::new("gpt-4o-mini", "test-key", Some(server.base_url()))
+        .unwrap()
+        .with_network_retries(0)
+        .with_structured_output_retries(2)
+        .with_default_max_tokens(Some(4096))
+        .create_structured_output_with_messages_raw(
+            user_msg(),
+            &schema(),
+            // The production shape: cognify sends no cap, so the provider's own
+            // default is what truncates.
+            Some(GenerationOptions {
+                max_tokens: None,
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect_err("a ceiling below the observed provider default cannot recover");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("truncated"),
+        "the error must name truncation; got: {msg}"
+    );
+    assert!(
+        msg.contains("8000"),
+        "the error must name the budget that actually truncated, taken from usage; got: {msg}"
+    );
+    assert!(
+        msg.contains("LLM_MAX_COMPLETION_TOKENS"),
+        "the error must say how to fix it; got: {msg}"
+    );
+
+    uncapped.assert_calls_async(1).await;
+    // The whole point: the lowered ceiling was never sent, and no later cascade
+    // mode ran either.
+    shrunk.assert_calls_async(0).await;
+}
+
+/// The bound must gate the raise, not block it. Same shape as the test above,
+/// but the provider stopped at 2000 and the ceiling is 16384 — genuine headroom,
+/// so this recovers.
+#[tokio::test]
+async fn a_ceiling_above_the_observed_budget_still_raises() {
+    let server = MockServer::start_async().await;
+
+    let uncapped = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions").is_true(|req| {
+                let body = req.body_string();
+                body.contains(r#""tools""#) && !body.contains("max_tokens")
+            });
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(truncated_tool_call_with_usage(2000));
+        })
+        .await;
+
+    let raised = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(format!(
+                    r#""max_tokens":{}"#,
+                    OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS
+                ))
+                // The corrective instruction may name the budget it is raising
+                // from, and 2000 is the only figure it can honestly cite here.
+                .body_includes("2000");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(complete_tool_call());
+        })
+        .await;
+
+    let value = adapter(server.base_url())
+        .create_structured_output_with_messages_raw(
+            user_msg(),
+            &schema(),
+            Some(GenerationOptions {
+                max_tokens: None,
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("a ceiling above the observed budget is real headroom");
+
+    assert_eq!(value["name"], "Alexander Graham Bell");
+    uncapped.assert_calls_async(1).await;
+    raised.assert_calls_async(1).await;
+}
+
+/// With no cap on the request and no `usage` in the response, the previous
+/// budget is genuinely unknown. The retry still goes out at the ceiling — that
+/// is the best available move — but the corrective instruction must not assert
+/// an increase it cannot verify.
+#[tokio::test]
+async fn an_unverifiable_raise_is_not_announced_as_one() {
+    let server = MockServer::start_async().await;
+
+    let uncapped = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions").is_true(|req| {
+                let body = req.body_string();
+                body.contains(r#""tools""#) && !body.contains("max_tokens")
+            });
+            then.status(200)
+                .header("content-type", "application/json")
+                // No `usage` block at all.
+                .body(truncated_tool_call("length"));
+        })
+        .await;
+
+    let retried = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/chat/completions")
+                .body_includes(format!(
+                    r#""max_tokens":{}"#,
+                    OpenAIAdapter::DEFAULT_MAX_COMPLETION_TOKENS
+                ))
+                .is_true(|req| !req.body_string().contains("has been raised to"));
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(complete_tool_call());
+        })
+        .await;
+
+    let value = adapter(server.base_url())
+        .create_structured_output_with_messages_raw(
+            user_msg(),
+            &schema(),
+            Some(GenerationOptions {
+                max_tokens: None,
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("an unknown previous budget still retries at the ceiling");
+
+    assert_eq!(value["name"], "Alexander Graham Bell");
+    uncapped.assert_calls_async(1).await;
+    retried.assert_calls_async(1).await;
 }


### PR DESCRIPTION
Closes SDK-581. The one defect found in a reviewed PR that was never fixed — #157 shipped truncation detection, and both halves of how it decided whether it *may* raise the budget were wrong.

## 1. A library default is not a caller's choice

The discriminator was `options.as_ref().and_then(|o| o.max_tokens)`, which separates `None` from `Some(_)` — not a caller's choice from the library's default. `GenerationOptions::default()` set `max_tokens: Some(16384)`, so:

```rust
GenerationOptions { temperature: Some(0.1), ..Default::default() }
```

handed the adapter a 16384 the caller never picked. The recovery path read it as a deliberate constraint, refused to raise, and failed the call terminally with an error naming *the caller-requested 16384-token output budget*. The comment above the line claimed the opposite distinction, which held only for the literal none-passed case.

Latent today — all four in-tree structured-output callers set `max_tokens` explicitly — but `..Default::default()` is the idiomatic spelling, the PR's own tests use it, and `cognee-llm` is published.

**Fix:** carry intent rather than infer it. `Default` now leaves `max_tokens: None`, so `Some(n)` is only ever a value a caller wrote. Both option-less paths keep the cap they had: `resolve_options` already substituted the configured `default_max_tokens` for `generate`, and the structured-output path now spells out the historical 16384 it had been getting as a side effect of the old `Default` — the cap is wanted there and not in `Default`, so it lives there now.

## 2. The "raise" could lower the budget

With no cap on the request — the shape cognify actually sends — `effective_output_budget` returns `0`, meaning "unknown, the provider's own default applied". `0 >= ceiling` is never true, so the code fell through and wrote `max_tokens: ceiling`. When the provider's own default was *higher* than `llm_max_completion_tokens`, the response to a truncation was to **shrink** the budget and re-ask, truncating again — while the reason string still announced "the budget has been raised to {ceiling}" and passed that claim down to every later cascade mode.

**Fix:** use evidence already in the parsed response. `usage.completion_tokens` is a lower bound on the budget the provider applied, so the ceiling must now exceed `max(request cap, tokens actually spent)` to count as headroom. Below that it is terminal, naming the observed figure so the operator raises the right setting. When the provider reports no usage the bound is unavailable and the previous attempt stands — but the reason string then says only what was sent, because there is nothing to claim an increase against.

The two halves pull in opposite directions: making a defaulted budget raisable *widens* the path where the ceiling gets written, so neither is safe to land alone.

## Behaviour change

Deliberate, and documented on the `Default` impl: a caller who builds options with `..Default::default()` and never sets `max_tokens` now sends no cap, so the provider's default applies instead of 16384. That is the documented meaning of an explicit `max_tokens: None`, and it matches Python parity — `acreate_structured_output` passes no cap either.

Two knock-on effects, both checked:

- **Anthropic `effective_max_tokens` needed no change.** `None` takes the configured ceiling, which is what its doc comment already claimed to do; previously a `..Default::default()` caller was clamped to 16384 even when the operator had configured more. Two comments there asserted the old default and are corrected.
- **The Anthropic vision path** defaults to 300 when no budget is set. The only in-tree caller (`ingestion/src/loaders/image.rs`) passes `None` and already took that path, so this is confined to external callers, where "no budget of my own → the path's own default" is now consistent.

## Tests

Four new regression cases in `crates/llm/tests/openai_truncation_retry.rs`, all offline via `httpmock`:

| Test | Pins |
|---|---|
| `a_defaulted_budget_is_not_treated_as_a_caller_choice` | The latent half: `..Default::default()` without `max_tokens` is raised, not refused |
| `a_ceiling_below_the_provider_default_is_not_written_as_a_raise` | Provider spends 8000, ceiling is 4096 → terminal, the 4096 is never sent, cascade does not run |
| `a_ceiling_above_the_observed_budget_still_raises` | The bound gates the raise rather than blocking it |
| `an_unverifiable_raise_is_not_announced_as_one` | No usage reported → still retries at the ceiling, but does not claim an increase |

`openai_truncation_retry.rs:290`, which pinned the old `current == 0` write, still passes unchanged: its fixture reports no `usage`, so it exercises the degrade path deliberately.

Verified: `cargo fmt --check`, `cargo clippy -p cognee-llm --lib -- -D warnings`, `cargo check --all-targets`, `cargo test -p cognee-llm` (11/11 truncation, 124 lib, anthropic truncation), `cargo test -p cognee-cognify --lib` — all clean.

Two pre-existing failures on `origin/main` at `40d65ca`, both reproduced on base and unrelated to this change:
- `cargo clippy -- -D warnings` fails on `cognee-vector`: `warn_zero_norm_query_batch` is never used (`crates/vector/src/zero_norm.rs:108`), introduced by #186. This makes `scripts/check_all.sh` red on main.
- `integration_openai::test_simple_text_generation` fails against the live endpoint — `gpt-oss-120b` spends its explicit 10-token budget on reasoning and returns empty content. Fittingly, an instance of the reasoning-burn case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGu4dPpU99DmyVA2TsWGjh
