### PR TITLE
fix(cli): keep machine-readable stdout clean of console logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,9 @@ and in-cluster Collectors).
 
 Cognee writes structured logs to **stdout** and (when a writable directory is
 available) to a rotating file, owned by the [`cognee-logging`](crates/logging/)
-crate (`cognee_logging::init_logging`, called by the CLI and HTTP server). The
+crate (`cognee_logging::init_logging`, called by the CLI and HTTP server).
+`cognee-cli` logs to **stderr** instead whenever its stdout is machine-readable
+(`-f json` / `-f simple`, and `export`/`visualize`/`bench`), so that output stays
+parseable. The
 full env-var table (`COGNEE_LOG_*`, `RUST_LOG`/`LOG_LEVEL`, `LOG_FILE_NAME`) is
 documented in [Configuration → Logging](https://docs.cognee.ai/rust/configuration#logging).

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -329,6 +329,61 @@ pub enum OutputFormatArg {
     Simple,
 }
 
+/// Which stream the console log layer should use for this invocation.
+///
+/// Any invocation whose stdout is a **contract with a program** gets stderr,
+/// because the console layer writing to stdout corrupts that contract: the
+/// payload ends up preceded by timestamped log lines, so `serde_json::from_str`
+/// reads the `2026` of the first timestamp as a number and fails with "trailing
+/// characters at line 1 column 5".
+///
+/// That covers more than `--output-format json`:
+///
+/// - `json` — the obvious one, a single JSON document.
+/// - `simple` — also machine output, not prose. `search`'s `Simple` arm prints
+///   `item.payload`, a `serde_json::Value`, one per line (NDJSON). This repo's
+///   own cross-SDK harness consumes it programmatically and had to work around
+///   the pollution with `RUST_LOG=error` plus a log-prefix-stripping regex
+///   (`e2e-cross-sdk/harness/helpers.py`).
+/// - `export` / `visualize` — `println!` a bare path, for `$(cognee-cli …)`.
+/// - `bench` — `println!` a JSON result, with every progress line deliberately
+///   on `eprintln!` already; `docs/performance/mock-benchmark.md` documents the
+///   stdout contract.
+///
+/// `pretty` and every other command keep stdout, deliberately. This CLI routes
+/// its whole human-facing surface through `tracing` — not only diagnostics but
+/// progress lines like "Cognify completed." — so switching those too would
+/// relocate all of it to stderr. That is a UX decision well beyond fixing a
+/// broken machine contract, and ten `cli_e2e`/`cli_memify` assertions pin the
+/// current placement as intended behaviour. The faithful end state is Python's
+/// (`cognee/cli/logging_utils.py` puts its handler on stderr in every mode,
+/// with data via `echo`), and getting there means routing CLI messages through
+/// something other than `tracing` — a separate change.
+///
+/// Known gap: `run-sequence` parses its steps internally
+/// (`commands/run_sequence.rs`), so a step's `-f json` is invisible here and
+/// that invocation keeps stdout.
+pub fn console_stream_for(command: &Commands) -> cognee_logging::ConsoleStream {
+    use cognee_logging::ConsoleStream;
+    let format = match command {
+        Commands::Search(args) => &args.output_format,
+        Commands::Recall(args) => &args.output_format,
+        // stdout is a path or a JSON document for these, regardless of flags.
+        // `Visualize` and `Bench` are feature-gated on the enum, so their arms
+        // must be too — a slim CLI build has no such variants.
+        Commands::Export(_) => return ConsoleStream::Stderr,
+        #[cfg(feature = "visualization")]
+        Commands::Visualize(_) => return ConsoleStream::Stderr,
+        #[cfg(feature = "bench")]
+        Commands::Bench(_) => return ConsoleStream::Stderr,
+        _ => return ConsoleStream::Stdout,
+    };
+    match format {
+        OutputFormatArg::Json | OutputFormatArg::Simple => ConsoleStream::Stderr,
+        OutputFormatArg::Pretty => ConsoleStream::Stdout,
+    }
+}
+
 #[derive(Debug, Args)]
 pub struct SearchArgs {
     pub query_text: String,
@@ -685,5 +740,68 @@ mod tests {
             settings.llm_max_retries, 7,
             "an absent flag must not clobber config or env",
         );
+    }
+}
+
+#[cfg(test)]
+mod console_stream_tests {
+    use super::*;
+    use clap::Parser;
+    use cognee_logging::ConsoleStream;
+
+    fn stream_for(args: &[&str]) -> ConsoleStream {
+        match Cli::try_parse_from(args) {
+            Ok(cli) => console_stream_for(&cli.command),
+            Err(e) => panic!("fixture args {args:?} must parse: {e}"),
+        }
+    }
+
+    #[test]
+    fn machine_readable_output_moves_console_logs_off_stdout() {
+        for args in [
+            // json: a single JSON document.
+            vec!["cognee-cli", "search", "q", "--output-format", "json"],
+            // Short flag and `=` form are clap's problem, not ours — assert
+            // they reach the same decision so the spelling cannot drift.
+            vec!["cognee-cli", "search", "q", "-f", "json"],
+            vec!["cognee-cli", "recall", "q", "--output-format=json"],
+            // simple: NDJSON, not prose — `Simple` prints `item.payload`,
+            // which is a `serde_json::Value`. The cross-SDK harness parses it.
+            vec!["cognee-cli", "search", "q", "--output-format", "simple"],
+            vec!["cognee-cli", "recall", "q", "-f", "simple"],
+            // These `println!` a bare path or a JSON document regardless of
+            // flags, so their stdout is a contract too. `visualize`/`bench` are
+            // feature-gated subcommands; only assert what this build has.
+            vec!["cognee-cli", "export", "-o", "out"],
+            #[cfg(feature = "visualization")]
+            vec!["cognee-cli", "visualize"],
+        ] {
+            assert_eq!(
+                stream_for(&args),
+                ConsoleStream::Stderr,
+                "expected stderr for {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn human_output_and_other_commands_keep_stdout() {
+        // Not a fallback. The CLI routes progress lines like "Cognify
+        // completed." through tracing too, and ten cli_e2e/cli_memify
+        // assertions pin those on stdout. Moving them is a UX change, not part
+        // of fixing a broken machine contract.
+        for args in [
+            vec!["cognee-cli", "search", "q"],
+            vec!["cognee-cli", "search", "q", "--output-format", "pretty"],
+            vec!["cognee-cli", "recall", "q", "-f", "pretty"],
+            vec!["cognee-cli", "cognify", "--datasets", "d"],
+            vec!["cognee-cli", "config", "get", "default_user_id"],
+        ] {
+            assert_eq!(
+                stream_for(&args),
+                ConsoleStream::Stdout,
+                "expected stdout for {args:?}"
+            );
+        }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -123,13 +123,26 @@ fn main() -> StdExitCode {
     // `cognee-logging::LoggingConfig`; if parsing fails we keep startup
     // alive by falling back to the documented defaults instead of
     // aborting before any log line could surface the problem.
-    let logging_cfg = match cognee_logging::LoggingConfig::from_env() {
+    let mut logging_cfg = match cognee_logging::LoggingConfig::from_env() {
         Ok(cfg) => cfg,
         Err(err) => {
             eprintln!("warning: invalid logging env var: {err}; falling back to defaults");
             cognee_logging::LoggingConfig::defaults()
         }
     };
+    // `--output-format json` needs a clean stdout to stay parseable. Scoped to
+    // that mode rather than applied to every invocation — see
+    // `cognee_cli::cli::console_stream_for` for why.
+    //
+    // `run()` does the real `Cli::parse()` later; this is a non-committal peek
+    // just to pick the stream, using clap so the flag's spellings (`-f json`,
+    // `--output-format=json`) stay defined in exactly one place. `try_parse`
+    // rather than `parse` on purpose: it returns instead of exiting, so a bad
+    // argument still surfaces from `run()` with clap's own message and exit
+    // code rather than being reported here, before logging even exists.
+    logging_cfg.console_stream = Cli::try_parse()
+        .map(|parsed| cognee_cli::cli::console_stream_for(&parsed.command))
+        .unwrap_or(cognee_logging::ConsoleStream::Stdout);
 
     // Extra tracing layers installed alongside the stdout logger. The
     // `profiling` build adds an offline per-stage span-timing layer that the

--- a/crates/cli/tests/cli_e2e.rs
+++ b/crates/cli/tests/cli_e2e.rs
@@ -317,7 +317,11 @@ fn search_errors_when_dataset_name_does_not_exist() {
         ])
         .assert()
         .failure()
-        .stdout(predicate::str::contains("dataset not found"));
+        // `simple` is a machine format — `search`'s Simple arm prints
+        // `item.payload`, i.e. NDJSON — so diagnostics go to stderr and stdout
+        // carries only rows. Asserting this on stdout previously passed because
+        // the console layer wrote there, which is the bug this pins the fix for.
+        .stderr(predicate::str::contains("dataset not found"));
 }
 
 #[test]
@@ -770,23 +774,13 @@ fn search_live_smoke() {
         .clone();
     let stdout = String::from_utf8(out).expect("search --output-format json emits UTF-8");
 
-    // `--output-format json` does not give clean stdout: the logger writes to it
-    // too, so the payload is preceded by timestamped lines. Parsing the whole
-    // buffer reads the `2026` of a timestamp as a JSON number and then fails on
-    // "trailing characters". Slice from the first line that starts a JSON object
-    // and take a single value off a streaming deserializer, so anything the
-    // logger emits before or after the payload is tolerated.
-    let json_start = if stdout.starts_with('{') {
-        Some(0)
-    } else {
-        stdout.find("\n{").map(|i| i + 1)
-    }
-    .unwrap_or_else(|| panic!("no JSON object in search stdout:\n{stdout}"));
-    let parsed: serde_json::Value = serde_json::Deserializer::from_str(&stdout[json_start..])
-        .into_iter::<serde_json::Value>()
-        .next()
-        .unwrap_or_else(|| panic!("no JSON value in search stdout:\n{stdout}"))
-        .unwrap_or_else(|e| panic!("search JSON parse failed: {e}\n{stdout}"));
+    // Parsed straight off stdout, with no slicing. That is the contract
+    // `--output-format json` owes a consumer, and asserting it here makes this
+    // test a canary: if the console log layer ever moves back to stdout, this
+    // fails with the same "trailing characters at line 1 column 5" a piping
+    // user would see. See `logging_e2e::machine_readable_stdout_is_exactly_the_payload`.
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("search stdout must be pure JSON: {e}\n{stdout}"));
 
     // Shape is `{"search_type": .., "result": {"kind": "Items", "data": [..]}}`.
     // Read it defensively so a shape change fails with the payload in hand
@@ -956,13 +950,14 @@ fn export_rejects_a_format_python_cannot_reimport() {
     // Only `cogx` round-trips into Python; the other Python export formats
     // have no reader, so accepting them would promise a restore we cannot do.
     let config_home = TempDir::new().expect("temp dir should be created");
-    // The CLI's tracing layer writes to stdout, so the rejection lands there,
-    // not on stderr.
+    // `export` prints the archive path on stdout for `$(cognee-cli export -o …)`,
+    // so its diagnostics go to stderr. This assertion used to read `.stdout`
+    // because the console layer wrote there — the bug, not the intent.
     make_cmd(&config_home)
         .args(["export", "--format", "graphml"])
         .assert()
         .failure()
-        .stdout(predicate::str::contains("graphml").and(predicate::str::contains("cogx")));
+        .stderr(predicate::str::contains("graphml").and(predicate::str::contains("cogx")));
 }
 
 #[test]

--- a/crates/cli/tests/logging_e2e.rs
+++ b/crates/cli/tests/logging_e2e.rs
@@ -151,3 +151,109 @@ fn cli_default_filter_suppresses_library_noise_in_log_file() {
         );
     }
 }
+
+/// In a machine-readable mode, stdout must be **exactly the payload**.
+///
+/// The console layer used to write to stdout, so the payload arrived preceded
+/// by timestamped log lines and `serde_json::from_str` read the `2026` of the
+/// first timestamp as a number, failing with "trailing characters at line 1
+/// column 5".
+///
+/// Three separate assertions, and the split is deliberate:
+///
+/// 1. stderr carries the log anchor — without this the test would also pass if
+///    logging stopped working altogether, a different bug with the same tick.
+/// 2. stdout parses as JSON — without this the test would also pass if the
+///    payload were never emitted, or were moved to stderr along with the logs.
+///    That was a real gap in the first version of this test, which only checked
+///    for the absence of log markers.
+/// 3. stdout carries no log markers — the original defect.
+///
+/// Keyless: `CYPHER` passes the query to the graph store verbatim rather than
+/// asking an LLM to generate it, so a dummy `llm_api_key` (the component
+/// manager builds an LLM eagerly) plus `MOCK_EMBEDDING=true` is enough. No
+/// network, and it still produces a real payload.
+#[test]
+fn machine_readable_stdout_is_exactly_the_payload() {
+    let dir = tempdir().expect("tempdir");
+    let bin = env!("CARGO_BIN_EXE_cognee-cli");
+    let doc = dir.path().join("doc.txt");
+    std::fs::write(&doc, "badgers and mushrooms").expect("write fixture");
+
+    let run = |args: &[&str]| {
+        Command::new(bin)
+            .env("COGNEE_LOGS_DIR", dir.path())
+            .env("COGNEE_CONFIG_HOME", dir.path())
+            .env("MOCK_EMBEDDING", "true")
+            .env_remove("LOG_FILE_NAME")
+            .env_remove("RUST_LOG")
+            .env_remove("LOG_LEVEL")
+            .env_remove("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .current_dir(dir.path())
+            .args(args)
+            .output()
+            .expect("spawn cognee-cli")
+    };
+
+    // The component manager constructs an LLM even for CYPHER, which never
+    // calls one; a placeholder satisfies it without any network.
+    assert!(
+        run(&["config", "set", "llm_api_key", "\"dummy-key\""])
+            .status
+            .success(),
+        "config set should succeed"
+    );
+    let added = run(&[
+        "add",
+        doc.to_str().expect("utf-8 path"),
+        "--dataset-name",
+        "logstream",
+    ]);
+    assert!(
+        added.status.success(),
+        "add should succeed; stderr=\n{}",
+        String::from_utf8_lossy(&added.stderr)
+    );
+
+    let output = run(&[
+        "search",
+        "MATCH (n) RETURN n",
+        "--query-type",
+        "CYPHER",
+        "--datasets",
+        "logstream",
+        "--output-format",
+        "json",
+    ]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "cypher search should succeed; stderr=\n{stderr}"
+    );
+
+    // (1) Logging happened, and it happened on stderr.
+    assert!(
+        stderr.contains("Logging initialized"),
+        "expected the console layer on stderr; an empty stderr means the layer \
+         is not installed at all, which this test must not pass for. \
+         stderr=\n{stderr}"
+    );
+
+    // (2) stdout is the payload, and it is parseable as-is.
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout must be exactly the JSON payload: {e}\n{stdout}"));
+    assert_eq!(
+        parsed.get("search_type").and_then(|v| v.as_str()),
+        Some("CYPHER"),
+        "expected the search payload on stdout, got:\n{stdout}"
+    );
+
+    // (3) And nothing log-shaped joined it.
+    for marker in ["Logging initialized", "[INFO", "[DEBUG", "[WARN", "[ERROR"] {
+        assert!(
+            !stdout.contains(marker),
+            "machine-readable stdout must carry only the payload, found {marker:?} in:\n{stdout}"
+        );
+    }
+}

--- a/crates/logging/src/config.rs
+++ b/crates/logging/src/config.rs
@@ -26,6 +26,23 @@ pub enum LogFormat {
     Json,
 }
 
+/// Which standard stream the console layer writes to.
+///
+/// Defaults to [`ConsoleStream::Stdout`], preserving the behaviour every
+/// existing consumer had. The CLI selects [`ConsoleStream::Stderr`]: it emits
+/// *data* on stdout (notably `--output-format json`), and diagnostics
+/// interleaved with that data make the output unparseable — `serde_json` reads
+/// the `2026` of a log timestamp as a number and fails with "trailing
+/// characters at line 1 column 5". Keeping logs on stderr is also the
+/// conventional split for a command-line tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsoleStream {
+    /// Write console logs to stdout.
+    Stdout,
+    /// Write console logs to stderr, leaving stdout for data.
+    Stderr,
+}
+
 /// Time-based rotation cadence. Size-based deferred per decision 1.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LogRotation {
@@ -105,6 +122,9 @@ pub struct LoggingConfig {
     /// `COGNEE_LOG_MAX_FILES` (decision 14): retention ceiling
     /// enforced by the startup cleanup pass (task 06-03). Default `10`.
     pub max_files: usize,
+    /// Which standard stream the console layer writes to. Not env-driven:
+    /// it is a property of the embedding program, not the deployment.
+    pub console_stream: ConsoleStream,
     /// Resolved `EnvFilter` directive string built from `RUST_LOG`
     /// (preferred) or `LOG_LEVEL` (fallback). `None` means neither
     /// env var was set, and the init layer should substitute the
@@ -129,6 +149,7 @@ impl LoggingConfig {
             format: LogFormat::Plain,
             backup_count: 5,
             max_files: 10,
+            console_stream: ConsoleStream::Stdout,
             level_filter: None,
         }
     }
@@ -196,6 +217,7 @@ impl LoggingConfig {
             format,
             backup_count,
             max_files,
+            console_stream: ConsoleStream::Stdout,
             level_filter,
         })
     }

--- a/crates/logging/src/init.rs
+++ b/crates/logging/src/init.rs
@@ -101,17 +101,27 @@ where
     let env_filter =
         EnvFilter::try_new(&filter_directive).unwrap_or_else(|_| EnvFilter::new("info"));
 
-    // (2) Stdout layer per cfg.format.
+    // (2) Console layer per cfg.format, on the stream cfg selects. The CLI
+    // picks stderr so that `--output-format json` leaves stdout as pure data;
+    // everything else keeps stdout, which is what it always had.
+    let console_writer = match cfg.console_stream {
+        crate::ConsoleStream::Stdout => {
+            tracing_subscriber::fmt::writer::BoxMakeWriter::new(std::io::stdout)
+        }
+        crate::ConsoleStream::Stderr => {
+            tracing_subscriber::fmt::writer::BoxMakeWriter::new(std::io::stderr)
+        }
+    };
     let stdout_layer: BoxedLayer = match cfg.format {
         LogFormat::Plain => Box::new(
             tracing_subscriber::fmt::layer()
                 .event_format(crate::PythonPlainFormatter)
-                .with_writer(std::io::stdout),
+                .with_writer(console_writer),
         ),
         LogFormat::Json => Box::new(
             tracing_subscriber::fmt::layer()
                 .json()
-                .with_writer(std::io::stdout),
+                .with_writer(console_writer),
         ),
     };
 

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -14,7 +14,7 @@ mod formatter;
 mod init;
 mod paths;
 
-pub use config::{LogFormat, LogRotation, LoggingConfig, LoggingConfigError};
+pub use config::{ConsoleStream, LogFormat, LogRotation, LoggingConfig, LoggingConfigError};
 pub use formatter::PythonPlainFormatter;
 pub use init::{BoxedLayer, LogGuards, default_filter, init_logging};
 pub use paths::{cleanup_old_logs, propagate_log_file_name, resolve_logs_dir};

--- a/crates/logging/src/paths.rs
+++ b/crates/logging/src/paths.rs
@@ -203,6 +203,7 @@ mod tests {
 
     fn cfg_with_override(dir: Option<PathBuf>) -> LoggingConfig {
         LoggingConfig {
+            console_stream: crate::ConsoleStream::Stdout,
             file_enabled: true,
             logs_dir_override: dir,
             log_file_name: None,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -860,6 +860,13 @@ flag-gated only — provider overload does not switch it on automatically.
 > structured logs to **stdout** and (when writable) to a rotating file. File logging
 > is owned by [`cognee-logging`](../crates/logging/), initialised by the CLI and HTTP
 > server via `cognee_logging::init_logging`.
+>
+> **Exception — machine-readable CLI output.** `cognee-cli` sends console logs to
+> **stderr** for any invocation whose stdout is a contract with a program:
+> `search`/`recall` with `-f json` or `-f simple`, and `export`, `visualize` and
+> `bench`, which print a path or a JSON document. Logs on stdout make those
+> unparseable (a leading timestamp is read as a JSON number). Human-facing
+> `pretty` output, and every other subcommand, still log to stdout.
 
 | Env var | Default | Purpose |
 |---|---|---|


### PR DESCRIPTION
`cognee-cli search --output-format json` was unparseable when piped. The console `tracing` layer wrote to **stdout** alongside the payload, so the buffer began with timestamped log lines and `serde_json::from_str` read the `2026` of the first timestamp as a number:

```
trailing characters at line 1 column 5
```

## The change

`LoggingConfig::console_stream` (`ConsoleStream::Stdout` | `Stderr`), honoured by the console layer via `BoxMakeWriter`. **The default stays `Stdout`** — the HTTP server, all four bindings and every other consumer are untouched. `cli::console_stream_for` derives the stream from the parsed command.

## Which invocations switch, and why it isn't only `json`

| invocation | stdout is | switches? |
|---|---|---|
| `search`/`recall` `-f json` | one JSON document | ✅ |
| `search`/`recall` `-f simple` | **NDJSON** — `Simple` prints `item.payload`, a `serde_json::Value` | ✅ |
| `export`, `visualize` | a bare path, for `$(cognee-cli …)` | ✅ |
| `bench` | a JSON result; progress already on `eprintln!` | ✅ |
| `search`/`recall` `-f pretty`, everything else | prose for a human | ❌ stays |

`simple` is the one I got wrong at first and it is not a judgement call: **this repo's own cross-SDK harness consumes `-f simple` programmatically** and had to work around the pollution with `RUST_LOG=error` plus a prefix-stripping regex (`e2e-cross-sdk/harness/helpers.py`). `bench` likewise carries `// No --output: still emit machine result on stdout for piping.` and documents that contract in `docs/performance/mock-benchmark.md`.

## What deliberately does *not* change

This CLI routes its whole human-facing surface through `tracing` — not only errors but progress lines like `"Cognify completed."` and `"Memify completed."`. Switching those too relocates all of it, and **ten** `cli_e2e`/`cli_memify` assertions pin the current placement as intended behaviour. Relocating the CLI's entire output is a UX decision, not part of fixing a broken machine contract. The faithful end state is Python's (`cognee/cli/logging_utils.py` puts its handler on stderr in every mode, with data via `echo`), which means routing CLI messages through something other than `tracing` — a separate change.

Two assertions *did* move, both machine-readable invocations: `search … -f simple` and `export --format graphml`. The latter carried the comment *"The CLI's tracing layer writes to stdout, so the rejection lands there, not on stderr"* — documenting the bug rather than the intent.

## The peek in `main`

`Cli::try_parse` before logging is initialised (the real parse happens later in `run`), so clap remains the single definition of the flag's spellings — `-f json` and `--output-format=json` reach the same decision. `try_parse` rather than `parse` means a bad argument still surfaces from `run` with clap's own message and exit code rather than being reported before logging exists.

Two known limitations, documented on `console_stream_for`: an unparseable argv falls back to `Stdout`, and `run-sequence` parses its steps internally, so a step's `-f json` is invisible to the peek.

## Guards — both keyless

- **`cli::console_stream_tests`** pins the decision for every machine-readable shape (including `-f` and `=` spellings) and that `pretty`/other commands keep stdout.
- **`logging_e2e::machine_readable_stdout_is_exactly_the_payload`** runs `add` + a `CYPHER` json search. Keyless because CYPHER passes the query to the graph store verbatim instead of asking an LLM to generate it. It asserts three things **separately**: the log anchor is on stderr, stdout parses as the JSON payload, and stdout carries no log markers. The middle one matters — an earlier version checked only for absent markers and still passed when the payload was moved off stdout entirely. Mutation-checked: turning the payload `println!` into `eprintln!` fails this test and passed the old one.
- **`cli_e2e::search_live_smoke`** keeps a plain `serde_json::from_str` on stdout, dropping the slicing workaround #186 needed — a canary in the keyed lane.

## Verification

`cargo fmt --check`; `clippy -D warnings` on `cognee-logging` + `cognee-cli`; 39 logging tests; all `cognee-cli` test targets (29 `cli_e2e`, 7 `cli_memify`, 3 `logging_e2e`, 17 lib); `cargo check --all-targets`. End to end with live credentials: `add` → `cognify` → `search -f json` piped straight into a strict parser — parses and returns its row, where it previously raised the error above.

`docs/configuration.md` and `README.md` both claimed logs go to stdout unconditionally; both now record the exception.

Found while writing the retrieval assertion in #186, which had to work around this to parse the CLI's own JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmwWAiTW184ZDFDdhW58Ki
