### PR TITLE
perf(vector): add an HNSW index to the pgvector collections (SDK-515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -927,7 +927,9 @@ jobs:
             --require-test create_collection_builds_an_hnsw_index \
             --require-test a_collection_over_the_dimension_ceiling_is_left_unindexed \
             --require-test backfill_indexes_pre_existing_collections_and_is_idempotent \
-            --require-test backfill_replaces_an_invalid_index_left_by_a_failed_build
+            --require-test backfill_replaces_an_invalid_index_left_by_a_failed_build \
+            --require-test a_search_returns_top_k_rows_even_above_the_default_ef_search \
+            --require-test a_collection_name_past_the_identifier_limit_is_still_tracked
 
   # ── Stage 2.5: single-database Postgres stack (depends on lint, parallel with `test`) ──
   # The `TEST_POSTGRES_URL` suites, which no CI job ever supplied that variable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -923,7 +923,11 @@ jobs:
             --require-test upsert_emits_pgvector_span \
             --require-test search_emits_pgvector_span \
             --require-test delete_emits_pgvector_span \
-            --require-test close_releases_the_pool_while_the_adapter_is_still_held
+            --require-test close_releases_the_pool_while_the_adapter_is_still_held \
+            --require-test create_collection_builds_an_hnsw_index \
+            --require-test a_collection_over_the_dimension_ceiling_is_left_unindexed \
+            --require-test backfill_indexes_pre_existing_collections_and_is_idempotent \
+            --require-test backfill_replaces_an_invalid_index_left_by_a_failed_build
 
   # ── Stage 2.5: single-database Postgres stack (depends on lint, parallel with `test`) ──
   # The `TEST_POSTGRES_URL` suites, which no CI job ever supplied that variable

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -444,7 +444,9 @@ jobs:
             --require-test create_collection_builds_an_hnsw_index \
             --require-test a_collection_over_the_dimension_ceiling_is_left_unindexed \
             --require-test backfill_indexes_pre_existing_collections_and_is_idempotent \
-            --require-test backfill_replaces_an_invalid_index_left_by_a_failed_build
+            --require-test backfill_replaces_an_invalid_index_left_by_a_failed_build \
+            --require-test a_search_returns_top_k_rows_even_above_the_default_ef_search \
+            --require-test a_collection_name_past_the_identifier_limit_is_still_tracked
 
   # ── Single-database Postgres stack (mirror of ci.yml's `pg-single-db-postgres`) ──
   # Two of the three suites in the keyed twin; `pg_full_stack_e2e` is deliberately

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -440,7 +440,11 @@ jobs:
             --require-test upsert_emits_pgvector_span \
             --require-test search_emits_pgvector_span \
             --require-test delete_emits_pgvector_span \
-            --require-test close_releases_the_pool_while_the_adapter_is_still_held
+            --require-test close_releases_the_pool_while_the_adapter_is_still_held \
+            --require-test create_collection_builds_an_hnsw_index \
+            --require-test a_collection_over_the_dimension_ceiling_is_left_unindexed \
+            --require-test backfill_indexes_pre_existing_collections_and_is_idempotent \
+            --require-test backfill_replaces_an_invalid_index_left_by_a_failed_build
 
   # ── Single-database Postgres stack (mirror of ci.yml's `pg-single-db-postgres`) ──
   # Two of the three suites in the keyed twin; `pg_full_stack_e2e` is deliberately

--- a/crates/vector/src/pgvector_adapter.rs
+++ b/crates/vector/src/pgvector_adapter.rs
@@ -3,12 +3,33 @@
 //! Each `(data_type, field_name)` pair maps to a dedicated PostgreSQL table with
 //! columns: `id UUID PRIMARY KEY`, `vector vector(N)`, `metadata JSONB`.
 //! A `_vector_collections` bookkeeping table tracks which collection tables exist.
+//!
+//! # Indexing
+//!
+//! Each collection also carries an HNSW index over its `vector` column, built at
+//! [`VectorDB::create_collection`] time with the `vector_cosine_ops` opclass —
+//! matching the `<=>` operator every search orders by. Without it, similarity
+//! search is an exact sequential scan over the whole collection.
+//!
+//! Two deliberate exceptions:
+//!
+//! - Collections wider than [`MAX_INDEXABLE_DIMENSION`] cannot be indexed by
+//!   pgvector and keep the exact scan.
+//! - [`VectorDB::search_similar_filtered`] forces the exact scan, because
+//!   pgvector post-filters an index scan and that would break the
+//!   filter-then-limit guarantee that path exists to provide. See the comment
+//!   at that call site.
+//!
+//! Collections created before indexing existed keep only their btree primary
+//! key; [`PgVectorAdapter::create_missing_vector_indexes`] backfills them.
 
 use async_trait::async_trait;
 use sea_orm::sea_query::{
     Alias, Asterisk, Expr, Func, Iden, OnConflict, Order, PostgresQueryBuilder, Query, Table,
 };
-use sea_orm::{ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement};
+use sea_orm::{
+    ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement, TransactionTrait,
+};
 use sea_orm_migration::MigratorTrait;
 use std::collections::HashMap;
 use std::fmt;
@@ -25,8 +46,30 @@ use crate::models::{SearchResult, VectorPoint};
 use crate::vector_db_trait::VectorDB;
 use crate::zero_norm::{warn_zero_norm_points, warn_zero_norm_query, warn_zero_norm_query_batch};
 
+#[cfg(test)]
+#[path = "pgvector_index_tests.rs"]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+mod vector_index_tests;
+
 /// Max points per INSERT batch (300 params = 100 rows × 3 columns).
 const BATCH_SIZE: usize = 100;
+
+/// HNSW graph degree. pgvector's own default; raising it trades build time and
+/// index size for recall.
+const HNSW_M: u32 = 16;
+
+/// HNSW build-time candidate list size. pgvector's own default.
+const HNSW_EF_CONSTRUCTION: u32 = 64;
+
+/// pgvector cannot index a `vector` wider than 2000 dimensions — the index
+/// tuple would not fit in a page. `text-embedding-3-large` at 3072 is over the
+/// line, so a collection that wide keeps the exact scan and says so, rather
+/// than failing `create_collection` outright.
+const MAX_INDEXABLE_DIMENSION: usize = 2000;
 
 // ---------------------------------------------------------------------------
 // Table / column identifiers for sea_query (`_vector_collections`)
@@ -235,6 +278,169 @@ impl PgVectorAdapter {
         Ok(())
     }
 
+    /// Name of the HNSW index over a collection's `vector` column.
+    ///
+    /// Derived from the collection name, which [`Self::validate_identifier`] has
+    /// already restricted to `[A-Za-z0-9_]`, so it is safe to interpolate.
+    fn vector_index_name(coll: &str) -> String {
+        format!("{coll}_vector_hnsw")
+    }
+
+    /// Create the HNSW index over `coll`'s `vector` column, if the collection is
+    /// narrow enough to index.
+    ///
+    /// The opclass is `vector_cosine_ops` because every search site orders by
+    /// the cosine operator `<=>`; an opclass that does not match the operator in
+    /// the `ORDER BY` is simply never used by the planner, which would leave the
+    /// sequential scan in place while looking like it had been fixed.
+    ///
+    /// `concurrently` builds without taking a write lock, at the cost of not
+    /// being runnable inside a transaction. Pass `false` from
+    /// [`VectorDB::create_collection`], where the table is empty and the lock is
+    /// free; pass `true` from [`Self::create_missing_vector_indexes`], which
+    /// backfills tables that already hold rows and may be serving traffic.
+    async fn create_vector_index(
+        db: &DatabaseConnection,
+        coll: &str,
+        dimension: usize,
+        concurrently: bool,
+    ) -> VectorDBResult<bool> {
+        if dimension > MAX_INDEXABLE_DIMENSION {
+            debug!(
+                "collection {coll} is {dimension}-dimensional, over pgvector's \
+                 {MAX_INDEXABLE_DIMENSION}-d index ceiling — keeping the exact scan"
+            );
+            return Ok(false);
+        }
+
+        let index = Self::vector_index_name(coll);
+        let concurrent_kw = if concurrently { " CONCURRENTLY" } else { "" };
+        let ddl = format!(
+            r#"CREATE INDEX{concurrent_kw} IF NOT EXISTS "{index}"
+               ON "{coll}" USING hnsw (vector vector_cosine_ops)
+               WITH (m = {HNSW_M}, ef_construction = {HNSW_EF_CONSTRUCTION})"#
+        );
+
+        db.execute_unprepared(&ddl)
+            .await
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+
+        debug!("created HNSW index {index} on {coll} (dim={dimension})");
+        Ok(true)
+    }
+
+    /// State of the index named `index`: `None` if it does not exist, else
+    /// whether Postgres considers it valid.
+    ///
+    /// Validity is the part that matters for the backfill. A `CREATE INDEX
+    /// CONCURRENTLY` that fails or is interrupted leaves the index in place but
+    /// marked invalid; the planner ignores an invalid index, and
+    /// `CREATE INDEX ... IF NOT EXISTS` sees the *name* and does nothing — so a
+    /// presence-only check would skip it on every subsequent run and the
+    /// collection would keep its sequential scan forever, while looking indexed.
+    /// The caller drops an invalid index and rebuilds it.
+    ///
+    /// Matches on `pg_class.relname`, which compares the name as *data*. The
+    /// obvious alternative, `to_regclass($1)`, parses its argument as an SQL
+    /// identifier and case-folds an unquoted one, so it would look for
+    /// `idx_f_vector_hnsw` and never match the `"Idx_f_vector_hnsw"` that was
+    /// actually created — collection names carry their case, coming from a
+    /// `data_type` like `DocumentChunk`.
+    async fn vector_index_state(
+        db: &DatabaseConnection,
+        index: &str,
+    ) -> VectorDBResult<Option<bool>> {
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                "SELECT i.indisvalid AS valid
+                   FROM pg_class c
+                   JOIN pg_index i ON i.indexrelid = c.oid
+                  WHERE c.relname = $1",
+                [index.into()],
+            ))
+            .await
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+
+        match row {
+            Some(row) => row
+                .try_get::<bool>("", "valid")
+                .map(Some)
+                .map_err(|e| VectorDBError::StorageError(e.to_string())),
+            None => Ok(None),
+        }
+    }
+
+    /// Build the HNSW index on every registered collection that does not have
+    /// one yet, and report how many were created.
+    ///
+    /// [`VectorDB::create_collection`] indexes new collections, but it guards on
+    /// `has_collection`, so it never runs for a collection that already exists.
+    /// Every collection created before this change therefore still has only its
+    /// btree primary key, and stays on the sequential scan until this runs once.
+    ///
+    /// Uses `CREATE INDEX CONCURRENTLY`, so it does not block writes and cannot
+    /// be called inside a transaction — which is also why it is not a migration.
+    /// Idempotent and safe to call on every startup, but building an HNSW index
+    /// over a large collection is expensive, so the caller decides when.
+    ///
+    /// The returned count is indexes this call actually built: collections that
+    /// already had one, and collections wider than [`MAX_INDEXABLE_DIMENSION`],
+    /// are skipped and not counted.
+    pub async fn create_missing_vector_indexes(&self) -> VectorDBResult<usize> {
+        let query = Query::select()
+            .columns([VColl::CollectionName, VColl::Dimension])
+            .from(VColl::Table)
+            .to_owned();
+
+        let rows = self
+            .db
+            .query_all(self.build(&query))
+            .await
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+
+        let mut created = 0usize;
+        for row in &rows {
+            let coll: String = row
+                .try_get("", "collection_name")
+                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+            let dimension: i32 = row
+                .try_get("", "dimension")
+                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+
+            // A row in the bookkeeping table came from `create_collection`, which
+            // validated the name before creating the table — but re-validate
+            // rather than trust the table, since this name is interpolated into
+            // DDL and the table is reachable by anything with the connection.
+            Self::validate_identifier(&coll)?;
+
+            // Check first rather than leaning on `IF NOT EXISTS`, so the count
+            // reports work actually done and an already-indexed collection is
+            // not handed a redundant CONCURRENTLY build.
+            let index = Self::vector_index_name(&coll);
+            match Self::vector_index_state(&self.db, &index).await? {
+                Some(true) => continue,
+                // Left behind by an interrupted CONCURRENTLY build. `IF NOT
+                // EXISTS` would refuse to replace it, so drop it and rebuild —
+                // otherwise this collection can never become indexed.
+                Some(false) => {
+                    debug!("dropping invalid index {index} left by a failed build, rebuilding");
+                    self.db
+                        .execute_unprepared(&format!(r#"DROP INDEX CONCURRENTLY "{index}""#))
+                        .await
+                        .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+                }
+                None => {}
+            }
+
+            if Self::create_vector_index(&self.db, &coll, dimension.max(0) as usize, true).await? {
+                created += 1;
+            }
+        }
+
+        Ok(created)
+    }
+
     /// Format a vector as pgvector text literal: `[1.0,2.0,3.0]`
     fn format_vector(v: &[f32]) -> String {
         let inner: String = v
@@ -422,6 +628,13 @@ impl VectorDB for PgVectorAdapter {
             .execute_unprepared(&ddl)
             .await
             .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+
+        // Build the ANN index while the table is empty, which is why HNSW and
+        // not IVFFlat: IVFFlat derives its centroids from existing rows, so it
+        // cannot be built here and would need a rebuild policy. HNSW builds
+        // incrementally, so an empty-table CREATE INDEX is instant and takes no
+        // meaningful lock.
+        Self::create_vector_index(&self.db, &coll, dimension, false).await?;
 
         // Register in bookkeeping table.
         let insert = Query::insert()
@@ -797,13 +1010,46 @@ impl VectorDB for PgVectorAdapter {
         values.push((top_k as i64).into());
         values.extend(name_values);
 
-        let rows = self
+        // Deliberately keep the HNSW index out of this one query.
+        //
+        // pgvector post-filters an index scan: the index yields roughly
+        // `hnsw.ef_search` (default 40) candidates by distance alone, and the
+        // `WHERE` clause is applied to *those*. A selective NodeSet filter then
+        // returns fewer than `top_k` rows, or none at all — the exact opposite
+        // of the filter-then-limit guarantee documented above, which
+        // `test_search_similar_filtered_filter_then_limit` pins with 64
+        // zero-distance out-of-set rows crowding 2 in-set ones.
+        //
+        // Disabling index and bitmap scans for the statement forces the exact
+        // scan that guarantee needs. The unfiltered paths — `search_similar` and
+        // `batch_search_similar`, which is where the volume is — are untouched
+        // and do use the index. Trading this exactness for indexed filtered
+        // search is possible (pgvector 0.8's `hnsw.iterative_scan`, or reshaping
+        // the predicate into something GIN-indexable) but it is a behaviour
+        // change that needs its own decision, not a side effect of adding an
+        // index.
+        let txn = self
             .db
+            .begin()
+            .await
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        for guc in [
+            "SET LOCAL enable_indexscan = off",
+            "SET LOCAL enable_bitmapscan = off",
+        ] {
+            txn.execute_unprepared(guc)
+                .await
+                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        }
+        let rows = txn
             .query_all(Statement::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 &sql,
                 values,
             ))
+            .await
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        txn.commit()
             .await
             .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
 

--- a/crates/vector/src/pgvector_adapter.rs
+++ b/crates/vector/src/pgvector_adapter.rs
@@ -33,7 +33,7 @@ use sea_orm::{
 use sea_orm_migration::MigratorTrait;
 use std::collections::HashMap;
 use std::fmt;
-use tracing::{Span, debug, instrument};
+use tracing::{Span, debug, instrument, warn};
 use uuid::Uuid;
 
 use cognee_utils::sanitize::sanitize_json;
@@ -70,6 +70,23 @@ const HNSW_EF_CONSTRUCTION: u32 = 64;
 /// line, so a collection that wide keeps the exact scan and says so, rather
 /// than failing `create_collection` outright.
 const MAX_INDEXABLE_DIMENSION: usize = 2000;
+
+/// pgvector's own default `hnsw.ef_search`.
+///
+/// Load-bearing, not decorative: an HNSW index scan returns **at most**
+/// `ef_search` tuples and then ends, so a `LIMIT` above it is silently unmet —
+/// no error, just fewer rows. cognee's retrieval paths ask for
+/// `DEFAULT_WIDE_SEARCH_TOP_K = 100`, so leaving this at 40 would quietly drop
+/// 60% of every graph-completion, triplet and temporal seed set.
+const HNSW_EF_SEARCH_DEFAULT: usize = 40;
+
+/// Largest `hnsw.ef_search` pgvector accepts. Beyond this a search cannot be
+/// made to return `top_k` rows by raising `ef_search`, so those queries fall
+/// back to the exact scan — see [`PgVectorAdapter::ann_search_locals`].
+const HNSW_EF_SEARCH_MAX: usize = 1000;
+
+/// Postgres truncates any identifier past this many bytes (`NAMEDATALEN - 1`).
+const PG_MAX_IDENTIFIER_BYTES: usize = 63;
 
 // ---------------------------------------------------------------------------
 // Table / column identifiers for sea_query (`_vector_collections`)
@@ -282,8 +299,78 @@ impl PgVectorAdapter {
     ///
     /// Derived from the collection name, which [`Self::validate_identifier`] has
     /// already restricted to `[A-Za-z0-9_]`, so it is safe to interpolate.
+    ///
+    /// Truncated to [`PG_MAX_IDENTIFIER_BYTES`] here, because Postgres would
+    /// truncate it anyway when creating the index — and then
+    /// [`Self::vector_index_state`], which compares the name as *data* against
+    /// `pg_class.relname`, would be looking for the untruncated string and never
+    /// match. The consequences of that mismatch are not cosmetic: the backfill
+    /// would re-issue `CREATE INDEX` and re-count it on every run, and an index
+    /// left invalid by an interrupted build would report as absent, so it would
+    /// never be dropped or rebuilt. Slicing bytes is safe because the name is
+    /// ASCII by construction.
+    ///
+    /// Two collections whose names agree in their first 51 characters therefore
+    /// collide on one index name. That is inherited from the collection names
+    /// themselves — they are table names under the same limit — so it is not
+    /// introduced here.
     fn vector_index_name(coll: &str) -> String {
-        format!("{coll}_vector_hnsw")
+        let mut name = format!("{coll}_vector_hnsw");
+        name.truncate(PG_MAX_IDENTIFIER_BYTES);
+        name
+    }
+
+    /// `SET LOCAL` statements that make an ANN search actually return `top_k`
+    /// rows, as one semicolon-separated string (one round trip).
+    ///
+    /// An HNSW index scan stops after `ef_search` tuples, so `ef_search` must be
+    /// at least `top_k` or the `LIMIT` is silently unmet. Past
+    /// [`HNSW_EF_SEARCH_MAX`] that lever runs out, and the only way left to
+    /// guarantee `top_k` rows is to not use the index — which is the right
+    /// trade at that size, since such a query is scanning most of the
+    /// collection regardless.
+    fn ann_search_locals(top_k: usize) -> String {
+        if top_k > HNSW_EF_SEARCH_MAX {
+            return Self::exact_scan_locals().to_string();
+        }
+        let ef = top_k.max(HNSW_EF_SEARCH_DEFAULT);
+        format!("SET LOCAL hnsw.ef_search = {ef}")
+    }
+
+    /// `SET LOCAL` statements that force an exact scan, for the paths whose
+    /// correctness depends on it.
+    fn exact_scan_locals() -> &'static str {
+        "SET LOCAL enable_indexscan = off; SET LOCAL enable_bitmapscan = off"
+    }
+
+    /// Run `stmt` in a transaction with `locals` applied first.
+    ///
+    /// The transaction is what makes `SET LOCAL` mean anything — outside one it
+    /// is a no-op with a warning — and it scopes the settings to this statement
+    /// so they cannot leak to the next borrower of a pooled connection. `locals`
+    /// goes over the simple-query protocol, so several `SET LOCAL`s cost one
+    /// round trip rather than one each.
+    async fn query_all_with_locals(
+        &self,
+        locals: &str,
+        stmt: Statement,
+    ) -> VectorDBResult<Vec<sea_orm::QueryResult>> {
+        let txn = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        txn.execute_unprepared(locals)
+            .await
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        let rows = txn
+            .query_all(stmt)
+            .await
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        txn.commit()
+            .await
+            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        Ok(rows)
     }
 
     /// Create the HNSW index over `coll`'s `vector` column, if the collection is
@@ -346,6 +433,17 @@ impl PgVectorAdapter {
     /// `idx_f_vector_hnsw` and never match the `"Idx_f_vector_hnsw"` that was
     /// actually created — collection names carry their case, coming from a
     /// `data_type` like `DocumentChunk`.
+    ///
+    /// Restricted to `current_schema()`, because `relname` alone matches across
+    /// every schema in the database while every other statement here is
+    /// unqualified and so `search_path`-relative. Without the filter, two cognee
+    /// installs in one database (the shared single-database deployment) would
+    /// interfere: schema A's valid index would make this report `Some(true)` for
+    /// schema B, leaving B on the sequential scan — and worse, an *invalid*
+    /// index in A would report `Some(false)`, so the caller's unqualified
+    /// `DROP INDEX` would resolve through `search_path` and drop B's valid one.
+    /// `current_schema()` is the first entry of `search_path`, which is exactly
+    /// what the unqualified DDL resolves to, so probe and DDL agree.
     async fn vector_index_state(
         db: &DatabaseConnection,
         index: &str,
@@ -356,7 +454,8 @@ impl PgVectorAdapter {
                 "SELECT i.indisvalid AS valid
                    FROM pg_class c
                    JOIN pg_index i ON i.indexrelid = c.oid
-                  WHERE c.relname = $1",
+                  WHERE c.relname = $1
+                    AND c.relnamespace = current_schema()::regnamespace",
                 [index.into()],
             ))
             .await
@@ -387,6 +486,13 @@ impl PgVectorAdapter {
     /// The returned count is indexes this call actually built: collections that
     /// already had one, and collections wider than [`MAX_INDEXABLE_DIMENSION`],
     /// are skipped and not counted.
+    ///
+    /// A collection that fails is logged and skipped rather than aborting the
+    /// run, so one bad entry cannot leave every collection after it unindexed.
+    /// That is reachable without any corruption: `delete_collection` drops the
+    /// table before deleting its bookkeeping row and not in one transaction, so
+    /// an interrupted delete leaves an orphan row whose `CREATE INDEX` fails
+    /// with `relation does not exist`.
     pub async fn create_missing_vector_indexes(&self) -> VectorDBResult<usize> {
         let query = Query::select()
             .columns([VColl::CollectionName, VColl::Dimension])
@@ -418,23 +524,39 @@ impl PgVectorAdapter {
             // reports work actually done and an already-indexed collection is
             // not handed a redundant CONCURRENTLY build.
             let index = Self::vector_index_name(&coll);
-            match Self::vector_index_state(&self.db, &index).await? {
-                Some(true) => continue,
-                // Left behind by an interrupted CONCURRENTLY build. `IF NOT
-                // EXISTS` would refuse to replace it, so drop it and rebuild —
-                // otherwise this collection can never become indexed.
-                Some(false) => {
-                    debug!("dropping invalid index {index} left by a failed build, rebuilding");
-                    self.db
-                        .execute_unprepared(&format!(r#"DROP INDEX CONCURRENTLY "{index}""#))
-                        .await
-                        .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+            let state = match Self::vector_index_state(&self.db, &index).await {
+                Ok(state) => state,
+                Err(e) => {
+                    warn!("could not read index state for collection {coll}, skipping it: {e}");
+                    continue;
                 }
-                None => {}
+            };
+
+            if state == Some(true) {
+                continue;
             }
 
-            if Self::create_vector_index(&self.db, &coll, dimension.max(0) as usize, true).await? {
-                created += 1;
+            // `Some(false)` is an index left behind by an interrupted
+            // CONCURRENTLY build. `IF NOT EXISTS` would refuse to replace it, so
+            // drop it and rebuild — otherwise this collection can never become
+            // indexed.
+            if state == Some(false) {
+                debug!("dropping invalid index {index} left by a failed build, rebuilding");
+                if let Err(e) = self
+                    .db
+                    .execute_unprepared(&format!(r#"DROP INDEX CONCURRENTLY "{index}""#))
+                    .await
+                {
+                    warn!("could not drop invalid index {index}, skipping {coll}: {e}");
+                    continue;
+                }
+            }
+
+            match Self::create_vector_index(&self.db, &coll, dimension.max(0) as usize, true).await
+            {
+                Ok(true) => created += 1,
+                Ok(false) => {}
+                Err(e) => warn!("could not index collection {coll}, skipping it: {e}"),
             }
         }
 
@@ -634,7 +756,22 @@ impl VectorDB for PgVectorAdapter {
         // cannot be built here and would need a rebuild policy. HNSW builds
         // incrementally, so an empty-table CREATE INDEX is instant and takes no
         // meaningful lock.
-        Self::create_vector_index(&self.db, &coll, dimension, false).await?;
+        //
+        // Best-effort on purpose. `CREATE TABLE` above has no `IF NOT EXISTS`
+        // and `has_collection` reads only the bookkeeping table, so propagating
+        // an error here would leave the table created and unregistered — and
+        // every retry would then fail at `CREATE TABLE` with `already exists`,
+        // wedging that collection permanently. An index failure (pgvector too
+        // old to have the `hnsw` access method, a restricted role, no
+        // `maintenance_work_mem`) must degrade to the sequential scan, which is
+        // exactly the behaviour before this index existed. The backfill picks it
+        // up later.
+        if let Err(e) = Self::create_vector_index(&self.db, &coll, dimension, false).await {
+            warn!(
+                "collection {coll} was created without an ANN index, so its searches will \
+                 be sequential scans until create_missing_vector_indexes() runs: {e}"
+            );
+        }
 
         // Register in bookkeeping table.
         let insert = Query::insert()
@@ -936,15 +1073,18 @@ impl VectorDB for PgVectorAdapter {
                LIMIT $2"#
         );
 
+        // `ef_search` must cover `top_k`, or the index scan ends early and the
+        // LIMIT is silently unmet — see `ann_search_locals`.
         let rows = self
-            .db
-            .query_all(Statement::from_sql_and_values(
-                DatabaseBackend::Postgres,
-                &sql,
-                [vec_str.into(), (top_k as i64).into()],
-            ))
-            .await
-            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+            .query_all_with_locals(
+                &Self::ann_search_locals(top_k),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    &sql,
+                    [vec_str.into(), (top_k as i64).into()],
+                ),
+            )
+            .await?;
 
         let mut results = Vec::with_capacity(rows.len());
         for row in &rows {
@@ -1028,30 +1168,12 @@ impl VectorDB for PgVectorAdapter {
         // the predicate into something GIN-indexable) but it is a behaviour
         // change that needs its own decision, not a side effect of adding an
         // index.
-        let txn = self
-            .db
-            .begin()
-            .await
-            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
-        for guc in [
-            "SET LOCAL enable_indexscan = off",
-            "SET LOCAL enable_bitmapscan = off",
-        ] {
-            txn.execute_unprepared(guc)
-                .await
-                .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
-        }
-        let rows = txn
-            .query_all(Statement::from_sql_and_values(
-                DatabaseBackend::Postgres,
-                &sql,
-                values,
-            ))
-            .await
-            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
-        txn.commit()
-            .await
-            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+        let rows = self
+            .query_all_with_locals(
+                Self::exact_scan_locals(),
+                Statement::from_sql_and_values(DatabaseBackend::Postgres, &sql, values),
+            )
+            .await?;
 
         let mut results = Vec::with_capacity(rows.len());
         for row in &rows {
@@ -1172,11 +1294,15 @@ impl VectorDB for PgVectorAdapter {
                ORDER BY q.idx, t.score DESC"#
         );
 
+        // Each LATERAL subquery is its own index scan with its own `LIMIT
+        // {top_k}`, so this path needs the same `ef_search` floor as
+        // `search_similar` or every one of them ends early.
         let rows = self
-            .db
-            .query_all(Statement::from_string(DatabaseBackend::Postgres, sql))
-            .await
-            .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
+            .query_all_with_locals(
+                &Self::ann_search_locals(top_k),
+                Statement::from_string(DatabaseBackend::Postgres, sql),
+            )
+            .await?;
 
         // Pre-size one bucket per query; `idx` (1-based ordinality) routes each row
         // back to its query, and queries with no hits keep their empty bucket.

--- a/crates/vector/src/pgvector_adapter.rs
+++ b/crates/vector/src/pgvector_adapter.rs
@@ -412,7 +412,10 @@ impl PgVectorAdapter {
             .await
             .map_err(|e| VectorDBError::StorageError(e.to_string()))?;
 
-        debug!("created HNSW index {index} on {coll} (dim={dimension})");
+        // "ensured", not "created": the statement carries `IF NOT EXISTS`, so it
+        // is a no-op when the index is already there — including when two
+        // backfills race — and claiming a creation would misreport that.
+        debug!("ensured HNSW index {index} on {coll} (dim={dimension})");
         Ok(true)
     }
 

--- a/crates/vector/src/pgvector_index_tests.rs
+++ b/crates/vector/src/pgvector_index_tests.rs
@@ -205,3 +205,114 @@ async fn backfill_replaces_an_invalid_index_left_by_a_failed_build() {
     )
     .await;
 }
+
+/// An HNSW index scan returns at most `hnsw.ef_search` tuples and then stops, so
+/// a `LIMIT` above that default of 40 is silently unmet — no error, just missing
+/// rows. cognee's retrieval paths ask for `DEFAULT_WIDE_SEARCH_TOP_K = 100`, so
+/// without an `ef_search` floor every graph-completion, triplet and temporal
+/// seed set would quietly lose 60% of its candidates.
+///
+/// The vectors here are tightly clustered on purpose. With uniformly random
+/// vectors the scan happens to return the full 100 and the bug hides; real
+/// embeddings cluster, which is when it bites.
+#[tokio::test]
+async fn a_search_returns_top_k_rows_even_above_the_default_ef_search() {
+    with_temp_db(
+        "a_search_returns_top_k_rows_even_above_the_default_ef_search",
+        |url| async move {
+            let adapter = PgVectorAdapter::new(&url, 8).await.unwrap();
+            adapter.create_collection("Clust", "f", 8).await.unwrap();
+
+            // 5000 rows is enough for the planner to prefer the index over a
+            // sequential scan, which is the only situation where the cap applies.
+            let points: Vec<_> = (0..5000)
+                .map(|i| {
+                    let jitter = f64::from(i) * 1e-6;
+                    #[allow(clippy::cast_possible_truncation)]
+                    let v = vec![1.0, jitter as f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+                    crate::models::VectorPoint::new(uuid::Uuid::new_v4(), v)
+                })
+                .collect();
+            for batch in points.chunks(500) {
+                adapter.index_points("Clust", "f", batch).await.unwrap();
+            }
+
+            let query = vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+            let hits = adapter
+                .search_similar("Clust", "f", &query, 100)
+                .await
+                .unwrap();
+            assert_eq!(
+                hits.len(),
+                100,
+                "top_k=100 must return 100 rows; {} means the HNSW scan stopped at \
+                 hnsw.ef_search and the LIMIT went silently unmet",
+                hits.len()
+            );
+
+            // The batched path runs one index scan per LATERAL subquery, each
+            // with its own LIMIT, so it needs the same floor.
+            let batched = adapter
+                .batch_search_similar("Clust", "f", &[query.clone(), query.clone()], 100)
+                .await
+                .unwrap();
+            assert_eq!(batched.len(), 2);
+            for (i, bucket) in batched.iter().enumerate() {
+                assert_eq!(
+                    bucket.len(),
+                    100,
+                    "batch query {i} returned {} rows instead of 100",
+                    bucket.len()
+                );
+            }
+
+            adapter.close().await.unwrap();
+        },
+    )
+    .await;
+}
+
+/// Postgres truncates identifiers at 63 bytes. The index name adds 12 characters
+/// to the collection name, so a collection over 51 characters gets an index
+/// whose real name is shorter than the one we computed — and the state probe
+/// compares the name as *data*, so it would never match. That silently breaks
+/// both guarantees the probe exists for: the backfill would re-issue
+/// `CREATE INDEX` and re-count it forever, and an index left invalid by a failed
+/// build would read as absent and so never be rebuilt.
+#[tokio::test]
+async fn a_collection_name_past_the_identifier_limit_is_still_tracked() {
+    with_temp_db(
+        "a_collection_name_past_the_identifier_limit_is_still_tracked",
+        |url| async move {
+            let adapter = PgVectorAdapter::new(&url, 8).await.unwrap();
+            // 57-char collection name -> 69-char index name, past the 63 limit.
+            let data_type = "L".repeat(55);
+            adapter.create_collection(&data_type, "f", 8).await.unwrap();
+
+            let expected = {
+                let mut n = format!("{data_type}_f_vector_hnsw");
+                n.truncate(63);
+                n
+            };
+
+            let db = Database::connect(&url).await.unwrap();
+            assert!(
+                index_present(&db, &expected).await,
+                "the probe must look for the name Postgres actually stored"
+            );
+
+            // The regression: with an untruncated name the probe finds nothing,
+            // so this reports 1 on every run instead of 0.
+            let again = adapter.create_missing_vector_indexes().await.unwrap();
+            assert_eq!(
+                again, 0,
+                "a long-named collection is already indexed; re-counting it means \
+                 the probe is blind and an invalid index would never be rebuilt"
+            );
+
+            drop(db);
+            adapter.close().await.unwrap();
+        },
+    )
+    .await;
+}

--- a/crates/vector/src/pgvector_index_tests.rs
+++ b/crates/vector/src/pgvector_index_tests.rs
@@ -1,0 +1,207 @@
+//! ANN index tests for [`super::PgVectorAdapter`] (SDK-515).
+//!
+//! Same gating and isolation as `pgvector_adapter`'s inline migration cases:
+//! they need a live Postgres with the `vector` extension via
+//! `PGVECTOR_TEST_URL`, and each provisions its own throwaway database so no
+//! `#[serial]` is required.
+//!
+//! These assert that the index *object* exists, not that the planner chose it.
+//! Plan choice depends on row count and cost settings, so asserting on `EXPLAIN`
+//! would pin a plan shape rather than the behaviour we care about. The behaviour
+//! that must hold regardless of plan — filtered search staying exact — is pinned
+//! by `test_search_similar_filtered_filter_then_limit` in the shared harness,
+//! which runs against this adapter in `pgvector_integration`.
+
+use super::{PgVectorAdapter, VectorDB};
+use sea_orm::{ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement};
+
+fn test_url() -> Option<String> {
+    std::env::var("PGVECTOR_TEST_URL")
+        .ok()
+        .filter(|v| !v.is_empty())
+}
+
+/// Mirrors `shared_db_migration_tests::with_temp_db` — see the rationale for the
+/// spawned task and the re-raised panic there.
+async fn with_temp_db<F, Fut>(what: &str, body: F)
+where
+    F: FnOnce(String) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    let Some(base_url) = test_url() else {
+        eprintln!("PGVECTOR_TEST_URL not set — skipping {what}");
+        return;
+    };
+    let tmp = cognee_test_utils::create_temp_postgres_db(&base_url)
+        .await
+        .expect("PGVECTOR_TEST_URL is set, so CREATE DATABASE must succeed on that server");
+    let outcome = tokio::spawn(body(tmp.url().to_string())).await;
+    tmp.cleanup().await;
+    if let Err(join_err) = outcome {
+        assert!(
+            join_err.is_panic(),
+            "the {what} task was cancelled instead of panicking: {join_err}"
+        );
+        std::panic::resume_unwind(join_err.into_panic());
+    }
+}
+
+/// Whether a *usable* index is in place: present and valid. An invalid index —
+/// what an interrupted concurrent build leaves — is not usable, because the
+/// planner ignores it.
+async fn index_present(db: &DatabaseConnection, index: &str) -> bool {
+    PgVectorAdapter::vector_index_state(db, index)
+        .await
+        .expect("index state lookup must succeed")
+        == Some(true)
+}
+
+#[tokio::test]
+async fn create_collection_builds_an_hnsw_index() {
+    with_temp_db("create_collection_builds_an_hnsw_index", |url| async move {
+        let adapter = PgVectorAdapter::new(&url, 8).await.unwrap();
+        adapter.create_collection("Idx", "f", 8).await.unwrap();
+
+        let db = Database::connect(&url).await.unwrap();
+        assert!(
+            index_present(&db, "Idx_f_vector_hnsw").await,
+            "create_collection must build the ANN index, or every search is a seq scan"
+        );
+
+        // The opclass has to match the `<=>` the searches order by, or the
+        // planner ignores the index and nothing is actually fixed.
+        let row = db
+            .query_one(Statement::from_string(
+                DatabaseBackend::Postgres,
+                "SELECT indexdef FROM pg_indexes WHERE indexname = 'Idx_f_vector_hnsw'",
+            ))
+            .await
+            .unwrap()
+            .expect("the index just asserted present must have a definition");
+        let def: String = row.try_get("", "indexdef").unwrap();
+        assert!(
+            def.contains("hnsw") && def.contains("vector_cosine_ops"),
+            "index must be HNSW over vector_cosine_ops, got: {def}"
+        );
+
+        drop(db);
+        adapter.close().await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn a_collection_over_the_dimension_ceiling_is_left_unindexed() {
+    with_temp_db(
+        "a_collection_over_the_dimension_ceiling_is_left_unindexed",
+        |url| async move {
+            let adapter = PgVectorAdapter::new(&url, 8).await.unwrap();
+            // 3072 = text-embedding-3-large, past pgvector's 2000-d ceiling.
+            // The collection must stay usable; only the index is skipped.
+            adapter.create_collection("Wide", "f", 3072).await.unwrap();
+
+            let db = Database::connect(&url).await.unwrap();
+            assert!(
+                !index_present(&db, "Wide_f_vector_hnsw").await,
+                "pgvector cannot index past 2000 dimensions — creating it would error"
+            );
+            assert!(
+                adapter.has_collection("Wide", "f").await.unwrap(),
+                "the collection itself must still be created and usable"
+            );
+
+            drop(db);
+            adapter.close().await.unwrap();
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn backfill_indexes_pre_existing_collections_and_is_idempotent() {
+    with_temp_db(
+        "backfill_indexes_pre_existing_collections_and_is_idempotent",
+        |url| async move {
+            let adapter = PgVectorAdapter::new(&url, 8).await.unwrap();
+            adapter.create_collection("Old", "f", 8).await.unwrap();
+            adapter.create_collection("Wide", "f", 3072).await.unwrap();
+
+            let db = Database::connect(&url).await.unwrap();
+            // Simulate a collection created before indexing existed.
+            db.execute_unprepared(r#"DROP INDEX "Old_f_vector_hnsw""#)
+                .await
+                .unwrap();
+            assert!(!index_present(&db, "Old_f_vector_hnsw").await);
+
+            let created = adapter.create_missing_vector_indexes().await.unwrap();
+            assert_eq!(
+                created, 1,
+                "only the indexable collection counts — the 3072-d one is skipped"
+            );
+            assert!(index_present(&db, "Old_f_vector_hnsw").await);
+
+            // Idempotent: nothing left to do, and nothing recounted.
+            let again = adapter.create_missing_vector_indexes().await.unwrap();
+            assert_eq!(
+                again, 0,
+                "a second run must report no work, not re-count existing indexes"
+            );
+
+            drop(db);
+            adapter.close().await.unwrap();
+        },
+    )
+    .await;
+}
+
+/// An interrupted `CREATE INDEX CONCURRENTLY` leaves the index present but
+/// marked invalid. The planner ignores it and `IF NOT EXISTS` refuses to replace
+/// it, so a presence-only check would skip the collection on every later run and
+/// it would keep its sequential scan permanently while looking indexed.
+#[tokio::test]
+async fn backfill_replaces_an_invalid_index_left_by_a_failed_build() {
+    with_temp_db(
+        "backfill_replaces_an_invalid_index_left_by_a_failed_build",
+        |url| async move {
+            let adapter = PgVectorAdapter::new(&url, 8).await.unwrap();
+            adapter.create_collection("Broken", "f", 8).await.unwrap();
+
+            let db = Database::connect(&url).await.unwrap();
+
+            // Forge the state an interrupted concurrent build leaves behind.
+            // There is no supported way to make Postgres produce it on demand,
+            // so mark the existing index invalid directly.
+            db.execute_unprepared(
+                "UPDATE pg_index SET indisvalid = false
+                   WHERE indexrelid = (
+                     SELECT oid FROM pg_class WHERE relname = 'Broken_f_vector_hnsw'
+                   )",
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                PgVectorAdapter::vector_index_state(&db, "Broken_f_vector_hnsw")
+                    .await
+                    .unwrap(),
+                Some(false),
+                "the forged invalid state must be visible to the state probe"
+            );
+            assert!(
+                !index_present(&db, "Broken_f_vector_hnsw").await,
+                "an invalid index must not count as usable — the planner ignores it"
+            );
+
+            let created = adapter.create_missing_vector_indexes().await.unwrap();
+            assert_eq!(created, 1, "the invalid index must be rebuilt, not skipped");
+            assert!(
+                index_present(&db, "Broken_f_vector_hnsw").await,
+                "after the rebuild the index must be valid and usable"
+            );
+
+            drop(db);
+            adapter.close().await.unwrap();
+        },
+    )
+    .await;
+}

--- a/crates/vector/src/pgvector_index_tests.rs
+++ b/crates/vector/src/pgvector_index_tests.rs
@@ -178,7 +178,11 @@ async fn backfill_replaces_an_invalid_index_left_by_a_failed_build() {
                    )",
             )
             .await
-            .unwrap();
+            .expect(
+                "writing to pg_index requires a superuser role; the CI service container \
+                 runs as one, so point PGVECTOR_TEST_URL at a superuser (e.g. the default \
+                 `postgres`) to run this case locally",
+            );
 
             assert_eq!(
                 PgVectorAdapter::vector_index_state(&db, "Broken_f_vector_hnsw")

--- a/docs/tools/backends.md
+++ b/docs/tools/backends.md
@@ -26,6 +26,18 @@ Notes:
   `ladybug`, and the `hf-tokenizer`/`tiktoken` counters are cargo features, on by
   default in `cognee`/`cognee-cli` (`pggraph` excepted) — see
   [architecture.md §feature strategy](../architecture.md#architecture-patterns).
+- **pgvector indexing.** Each collection gets an HNSW index over its `vector`
+  column (`vector_cosine_ops`, matching the `<=>` the searches order by) when the
+  collection is created, so similarity search is not a sequential scan.
+  Two exceptions: collections wider than 2000 dimensions cannot be indexed by
+  pgvector and keep the exact scan, and `search_similar_filtered` deliberately
+  forces the exact scan so its filter-then-limit guarantee holds — pgvector
+  post-filters an index scan, which would return fewer rows than asked for.
+  Collections created *before* this existed have only their primary key;
+  `PgVectorAdapter::create_missing_vector_indexes()` backfills them with
+  `CREATE INDEX CONCURRENTLY` (online, idempotent, and it rebuilds an index left
+  invalid by an interrupted build). It is not automatic: building HNSW over a
+  large collection is expensive, so the caller chooses when.
 - **Closed-source companions.** Embedded Qdrant (`cognee-vector-qdrant`) and
   on-device LiteRT inference (`cognee-llm-litert`, Android) live in the closed
   `cognee-cloud-rs` repository and are not part of OSS.

--- a/docs/tools/backends.md
+++ b/docs/tools/backends.md
@@ -28,11 +28,16 @@ Notes:
   [architecture.md §feature strategy](../architecture.md#architecture-patterns).
 - **pgvector indexing.** Each collection gets an HNSW index over its `vector`
   column (`vector_cosine_ops`, matching the `<=>` the searches order by) when the
-  collection is created, so similarity search is not a sequential scan.
-  Two exceptions: collections wider than 2000 dimensions cannot be indexed by
-  pgvector and keep the exact scan, and `search_similar_filtered` deliberately
-  forces the exact scan so its filter-then-limit guarantee holds — pgvector
-  post-filters an index scan, which would return fewer rows than asked for.
+  collection is created, so similarity search is not a sequential scan. Each
+  search raises `hnsw.ef_search` to cover its own `top_k`, because an HNSW scan
+  returns at most `ef_search` rows (default 40) and then stops — a larger
+  `LIMIT` is otherwise silently unmet.
+  Three exceptions: collections wider than 2000 dimensions cannot be indexed by
+  pgvector and keep the exact scan; a `top_k` above 1000 exceeds the largest
+  `ef_search` pgvector accepts and so also falls back to the exact scan; and
+  `search_similar_filtered` deliberately forces the exact scan so its
+  filter-then-limit guarantee holds — pgvector post-filters an index scan, which
+  would return fewer rows than asked for.
   Collections created *before* this existed have only their primary key;
   `PgVectorAdapter::create_missing_vector_indexes()` backfills them with
   `CREATE INDEX CONCURRENTLY` (online, idempotent, and it rebuilds an index left


### PR DESCRIPTION
Closes SDK-515.

Every pgvector collection carried only its btree primary key, so each similarity search was an exact sequential scan over the whole collection. `create_collection` now also builds an HNSW index over the `vector` column with `vector_cosine_ops` — the opclass has to match the `<=>` operator the searches order by, or the planner ignores the index and nothing is actually fixed.

HNSW rather than IVFFlat because IVFFlat derives its centroids from existing rows, so it cannot be built at collection-create time and would need a rebuild policy. HNSW builds incrementally, so the empty-table `CREATE INDEX` is instant and takes no meaningful lock.

## The filter-then-limit blocker

SDK-515 flagged this and it is not theoretical. pgvector post-filters an index scan: the index yields roughly `hnsw.ef_search` candidates by distance alone and the `WHERE` clause is applied to those, so a selective NodeSet filter returns fewer rows than asked for — the opposite of the guarantee `search_similar_filtered` exists to provide, which `test_search_similar_filtered_filter_then_limit` pins with 64 zero-distance out-of-set rows crowding two in-set ones.

Measured against pgvector 0.8.5, 20k rows, a 5%-selective predicate:

| | plan |
|---|---|
| filtered, no guard | `Index Scan using probe_vector_hnsw … Filter:` — post-filters |
| filtered, guard applied | `Seq Scan` + `Sort` — exact |
| unfiltered | `Index Scan using probe_vector_hnsw` |

So this PR keeps the guarantee: the index accelerates the unfiltered paths, where the volume is, and the filtered path is pinned to an exact scan. Trading that exactness for indexed filtered search is possible (`hnsw.iterative_scan`, or reshaping the predicate to be GIN-indexable) but it is a behaviour change deserving its own decision, not a side effect of adding an index.

## Backfill

`create_collection` guards on `has_collection`, so it never runs for a collection that already exists — every collection created before this change would keep its sequential scan. `create_missing_vector_indexes()` backfills them with `CREATE INDEX CONCURRENTLY`, which is why it is a method and not a migration: the concurrent form cannot run inside a transaction. It is deliberately **not** automatic, because building HNSW over a large collection is expensive and the caller should choose when.

## Edge cases the second commit addresses

A code review caught one regression this introduced plus several failure modes it opened. All are reachable without any data corruption:

- **`top_k` was silently capped at 40.** An HNSW scan returns at most `hnsw.ef_search` tuples and then ends, so a larger `LIMIT` goes unmet with no error. `DEFAULT_WIDE_SEARCH_TOP_K = 100` flows straight into `search_similar`, so graph-completion, triplet and temporal search had begun seeding from 40 candidates instead of 100. Both `search_similar` and `batch_search_similar` (one index scan per LATERAL subquery, each with its own `LIMIT`) now raise `ef_search` to cover `top_k`; above pgvector's `ef_search` ceiling the query falls back to the exact scan.
- **A failed index build wedged the collection permanently.** `CREATE TABLE` has no `IF NOT EXISTS` and `has_collection` reads only the bookkeeping table, so propagating an index error left the table created and unregistered — and every retry then failed at `CREATE TABLE` with `already exists`. Index creation is now best-effort and degrades to the sequential scan, which is what the code did before the index existed. Reachable with a pgvector too old to have the `hnsw` access method, a restricted role, or no `maintenance_work_mem`.
- **Identifier truncation made the state probe blind.** Postgres truncates identifiers at 63 bytes; the index name adds 12 characters, so a collection name over 51 characters produced a name the probe could never match. The backfill then re-issued `CREATE INDEX` and re-counted it on every run, and an index left invalid by an interrupted build read as absent and so was never rebuilt — the exact permanent-sequential-scan failure the validity check exists to prevent.
- **The probe spanned every schema.** Matching `pg_class.relname` alone is schema-wide while all the DDL here is unqualified and so `search_path`-relative. With two installs in one database — the shared single-database deployment — schema A's valid index made the probe report present for schema B, and an *invalid* index in A would have had the unqualified `DROP INDEX` resolve onto B's valid one. Now restricted to `current_schema()`.
- **One bad collection aborted the whole backfill.** `delete_collection` drops the table before deleting its bookkeeping row, and not in one transaction, so an interrupted delete leaves an orphan row whose `CREATE INDEX` fails. The backfill now logs and continues.

## Testing

Six cases gated on `PGVECTOR_TEST_URL`, each on its own throwaway database. They assert the index object exists and its definition names `hnsw`/`vector_cosine_ops`, not that the planner picked it — plan choice depends on row counts and cost settings, so an `EXPLAIN` assertion would pin a plan shape rather than the behaviour.

The `ef_search` case was verified to actually catch its regression: with the floor removed it fails with `left: 40, right: 100`. Its vectors are deliberately clustered, because with uniformly random vectors the scan happens to return the full 100 and the bug hides — which is roughly why it slipped through the first round of manual `EXPLAIN` checks.

- `cognee-vector` suite: 92 passing, including the 25-case `pgvector_integration` run with `test_search_similar_filtered_filter_then_limit` green with the index in place
- `cargo clippy -D warnings`, `cargo fmt --check`, and a workspace `cargo check --all-targets`: clean

Both CI lanes name the six cases with `--require-test` rather than raising the `--lib` count floor, following the reasoning already recorded in the pgvector lane: most of that target's tests are unrelated unit tests, so a tight floor would fire on unrelated churn.

## Not in scope

LanceDB has the same gap — it searches cosine but never calls `create_index`. SDK-515 does not cover it and it has no issue of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012e8Qh5MXVfasfPpGdpeMNA
