### PR TITLE
fix(recall): thread the caller's owner so recall -d <name> resolves

### DIFF
--- a/crates/cli/tests/cli_e2e.rs
+++ b/crates/cli/tests/cli_e2e.rs
@@ -324,6 +324,95 @@ fn search_errors_when_dataset_name_does_not_exist() {
         .stderr(predicate::str::contains("dataset not found"));
 }
 
+/// Regression: `cognee-cli recall "..." -d <name>` used to fail with
+/// `dataset name filter requires SearchRequest.user_id to identify the owner`
+/// because `run_graph` built its `SearchRequest` with `user_id: None`, even
+/// though the CLI hands `recall()` the configured owner. `search -d` never had
+/// the problem, so the two convenience paths disagreed on the same flag.
+///
+/// Keyless on purpose (`MOCK_EMBEDDING=true`, dummy `llm_api_key`) so it runs
+/// in every CI lane. Nothing is cognified, so a recall against the *real*
+/// dataset still fails downstream in the retriever -- the assertion there is
+/// only that the owner-threading error is gone. The bogus-name recall is the
+/// positive proof: reaching `dataset not found` means resolution actually ran
+/// with an owner.
+#[test]
+#[cfg(feature = "ladybug")]
+fn recall_dataset_name_filter_threads_the_owner() {
+    let config_home = TempDir::new().expect("temp dir should be created");
+    let workdir = TempDir::new().expect("temp dir should be created");
+
+    let owner_id = Uuid::from_u128(0);
+    let db_file_path = workdir.path().join("cognee.db");
+    let db_url = format!("sqlite://{}", db_file_path.display());
+    std::fs::File::create(&db_file_path).expect("sqlite database file should be created");
+
+    for (key, value) in [
+        ("default_user_id", format!("\"{owner_id}\"")),
+        (
+            "data_root_directory",
+            format!("\"{}\"", workdir.path().join("cognee_data").display()),
+        ),
+        ("relational_db_url", format!("\"{db_url}\"")),
+        (
+            "graph_file_path",
+            format!("\"{}\"", workdir.path().join("graph").display()),
+        ),
+        (
+            "vector_db_url",
+            format!("\"{}\"", workdir.path().join("vectors").display()),
+        ),
+        ("graph_database_provider", "\"ladybug\"".to_string()),
+        ("vector_db_provider", "\"brute-force\"".to_string()),
+        ("embedding_dimensions", "2".to_string()),
+        ("llm_api_key", "\"dummy-key\"".to_string()),
+    ] {
+        config_set(&config_home, workdir.path(), key, &value);
+    }
+
+    make_cmd_in(&config_home, workdir.path())
+        .args(["add", "real content", "--dataset-name", "real_dataset"])
+        .assert()
+        .success();
+
+    let owner_error = "requires SearchRequest.user_id";
+
+    // Unknown name: resolution must run as the owner and report the miss.
+    make_cmd_in(&config_home, workdir.path())
+        .env("MOCK_EMBEDDING", "true")
+        .args([
+            "recall",
+            "anything",
+            "--query-type",
+            "CHUNKS",
+            "-d",
+            "this_dataset_does_not_exist",
+            "--output-format",
+            "simple",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("dataset not found"))
+        .stderr(predicate::str::contains(owner_error).not());
+
+    // Known name: whatever happens downstream, the owner-threading error is
+    // no longer the reason `-d` fails.
+    make_cmd_in(&config_home, workdir.path())
+        .env("MOCK_EMBEDDING", "true")
+        .args([
+            "recall",
+            "anything",
+            "--query-type",
+            "CHUNKS",
+            "-d",
+            "real_dataset",
+            "--output-format",
+            "simple",
+        ])
+        .assert()
+        .stderr(predicate::str::contains(owner_error).not());
+}
+
 #[test]
 fn delete_rejects_missing_scope() {
     let config_home = TempDir::new().expect("temp dir should be created");

--- a/crates/http-server/src/routers/recall.rs
+++ b/crates/http-server/src/routers/recall.rs
@@ -237,6 +237,7 @@ pub async fn post_recall(
                     top_k,
                     /* auto_route = */ false,
                     session_id_opt,
+                    user_id_opt,
                     orchestrator.as_ref(),
                     &span,
                     None,

--- a/crates/lib/src/api/recall.rs
+++ b/crates/lib/src/api/recall.rs
@@ -179,6 +179,7 @@ pub async fn recall(
                     top_k,
                     auto_route,
                     session_id,
+                    user_id,
                     search_orchestrator,
                     &span,
                     options.as_ref(),

--- a/crates/search/src/recall_scope.rs
+++ b/crates/search/src/recall_scope.rs
@@ -14,6 +14,7 @@ use std::collections::HashSet;
 use cognee_session::{SessionManager, SessionStore};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
+use uuid::Uuid;
 
 use crate::observability::COGNEE_SEARCH_TYPE;
 use crate::types::SearchError;
@@ -416,6 +417,11 @@ pub async fn fetch_graph_context(
 /// orchestrator. Mirrors Python's inline `_run_graph` closure
 /// (`recall.py:455-493`). Returns `(items, search_type_used, auto_routed,
 /// raw_response)`.
+///
+/// `user_id` is the caller's identity in the same string form the session
+/// helpers take. It becomes `SearchRequest.user_id`, which the orchestrator
+/// needs to resolve `datasets` *names* owner-scoped — without it any name
+/// filter fails with "dataset name filter requires SearchRequest.user_id".
 #[allow(clippy::too_many_arguments)]
 pub async fn run_graph(
     query_text: &str,
@@ -424,10 +430,32 @@ pub async fn run_graph(
     top_k: usize,
     auto_route: bool,
     session_id: Option<&str>,
+    user_id: Option<&str>,
     search_orchestrator: &SearchOrchestrator,
     span: &tracing::Span,
     options: Option<&RecallOptions>,
 ) -> Result<(Vec<RecallItem>, SearchType, bool, SearchResponse), SearchError> {
+    // The orchestrator resolves dataset *names* owner-scoped (Python
+    // `_run_graph` -> `get_authorized_existing_datasets(datasets, "read",
+    // user)`), so it needs the caller's identity on the request. Recall's
+    // `user_id` is a string because the session helpers key on strings; the
+    // graph side needs the UUID form. A non-UUID caller id only matters when a
+    // name filter is in play -- without one the graph search has no owner scope
+    // to apply and the value is simply not forwarded, as before.
+    let owner_id: Option<Uuid> = match user_id {
+        None => None,
+        Some(raw) => match Uuid::parse_str(raw) {
+            Ok(id) => Some(id),
+            Err(error) if datasets.as_ref().is_some_and(|d| !d.is_empty()) => {
+                return Err(SearchError::InvalidInput(format!(
+                    "dataset name filter requires a UUID user_id to identify the owner, \
+                     got '{raw}': {error}"
+                )));
+            }
+            Err(_) => None,
+        },
+    };
+
     // Python recall.py:458-472: still run the router on explicit query_type
     // + auto_route=true so the override gets recorded.
     let (search_type, auto_routed) = match (query_type, auto_route) {
@@ -467,7 +495,7 @@ pub async fn run_graph(
         wide_search_top_k: options.and_then(|o| o.wide_search_top_k),
         triplet_distance_penalty: options.and_then(|o| o.triplet_distance_penalty),
         save_interaction: None,
-        user_id: None,
+        user_id: owner_id,
         verbose: None,
         feedback_influence: options.and_then(|o| o.feedback_influence),
         retriever_specific_config: None,
@@ -697,5 +725,197 @@ mod tests {
         assert_eq!(RecallScope::Session.as_wire(), "session");
         assert_eq!(RecallScope::Trace.as_wire(), "trace");
         assert_eq!(RecallScope::GraphContext.as_wire(), "graph_context");
+    }
+
+    // -----------------------------------------------------------------------
+    // run_graph threads the caller identity into the dataset-name filter
+    // -----------------------------------------------------------------------
+
+    use crate::orchestration::SearchTypeRegistry;
+    use crate::retrievers::SearchRetriever;
+    use crate::types::{SearchContext, SearchOutput, SearchParams};
+    use async_trait::async_trait;
+    use cognee_database::ops as db_ops;
+    use cognee_database::{IngestDb, connect, initialize};
+    use cognee_models::Dataset;
+    use cognee_session::SessionContext;
+    use std::sync::Arc;
+
+    /// Records the `SearchParams` it was invoked with so a test can assert on
+    /// what the orchestrator handed down after dataset-name resolution.
+    struct RecordingRetriever {
+        seen: std::sync::Mutex<Option<SearchParams>>,
+    }
+
+    #[async_trait]
+    impl SearchRetriever for RecordingRetriever {
+        fn search_type(&self) -> SearchType {
+            SearchType::Chunks
+        }
+
+        async fn get_context(
+            &self,
+            _query: &str,
+            params: &SearchParams,
+        ) -> Result<SearchContext, SearchError> {
+            *self.seen.lock().expect("test mutex") = Some(params.clone());
+            Ok(vec![])
+        }
+
+        async fn get_completion(
+            &self,
+            _query: &str,
+            _context: Option<SearchContext>,
+            _session: &SessionContext,
+            _params: &SearchParams,
+        ) -> Result<SearchOutput, SearchError> {
+            Ok(SearchOutput::Text("graph-stub".to_string()))
+        }
+    }
+
+    async fn orchestrator_with_seeded_dataset(
+        name: &str,
+        owner: Uuid,
+    ) -> (SearchOrchestrator, Arc<RecordingRetriever>, Uuid) {
+        let db = Arc::new(connect("sqlite::memory:").await.expect("in-memory sqlite"));
+        initialize(&db).await.expect("schema init");
+        let dataset = db_ops::datasets::create_dataset(
+            &db,
+            Dataset::new(name.to_string(), owner, None, Uuid::new_v4()),
+        )
+        .await
+        .expect("seed dataset");
+
+        let retriever = Arc::new(RecordingRetriever {
+            seen: std::sync::Mutex::new(None),
+        });
+        let mut registry = SearchTypeRegistry::new();
+        registry.register(Arc::clone(&retriever) as Arc<dyn SearchRetriever>);
+        let orchestrator =
+            SearchOrchestrator::new(registry).with_dataset_resolver(db as Arc<dyn IngestDb>);
+        (orchestrator, retriever, dataset.id)
+    }
+
+    /// Regression: `recall -d <name>` used to fail with "dataset name filter
+    /// requires SearchRequest.user_id" because `run_graph` built the request
+    /// with `user_id: None` even though every caller had the owner in hand.
+    /// The owner must reach the orchestrator so the name resolves to the
+    /// caller's dataset id.
+    #[tokio::test]
+    async fn run_graph_forwards_owner_so_dataset_names_resolve() {
+        let owner = Uuid::new_v4();
+        let (orchestrator, retriever, dataset_id) =
+            orchestrator_with_seeded_dataset("notes", owner).await;
+        let owner_str = owner.to_string();
+        let span = tracing::Span::none();
+
+        let (_items, used, auto, _response) = run_graph(
+            "anything",
+            Some(SearchType::Chunks),
+            Some(vec!["notes".to_string()]),
+            5,
+            false,
+            None,
+            Some(owner_str.as_str()),
+            &orchestrator,
+            &span,
+            None,
+        )
+        .await
+        .expect("dataset name must resolve for its owner");
+
+        assert_eq!(used, SearchType::Chunks);
+        assert!(!auto);
+        let seen = retriever
+            .seen
+            .lock()
+            .expect("test mutex")
+            .clone()
+            .expect("retriever must have been invoked");
+        assert_eq!(
+            seen.dataset_ids.as_deref(),
+            Some([dataset_id].as_slice()),
+            "resolved dataset id must reach the retriever"
+        );
+    }
+
+    /// Name resolution stays owner-scoped: another user's dataset of the same
+    /// name is not visible, so the filter surfaces `DatasetNotFound` instead
+    /// of silently widening.
+    #[tokio::test]
+    async fn run_graph_dataset_name_is_owner_scoped() {
+        let owner = Uuid::new_v4();
+        let stranger = Uuid::new_v4().to_string();
+        let (orchestrator, _retriever, _dataset_id) =
+            orchestrator_with_seeded_dataset("notes", owner).await;
+        let span = tracing::Span::none();
+
+        let err = run_graph(
+            "anything",
+            Some(SearchType::Chunks),
+            Some(vec!["notes".to_string()]),
+            5,
+            false,
+            None,
+            Some(stranger.as_str()),
+            &orchestrator,
+            &span,
+            None,
+        )
+        .await
+        .expect_err("a stranger must not resolve another owner's dataset");
+        assert!(
+            matches!(err, SearchError::DatasetNotFound(_)),
+            "expected DatasetNotFound, got {err:?}"
+        );
+    }
+
+    /// A caller id that is not a UUID cannot identify an owner. That is fine
+    /// when no name filter is requested (the session helpers accept arbitrary
+    /// strings), but with one it must be reported as the caller's mistake
+    /// rather than resurfacing as the misleading "requires user_id" error.
+    #[tokio::test]
+    async fn run_graph_rejects_non_uuid_user_only_when_names_are_filtered() {
+        let owner = Uuid::new_v4();
+        let (orchestrator, _retriever, _dataset_id) =
+            orchestrator_with_seeded_dataset("notes", owner).await;
+        let span = tracing::Span::none();
+
+        let err = run_graph(
+            "anything",
+            Some(SearchType::Chunks),
+            Some(vec!["notes".to_string()]),
+            5,
+            false,
+            None,
+            Some("user-1"),
+            &orchestrator,
+            &span,
+            None,
+        )
+        .await
+        .expect_err("non-UUID id with a name filter must be rejected");
+        match err {
+            SearchError::InvalidInput(msg) => {
+                assert!(msg.contains("user-1"), "message must name the value: {msg}")
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+
+        // Without a name filter the same id is tolerated, as before the fix.
+        run_graph(
+            "anything",
+            Some(SearchType::Chunks),
+            None,
+            5,
+            false,
+            None,
+            Some("user-1"),
+            &orchestrator,
+            &span,
+            None,
+        )
+        .await
+        .expect("no name filter -> non-UUID id is simply not forwarded");
     }
 }


### PR DESCRIPTION
`cognee-cli recall <query> -d <dataset-name>` failed outright:

```
$ cognee-cli recall anything -t CHUNKS -d real_dataset
Error: Recall failed: Search error: invalid input:
  dataset name filter requires SearchRequest.user_id to identify the owner
```

`search` with the same `-d` works, so the flag is broken specifically on `recall`. **`POST /v1/recall` with `datasets` fails identically** — this is not CLI-only.

## Root cause

`crates/search/src/recall_scope.rs` — `run_graph` built its `SearchRequest` with `user_id: None` and had no parameter to receive an owner. The orchestrator resolves dataset *names* owner-scoped (`orchestration/search_orchestrator.rs:279-283`) and requires `request.user_id`, so the error was correct and the caller was wrong.

Both callers already held the identity and dropped it:
- `crates/lib/src/api/recall.rs` — `recall()` takes `user_id: Option<&str>` and used it for the session helpers but not for `run_graph`
- `crates/http-server/src/routers/recall.rs` — has `user.id` from auth and dropped it

The CLI itself was not at fault (`commands/recall.rs` already passed `Some(owner_id)`).

**Was `user_id: None` deliberate?** No. `git blame` traces it to the initial `init: cognee-rs v0.1.0` import, with no comment and no caller that lacks an owner. Python parity confirms the intended shape: `_run_graph` resolves names via `get_authorized_existing_datasets(datasets, "read", user)`.

## The fix

`run_graph` takes `user_id: Option<&str>` and sets it on the request. A non-UUID id is rejected with an `InvalidInput` naming the value **only when a name filter is actually requested**; otherwise it is not forwarded, exactly as before — so callers passing session-style ids (the lib tests use `"user-1"`) keep working. Two call sites pass their owner through, one line each.

Side effect worth knowing: with `user_id` on the request, the orchestrator's session-history lookup and query logging are now attributed to the caller — identical to what `search` already does, and to what recall's own `search_session` helper already did.

Deliberately untouched: `remember` and `forget` build no `SearchRequest` (add+cognify and delete), so they do not share the defect. `docs/tools/cli.md:56` already documents `recall … -d my_dataset`, so no doc change is needed — the docs were right and the code was wrong.

## Tests — four, all keyless

| test | asserts |
|---|---|
| `run_graph_forwards_owner_so_dataset_names_resolve` | the resolved `dataset_ids` reach the retriever |
| `run_graph_dataset_name_is_owner_scoped` | a stranger's UUID → `DatasetNotFound`, not someone else's data |
| `run_graph_rejects_non_uuid_user_only_when_names_are_filtered` | non-UUID + name filter → `InvalidInput`; without a filter → `Ok` |
| `cli_e2e::recall_dataset_name_filter_threads_the_owner` | end-to-end; bogus name → `dataset not found`, never the owner error |

Mutation-checked in two directions, both observed:

- Revert `user_id: owner_id` → `None`: two unit tests and the CLI test fail; the parse-guard test correctly still passes (it guards a different line).
- Drop the strict-parse arm: only `run_graph_rejects_non_uuid_user_only_when_names_are_filtered` fails.

Restored, all green. Every test has been seen both red and green.

## Verification

All seven CI lint lanes run locally: `fmt --check`; `clippy --all-targets -D warnings`; `check --all-targets --features telemetry`; the same under clippy; `check -p cognee --no-default-features`; the slim CLI facade; and `android-default` (3m04s). Plus `cargo test -p cognee-cli`, `-p cognee-search`, `-p cognee-http-server`, and `cognee`'s recall integration suites.

End-to-end on a real binary: `add` → `cognify` → the originally failing `recall … -t CHUNKS -d rcds` now exits 0 with no owner error.

Base is `8236014d`; #196 landed during preparation and is disjoint.

## Known gap, worth a follow-up

`POST /v1/recall` shares the fix but has **no test covering that route** — `crates/http-server/tests/test_recall.rs` never passes `datasets`, and the support stubs have no dataset resolver. The unit tests are the only guard on that path.

Also noticed and not fixed here: `crates/search/tests/last_accessed_update.rs` panics instead of skipping when `OPENAI_URL` is unset, against the repo's "skip gracefully" convention — it passes locally only because `.env` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmwWAiTW184ZDFDdhW58Ki
