### PR TITLE
test(http-server): pin that POST /v1/recall resolves dataset names as the caller

### DIFF
--- a/crates/http-server/tests/support/mod.rs
+++ b/crates/http-server/tests/support/mod.rs
@@ -305,3 +305,99 @@ pub async fn build_p4_state(
     state.lib = Some(handles);
     state
 }
+
+// ─── Dataset-scoped search helpers ───────────────────────────────────────────
+
+use cognee_database::IngestDb;
+use cognee_models::Dataset;
+use uuid::Uuid;
+
+/// The id `AuthenticatedUser` resolves to when no auth resolver is wired and
+/// `require_authentication=false` — `uuid5(NAMESPACE_OID, default_user_email)`
+/// per `auth::extractor::default_user_from_state`. Derived from the same
+/// default config the test state is built from, so a seeded dataset owned by
+/// this id is the *caller's* dataset from the router's point of view.
+pub fn default_test_user_id() -> Uuid {
+    let email = HttpServerConfig::default().default_user_email;
+    Uuid::new_v5(&Uuid::NAMESPACE_OID, email.as_bytes())
+}
+
+/// Insert a dataset row named `name` owned by `owner` and return its id.
+pub async fn seed_dataset(db: &DatabaseConnection, name: &str, owner: Uuid) -> Uuid {
+    let dataset = Dataset::new(name.to_string(), owner, None, Uuid::new_v4());
+    IngestDb::create_dataset(db, dataset)
+        .await
+        .expect("seed dataset")
+        .id
+}
+
+/// Like [`build_orchestrator`], but also wires `db` as the dataset-name
+/// resolver so a `datasets: [<name>]` filter is resolved owner-scoped instead
+/// of failing with "no dataset resolver is wired".
+pub async fn build_orchestrator_with_dataset_resolver(
+    db: Arc<DatabaseConnection>,
+    retriever: Arc<dyn SearchRetriever>,
+) -> Arc<SearchOrchestrator> {
+    let mut registry = SearchTypeRegistry::new();
+    registry.register(retriever);
+    let orchestrator = SearchOrchestrator::new(registry)
+        .with_database(db.clone() as Arc<dyn cognee_database::SearchHistoryDb>)
+        .with_dataset_resolver(db as Arc<dyn IngestDb>);
+    Arc::new(orchestrator)
+}
+
+/// Retriever that records the `SearchParams` the orchestrator handed it, so a
+/// test can assert on what dataset-name resolution produced rather than on the
+/// status code alone.
+pub struct RecordingRetriever {
+    kind: SearchType,
+    seen: std::sync::Mutex<Option<SearchParams>>,
+}
+
+impl RecordingRetriever {
+    pub fn new(kind: SearchType) -> Self {
+        Self {
+            kind,
+            seen: std::sync::Mutex::new(None),
+        }
+    }
+
+    /// The params from the most recent invocation, or `None` if the retriever
+    /// was never reached.
+    pub fn last_params(&self) -> Option<SearchParams> {
+        // lock poison is unrecoverable
+        self.seen.lock().unwrap().clone()
+    }
+
+    fn record(&self, params: &SearchParams) {
+        // lock poison is unrecoverable
+        *self.seen.lock().unwrap() = Some(params.clone());
+    }
+}
+
+#[async_trait]
+impl SearchRetriever for RecordingRetriever {
+    fn search_type(&self) -> SearchType {
+        self.kind
+    }
+
+    async fn get_context(
+        &self,
+        _query: &str,
+        params: &SearchParams,
+    ) -> Result<SearchContext, SearchError> {
+        self.record(params);
+        Ok(vec![])
+    }
+
+    async fn get_completion(
+        &self,
+        _query: &str,
+        _context: Option<SearchContext>,
+        _session: &SessionContext,
+        params: &SearchParams,
+    ) -> Result<SearchOutput, SearchError> {
+        self.record(params);
+        Ok(SearchOutput::Text("recorded".to_string()))
+    }
+}

--- a/crates/http-server/tests/test_recall.rs
+++ b/crates/http-server/tests/test_recall.rs
@@ -12,7 +12,11 @@ use cognee_search::types::SearchType;
 use std::sync::Arc;
 use tower::ServiceExt;
 
-use support::{StubRetriever, body_json, build_orchestrator, build_p4_state, build_search_db};
+use support::{
+    RecordingRetriever, StubRetriever, body_json, build_orchestrator,
+    build_orchestrator_with_dataset_resolver, build_p4_state, build_search_db,
+    default_test_user_id, seed_dataset,
+};
 
 async fn build_app_with(
     retriever: Arc<dyn cognee_search::retrievers::SearchRetriever>,
@@ -279,4 +283,102 @@ async fn get_recall_returns_same_history_as_get_search() {
     let s = body_json(app.clone().oneshot(search_req).await.expect("search")).await;
     let r = body_json(app.oneshot(recall_req).await.expect("recall")).await;
     assert_eq!(s, r, "search and recall histories must match");
+}
+
+/// Regression guard for #197 (issue #198): `POST /v1/recall` with a
+/// `datasets` *name* filter must run dataset resolution as the caller.
+///
+/// The orchestrator resolves names owner-scoped and refuses to guess an owner
+/// (`dataset name filter requires SearchRequest.user_id to identify the
+/// owner`), so the router has to hand `run_graph` the authenticated
+/// `user.id`. Before #197 it passed `None` and every name filter died with
+/// that error; the lib `recall()` and CLI paths are pinned elsewhere, this is
+/// the HTTP layer's copy.
+///
+/// The assertion is deliberately stronger than "200": the recording
+/// retriever must have been reached with `dataset_ids == [<seeded id>]`.
+/// That can only happen if the name resolved against the caller's owner id,
+/// so the case goes red as soon as the router stops forwarding the user
+/// (the orchestrator then returns 422 and the retriever is never invoked).
+#[tokio::test]
+async fn post_recall_dataset_name_filter_resolves_as_the_caller() {
+    let db = build_search_db().await;
+    let dataset_id = seed_dataset(&db, "notes", default_test_user_id()).await;
+    let retriever = Arc::new(RecordingRetriever::new(SearchType::Chunks));
+    let orchestrator = build_orchestrator_with_dataset_resolver(
+        db,
+        Arc::clone(&retriever) as Arc<dyn cognee_search::retrievers::SearchRetriever>,
+    )
+    .await;
+    let state = build_p4_state(Some(orchestrator), None, None).await;
+    let app = cognee_http_server::build_router(state)
+        .await
+        .expect("router");
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/recall")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            r#"{"query":"hi","searchType":"CHUNKS","scope":"graph","datasets":["notes"]}"#,
+        ))
+        .unwrap();
+    let resp = app.oneshot(req).await.expect("resp");
+    let status = resp.status();
+    let body = body_json(resp).await;
+    assert_eq!(
+        status, 200,
+        "dataset name must resolve for its owner, got {status} with body {body}"
+    );
+
+    let seen = retriever
+        .last_params()
+        .expect("retriever must have been invoked after the dataset name resolved");
+    assert_eq!(
+        seen.dataset_ids.as_deref(),
+        Some([dataset_id].as_slice()),
+        "the caller's dataset id must reach the retriever"
+    );
+}
+
+/// Complement to the guard above: resolution stays scoped to the caller.
+/// A same-named dataset owned by someone else is invisible, so the request
+/// surfaces the 422 prerequisites envelope (DatasetNotFound) rather than
+/// silently widening to another owner's rows. Note this case cannot by
+/// itself detect a dropped `user_id` — both failures map to 422 — which is
+/// why the positive case above carries the #197 regression.
+#[tokio::test]
+async fn post_recall_dataset_name_filter_does_not_widen_to_another_owner() {
+    let db = build_search_db().await;
+    let stranger = uuid::Uuid::new_v4();
+    assert_ne!(stranger, default_test_user_id());
+    let _foreign_dataset_id = seed_dataset(&db, "notes", stranger).await;
+    let retriever = Arc::new(RecordingRetriever::new(SearchType::Chunks));
+    let orchestrator = build_orchestrator_with_dataset_resolver(
+        db,
+        Arc::clone(&retriever) as Arc<dyn cognee_search::retrievers::SearchRetriever>,
+    )
+    .await;
+    let state = build_p4_state(Some(orchestrator), None, None).await;
+    let app = cognee_http_server::build_router(state)
+        .await
+        .expect("router");
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/recall")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            r#"{"query":"hi","searchType":"CHUNKS","scope":"graph","datasets":["notes"]}"#,
+        ))
+        .unwrap();
+    let resp = app.oneshot(req).await.expect("resp");
+    assert_eq!(resp.status(), 422);
+    let body = body_json(resp).await;
+    assert_eq!(body["error"], "Recall prerequisites not met");
+    assert!(body["hint"].is_string());
+    assert!(
+        retriever.last_params().is_none(),
+        "retriever must not run when the name does not resolve for the caller"
+    );
 }


### PR DESCRIPTION
Closes #198

## The gap

#197 (`298b0945`) fixed `POST /v1/recall` with a `datasets` *name* filter by handing `run_graph` the caller's `user_id`, so names resolve owner-scoped. It shipped with lib-level tests (`crates/search/src/recall_scope.rs`) and a CLI e2e, but nothing at the HTTP layer: `crates/http-server/tests/test_recall.rs` had zero occurrences of `datasets`, and `tests/support/mod.rs` built its orchestrator without a dataset resolver, so no HTTP test could even reach name resolution. A refactor of `routers/recall.rs` that dropped the `user_id_opt` argument again would have passed a fully green board.

## What the test asserts, and why that assertion

`post_recall_dataset_name_filter_resolves_as_the_caller`:

1. Seeds a dataset `notes` owned by the id the no-auth extractor resolves to (`uuid5(NAMESPACE_OID, default_user_email)`, derived from `HttpServerConfig::default()` rather than hard-coded, so it tracks the extractor).
2. Wires the same in-memory DB as the orchestrator's dataset resolver and registers a `RecordingRetriever`.
3. Posts `{"query":"hi","searchType":"CHUNKS","scope":"graph","datasets":["notes"]}`.
4. Asserts **200 and** that the retriever was reached with `SearchParams.dataset_ids == [<seeded id>]`.

Why not just 200: the failure being guarded is the orchestrator's `dataset name filter requires SearchRequest.user_id to identify the owner`, which surfaces through recall's error map as a 422. Asserting the resolved id reached the retriever proves the name was looked up *against the caller's owner id* — that is the only way the seeded id can appear there. A test that passes with `user_id: None` would be worthless here; this one cannot.

`post_recall_dataset_name_filter_does_not_widen_to_another_owner` (complement): the same name owned by a stranger yields the 422 `{error, hint}` envelope and the retriever is never invoked. Its doc comment states plainly that it cannot by itself catch a dropped `user_id` (both failures map to 422) — the positive case carries the #197 regression; this one pins that scoping is not widened.

Both are keyless (in-memory SQLite, stub retriever, no LLM/embedder), so they run in every CI lane including `community.yml`.

## Mutation result

Reverted #197's one line in `crates/http-server/src/routers/recall.rs` (`user_id_opt,` → `None,` in the `run_graph` call):

```
test post_recall_dataset_name_filter_does_not_widen_to_another_owner ... ok
test post_recall_dataset_name_filter_resolves_as_the_caller ... FAILED

thread 'post_recall_dataset_name_filter_resolves_as_the_caller' panicked at crates/http-server/tests/test_recall.rs:329:5:
assertion `left == right` failed: dataset name must resolve for its owner, got 422 Unprocessable Entity with body {"error":"Recall prerequisites not met","hint":"Run `await cognee.remember(...)` or `await cognee.add(...)` then `await cognee.cognify()` before recalling."}
  left: 422
 right: 200

test result: FAILED. 11 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

Restored the line (`git checkout -- crates/http-server/src/routers/recall.rs`):

```
test post_recall_dataset_name_filter_does_not_widen_to_another_owner ... ok
test post_recall_dataset_name_filter_resolves_as_the_caller ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Python port?

**No — nothing equivalent exists upstream.** Searched `topoteretes/cognee` (clone at Sep 6 2026, `e93a4f0`): the tests touching the recall router (`tests/unit/api/test_query_required_on_recall_and_search.py`, `test_api_error_responses.py`, `tests/unit/api/recall/test_recall_streaming.py`, `test_recall_code_scope.py`, `test_recall_logs_query_history.py`) stub `authorized_search` and never post a `datasets` filter, and no test asserts owner-scoped name resolution through HTTP. The only HTTP-level `datasets` post is `tests/test_usage_logger_e2e.py` against `/api/v1/search`, a full-stack e2e about usage logs, not owner forwarding. The closest analogue is `test_recall_code_scope.py`'s `captured_search` fixture (a kwargs-recording stub), which is the pattern `RecordingRetriever` mirrors — the same approach #197 took in `recall_scope.rs`.

## Verification (run on this branch, all exit 0)

| Command | Result |
|---|---|
| `cargo fmt --check` | ok |
| `cargo clippy --all-targets -- -D warnings` | ok (2m25s) |
| `cargo check --all-targets --features telemetry` | ok |
| `cargo clippy --all-targets --features telemetry -- -D warnings` | ok |
| `cargo check -p cognee --no-default-features` | ok |
| `cargo check -p cognee-cli --no-default-features` | ok |
| `cargo check -p cognee-cli --no-default-features --features cognee-cli/android-default` | ok |
| `cargo test -p cognee-http-server` | 24 binaries, 368 passed, 0 failed, 5 ignored |

## Not covered

- `RecallPayloadDTO.dataset_ids` is deserialized but never forwarded by `post_recall` (`run_graph` has no `dataset_ids` parameter; only `datasets` names are passed). Python's `_run_graph` honours UUIDs over names. Out of scope here; noted for a follow-up.
- No `GET /v1/recall` change; the ACL-based `200 []` permission-denied path remains unreachable in OSS as documented in `map_recall_error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmwWAiTW184ZDFDdhW58Ki
