### PR TITLE
fix(bedrock): count real tokens, and survive a runaway generation

### DIFF
--- a/crates/chunking/src/config.rs
+++ b/crates/chunking/src/config.rs
@@ -195,27 +195,33 @@ impl TokenCounterKind {
             // the user that their configured tokenizer is not active.
             #[cfg(not(feature = "hf-tokenizer"))]
             TokenCounterKind::HuggingFace { model_id: _ } => {
-                eprintln!(
+                tracing::warn!(
                     "cognee-chunking: HuggingFace tokenizer requested but `hf-tokenizer` \
-                     feature is not enabled — falling back to WordCounter"
+                     feature is not enabled — falling back to WordCounter. A token budget \
+                     spent in words undercounts real tokens by ~35%, which can \
+                     exceed an embedding model's input cap."
                 );
                 Ok(Box::new(WordCounter))
             }
 
             #[cfg(not(feature = "hf-tokenizer"))]
             TokenCounterKind::HuggingFaceFile { path: _ } => {
-                eprintln!(
+                tracing::warn!(
                     "cognee-chunking: HuggingFaceFile tokenizer requested but `hf-tokenizer` \
-                     feature is not enabled — falling back to WordCounter"
+                     feature is not enabled — falling back to WordCounter. A token budget \
+                     spent in words undercounts real tokens by ~35%, which can \
+                     exceed an embedding model's input cap."
                 );
                 Ok(Box::new(WordCounter))
             }
 
             #[cfg(not(feature = "tiktoken"))]
             TokenCounterKind::TikToken => {
-                eprintln!(
+                tracing::warn!(
                     "cognee-chunking: TikToken tokenizer requested but `tiktoken` feature is \
-                     not enabled — falling back to WordCounter"
+                     not enabled — falling back to WordCounter. A token budget spent \
+                     in words undercounts real tokens by ~35%, which can exceed an \
+                     embedding model's input cap."
                 );
                 Ok(Box::new(WordCounter))
             }

--- a/crates/chunking/src/config.rs
+++ b/crates/chunking/src/config.rs
@@ -96,18 +96,11 @@ impl TokenCounterKind {
                 TokenCounterKind::Word
             }
             "openai" | "openai_compatible" => TokenCounterKind::TikToken,
-            // Bedrock previously fell through to `Word`, and whitespace counting
-            // against a token budget is not a rounding error — it is a different
-            // unit. `auto_chunk_size` derives its number from the EMBEDDING
-            // MODEL'S TOKEN LIMIT (8191 for Titan v2), so counting words spent
-            // that budget in the wrong currency: 8191 words measured ~11100
-            // Titan tokens on real text, and every embed call 400d with
-            // "Too many input tokens. Max input tokens: 8192".
-            //
-            // Titan's own tokenizer is not published, so no counter here is
-            // exact. cl100k BPE is nonetheless far closer to it than whitespace
-            // (~1.3 tokens/word vs 1.0 by construction), and the clamp in
-            // `CognifyConfig::with_auto_chunk_size` covers the residual error.
+            // Titan's tokenizer is not published, so no counter here is exact.
+            // cl100k BPE is the closest available proxy: both are byte-level BPE
+            // over a ~100k vocabulary and agree within a few percent on prose,
+            // where whitespace counting is off by ~35% and in the wrong unit
+            // entirely. `fit_token_budget` absorbs the residual difference.
             "bedrock" => TokenCounterKind::TikToken,
             "ollama" => {
                 if let Ok(model_id) = std::env::var("HUGGINGFACE_TOKENIZER")
@@ -134,8 +127,7 @@ impl TokenCounterKind {
     /// Bedrock, degraded silently to `WordCounter`, and the resulting 8191-word
     /// chunks measured ~11149 real tokens against an 8192-token embedder limit,
     /// failing every embedding call with HTTP 400.
-    #[must_use]
-    pub fn effective(&self) -> TokenCounterKind {
+    fn effective(&self) -> TokenCounterKind {
         match self {
             TokenCounterKind::Word => TokenCounterKind::Word,
             TokenCounterKind::HuggingFace { .. } | TokenCounterKind::HuggingFaceFile { .. } => {
@@ -158,6 +150,38 @@ impl TokenCounterKind {
                     TokenCounterKind::Word
                 }
             }
+        }
+    }
+
+    /// Convert a TOKEN budget into whatever unit this counter actually measures.
+    ///
+    /// The single entry point callers need: it resolves the counter that will
+    /// really run (a BPE counter degrades to `WordCounter` when its cargo
+    /// feature is absent) and converts the budget for it. There is deliberately
+    /// no way to size a budget against a counter that will not run.
+    ///
+    /// `auto_chunk_size`-style budgets are derived from an embedding model's
+    /// TOKEN limit, so handing one to a word counter overshoots that limit by
+    /// construction: 8191 spent as words measured ~11100 real tokens and every
+    /// Bedrock embedding call failed with "Too many input tokens. Max input
+    /// tokens: 8192".
+    ///
+    /// `WORD_TOKENS_UPPER_BOUND` is deliberately pessimistic. English prose runs
+    /// ~1.3 tokens/word, the observed ratio on the corpus that produced the bug
+    /// was 1.36, and dense or punctuation-heavy text goes higher. Undershooting
+    /// costs a few more chunks; overshooting costs the whole run.
+    #[must_use]
+    pub fn fit_token_budget(&self, token_budget: usize) -> usize {
+        /// Pessimistic tokens-per-word, scaled by 100 to stay in integer maths.
+        const WORD_TOKENS_UPPER_BOUND: usize = 150;
+        match self.effective() {
+            // Already BPE/WordPiece: the budget is in the right unit. Exactness
+            // against a *different* BPE vocabulary is covered by the caller's own
+            // headroom, not by this conversion.
+            TokenCounterKind::HuggingFace { .. }
+            | TokenCounterKind::HuggingFaceFile { .. }
+            | TokenCounterKind::TikToken => token_budget,
+            TokenCounterKind::Word => (token_budget * 100 / WORD_TOKENS_UPPER_BOUND).max(1),
         }
     }
 
@@ -338,6 +362,72 @@ mod tests {
         assert!(
             matches!(kind, TokenCounterKind::TikToken),
             "bedrock must count BPE tokens, not whitespace words: {kind:?}",
+        );
+    }
+
+    /// A token budget must be converted before a word counter spends it.
+    ///
+    /// This is the bug that produced `Too many input tokens. Max input tokens:
+    /// 8192, request input token count: 11100` on Bedrock: the budget is the
+    /// embedding model's TOKEN limit, the chunker measured whitespace, and 8191
+    /// words is ~11100 tokens. An auto-derived budget could only ever exceed the
+    /// limit it was derived from.
+    #[test]
+    fn a_token_budget_is_converted_before_a_word_counter_spends_it() {
+        // Word counting must be scaled down, and far enough that the observed
+        // 1.36 tokens/word on real prose still lands under the limit.
+        let words = TokenCounterKind::Word.fit_token_budget(8191);
+        assert!(
+            words < 8191,
+            "a word budget must be smaller than the token budget, got {words}",
+        );
+        let worst_case_tokens = (words as f64 * 1.36) as usize;
+        assert!(
+            worst_case_tokens <= 8191,
+            "{words} words is ~{worst_case_tokens} tokens at the observed ratio, \
+             which must not exceed the 8191-token budget it came from",
+        );
+
+        // Never zero, however small the budget.
+        assert!(TokenCounterKind::Word.fit_token_budget(1) >= 1);
+    }
+
+    /// Sizing must follow the counter that will ACTUALLY run, not the one that
+    /// was requested. `build()` degrades a BPE counter to `WordCounter` when its
+    /// cargo feature is absent, so a request for TikToken in a build without the
+    /// `tiktoken` feature means whitespace counting.
+    ///
+    /// This shipped: an image requested TikToken for Bedrock, silently got
+    /// WordCounter, and 8191 "tokens" became 8191 words ~= 11149 real tokens
+    /// against an 8192-token embedder cap — HTTP 400 on every embedding call.
+    #[test]
+    fn sizing_follows_the_effective_counter_not_the_requested_one() {
+        let sized = TokenCounterKind::TikToken.fit_token_budget(8191);
+        if cfg!(feature = "tiktoken") {
+            assert_eq!(sized, 8191, "a real BPE counter spends the budget as-is");
+        } else {
+            assert!(
+                sized < 8191,
+                "a counter that degraded to whitespace must still get a converted \
+                 budget, got {sized}",
+            );
+        }
+    }
+
+    /// A budget already in BPE units passes through untouched.
+    #[test]
+    fn a_bpe_counter_receives_the_token_budget_unchanged() {
+        let hf = TokenCounterKind::HuggingFace {
+            model_id: "bert-base-uncased".to_string(),
+        };
+        assert_eq!(
+            hf.fit_token_budget(8191),
+            if cfg!(feature = "hf-tokenizer") {
+                8191
+            } else {
+                5460
+            },
+            "a HuggingFace request keeps the token budget only when compiled in",
         );
     }
 }

--- a/crates/chunking/src/config.rs
+++ b/crates/chunking/src/config.rs
@@ -121,6 +121,46 @@ impl TokenCounterKind {
         }
     }
 
+    /// What this kind will ACTUALLY be at runtime, given the compiled features.
+    ///
+    /// `build()` falls back to `WordCounter` when the feature backing the
+    /// requested counter is not compiled in, and says so only on stderr. Callers
+    /// that size a budget by unit therefore cannot trust the requested kind:
+    /// asking for `TikToken` in an image built without the `tiktoken` feature
+    /// yields whitespace counting, and any token budget handed to it is spent in
+    /// the wrong unit.
+    ///
+    /// That is not hypothetical — it shipped. A build requested TikToken for
+    /// Bedrock, degraded silently to `WordCounter`, and the resulting 8191-word
+    /// chunks measured ~11149 real tokens against an 8192-token embedder limit,
+    /// failing every embedding call with HTTP 400.
+    #[must_use]
+    pub fn effective(&self) -> TokenCounterKind {
+        match self {
+            TokenCounterKind::Word => TokenCounterKind::Word,
+            TokenCounterKind::HuggingFace { .. } | TokenCounterKind::HuggingFaceFile { .. } => {
+                #[cfg(feature = "hf-tokenizer")]
+                {
+                    self.clone()
+                }
+                #[cfg(not(feature = "hf-tokenizer"))]
+                {
+                    TokenCounterKind::Word
+                }
+            }
+            TokenCounterKind::TikToken => {
+                #[cfg(feature = "tiktoken")]
+                {
+                    TokenCounterKind::TikToken
+                }
+                #[cfg(not(feature = "tiktoken"))]
+                {
+                    TokenCounterKind::Word
+                }
+            }
+        }
+    }
+
     /// Construct a boxed `TokenCounter` from this kind.
     ///
     /// Returns an error if the selected kind cannot be constructed (e.g. file not found,

--- a/crates/chunking/src/config.rs
+++ b/crates/chunking/src/config.rs
@@ -96,6 +96,19 @@ impl TokenCounterKind {
                 TokenCounterKind::Word
             }
             "openai" | "openai_compatible" => TokenCounterKind::TikToken,
+            // Bedrock previously fell through to `Word`, and whitespace counting
+            // against a token budget is not a rounding error — it is a different
+            // unit. `auto_chunk_size` derives its number from the EMBEDDING
+            // MODEL'S TOKEN LIMIT (8191 for Titan v2), so counting words spent
+            // that budget in the wrong currency: 8191 words measured ~11100
+            // Titan tokens on real text, and every embed call 400d with
+            // "Too many input tokens. Max input tokens: 8192".
+            //
+            // Titan's own tokenizer is not published, so no counter here is
+            // exact. cl100k BPE is nonetheless far closer to it than whitespace
+            // (~1.3 tokens/word vs 1.0 by construction), and the clamp in
+            // `CognifyConfig::with_auto_chunk_size` covers the residual error.
+            "bedrock" => TokenCounterKind::TikToken,
             "ollama" => {
                 if let Ok(model_id) = std::env::var("HUGGINGFACE_TOKENIZER")
                     && !model_id.trim().is_empty()
@@ -258,5 +271,27 @@ mod tests {
         assert!(counter.is_ok(), "should fall back to WordCounter");
         let counter = counter.unwrap();
         assert_eq!(counter.count_tokens("hello world"), 2);
+    }
+    /// Bedrock must not fall through to whitespace counting. `auto_chunk_size`
+    /// derives its budget from the embedding model's TOKEN limit, so a word
+    /// counter spends it in the wrong unit — 8191 words measured ~11100 Titan
+    /// tokens and every embed call 400d against Titan v2's 8192 cap.
+    ///
+    /// # Safety
+    /// Same as the sibling tests: env mutation under a single-threaded harness.
+    #[test]
+    fn bedrock_gets_a_bpe_counter_not_whitespace() {
+        unsafe {
+            std::env::remove_var("COGNEE_TOKEN_COUNTER");
+            std::env::remove_var("HUGGINGFACE_TOKENIZER");
+            std::env::remove_var("EMBEDDING_TOKENIZER_PATH");
+            std::env::set_var("EMBEDDING_PROVIDER", "bedrock");
+        }
+        let kind = TokenCounterKind::from_env();
+        unsafe { std::env::remove_var("EMBEDDING_PROVIDER") };
+        assert!(
+            matches!(kind, TokenCounterKind::TikToken),
+            "bedrock must count BPE tokens, not whitespace words: {kind:?}",
+        );
     }
 }

--- a/crates/cognify/Cargo.toml
+++ b/crates/cognify/Cargo.toml
@@ -15,6 +15,10 @@ authors.workspace = true
 workspace = true
 
 [features]
+# Forwarded so a deployment can compile a real BPE token counter. Without it
+# `TokenCounterKind::TikToken` degrades to whitespace counting at runtime and a
+# token budget gets spent in words — see cognee-chunking::TokenCounterKind::effective.
+tiktoken = ["cognee-chunking/tiktoken"]
 testing = ["cognee-storage/testing", "cognee-graph/testing", "cognee-vector/testing"]
 html-loader = ["cognee-ingestion/html-loader"]
 image-loader = ["cognee-ingestion/image-loader"]

--- a/crates/cognify/src/config.rs
+++ b/crates/cognify/src/config.rs
@@ -1228,9 +1228,17 @@ mod tests {
             ..Default::default()
         }
         .with_auto_chunk_size(&embed, &llm);
+        // `cfg!(feature = "tiktoken")` here would name COGNIFY's passthrough
+        // feature, not the one cognee-chunking actually compiles the counter
+        // behind — the two differ, and reading the wrong one is the same
+        // cross-crate confusion that produced this bug. Ask the counter.
+        let keeps_token_budget = matches!(
+            TokenCounterKind::TikToken.effective(),
+            TokenCounterKind::TikToken
+        );
         assert_eq!(
             bpe.max_chunk_size,
-            Some(if cfg!(feature = "tiktoken") { 512 } else { 341 }),
+            Some(if keeps_token_budget { 512 } else { 341 }),
             "a TikToken request only keeps the token budget when the feature is compiled in",
         );
         // Other fields should remain at defaults

--- a/crates/cognify/src/config.rs
+++ b/crates/cognify/src/config.rs
@@ -655,9 +655,13 @@ impl CognifyConfig {
         llm: &dyn Llm,
     ) -> Self {
         let budget = Self::auto_chunk_size(embedding_engine, llm);
+        // `effective()`, not the configured kind: a requested BPE counter degrades
+        // to whitespace when its cargo feature is absent, and sizing against the
+        // request rather than the reality is how an 8192-token embedder limit was
+        // blown by an 8191-"token" budget that was really 8191 words.
         self.max_chunk_size = Some(Self::fit_budget_to_counter(
             budget,
-            &self.token_counter_kind,
+            &self.token_counter_kind.effective(),
         ));
         self
     }
@@ -1152,13 +1156,21 @@ mod tests {
     fn validation_catches_a_too_large_overlap_once_the_size_is_resolved() {
         let embed = MockEmbedding { max_seq: 512 };
         let llm = MockLlm::with_ctx(4096);
+        // Counter pinned explicitly. `Default::default()` reads
+        // `TokenCounterKind::from_env()`, so leaving it ambient made the expected
+        // value depend on whatever EMBEDDING_PROVIDER the developer's shell had —
+        // and, once budgets became unit-converted, on which cargo features the
+        // test binary happened to be built with.
         let resolved = CognifyConfig {
             max_chunk_size: None,
             chunk_overlap: 100_000,
+            token_counter_kind: TokenCounterKind::Word,
             ..Default::default()
         }
         .with_auto_chunk_size(&embed, &llm);
-        assert_eq!(resolved.max_chunk_size, Some(512));
+        // 512 TOKENS converted for a word counter at the pessimistic 1.50
+        // tokens/word: 512 * 100 / 150 = 341.
+        assert_eq!(resolved.max_chunk_size, Some(341));
         assert!(matches!(
             resolved.validate(),
             Err(ConfigError::InvalidParameter(_))
@@ -1201,8 +1213,26 @@ mod tests {
     fn test_with_auto_chunk_size_builder() {
         let embed = MockEmbedding { max_seq: 512 };
         let llm = MockLlm::with_ctx(4096);
-        let config = CognifyConfig::default().with_auto_chunk_size(&embed, &llm);
-        assert_eq!(config.max_chunk_size, Some(512));
+        // Counter pinned so the expectation does not depend on ambient env or
+        // on the feature set this test binary was built with.
+        let config = CognifyConfig {
+            token_counter_kind: TokenCounterKind::Word,
+            ..Default::default()
+        }
+        .with_auto_chunk_size(&embed, &llm);
+        // 512 tokens -> 341 words at the pessimistic 1.50 tokens/word.
+        assert_eq!(config.max_chunk_size, Some(341));
+        // And a BPE counter spends the same budget untouched.
+        let bpe = CognifyConfig {
+            token_counter_kind: TokenCounterKind::TikToken,
+            ..Default::default()
+        }
+        .with_auto_chunk_size(&embed, &llm);
+        assert_eq!(
+            bpe.max_chunk_size,
+            Some(if cfg!(feature = "tiktoken") { 512 } else { 341 }),
+            "a TikToken request only keeps the token budget when the feature is compiled in",
+        );
         // Other fields should remain at defaults
         assert_eq!(config.chunk_overlap, 10);
         assert_eq!(config.chunks_per_batch, DEFAULT_CHUNKS_PER_BATCH);
@@ -1270,5 +1300,39 @@ mod tests {
 
         // Never zero, however small the budget.
         assert!(CognifyConfig::fit_budget_to_counter(1, &TokenCounterKind::Word) >= 1);
+    }
+
+    /// Sizing must follow the counter that will ACTUALLY run, not the one that
+    /// was requested. `TokenCounterKind::build` degrades a BPE counter to
+    /// `WordCounter` when its cargo feature is absent and only says so on
+    /// stderr, so a request for TikToken in a build without the `tiktoken`
+    /// feature means whitespace counting.
+    ///
+    /// This shipped: an image requested TikToken for Bedrock, silently got
+    /// WordCounter, and 8191 "tokens" became 8191 words ~= 11149 real tokens
+    /// against an 8192-token embedder cap — HTTP 400 on every embedding call.
+    ///
+    /// The assertion is on the invariant rather than on a `cfg!`, deliberately:
+    /// this crate's `cfg!(feature = "tiktoken")` describes ITS OWN feature, not
+    /// cognee-chunking's, so predicting the outcome that way is exactly the
+    /// cross-crate confusion the bug came from.
+    #[test]
+    fn sizing_follows_the_effective_counter_not_the_requested_one() {
+        let effective = TokenCounterKind::TikToken.effective();
+        let sized = CognifyConfig::fit_budget_to_counter(8191, &effective);
+
+        match effective {
+            TokenCounterKind::TikToken
+            | TokenCounterKind::HuggingFace { .. }
+            | TokenCounterKind::HuggingFaceFile { .. } => assert_eq!(
+                sized, 8191,
+                "a real BPE counter spends the token budget as-is",
+            ),
+            TokenCounterKind::Word => assert!(
+                sized < 8191,
+                "a counter that degraded to whitespace must still get a converted \
+                 budget, got {sized}",
+            ),
+        }
     }
 }

--- a/crates/cognify/src/config.rs
+++ b/crates/cognify/src/config.rs
@@ -655,46 +655,8 @@ impl CognifyConfig {
         llm: &dyn Llm,
     ) -> Self {
         let budget = Self::auto_chunk_size(embedding_engine, llm);
-        // `effective()`, not the configured kind: a requested BPE counter degrades
-        // to whitespace when its cargo feature is absent, and sizing against the
-        // request rather than the reality is how an 8192-token embedder limit was
-        // blown by an 8191-"token" budget that was really 8191 words.
-        self.max_chunk_size = Some(Self::fit_budget_to_counter(
-            budget,
-            &self.token_counter_kind.effective(),
-        ));
+        self.max_chunk_size = Some(self.token_counter_kind.fit_token_budget(budget));
         self
-    }
-
-    /// Convert a TOKEN budget into whatever unit the configured counter measures.
-    ///
-    /// `auto_chunk_size` returns tokens, because it is derived from the embedding
-    /// model's token limit and the LLM's completion ceiling. The chunker then
-    /// spends that number using `token_counter_kind` — and `TokenCounterKind::Word`
-    /// counts whitespace, which is a different unit, not an approximation of one.
-    ///
-    /// Handing 8191 straight to a word counter produced ~11100 real tokens on
-    /// English prose and every embedding call failed with Bedrock's
-    /// "Too many input tokens. Max input tokens: 8192". The overshoot is
-    /// structural: an auto-derived budget can only ever exceed the limit it was
-    /// derived from.
-    ///
-    /// `WORD_TOKENS_UPPER_BOUND` is deliberately pessimistic. English prose runs
-    /// ~1.3 tokens/word; the observed ratio on this corpus was 1.36; dense or
-    /// punctuation-heavy text goes higher. Undershooting costs a few more chunks,
-    /// overshooting costs the whole run.
-    fn fit_budget_to_counter(token_budget: usize, kind: &TokenCounterKind) -> usize {
-        /// Pessimistic tokens-per-word, scaled by 100 to stay in integer maths.
-        const WORD_TOKENS_UPPER_BOUND: usize = 150;
-        match kind {
-            // Already BPE/WordPiece: the budget is in the right unit. Exactness
-            // against a *different* BPE vocabulary is covered by the caller's own
-            // headroom, not by this conversion.
-            TokenCounterKind::HuggingFace { .. }
-            | TokenCounterKind::HuggingFaceFile { .. }
-            | TokenCounterKind::TikToken => token_budget,
-            TokenCounterKind::Word => (token_budget * 100 / WORD_TOKENS_UPPER_BOUND).max(1),
-        }
     }
 
     /// Validate configuration parameters.
@@ -1228,17 +1190,13 @@ mod tests {
             ..Default::default()
         }
         .with_auto_chunk_size(&embed, &llm);
-        // `cfg!(feature = "tiktoken")` here would name COGNIFY's passthrough
-        // feature, not the one cognee-chunking actually compiles the counter
-        // behind — the two differ, and reading the wrong one is the same
-        // cross-crate confusion that produced this bug. Ask the counter.
-        let keeps_token_budget = matches!(
-            TokenCounterKind::TikToken.effective(),
-            TokenCounterKind::TikToken
-        );
+        // Predicted from the counter itself, not from `cfg!(feature = "tiktoken")`,
+        // which inside cognify names COGNIFY's passthrough rather than the feature
+        // cognee-chunking compiles the counter behind. The two differ, and reading
+        // the wrong one is the cross-crate confusion this bug came from.
         assert_eq!(
             bpe.max_chunk_size,
-            Some(if keeps_token_budget { 512 } else { 341 }),
+            Some(TokenCounterKind::TikToken.fit_token_budget(512)),
             "a TikToken request only keeps the token budget when the feature is compiled in",
         );
         // Other fields should remain at defaults
@@ -1268,79 +1226,5 @@ mod tests {
             crate::summarization::SummaryExtractor::DEFAULT_MAX_PARALLEL,
             CognifyConfig::default().max_parallel_extractions,
         );
-    }
-    /// A token budget must be converted before a word counter spends it.
-    ///
-    /// This is the bug that produced `Too many input tokens. Max input tokens:
-    /// 8192, request input token count: 11100` on Bedrock: `auto_chunk_size`
-    /// returns the embedding model's TOKEN limit, the chunker measured
-    /// whitespace, and 8191 words is ~11100 tokens. An auto-derived budget could
-    /// only ever exceed the limit it was derived from.
-    #[test]
-    fn a_token_budget_is_converted_before_a_word_counter_spends_it() {
-        // BPE counters already speak the right unit — pass through untouched.
-        for kind in [
-            TokenCounterKind::TikToken,
-            TokenCounterKind::HuggingFace {
-                model_id: "bert-base-uncased".to_string(),
-            },
-        ] {
-            assert_eq!(
-                CognifyConfig::fit_budget_to_counter(8191, &kind),
-                8191,
-                "a BPE counter must receive the token budget unchanged: {kind:?}",
-            );
-        }
-
-        // Word counting must be scaled down, and far enough that the observed
-        // 1.36 tokens/word on real prose still lands under the limit.
-        let words = CognifyConfig::fit_budget_to_counter(8191, &TokenCounterKind::Word);
-        assert!(
-            words < 8191,
-            "a word budget must be smaller than the token budget, got {words}",
-        );
-        let worst_case_tokens = (words as f64 * 1.36) as usize;
-        assert!(
-            worst_case_tokens <= 8191,
-            "{words} words is ~{worst_case_tokens} tokens at the observed ratio, \
-             which must not exceed the 8191-token budget it came from",
-        );
-
-        // Never zero, however small the budget.
-        assert!(CognifyConfig::fit_budget_to_counter(1, &TokenCounterKind::Word) >= 1);
-    }
-
-    /// Sizing must follow the counter that will ACTUALLY run, not the one that
-    /// was requested. `TokenCounterKind::build` degrades a BPE counter to
-    /// `WordCounter` when its cargo feature is absent and only says so on
-    /// stderr, so a request for TikToken in a build without the `tiktoken`
-    /// feature means whitespace counting.
-    ///
-    /// This shipped: an image requested TikToken for Bedrock, silently got
-    /// WordCounter, and 8191 "tokens" became 8191 words ~= 11149 real tokens
-    /// against an 8192-token embedder cap — HTTP 400 on every embedding call.
-    ///
-    /// The assertion is on the invariant rather than on a `cfg!`, deliberately:
-    /// this crate's `cfg!(feature = "tiktoken")` describes ITS OWN feature, not
-    /// cognee-chunking's, so predicting the outcome that way is exactly the
-    /// cross-crate confusion the bug came from.
-    #[test]
-    fn sizing_follows_the_effective_counter_not_the_requested_one() {
-        let effective = TokenCounterKind::TikToken.effective();
-        let sized = CognifyConfig::fit_budget_to_counter(8191, &effective);
-
-        match effective {
-            TokenCounterKind::TikToken
-            | TokenCounterKind::HuggingFace { .. }
-            | TokenCounterKind::HuggingFaceFile { .. } => assert_eq!(
-                sized, 8191,
-                "a real BPE counter spends the token budget as-is",
-            ),
-            TokenCounterKind::Word => assert!(
-                sized < 8191,
-                "a counter that degraded to whitespace must still get a converted \
-                 budget, got {sized}",
-            ),
-        }
     }
 }

--- a/crates/cognify/src/config.rs
+++ b/crates/cognify/src/config.rs
@@ -654,8 +654,43 @@ impl CognifyConfig {
         embedding_engine: &dyn EmbeddingEngine,
         llm: &dyn Llm,
     ) -> Self {
-        self.max_chunk_size = Some(Self::auto_chunk_size(embedding_engine, llm));
+        let budget = Self::auto_chunk_size(embedding_engine, llm);
+        self.max_chunk_size = Some(Self::fit_budget_to_counter(
+            budget,
+            &self.token_counter_kind,
+        ));
         self
+    }
+
+    /// Convert a TOKEN budget into whatever unit the configured counter measures.
+    ///
+    /// `auto_chunk_size` returns tokens, because it is derived from the embedding
+    /// model's token limit and the LLM's completion ceiling. The chunker then
+    /// spends that number using `token_counter_kind` — and `TokenCounterKind::Word`
+    /// counts whitespace, which is a different unit, not an approximation of one.
+    ///
+    /// Handing 8191 straight to a word counter produced ~11100 real tokens on
+    /// English prose and every embedding call failed with Bedrock's
+    /// "Too many input tokens. Max input tokens: 8192". The overshoot is
+    /// structural: an auto-derived budget can only ever exceed the limit it was
+    /// derived from.
+    ///
+    /// `WORD_TOKENS_UPPER_BOUND` is deliberately pessimistic. English prose runs
+    /// ~1.3 tokens/word; the observed ratio on this corpus was 1.36; dense or
+    /// punctuation-heavy text goes higher. Undershooting costs a few more chunks,
+    /// overshooting costs the whole run.
+    fn fit_budget_to_counter(token_budget: usize, kind: &TokenCounterKind) -> usize {
+        /// Pessimistic tokens-per-word, scaled by 100 to stay in integer maths.
+        const WORD_TOKENS_UPPER_BOUND: usize = 150;
+        match kind {
+            // Already BPE/WordPiece: the budget is in the right unit. Exactness
+            // against a *different* BPE vocabulary is covered by the caller's own
+            // headroom, not by this conversion.
+            TokenCounterKind::HuggingFace { .. }
+            | TokenCounterKind::HuggingFaceFile { .. }
+            | TokenCounterKind::TikToken => token_budget,
+            TokenCounterKind::Word => (token_budget * 100 / WORD_TOKENS_UPPER_BOUND).max(1),
+        }
     }
 
     /// Validate configuration parameters.
@@ -1195,5 +1230,45 @@ mod tests {
             crate::summarization::SummaryExtractor::DEFAULT_MAX_PARALLEL,
             CognifyConfig::default().max_parallel_extractions,
         );
+    }
+    /// A token budget must be converted before a word counter spends it.
+    ///
+    /// This is the bug that produced `Too many input tokens. Max input tokens:
+    /// 8192, request input token count: 11100` on Bedrock: `auto_chunk_size`
+    /// returns the embedding model's TOKEN limit, the chunker measured
+    /// whitespace, and 8191 words is ~11100 tokens. An auto-derived budget could
+    /// only ever exceed the limit it was derived from.
+    #[test]
+    fn a_token_budget_is_converted_before_a_word_counter_spends_it() {
+        // BPE counters already speak the right unit — pass through untouched.
+        for kind in [
+            TokenCounterKind::TikToken,
+            TokenCounterKind::HuggingFace {
+                model_id: "bert-base-uncased".to_string(),
+            },
+        ] {
+            assert_eq!(
+                CognifyConfig::fit_budget_to_counter(8191, &kind),
+                8191,
+                "a BPE counter must receive the token budget unchanged: {kind:?}",
+            );
+        }
+
+        // Word counting must be scaled down, and far enough that the observed
+        // 1.36 tokens/word on real prose still lands under the limit.
+        let words = CognifyConfig::fit_budget_to_counter(8191, &TokenCounterKind::Word);
+        assert!(
+            words < 8191,
+            "a word budget must be smaller than the token budget, got {words}",
+        );
+        let worst_case_tokens = (words as f64 * 1.36) as usize;
+        assert!(
+            worst_case_tokens <= 8191,
+            "{words} words is ~{worst_case_tokens} tokens at the observed ratio, \
+             which must not exceed the 8191-token budget it came from",
+        );
+
+        // Never zero, however small the budget.
+        assert!(CognifyConfig::fit_budget_to_counter(1, &TokenCounterKind::Word) >= 1);
     }
 }

--- a/crates/http-server/Cargo.toml
+++ b/crates/http-server/Cargo.toml
@@ -37,6 +37,10 @@ path = "src/main.rs"
 required-features = ["bin"]
 
 [features]
+# Forwarded so a deployment can compile a real BPE token counter. Without it
+# `TokenCounterKind::TikToken` degrades to whitespace counting at runtime and a
+# token budget gets spent in words — see cognee-chunking::TokenCounterKind::effective.
+tiktoken = ["cognee-cognify/tiktoken"]
 # decision 1: telemetry is ON by default in cognee-http-server. Disable with
 # --no-default-features for compile-time opt-out.
 # html-loader is on by default so the server binary supports URL ingestion and

--- a/crates/http-server/Cargo.toml
+++ b/crates/http-server/Cargo.toml
@@ -45,7 +45,8 @@ tiktoken = ["cognee-cognify/tiktoken"]
 # --no-default-features for compile-time opt-out.
 # html-loader is on by default so the server binary supports URL ingestion and
 # HTML documents out of the box (parity with the Python `/add` URL path).
-default = ["telemetry", "html-loader", "onnx", "ladybug", "lancedb", "pgvector", "bedrock"]
+default = ["telemetry", "html-loader", "onnx", "ladybug", "lancedb", "pgvector", "bedrock",
+           "tiktoken"]
 # Embedded LanceDB vector store, forwarded to cognee-components + cognee-vector.
 # Default-on, so a plain build of this crate is unchanged; a consumer whose vector
 # backend is pgvector (or a closed adapter) can now drop the Arrow + lance native

--- a/crates/llm/src/adapters/bedrock/mod.rs
+++ b/crates/llm/src/adapters/bedrock/mod.rs
@@ -579,17 +579,50 @@ impl BedrockAdapter {
                             .as_u64()
                             .map_or(self.caps.max_output_tokens, |v| v as u32);
                         truncation_retry = true;
-                        if current >= cap {
-                            return Err(LlmError::InvalidResponse(format!(
-                                "Bedrock structured output was truncated at the effective \
-                                 {cap}-token output budget (the lesser of the \
-                                 llm_max_completion_tokens ceiling and the model cap) and \
-                                 cannot be completed within that budget"
-                            )));
+                        // At the cap there is no larger budget to move to, but a
+                        // re-ask is still worth an attempt, because this failure
+                        // is STOCHASTIC rather than a property of the input.
+                        //
+                        // Measured on Bedrock/Sonnet 4.5 with native structured
+                        // output: ~4.5% of extraction calls run away and emit
+                        // until they hit the model maximum, on ordinary ~2.7k-token
+                        // chunks whose siblings answer in under 2k. It is a
+                        // per-call dice roll, not a poisoned chunk — the runaway
+                        // chunk ids differ between runs of the same document.
+                        //
+                        // Direct evidence that a re-ask clears it: in one run a
+                        // call ran past the 600s transport timeout, the network
+                        // ladder re-POSTed the IDENTICAL body, and the retry
+                        // returned a normal 686-token answer 11 seconds later.
+                        // Same chunk, same request, same budget.
+                        //
+                        // Returning terminally here therefore threw away a run for
+                        // a failure that a second attempt usually survives — and
+                        // because `RollbackScope::WholeRun` then sweeps, 2 bad
+                        // chunks out of 55 discarded all 53 good extractions.
+                        //
+                        // Bounded by `structured_output_retries`, so a chunk that
+                        // truly cannot be answered still terminates, now with the
+                        // exhaustion error rather than this one.
+                        let at_cap = current >= cap;
+                        if !at_cap {
+                            body["inferenceConfig"]["maxTokens"] = json!(cap);
                         }
-                        body["inferenceConfig"]["maxTokens"] = json!(cap);
-                        let reason = "the previous answer was cut off at maxTokens before the \
-                                      object was complete";
+                        // The cap is named in the message so the exhaustion error a
+                        // caller finally sees still says which budget was hit, not
+                        // merely that something truncated.
+                        let at_cap_reason;
+                        let reason: &str = if at_cap {
+                            at_cap_reason = format!(
+                                "the previous answer ran to the effective {cap}-token output \
+                                 budget without completing the object; produce a smaller, \
+                                 complete result rather than continuing the previous one"
+                            );
+                            &at_cap_reason
+                        } else {
+                            "the previous answer was cut off at maxTokens before the \
+                             object was complete"
+                        };
                         last_error = LlmError::InvalidResponse(format!(
                             "Bedrock structured output truncated: {reason}"
                         ));

--- a/crates/llm/tests/bedrock_integration.rs
+++ b/crates/llm/tests/bedrock_integration.rs
@@ -615,11 +615,16 @@ async fn a_truncated_answer_is_re_asked_with_a_raised_budget() {
     retried.assert_calls_async(1).await;
 }
 
-/// ...but truncation *at* the effective cap is unrecoverable by design: raising
-/// the budget further would breach the `llm_max_completion_tokens` ceiling, so
-/// it fails terminally instead of looping until the retry budget is gone.
+/// ...and truncation *at* the effective cap is now RE-ASKED rather than returned
+/// terminally. The budget cannot be raised — there is nothing above the cap — but
+/// the failure it guards against is stochastic, not a property of the input:
+/// measured at ~4.5% of extraction calls on Bedrock/Sonnet 4.5, with the runaway
+/// chunks differing between runs of the same document, and a re-POST of an
+/// identical body observed returning a normal answer.
+///
+/// So the contract is "exhaust the retry budget", not "give up after one".
 #[tokio::test]
-async fn truncation_at_the_effective_cap_fails_terminally() {
+async fn truncation_at_the_effective_cap_is_re_asked_until_the_budget_is_gone() {
     let server = MockServer::start_async().await;
     let mock = server
         .mock_async(|when, then| {
@@ -636,7 +641,7 @@ async fn truncation_at_the_effective_cap_fails_terminally() {
 
     let error = adapter(&server, NOVA_LITE)
         .await
-        .with_structured_output_retries(5)
+        .with_structured_output_retries(3)
         .create_structured_output_with_messages_raw(
             // nova-lite's 10_000 cap is already the effective budget.
             vec![Message::user("who?")],
@@ -644,12 +649,13 @@ async fn truncation_at_the_effective_cap_fails_terminally() {
             None,
         )
         .await
-        .expect_err("a truncation at the cap cannot be repaired");
+        .expect_err("a mock that always truncates must still exhaust");
 
-    assert!(matches!(error, LlmError::InvalidResponse(_)), "{error:?}");
     assert!(
-        error.to_string().contains("truncated"),
-        "the error must name the cause: {error}",
+        error.to_string().contains("truncat"),
+        "the exhaustion error must still name the cause: {error}",
     );
-    mock.assert_calls_async(1).await;
+    // Every attempt is spent, rather than bailing out after the first — that is
+    // the whole change. A real runaway usually clears on the second try.
+    mock.assert_calls_async(3).await;
 }

--- a/crates/llm/tests/bedrock_truncation_retry.rs
+++ b/crates/llm/tests/bedrock_truncation_retry.rs
@@ -104,12 +104,18 @@ async fn a_truncated_native_answer_is_reported_as_truncation_not_as_unparseable_
         .with_structured_output_retries(3)
         .create_structured_output_with_messages_raw(vec![Message::user("who?")], &schema(), None)
         .await
-        .expect_err("a truncation at the effective cap cannot be repaired");
+        .expect_err("a mock that always truncates must exhaust the retry budget");
 
-    // Exactly one exchange: the loop stopped instead of re-asking at a budget
-    // that would truncate at the same point.
-    mock.assert_calls_async(1).await;
-    assert!(matches!(error, LlmError::InvalidResponse(_)), "{error:?}");
+    // Exhausts rather than bailing after one attempt: a cap truncation is a
+    // stochastic runaway, not a property of the input, so a re-ask is worth
+    // spending. This mock always truncates, so it burns the full budget.
+    mock.assert_calls_async(3).await;
+    // Exhaustion surfaces as MaxRetriesExceeded wrapping the truncation reason;
+    // the inner cause is what #187 pinned and is asserted on the message below.
+    assert!(
+        matches!(error, LlmError::MaxRetriesExceeded(_)),
+        "{error:?}"
+    );
     let message = error.to_string();
     assert!(
         message.contains("truncated") && message.contains("output budget"),
@@ -150,9 +156,12 @@ async fn a_blank_truncated_native_answer_is_reported_as_truncation() {
         .with_structured_output_retries(3)
         .create_structured_output_with_messages_raw(vec![Message::user("who?")], &schema(), None)
         .await
-        .expect_err("a blank truncation at the effective cap cannot be repaired");
+        .expect_err("a blank truncation that always repeats must exhaust the budget");
 
-    mock.assert_calls_async(1).await;
+    // Exhausts rather than bailing after one attempt: a cap truncation is a
+    // stochastic runaway, not a property of the input, so a re-ask is worth
+    // spending. This mock always truncates, so it burns the full budget.
+    mock.assert_calls_async(3).await;
     let message = error.to_string();
     assert!(
         message.contains("truncated") && message.contains("output budget"),


### PR DESCRIPTION
Five consecutive AWS BYOD deployment runs failed to cognify a single PDF. This is
the fix, in four commits, each of which was proven necessary by a run that failed
*after* the previous one landed.

## What was wrong

`TokenCounterKind::from_env` selects a BPE counter for the openai and bedrock
providers. Nothing in the server build compiled one, so `build()` handed back a
`WordCounter` and said so only on raw stderr.

That is not a rounding error, it is a unit change. `auto_chunk_size` derives its
number from the **embedding model's token limit**, so a word counter spends a
token budget in the wrong currency. On Bedrock with Titan v2 the 8191-token
budget became 8191 *words* — ~11149 real tokens against an 8192 cap — and every
embedding call returned HTTP 400. `RollbackScope::WholeRun` then swept the 99
nodes and 335 edges extraction had already produced.

Separately, ~4.5% of Bedrock structured-output calls run away and emit until they
hit the model maximum. At the cap the adapter returned terminally, so two bad
chunks out of 55 discarded all 53 good extractions.

## The commits

1. **`fix(llm)`** — re-ask a cap truncation instead of failing the run. The
   failure is stochastic, not a property of the input: the runaway chunk ids
   differ between runs of the same document, and in one run the transport layer
   re-POSTed an identical body and got a normal 686-token answer 11s later.
   Bounded by `structured_output_retries`.
2. **`fix(chunking)`** — dispatch bedrock to a BPE counter, and convert a token
   budget before a word counter spends it.
3. **`fix(chunking)`** — `TokenCounterKind::effective()`. Commit 2 was correct and
   inert: it reasoned about the *requested* counter while `build()` degrades to
   whitespace at runtime. Sizing now follows what will actually run.
4. **`fix(http-server)`** — `tiktoken` in the default feature list, and the three
   fallback notices promoted from `eprintln!` to `tracing::warn!`.

## Where the default does *not* go

Not on `cognee-chunking`. That was the first attempt and `scripts/check_all.sh`
rejected it: `tiktoken-rs` is on the forbidden list for `cognee-cli/android-default`
alongside `lancedb`, `pdfium-render` and `aws-config`, because a leaf-crate default
flows past every `default-features = false` upstream of it. The guard's own
wording — *"a feature forward has stopped subtracting"* — describes exactly what
that change did.

`cognee` (lib) has carried `"tiktoken"` in its defaults all along, so the library
was never the gap: the server image builds `--no-default-features` with an
explicit list, and `cognee-http-server` had no `tiktoken` feature to name.

## Verification

Run 6 on AWS BYOD, same stack and document as the five failures:

| | run 5 | run 6 |
|---|---|---|
| `falling back to WordCounter` | present | 0 |
| Titan input-cap 400s | every embed call | 0 (peak input 7290 / 8192) |
| cognify | HTTP 500 | **HTTP 200 in 486s** |
| searches | never reached | 4/5 HTTP 200, grounded answers |

Local: `scripts/check_all.sh` — Rust compile/clippy/all feature variants, the
android forbidden-list **and both sentinels**, C API (9 steps + slim-build
`CG_ERR_FEATURE_NOT_BUILT`), Python (128 passed / 100 skipped), TS. Java skipped
locally (no JDK); CI covers it. cognify 327 green in all three feature states.

## Known and not addressed here

One runaway generation still cost ~352s of run 6's 486s — 72% of wall-clock —
because extraction passes `max_tokens: None` as a deliberate Python-parity
invariant. Python carries the same `None` and does not hit this, so the useful
question is what protects Python, not what number to pick for Rust. Left alone
rather than guessed at.

The deployment image passes `--no-default-features`, so it still needs `tiktoken`
in its `BASE_FEATURES` for the new default to reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01374TL13k6r1CN8v6iJnhH9