### PR TITLE
fix(acl): route every permission check through the roles-aware AclDb variants

### DIFF
--- a/crates/delete/src/authorized.rs
+++ b/crates/delete/src/authorized.rs
@@ -5,6 +5,7 @@
 //! inner [`DeleteService`]. The plain `DeleteService` remains available for
 //! edge/embedded deployments that do not require ACL enforcement.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use cognee_database::{AclDb, DeleteDb};
@@ -108,12 +109,16 @@ impl AuthorizedDeleteService {
                 // For user-scoped deletion, verify the principal has delete
                 // on all datasets that would be affected. The inner service
                 // will list all datasets by owner. We check that the
-                // principal's authorized set covers them.
-                let authorized = self
+                // principal's authorized set covers them. Collected into a set:
+                // with tenant/role inheritance the authorized list can be
+                // tenant-wide, and the cover check below is per dataset.
+                let authorized: HashSet<Uuid> = self
                     .acl_db
-                    .authorized_dataset_ids(principal_id, "delete")
+                    .authorized_dataset_ids_with_roles(principal_id, "delete")
                     .await
-                    .map_err(|e| DeleteError::Runtime(format!("ACL query failed: {e}")))?;
+                    .map_err(|e| DeleteError::Runtime(format!("ACL query failed: {e}")))?
+                    .into_iter()
+                    .collect();
 
                 let owner_datasets = self
                     .database
@@ -136,11 +141,13 @@ impl AuthorizedDeleteService {
                 // All-scope is an administrative operation. We check that
                 // the principal has delete permission on every dataset that
                 // exists. If any dataset lacks the permission, deny.
-                let authorized = self
+                let authorized: HashSet<Uuid> = self
                     .acl_db
-                    .authorized_dataset_ids(principal_id, "delete")
+                    .authorized_dataset_ids_with_roles(principal_id, "delete")
                     .await
-                    .map_err(|e| DeleteError::Runtime(format!("ACL query failed: {e}")))?;
+                    .map_err(|e| DeleteError::Runtime(format!("ACL query failed: {e}")))?
+                    .into_iter()
+                    .collect();
 
                 let all_datasets = self.database.list_datasets().await.map_err(|e| {
                     DeleteError::Runtime(format!("Failed to list all datasets: {e}"))
@@ -190,7 +197,7 @@ impl AuthorizedDeleteService {
     ) -> Result<(), DeleteError> {
         let has_perm = self
             .acl_db
-            .has_permission(principal_id, dataset_id, "delete")
+            .has_permission_with_roles(principal_id, dataset_id, "delete")
             .await
             .map_err(|e| DeleteError::Runtime(format!("ACL check failed: {e}")))?;
 

--- a/crates/delete/src/lib.rs
+++ b/crates/delete/src/lib.rs
@@ -3732,6 +3732,200 @@ mod tests {
         );
     }
 
+    // ------------------------------------------------------------------
+    // Role / tenant inheritance (issue #206)
+    //
+    // Python `check_permission_on_dataset` → `get_specific_user_permission_
+    // datasets` → `get_all_user_permission_datasets` resolves direct, tenant
+    // and role grants for every permission type. The delete path must use
+    // the `_with_roles` variants so a principal holding `delete` only through
+    // a role or tenant is admitted. Each test below grants to a role/tenant
+    // id and calls as the member user; with the plain variants the grant is
+    // invisible and every one of these goes red.
+    // ------------------------------------------------------------------
+
+    /// Scenario: `delete` granted to a *role*; the caller holds the role.
+    /// Exercises `require_delete_permission` (Dataset scope →
+    /// `has_permission_with_roles`).
+    #[tokio::test]
+    async fn authorized_delete_via_role_grant_dataset_scope() {
+        use cognee_database::AclDb;
+        let (svc, storage, db, acl) = make_authorized_service().await;
+        let owner = Uuid::new_v4();
+        let member = Uuid::new_v4();
+        let role = Uuid::new_v4();
+        let (dataset_id, _data_id) =
+            seed_dataset_with_data(&db, &storage, owner, "acl_role_ds").await;
+
+        // A role only confers grants within a tenant the user belongs to
+        // (AclDb's contract, and Python nests the role walk in the tenant loop).
+        acl.add_user_to_tenant(member, Uuid::new_v4());
+        acl.add_user_to_role(member, role);
+        let acl_dyn: &dyn AclDb = acl.as_ref();
+        acl_dyn
+            .grant_permission(role, dataset_id, "delete")
+            .await
+            .unwrap();
+        // Sanity: the member has no direct grant of its own.
+        assert!(!acl.has_grant(member, dataset_id, "delete"));
+
+        let result = svc
+            .execute(
+                &DeleteRequest {
+                    scope: DeleteScope::Dataset {
+                        owner_id: owner,
+                        dataset_name: "acl_role_ds".to_string(),
+                    },
+                    mode: DeleteMode::Soft,
+                    memory_only: false,
+                },
+                member,
+            )
+            .await
+            .expect("a role-held delete grant must authorize the delete");
+        assert_eq!(result.deleted_datasets, 1);
+    }
+
+    /// Scenario: a role grants `read` but not `delete`.
+    /// Expected: still denied — inheritance must not widen the permission.
+    #[tokio::test]
+    async fn authorized_delete_via_role_with_wrong_permission_is_denied() {
+        use cognee_database::AclDb;
+        let (svc, storage, db, acl) = make_authorized_service().await;
+        let owner = Uuid::new_v4();
+        let member = Uuid::new_v4();
+        let role = Uuid::new_v4();
+        let (dataset_id, _data_id) =
+            seed_dataset_with_data(&db, &storage, owner, "acl_role_read_only").await;
+
+        // A role only confers grants within a tenant the user belongs to
+        // (AclDb's contract, and Python nests the role walk in the tenant loop).
+        acl.add_user_to_tenant(member, Uuid::new_v4());
+        acl.add_user_to_role(member, role);
+        let acl_dyn: &dyn AclDb = acl.as_ref();
+        acl_dyn
+            .grant_permission(role, dataset_id, "read")
+            .await
+            .unwrap();
+
+        let err = svc
+            .execute(
+                &DeleteRequest {
+                    scope: DeleteScope::Dataset {
+                        owner_id: owner,
+                        dataset_name: "acl_role_read_only".to_string(),
+                    },
+                    mode: DeleteMode::Soft,
+                    memory_only: false,
+                },
+                member,
+            )
+            .await
+            .expect_err("a role-held read grant must not authorize delete");
+        assert!(
+            matches!(err, DeleteError::PermissionDenied(_)),
+            "expected PermissionDenied, got: {err:?}"
+        );
+    }
+
+    /// Scenario: User scope; the owner has two datasets, one granted to the
+    /// caller directly and one granted only to a *tenant* the caller belongs
+    /// to. Exercises the `authorized_dataset_ids_with_roles` set-cover in the
+    /// `DeleteScope::User` branch. A third, ungranted dataset must still deny.
+    #[tokio::test]
+    async fn authorized_delete_via_tenant_grant_user_scope() {
+        use cognee_database::AclDb;
+        let (svc, storage, db, acl) = make_authorized_service().await;
+        let owner = Uuid::new_v4();
+        let member = Uuid::new_v4();
+        let tenant = Uuid::new_v4();
+        let (direct_ds, _) = seed_dataset_with_data(&db, &storage, owner, "user_direct").await;
+        let (tenant_ds, _) = seed_dataset_with_data(&db, &storage, owner, "user_tenant").await;
+
+        acl.add_user_to_tenant(member, tenant);
+        let acl_dyn: &dyn AclDb = acl.as_ref();
+        acl_dyn
+            .grant_permission(member, direct_ds, "delete")
+            .await
+            .unwrap();
+        acl_dyn
+            .grant_permission(tenant, tenant_ds, "delete")
+            .await
+            .unwrap();
+
+        let request = DeleteRequest {
+            scope: DeleteScope::User { owner_id: owner },
+            mode: DeleteMode::Soft,
+            memory_only: false,
+        };
+        let result = svc
+            .execute(&request, member)
+            .await
+            .expect("direct + tenant grants must cover every owner dataset");
+        assert_eq!(result.deleted_datasets, 2);
+
+        // Now an ungranted dataset appears for the same owner: the cover
+        // check must fail even though the member still holds the others.
+        seed_dataset_with_data(&db, &storage, owner, "user_ungranted").await;
+        let err = svc
+            .execute(&request, member)
+            .await
+            .expect_err("an owner dataset with no grant must deny User scope");
+        assert!(
+            matches!(err, DeleteError::PermissionDenied(_)),
+            "expected PermissionDenied, got: {err:?}"
+        );
+    }
+
+    /// Scenario: All scope; every dataset in the DB is granted to a *role*
+    /// the caller holds. Exercises `authorized_dataset_ids_with_roles` in the
+    /// `DeleteScope::All` branch.
+    #[tokio::test]
+    async fn authorized_delete_via_role_grant_all_scope() {
+        use cognee_database::AclDb;
+        let (svc, storage, db, acl) = make_authorized_service().await;
+        let owner_a = Uuid::new_v4();
+        let owner_b = Uuid::new_v4();
+        let admin = Uuid::new_v4();
+        let admin_role = Uuid::new_v4();
+        let (ds_a, _) = seed_dataset_with_data(&db, &storage, owner_a, "all_a").await;
+        let (ds_b, _) = seed_dataset_with_data(&db, &storage, owner_b, "all_b").await;
+
+        // A role only confers grants within a tenant the user belongs to
+        // (AclDb's contract, and Python nests the role walk in the tenant loop).
+        acl.add_user_to_tenant(admin, Uuid::new_v4());
+        acl.add_user_to_role(admin, admin_role);
+        let acl_dyn: &dyn AclDb = acl.as_ref();
+        for ds in [ds_a, ds_b] {
+            acl_dyn
+                .grant_permission(admin_role, ds, "delete")
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            acl_dyn
+                .authorized_dataset_ids(admin, "delete")
+                .await
+                .unwrap()
+                .len(),
+            0,
+            "sanity: the admin holds nothing directly"
+        );
+
+        let result = svc
+            .execute(
+                &DeleteRequest {
+                    scope: DeleteScope::All,
+                    mode: DeleteMode::Soft,
+                    memory_only: false,
+                },
+                admin,
+            )
+            .await
+            .expect("role-held delete on every dataset must authorize All scope");
+        assert_eq!(result.deleted_datasets, 2);
+    }
+
     #[tokio::test]
     async fn unauthorized_service_still_works() {
         // The plain DeleteService (without ACL wrapper) should continue

--- a/crates/http-server/src/routers/visualize.rs
+++ b/crates/http-server/src/routers/visualize.rs
@@ -86,20 +86,8 @@ pub async fn get_visualize(
                 format!("dataset {} not found", query.dataset_id),
             )
         })?;
-    let allowed = if let Some(ref acl) = components.acl_db {
-        acl.has_permission(user.id, dataset.id, "read")
-            .await
-            .map_err(|err| ApiError::VisualizeError(StatusCode::CONFLICT, err.to_string()))?
-    } else {
-        // No ACL backend wired (pure-OSS); allow.
-        true
-    };
-    if !allowed {
-        return Err(ApiError::VisualizeError(
-            StatusCode::CONFLICT,
-            "permission denied".to_string(),
-        ));
-    }
+    // No ACL backend wired (pure-OSS) → allow.
+    require_read_permission(components.acl_db.as_deref(), user.id, dataset.id).await?;
 
     let Some(graph_db) = components.graph_db.clone() else {
         return Err(ApiError::VisualizeError(
@@ -176,19 +164,7 @@ pub async fn post_visualize_multi(
         // OSS does not bundle an ACL backend — when no `acl_db` is wired
         // (the pure-OSS case), allow the read. Closed embedders install
         // a real `AclDb` impl via `ComponentHandles::acl_db`.
-        let allowed = if let Some(ref acl) = components.acl_db {
-            acl.has_permission(pair.user_id, dataset.id, "read")
-                .await
-                .map_err(|err| ApiError::VisualizeError(StatusCode::CONFLICT, err.to_string()))?
-        } else {
-            true
-        };
-        if !allowed {
-            return Err(ApiError::VisualizeError(
-                StatusCode::CONFLICT,
-                "permission denied".to_string(),
-            ));
-        }
+        require_read_permission(components.acl_db.as_deref(), pair.user_id, dataset.id).await?;
         let Some(graph_db) = components.graph_db.clone() else {
             return Err(ApiError::VisualizeError(
                 StatusCode::CONFLICT,
@@ -209,4 +185,98 @@ pub async fn post_visualize_multi(
         .await
         .map_err(|err| ApiError::VisualizeError(StatusCode::CONFLICT, err.to_string()))?;
     Ok(Html(html))
+}
+
+/// Deny the visualization unless `user_id` can `read` `dataset_id`.
+///
+/// `acl` is `None` when no ACL backend is wired (pure-OSS) — the read is
+/// allowed. Otherwise the roles-aware check is used, matching Python's
+/// `get_authorized_existing_datasets([dataset_id], "read", user)`, which
+/// resolves tenant and role grants alongside direct ones. Any failure —
+/// backend error or denial — collapses into the 409 envelope per the
+/// module-level parity note.
+async fn require_read_permission(
+    acl: Option<&dyn cognee_database::AclDb>,
+    user_id: uuid::Uuid,
+    dataset_id: uuid::Uuid,
+) -> Result<(), ApiError> {
+    let Some(acl) = acl else {
+        return Ok(());
+    };
+    let allowed = acl
+        .has_permission_with_roles(user_id, dataset_id, "read")
+        .await
+        .map_err(|err| ApiError::VisualizeError(StatusCode::CONFLICT, err.to_string()))?;
+    if allowed {
+        Ok(())
+    } else {
+        Err(ApiError::VisualizeError(
+            StatusCode::CONFLICT,
+            "permission denied".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cognee_database::AclDb;
+    use cognee_test_utils::MockAclDb;
+    use uuid::Uuid;
+
+    /// Scenario: the caller can read the dataset only through a tenant grant.
+    /// Expected: allowed — Python's visualize path resolves tenant/role grants.
+    #[tokio::test]
+    async fn read_grant_via_tenant_is_admitted() {
+        let acl = MockAclDb::new();
+        let user = Uuid::new_v4();
+        let tenant = Uuid::new_v4();
+        let dataset = Uuid::new_v4();
+        acl.add_user_to_tenant(user, tenant);
+        assert!(acl.grant_permission(tenant, dataset, "read").await.is_ok());
+
+        assert!(
+            require_read_permission(Some(&acl), user, dataset)
+                .await
+                .is_ok(),
+            "a tenant-held read grant must satisfy the visualize gate"
+        );
+    }
+
+    /// Scenario: direct `read` grant. Expected: allowed (unchanged).
+    #[tokio::test]
+    async fn direct_read_grant_is_admitted() {
+        let acl = MockAclDb::new();
+        let user = Uuid::new_v4();
+        let dataset = Uuid::new_v4();
+        assert!(acl.grant_permission(user, dataset, "read").await.is_ok());
+
+        assert!(
+            require_read_permission(Some(&acl), user, dataset)
+                .await
+                .is_ok()
+        );
+    }
+
+    /// Scenario: no grant at all. Expected: the 409 parity envelope, not 403.
+    #[tokio::test]
+    async fn missing_read_grant_is_a_409() {
+        let acl = MockAclDb::new();
+        let user = Uuid::new_v4();
+        let dataset = Uuid::new_v4();
+
+        let err = require_read_permission(Some(&acl), user, dataset).await;
+        assert!(
+            matches!(err, Err(ApiError::VisualizeError(StatusCode::CONFLICT, _))),
+            "got {err:?}"
+        );
+    }
+
+    /// Scenario: no ACL backend wired (pure-OSS). Expected: allowed.
+    #[tokio::test]
+    async fn no_acl_backend_allows() {
+        let user = Uuid::new_v4();
+        let dataset = Uuid::new_v4();
+        assert!(require_read_permission(None, user, dataset).await.is_ok());
+    }
 }

--- a/crates/lib/src/api/datasets.rs
+++ b/crates/lib/src/api/datasets.rs
@@ -54,7 +54,9 @@ impl DatasetManager {
     /// on are returned. Without ACL, all datasets owned by the user are listed.
     pub async fn list_datasets(&self, owner_id: Uuid) -> Result<Vec<Dataset>, DatasetError> {
         if let Some(acl) = &self.acl_db {
-            let authorized_ids = acl.authorized_dataset_ids(owner_id, "read").await?;
+            let authorized_ids = acl
+                .authorized_dataset_ids_with_roles(owner_id, "read")
+                .await?;
             let mut datasets = Vec::with_capacity(authorized_ids.len());
             for id in authorized_ids {
                 if let Some(ds) = self.db.get_dataset(id).await? {
@@ -284,7 +286,9 @@ impl DatasetManager {
         dataset_id: Uuid,
     ) -> Result<(), DatasetError> {
         if let Some(acl) = &self.acl_db
-            && !acl.has_permission(owner_id, dataset_id, "read").await?
+            && !acl
+                .has_permission_with_roles(owner_id, dataset_id, "read")
+                .await?
         {
             return Err(DatasetError::PermissionDenied);
         }
@@ -297,7 +301,9 @@ impl DatasetManager {
         dataset_id: Uuid,
     ) -> Result<(), DatasetError> {
         if let Some(acl) = &self.acl_db
-            && !acl.has_permission(owner_id, dataset_id, "delete").await?
+            && !acl
+                .has_permission_with_roles(owner_id, dataset_id, "delete")
+                .await?
         {
             return Err(DatasetError::PermissionDenied);
         }
@@ -697,5 +703,156 @@ mod tests {
                 "owner must have '{perm}'"
             );
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Role / tenant inheritance (issue #206)
+    //
+    // Python's `datasets.list_datasets` → `get_authorized_existing_datasets
+    // ([], "read", user)` and `get_authorized_dataset(user, id, perm)` walk
+    // tenant and role grants. These tests grant to a role/tenant id and call
+    // as the member; with the plain `AclDb` variants they go red.
+    // ------------------------------------------------------------------
+
+    /// Scenario: one dataset granted `read` directly, one only via a role,
+    /// one not at all. Expected: `list_datasets` returns exactly the first two
+    /// (exercises `authorized_dataset_ids_with_roles`).
+    #[tokio::test]
+    async fn acl_list_datasets_includes_role_granted_dataset() {
+        let db = fresh_db().await;
+        let owner_id = Uuid::new_v4();
+        let member = Uuid::new_v4();
+        let role = Uuid::new_v4();
+        let direct = make_dataset(owner_id);
+        let via_role = make_dataset(owner_id);
+        let ungranted = make_dataset(owner_id);
+        let ingest: &dyn IngestDb = db.as_ref();
+        for ds in [&direct, &via_role, &ungranted] {
+            ingest
+                .create_dataset(ds.clone())
+                .await
+                .expect("create_dataset");
+        }
+
+        let acl = Arc::new(cognee_test_utils::MockAclDb::new());
+        // A role only confers grants within a tenant the user belongs to
+        // (AclDb's contract, and Python nests the role walk in the tenant loop).
+        acl.add_user_to_tenant(member, Uuid::new_v4());
+        acl.add_user_to_role(member, role);
+        acl.grant_permission(member, direct.id, "read")
+            .await
+            .expect("grant direct");
+        acl.grant_permission(role, via_role.id, "read")
+            .await
+            .expect("grant role");
+
+        let mgr =
+            DatasetManager::new(db.clone() as Arc<dyn DatasetDb>).with_acl(acl as Arc<dyn AclDb>);
+        let mut listed: Vec<Uuid> = mgr
+            .list_datasets(member)
+            .await
+            .expect("list_datasets")
+            .into_iter()
+            .map(|d| d.id)
+            .collect();
+        listed.sort();
+        let mut expected = vec![direct.id, via_role.id];
+        expected.sort();
+        assert_eq!(listed, expected, "direct + role grants, nothing else");
+    }
+
+    /// Scenario: `read` granted only to a tenant the caller belongs to.
+    /// Expected: `has_data` / `list_data` succeed (exercises
+    /// `check_read_permission` → `has_permission_with_roles`).
+    #[tokio::test]
+    async fn acl_read_grant_via_tenant_admits_has_data_and_list_data() {
+        let db = fresh_db().await;
+        let owner_id = Uuid::new_v4();
+        let member = Uuid::new_v4();
+        let tenant = Uuid::new_v4();
+        let ds = make_dataset(owner_id);
+        let ingest: &dyn IngestDb = db.as_ref();
+        ingest
+            .create_dataset(ds.clone())
+            .await
+            .expect("create_dataset");
+
+        let acl = Arc::new(cognee_test_utils::MockAclDb::new());
+        acl.add_user_to_tenant(member, tenant);
+        acl.grant_permission(tenant, ds.id, "read")
+            .await
+            .expect("grant tenant");
+
+        let mgr =
+            DatasetManager::new(db.clone() as Arc<dyn DatasetDb>).with_acl(acl as Arc<dyn AclDb>);
+        assert!(
+            mgr.has_data(ds.id, member).await.is_ok(),
+            "tenant-held read must admit has_data"
+        );
+        assert!(
+            mgr.list_data(ds.id, member).await.is_ok(),
+            "tenant-held read must admit list_data"
+        );
+    }
+
+    /// Scenario: the dataset owner holds `delete` only through a role (no
+    /// direct grant — e.g. revoked), and a second user holds `read` through
+    /// another role. Expected: the owner's `empty_dataset` passes the gate
+    /// (exercises `check_delete_permission` → `has_permission_with_roles`);
+    /// the reader is denied.
+    ///
+    /// The caller is made the owner deliberately: `empty_dataset` feeds the
+    /// caller id into `DeleteScope::Dataset { owner_id }`, so the inner
+    /// `DeleteService` resolves the dataset by `(name, caller)` and a
+    /// non-owner would fail *after* the gate with `Validation(not found)`.
+    #[tokio::test]
+    async fn acl_delete_grant_via_role_admits_empty_dataset() {
+        use cognee_database::DeleteDb;
+        let db = fresh_db().await;
+        let member = Uuid::new_v4();
+        let reader = Uuid::new_v4();
+        let deleter_role = Uuid::new_v4();
+        let reader_role = Uuid::new_v4();
+        let ds = make_dataset(member);
+        let ingest: &dyn IngestDb = db.as_ref();
+        ingest
+            .create_dataset(ds.clone())
+            .await
+            .expect("create_dataset");
+
+        let acl = Arc::new(cognee_test_utils::MockAclDb::new());
+        // A role only confers grants within a tenant the user belongs to
+        // (AclDb's contract, and Python nests the role walk in the tenant loop).
+        acl.add_user_to_tenant(member, Uuid::new_v4());
+        acl.add_user_to_tenant(reader, Uuid::new_v4());
+        acl.add_user_to_role(member, deleter_role);
+        acl.add_user_to_role(reader, reader_role);
+        acl.grant_permission(deleter_role, ds.id, "delete")
+            .await
+            .expect("grant delete to role");
+        acl.grant_permission(reader_role, ds.id, "read")
+            .await
+            .expect("grant read to role");
+
+        let storage = Arc::new(cognee_storage::MockStorage::new());
+        let delete_service = DeleteService::new(
+            storage as Arc<dyn cognee_storage::StorageTrait>,
+            db.clone() as Arc<dyn DeleteDb>,
+        );
+        let mgr =
+            DatasetManager::new(db.clone() as Arc<dyn DatasetDb>).with_acl(acl as Arc<dyn AclDb>);
+
+        let err = mgr
+            .empty_dataset(ds.id, reader, &delete_service)
+            .await
+            .expect_err("a role-held read grant must not authorize delete");
+        assert!(
+            matches!(err, DatasetError::PermissionDenied),
+            "expected PermissionDenied, got {err:?}"
+        );
+
+        mgr.empty_dataset(ds.id, member, &delete_service)
+            .await
+            .expect("a role-held delete grant must authorize empty_dataset");
     }
 }

--- a/crates/lib/src/api/update.rs
+++ b/crates/lib/src/api/update.rs
@@ -55,8 +55,12 @@ pub struct UpdateResult {
 /// * `llm` .. `cognify_config` - Components for the cognify phase.
 ///
 /// # Errors
-/// Returns `ApiError::PermissionDenied` when `acl_db` is set and the caller
-/// lacks `write` on the dataset. Propagates errors from delete, add, or
+/// Returns `ApiError::InvalidArgument` when `acl_db` is set and the caller
+/// lacks `write` on the dataset — **not** `PermissionDenied`, which this
+/// doc previously claimed. The variant exists (`api::error::ApiError`) and is
+/// arguably the right one, but changing it is a caller-visible break, so the
+/// doc is corrected to the shipped behaviour and the shape is pinned by
+/// `missing_write_grant_is_denied`. Propagates errors from delete, add, or
 /// cognify phases.
 #[allow(clippy::too_many_arguments)]
 pub async fn update(
@@ -83,15 +87,7 @@ pub async fn update(
 ) -> Result<UpdateResult, ApiError> {
     // ── Permission gate ───────────────────────────────────────────────────────
     if let Some(acl) = acl_db {
-        let permitted = acl
-            .has_permission(owner_id, dataset_id, "write")
-            .await
-            .map_err(|e| ApiError::InvalidArgument(e.to_string()))?;
-        if !permitted {
-            return Err(ApiError::InvalidArgument(
-                "write permission denied on dataset".to_string(),
-            ));
-        }
+        require_write_permission(acl, owner_id, dataset_id).await?;
     }
 
     // ── Step 1: Delete old data ───────────────────────────────────────────────
@@ -182,4 +178,91 @@ pub async fn update(
         new_data: data_items,
         cognify_result,
     })
+}
+
+/// Deny the update unless `owner_id` holds `write` on `dataset_id`.
+///
+/// Uses the roles-aware check: Python authorizes `update()` through the
+/// dataset ACL (`ingest_data` → `get_specific_user_permission_datasets(user.id,
+/// "write", [dataset_id])`), which walks the caller's tenant and role grants
+/// as well as direct ones. A collaborator who holds `write` only via a role
+/// must therefore be admitted here too.
+async fn require_write_permission(
+    acl: &dyn AclDb,
+    owner_id: Uuid,
+    dataset_id: Uuid,
+) -> Result<(), ApiError> {
+    let permitted = acl
+        .has_permission_with_roles(owner_id, dataset_id, "write")
+        .await
+        .map_err(|e| ApiError::InvalidArgument(e.to_string()))?;
+    if permitted {
+        Ok(())
+    } else {
+        Err(ApiError::InvalidArgument(
+            "write permission denied on dataset".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cognee_test_utils::MockAclDb;
+
+    /// Scenario: the caller holds `write` on the dataset only through a role.
+    /// Expected: admitted — Python's `get_specific_user_permission_datasets`
+    /// resolves role grants, so a direct-grant-only check would wrongly deny.
+    #[tokio::test]
+    async fn write_grant_via_role_is_admitted() {
+        let acl = MockAclDb::new();
+        let user = Uuid::new_v4();
+        let role = Uuid::new_v4();
+        let dataset = Uuid::new_v4();
+        // A role only confers grants within a tenant the user belongs to
+        // (AclDb's contract, and Python nests the role walk in the tenant loop).
+        acl.add_user_to_tenant(user, Uuid::new_v4());
+        acl.add_user_to_role(user, role);
+        assert!(acl.grant_permission(role, dataset, "write").await.is_ok());
+
+        assert!(
+            require_write_permission(&acl, user, dataset).await.is_ok(),
+            "a role-held write grant must satisfy the update gate"
+        );
+    }
+
+    /// Scenario: the caller holds `write` directly.
+    /// Expected: admitted — behaviour unchanged by the roles-aware switch.
+    #[tokio::test]
+    async fn direct_write_grant_is_admitted() {
+        let acl = MockAclDb::new();
+        let user = Uuid::new_v4();
+        let dataset = Uuid::new_v4();
+        assert!(acl.grant_permission(user, dataset, "write").await.is_ok());
+
+        assert!(require_write_permission(&acl, user, dataset).await.is_ok());
+    }
+
+    /// Scenario: the caller holds `read` (directly and via a role) but not
+    /// `write`. Expected: denied with `InvalidArgument`, the pre-existing
+    /// error shape for this gate.
+    #[tokio::test]
+    async fn missing_write_grant_is_denied() {
+        let acl = MockAclDb::new();
+        let user = Uuid::new_v4();
+        let role = Uuid::new_v4();
+        let dataset = Uuid::new_v4();
+        // A role only confers grants within a tenant the user belongs to
+        // (AclDb's contract, and Python nests the role walk in the tenant loop).
+        acl.add_user_to_tenant(user, Uuid::new_v4());
+        acl.add_user_to_role(user, role);
+        assert!(acl.grant_permission(user, dataset, "read").await.is_ok());
+        assert!(acl.grant_permission(role, dataset, "read").await.is_ok());
+
+        let err = require_write_permission(&acl, user, dataset).await;
+        assert!(
+            matches!(err, Err(ApiError::InvalidArgument(_))),
+            "got {err:?}"
+        );
+    }
 }

--- a/crates/test-utils/src/mock_acl_db.rs
+++ b/crates/test-utils/src/mock_acl_db.rs
@@ -6,7 +6,7 @@
     reason = "mock infrastructure — panics are acceptable"
 )]
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
 use async_trait::async_trait;
@@ -15,12 +15,38 @@ use uuid::Uuid;
 
 /// A `HashMap`-backed mock ACL database for unit and integration tests.
 ///
-/// Thread-safe via `Mutex`. The inner store is a set of `(principal_id, dataset_id, permission_name)` tuples.
+/// Thread-safe via `Mutex`. The inner store is a set of
+/// `(principal_id, dataset_id, permission_name)` tuples, exactly like the
+/// production `acls` table: a *principal* may be a user, a role, or a
+/// tenant, and [`AclDb::grant_permission`] does not care which.
+///
+/// What makes the two halves of the [`AclDb`] trait observably different
+/// here is **membership**. [`MockAclDb::add_user_to_tenant`] and
+/// [`MockAclDb::add_user_to_role`] record which tenants a user belongs to
+/// and which roles it holds. The plain `has_permission` /
+/// `authorized_dataset_ids` consult only rows whose `principal_id` is the
+/// caller itself; the `_with_roles` variants additionally consult rows
+/// granted to any tenant or role the caller is a member of. A test that
+/// grants `delete` to a *role* and then calls a code path as a *user*
+/// therefore passes only if that path uses the roles-aware variant — which
+/// is the property the mock exists to make testable.
+///
+/// Divergences from Python `get_all_user_permission_datasets` that this
+/// mock does **not** model (it has no dataset table or user table):
+/// - Python only walks roles inside the tenant loop, so a user with zero
+///   tenants gets no role grants at all. Here role membership counts on
+///   its own.
+/// - Python drops every result whose `dataset.tenant_id != user.tenant_id`.
+///   The mock cannot see dataset tenancy and applies no such filter.
 pub struct MockAclDb {
     /// Set of granted permissions: (principal_id, dataset_id, permission_name).
     grants: Mutex<HashSet<(Uuid, Uuid, String)>>,
     /// Set of principals: (principal_id, principal_type).
     principals: Mutex<HashSet<(Uuid, String)>>,
+    /// user_id → tenant ids the user belongs to.
+    tenant_memberships: Mutex<HashMap<Uuid, HashSet<Uuid>>>,
+    /// user_id → role ids the user holds.
+    role_memberships: Mutex<HashMap<Uuid, HashSet<Uuid>>>,
 }
 
 impl MockAclDb {
@@ -28,6 +54,8 @@ impl MockAclDb {
         Self {
             grants: Mutex::new(HashSet::new()),
             principals: Mutex::new(HashSet::new()),
+            tenant_memberships: Mutex::new(HashMap::new()),
+            role_memberships: Mutex::new(HashMap::new()),
         }
     }
 
@@ -53,6 +81,69 @@ impl MockAclDb {
     pub fn cascade_delete_dataset(&self, dataset_id: Uuid) {
         let mut grants = self.grants.lock().unwrap(); // lock poison is unrecoverable
         grants.retain(|(_, ds_id, _)| *ds_id != dataset_id);
+    }
+
+    /// Record that `user_id` belongs to `tenant_id`.
+    ///
+    /// Grants made to `tenant_id` (via [`AclDb::grant_permission`] with the
+    /// tenant id as the principal) become visible to `user_id` through the
+    /// `_with_roles` variants only. Also registers `tenant_id` as a
+    /// `"tenant"` principal.
+    pub fn add_user_to_tenant(&self, user_id: Uuid, tenant_id: Uuid) {
+        {
+            let mut principals = self.principals.lock().unwrap(); // lock poison is unrecoverable
+            principals.insert((tenant_id, "tenant".to_string()));
+        }
+        let mut memberships = self.tenant_memberships.lock().unwrap(); // lock poison is unrecoverable
+        memberships.entry(user_id).or_default().insert(tenant_id);
+    }
+
+    /// Record that `user_id` holds `role_id`.
+    ///
+    /// Grants made to `role_id` (via [`AclDb::grant_permission`] with the
+    /// role id as the principal) become visible to `user_id` through the
+    /// `_with_roles` variants only. Also registers `role_id` as a `"role"`
+    /// principal.
+    pub fn add_user_to_role(&self, user_id: Uuid, role_id: Uuid) {
+        {
+            let mut principals = self.principals.lock().unwrap(); // lock poison is unrecoverable
+            principals.insert((role_id, "role".to_string()));
+        }
+        let mut memberships = self.role_memberships.lock().unwrap(); // lock poison is unrecoverable
+        memberships.entry(user_id).or_default().insert(role_id);
+    }
+
+    /// Every principal id whose grants `user_id` inherits, in the trait's
+    /// documented resolution order: the user itself, then its tenants, then
+    /// the roles it holds *in those tenants*.
+    ///
+    /// Roles are gated on tenant membership on purpose. `AclDb`'s contract
+    /// (`crates/database/src/traits/acl_db.rs`) says "Role-level ACL for each
+    /// role the user holds **in those tenants**", and Python nests its role
+    /// walk inside the tenant loop
+    /// (`get_all_user_permission_datasets.py`), so a user belonging to no
+    /// tenant inherits nothing from roles. A mock that granted role access
+    /// without tenant membership would be *more permissive than the contract*,
+    /// and any test relying on it would certify a scenario a conforming
+    /// backend denies — passing here and failing in production.
+    fn inherited_principals(&self, user_id: Uuid) -> Vec<Uuid> {
+        let mut principals = vec![user_id];
+        let tenants: Vec<Uuid> = {
+            let memberships = self.tenant_memberships.lock().unwrap(); // lock poison is unrecoverable
+            memberships
+                .get(&user_id)
+                .map(|ids| ids.iter().copied().collect())
+                .unwrap_or_default()
+        };
+        principals.extend(tenants.iter().copied());
+        // No tenants, no roles — see the note above.
+        if !tenants.is_empty() {
+            let roles = self.role_memberships.lock().unwrap(); // lock poison is unrecoverable
+            if let Some(ids) = roles.get(&user_id) {
+                principals.extend(ids.iter().copied());
+            }
+        }
+        principals
     }
 }
 
@@ -126,9 +217,11 @@ impl AclDb for MockAclDb {
         dataset_id: Uuid,
         permission_name: &str,
     ) -> Result<bool, DatabaseError> {
-        // In the mock, just delegate to the direct check (no role/tenant resolution).
-        self.has_permission(user_id, dataset_id, permission_name)
-            .await
+        let principals = self.inherited_principals(user_id);
+        let grants = self.grants.lock().unwrap(); // lock poison is unrecoverable
+        Ok(principals
+            .iter()
+            .any(|pid| grants.contains(&(*pid, dataset_id, permission_name.to_string()))))
     }
 
     async fn authorized_dataset_ids_with_roles(
@@ -136,7 +229,195 @@ impl AclDb for MockAclDb {
         user_id: Uuid,
         permission_name: &str,
     ) -> Result<Vec<Uuid>, DatabaseError> {
-        // In the mock, just delegate to the direct check (no role/tenant resolution).
-        self.authorized_dataset_ids(user_id, permission_name).await
+        let principals = self.inherited_principals(user_id);
+        let grants = self.grants.lock().unwrap(); // lock poison is unrecoverable
+        // Deduplicate: the same dataset may be granted to the user directly
+        // and to one of its roles or tenants (the trait promises a deduped
+        // result, as does Python's `unique.setdefault(dataset.id, ...)`).
+        let mut seen = HashSet::new();
+        let ids: Vec<Uuid> = grants
+            .iter()
+            .filter(|(pid, _, pname)| principals.contains(pid) && pname == permission_name)
+            .map(|(_, ds_id, _)| *ds_id)
+            .filter(|ds_id| seen.insert(*ds_id))
+            .collect();
+        Ok(ids)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property every consumer test relies on: a grant to a role or a
+    /// tenant is visible to a member only through the `_with_roles`
+    /// variants. If this ever regresses to delegation, tests that switch a
+    /// call site from the plain variant become vacuous.
+    #[tokio::test]
+    async fn with_roles_variants_see_role_and_tenant_grants_plain_ones_do_not() {
+        let acl = MockAclDb::new();
+        let user = Uuid::new_v4();
+        let role = Uuid::new_v4();
+        let tenant = Uuid::new_v4();
+        let via_role = Uuid::new_v4();
+        let via_tenant = Uuid::new_v4();
+        let direct = Uuid::new_v4();
+
+        acl.add_user_to_role(user, role);
+        acl.add_user_to_tenant(user, tenant);
+        acl.grant_permission(role, via_role, "read").await.unwrap();
+        acl.grant_permission(tenant, via_tenant, "read")
+            .await
+            .unwrap();
+        acl.grant_permission(user, direct, "read").await.unwrap();
+
+        // Plain: direct only.
+        assert!(acl.has_permission(user, direct, "read").await.unwrap());
+        assert!(!acl.has_permission(user, via_role, "read").await.unwrap());
+        assert!(!acl.has_permission(user, via_tenant, "read").await.unwrap());
+        assert_eq!(
+            acl.authorized_dataset_ids(user, "read").await.unwrap(),
+            vec![direct]
+        );
+
+        // Roles-aware: direct ∪ tenant ∪ role.
+        assert!(
+            acl.has_permission_with_roles(user, direct, "read")
+                .await
+                .unwrap()
+        );
+        assert!(
+            acl.has_permission_with_roles(user, via_role, "read")
+                .await
+                .unwrap()
+        );
+        assert!(
+            acl.has_permission_with_roles(user, via_tenant, "read")
+                .await
+                .unwrap()
+        );
+        let mut all = acl
+            .authorized_dataset_ids_with_roles(user, "read")
+            .await
+            .unwrap();
+        all.sort();
+        let mut expected = vec![direct, via_role, via_tenant];
+        expected.sort();
+        assert_eq!(all, expected);
+    }
+
+    /// The tenant gate in `inherited_principals`. `AclDb`'s contract scopes
+    /// role grants to "each role the user holds **in those tenants**", so a
+    /// user who holds a role but belongs to no tenant must inherit nothing
+    /// from it. Without this test the gate is invisible: every other case
+    /// here grants tenant membership alongside the role, so removing the
+    /// gate leaves them all green while the mock silently becomes more
+    /// permissive than any conforming backend.
+    #[tokio::test]
+    async fn a_role_grant_confers_nothing_without_tenant_membership() {
+        let acl = MockAclDb::new();
+        let tenantless = Uuid::new_v4();
+        let role = Uuid::new_v4();
+        let via_role = Uuid::new_v4();
+
+        // A role membership and a grant to that role — but no tenant.
+        acl.add_user_to_role(tenantless, role);
+        acl.grant_permission(role, via_role, "read").await.unwrap();
+
+        assert!(
+            !acl.has_permission_with_roles(tenantless, via_role, "read")
+                .await
+                .unwrap(),
+            "a role grant must not reach a user who belongs to no tenant"
+        );
+        assert!(
+            acl.authorized_dataset_ids_with_roles(tenantless, "read")
+                .await
+                .unwrap()
+                .is_empty(),
+            "enumeration must agree with the point check"
+        );
+
+        // Joining any tenant activates the role the user already held.
+        acl.add_user_to_tenant(tenantless, Uuid::new_v4());
+        assert!(
+            acl.has_permission_with_roles(tenantless, via_role, "read")
+                .await
+                .unwrap(),
+            "once the user is in a tenant, the role grant applies"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_roles_respects_permission_name_and_membership() {
+        let acl = MockAclDb::new();
+        let member = Uuid::new_v4();
+        let stranger = Uuid::new_v4();
+        let role = Uuid::new_v4();
+        let ds = Uuid::new_v4();
+
+        // Both users belong to a tenant: role inheritance is gated on tenant
+        // membership, so without this the role below is ignored and every
+        // assertion here would hold even if role grants were broken outright.
+        acl.add_user_to_tenant(member, Uuid::new_v4());
+        acl.add_user_to_tenant(stranger, Uuid::new_v4());
+        acl.add_user_to_role(member, role);
+        acl.grant_permission(role, ds, "delete").await.unwrap();
+
+        // The grant that does exist is visible — this is what makes the
+        // negatives below meaningful rather than vacuous.
+        assert!(
+            acl.has_permission_with_roles(member, ds, "delete")
+                .await
+                .unwrap()
+        );
+        // Wrong permission name on the same role grant does not count.
+        assert!(
+            !acl.has_permission_with_roles(member, ds, "read")
+                .await
+                .unwrap()
+        );
+        // A user who does not hold the role gets nothing from it, even though
+        // they too belong to a tenant.
+        assert!(
+            !acl.has_permission_with_roles(stranger, ds, "delete")
+                .await
+                .unwrap()
+        );
+        assert!(
+            acl.authorized_dataset_ids_with_roles(stranger, "delete")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn with_roles_deduplicates_a_dataset_granted_both_directly_and_via_role() {
+        let acl = MockAclDb::new();
+        let user = Uuid::new_v4();
+        let role = Uuid::new_v4();
+        let shared = Uuid::new_v4();
+        let role_only = Uuid::new_v4();
+
+        // Tenant membership is what activates the role grant at all.
+        acl.add_user_to_tenant(user, Uuid::new_v4());
+        acl.add_user_to_role(user, role);
+        // `shared` is granted twice over; `role_only` just once, via the role.
+        acl.grant_permission(user, shared, "read").await.unwrap();
+        acl.grant_permission(role, shared, "read").await.unwrap();
+        acl.grant_permission(role, role_only, "read").await.unwrap();
+
+        // `role_only` is what makes this test able to fail: asserting solely
+        // on the doubly-granted id cannot tell deduplication apart from the
+        // role being dropped, since both yield exactly one id.
+        let mut got = acl
+            .authorized_dataset_ids_with_roles(user, "read")
+            .await
+            .unwrap();
+        got.sort();
+        let mut expected = vec![shared, role_only];
+        expected.sort();
+        assert_eq!(got, expected, "each id exactly once, role grants included");
     }
 }


### PR DESCRIPTION
Closes #206

## Why

Python resolves **every** permission type through one roles-aware chain, so a user holding a grant only via a tenant or a role is authorized there but was denied by every Rust site using the direct-grant-only `AclDb` variants.

**Python evidence** (`topoteretes/cognee`, `cognee/`):

| Python site | what it does |
|---|---|
| `modules/users/permissions/methods/check_permission_on_dataset.py:27` | `get_specific_user_permission_datasets(user.id, permission_type, [dataset_id])` — for any `permission_type` |
| `…/get_specific_user_permission_datasets.py:27` | → `get_all_user_permission_datasets(user, permission_type)` |
| `…/get_all_user_permission_datasets.py:23-34` | direct rows ∪ per-tenant rows ∪ per-role rows via `get_principal_datasets`; dedup at `:39-41`; **tenant filter** `dataset.tenant_id == user.tenant_id` at `:43-46` |
| `modules/data/methods/get_authorized_existing_datasets.py:30,37` | specific ids → `get_specific…`; none → `get_all…` |
| `api/v1/datasets/datasets.py:124` (`list_datasets`) | `get_authorized_existing_datasets([], "read", user)` |
| `api/v1/datasets/datasets.py:148,157,185,228` (`list_data`/`has_data`/`delete_dataset`/`delete_data`) | `get_authorized_dataset(user, dataset_id[, "delete"])` → same chain |
| `api/v1/datasets/datasets.py:307` (`delete_all`) | `get_authorized_existing_datasets([], "delete", user)` |
| `api/v1/visualize/visualize.py:80,554` | `get_authorized_existing_datasets([dataset], "read", user)` |
| `tasks/ingestion/ingest_data.py:174` (write gate behind `update()`) | `get_specific_user_permission_datasets(user.id, "write", [dataset_id])` |

## Every plain-variant call site found (workspace `grep` for `.has_permission(` and `.authorized_dataset_ids(`)

| # | site | before | decision |
|---|---|---|---|
| 1 | `crates/delete/src/authorized.rs` User scope (was :114) | `authorized_dataset_ids` | **switched**, result collected into `HashSet` |
| 2 | `crates/delete/src/authorized.rs` All scope (was :141) | `authorized_dataset_ids` | **switched**, `HashSet` |
| 3 | `crates/delete/src/authorized.rs` `require_delete_permission` (was :193) | `has_permission` | **switched** |
| 4 | `crates/lib/src/api/datasets.rs` `list_datasets` (was :57) | `authorized_dataset_ids` | **switched** |
| 5 | `crates/lib/src/api/datasets.rs` `check_read_permission` (was :287) | `has_permission` | **switched** — *not in the issue* |
| 6 | `crates/lib/src/api/datasets.rs` `check_delete_permission` (was :300) | `has_permission` | **switched** — *not in the issue* |
| 7 | `crates/lib/src/api/update.rs` write gate (was :87) | `has_permission` | **switched** — *not in the issue*; extracted to `require_write_permission` so it is testable; `InvalidArgument` error shape preserved |
| 8 | `crates/http-server/src/routers/visualize.rs` GET (was :90) | `has_permission` | **switched** — *not in the issue*; extracted to `require_read_permission`; 409 collapse preserved |
| 9 | `crates/http-server/src/routers/visualize.rs` POST /multi (was :180) | `has_permission` | **switched** — *not in the issue*; same helper, still checks the *target* user |
| — | `http-server/routers/datasets.rs:72`, `sessions.rs` ×4, `permissions.rs:39`, `search/…/search_orchestrator.rs:287` | already `_with_roles` | unchanged |
| — | `lib/api/datasets.rs` tests (:671/:675/:696), `delete/src/lib.rs` tests (:3712/:3725) | `has_permission` | **left** — they assert that `grant_permission` stored a *direct* grant; the plain variant is the right probe there |
| — | `test-utils/src/mock_acl_db.rs` (:130/:140) | `_with_roles` delegating to plain | **replaced** (below) |

## `MockAclDb` — the critical risk

Confirmed: both `_with_roles` methods were `self.has_permission(..)` / `self.authorized_dataset_ids(..)`. A test on the mock could not distinguish the variants, so any test for this change would have been vacuous.

Fix (first commit): grants stay `(principal_id, dataset_id, permission)` rows like the production `acls` table (principal = user, role or tenant). New `add_user_to_tenant(user, tenant)` / `add_user_to_role(user, role)` record membership. Plain variants consult only rows whose principal is the caller; `_with_roles` also consult the caller's tenants and roles (trait order: user → tenants → roles) and dedupe. Three mock unit tests pin the property. Documented divergences from Python: roles count without tenant membership (Python only walks roles inside the tenant loop), and there is no `dataset.tenant_id == user.tenant_id` filter (mock has no dataset table).

## Tests (modelled on #204's `acl_read_grant_admits_a_dataset_the_caller_does_not_own`)

- `cognee-delete` lib: `authorized_delete_via_role_grant_dataset_scope`, `…_via_tenant_grant_user_scope` (direct + tenant cover; then an ungranted dataset denies), `…_via_role_grant_all_scope`, `…_via_role_with_wrong_permission_is_denied`.
- `cognee` lib `datasets.rs`: `acl_list_datasets_includes_role_granted_dataset` (direct + role, ungranted excluded), `acl_read_grant_via_tenant_admits_has_data_and_list_data`, `acl_delete_grant_via_role_admits_empty_dataset` (reader-role denied, deleter-role admitted).
- `cognee` lib `update.rs`: `write_grant_via_role_is_admitted`, `direct_write_grant_is_admitted`, `missing_write_grant_is_denied`.
- `cognee-http-server` `visualize.rs`: `read_grant_via_tenant_is_admitted`, `direct_read_grant_is_admitted`, `missing_read_grant_is_a_409`, `no_acl_backend_allows`.
- `cognee-test-utils`: 3 mock tests. Existing direct-grant tests all still pass (delete 59, cognee 132, http-server 284 unit tests).

### Mutation results — one line reverted at a time, `grep` proof printed before each run

Each mutation killed **exactly one** test; every other new test stayed green; revert proven by re-grep and re-run; `git diff | md5sum` identical before/after the harness.

| mutated line | proof line (mutated) | test that went red |
|---|---|---|
| `authorized.rs:117` | `.authorized_dataset_ids(principal_id, "delete")` | `authorized_delete_via_tenant_grant_user_scope` |
| `authorized.rs:146` | `.authorized_dataset_ids(principal_id, "delete")` | `authorized_delete_via_role_grant_all_scope` |
| `authorized.rs:193` | `.has_permission(principal_id, dataset_id, "delete")` | `authorized_delete_via_role_grant_dataset_scope` |
| `datasets.rs:58` | `.authorized_dataset_ids(owner_id, "read")` | `acl_list_datasets_includes_role_granted_dataset` |
| `datasets.rs:290` | `.has_permission(owner_id, dataset_id, "read")` | `acl_read_grant_via_tenant_admits_has_data_and_list_data` |
| `datasets.rs:305` | `.has_permission(owner_id, dataset_id, "delete")` | `acl_delete_grant_via_role_admits_empty_dataset` |
| `update.rs:192` | `.has_permission(owner_id, dataset_id, "write")` | `write_grant_via_role_is_admitted` |
| `visualize.rs:207` | `.has_permission(user_id, dataset_id, "read")` | `read_grant_via_tenant_is_admitted` |

A first harness pass anchored on the pre-`cargo fmt` text of the three `datasets.rs` sites; fmt had re-wrapped them, the anchor matched nothing, and `sed` ran file-wide (also flipping three test assertions). Caught via an empty proof line and a tree-hash mismatch; repaired, harness hardened to abort on a non-unique anchor, and the three sites re-run — the table above is from the hardened run.

## Verification (all ran in a worktree off `7c7a0269`, warm `CARGO_TARGET_DIR`)

- `cargo fmt --check` — OK
- `cargo clippy --all-targets -- -D warnings` — no issues
- `cargo check --all-targets --features telemetry` — OK
- `cargo clippy --all-targets --features telemetry -- -D warnings` — no issues
- `cargo check -p cognee --no-default-features` — OK
- `CARGO_TARGET_DIR=target/no-default cargo check -p cognee-cli --no-default-features` — OK
- `… --features cognee-cli/android-default` — OK
- `cargo test -p cognee-test-utils -p cognee-delete -p cognee -p cognee-http-server` — all green except `delete/tests/hard_mode_orphan_sweep.rs` ×2, which panic in `require_env` keyless (no ACL involvement); green under `COGNEE_TEST_REPLAY=1`.
- `COGNEE_TEST_REPLAY=1 cargo test -p cognee-search` (a `MockAclDb` consumer) — green (`cargo test -p cognee-search` exits 101 keyless per #199).
- `scripts/check_all.sh` — Rust stages passed; the C-API binding stage aborted with `No space left on device` (host root disk at 100%). **Binding checks are unverified here.**

## Recommendation on the plain variants (not acted on)

**Rename, do not remove**: e.g. `has_direct_permission` / `directly_authorized_dataset_ids`, and consider giving the roles-aware pair the unsuffixed names. Reasons: (1) Python keeps the direct primitive — `get_principal_datasets` is used by `authorized_get_principal_datasets` for the permissions router, which lists what a *principal* (user, role **or tenant**) holds; the roles-aware variant is meaningless for a role id. (2) The closed `cognee-access-control` crate implements this trait and its `permissions` router is the likely legitimate caller; removing the methods breaks it with no in-repo compile signal. (3) Three callers picked the wrong one because the names carry no hint of narrowness — a rename fixes the failure mode and the compiler finds every caller. Coordinate with the closed crate.

## Self-review findings

1. **Five call sites the issue did not list** (rows 5–9) had the same defect; switched. Python evidence per site is in the table.
2. **Hot path**: the User/All set-cover did `Vec::contains` per dataset; the roles-aware list can be tenant-wide, making `All` quadratic. Changed to `HashSet` (both mutations re-run on the final code).
3. **Mock faithfulness**: it models direct vs inherited grants distinctly and the mutation kills prove the tests depend on that distinction, not on delegation. It was *more* permissive than Python in two ways (roles without tenant membership; no `tenant_id` filter).

   **Correction (this revision).** The original text here claimed "the tests do not lean on either." That was wrong for the first one: five tests granted a role with no tenant membership and so relied on exactly the permissive gap — `authorized_delete_via_role_grant_dataset_scope`, `authorized_delete_via_role_grant_all_scope`, `acl_list_datasets_includes_role_granted_dataset`, `acl_delete_grant_via_role_admits_empty_dataset` and `write_grant_via_role_is_admitted`. They would have passed here and failed against a conforming backend.

   Fixed in this revision: `MockAclDb::inherited_principals` now gates the role walk on non-empty tenant membership, matching `AclDb`'s contract ("each role the user holds **in those tenants**") and Python's nested loop in `get_all_user_permission_datasets.py`. Every affected fixture now joins a tenant alongside the role, and all five still pass — so they were genuinely testing role inheritance, not the gap. A new test, `a_role_grant_confers_nothing_without_tenant_membership`, pins the gate; mutating it to `if true` fails that test and only that test.

   The second divergence (no `tenant_id` filter) stands, and the tests still do not lean on it: every dataset is created with `tenant_id = None`.
4. **Semantics unchanged**: every error type is preserved (`DeleteError::{Runtime,PermissionDenied}`, `DatasetError::PermissionDenied`, `ApiError::InvalidArgument` in `update`, 409 in visualize). `list_datasets` ordering follows the backend's result order, as before. Dedup: the trait guarantees it for `_with_roles`; the plain variant could not produce duplicates for one principal, so nothing changes.
5. **Issue/trait claims that are only partly right**: the trait doc says `_with_roles` "mirrors Python `get_all_user_permission_datasets`", but Python also drops datasets outside the user's tenant (`:43-46`) and only walks roles *within* the tenant loop; the trait contract says neither. Whether the closed impl does is unverifiable from OSS.
6. **Uncovered, not fixed (out of scope)** — reported, not filed:
   - `DatasetManager::empty_dataset` / `delete_data` / `delete_all` feed the *caller* id into `DeleteScope::{Dataset,Data}.owner_id`, so a non-owner who passes the (now roles-aware) gate fails afterwards with `Validation("… not found for owner …")`. Delegated delete through `DatasetManager` cannot succeed today; my first draft of `acl_delete_grant_via_role_admits_empty_dataset` tripped exactly this.
   - `DatasetManager::delete_all` enumerates by `"read"` (via `list_datasets`) where Python uses `"delete"` (`datasets.py:307`), and the inner `DeleteService` has no ACL. The owner/caller conflation above is currently the only thing preventing deletion of a merely-readable shared dataset; this PR widens what gets enumerated (tenant/role read grants), so `delete_all` will abort with `Validation` in more configurations. Same class as before, broader trigger.
   - `update()` rustdoc says it returns `ApiError::PermissionDenied`; the gate returns `InvalidArgument` (pre-existing, preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmwWAiTW184ZDFDdhW58Ki

