### PR TITLE
fix(cognify): stop the Bedrock runaway — declaration-order schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,16 @@ rayon = "1.10"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "gzip", "json", "stream", "multipart"] }
 scraper = "0.21"
-schemars = "0.8"
+# `preserve_order` makes `schemars::Map` an `IndexMap`, so a generated schema
+# lists properties in DECLARATION order instead of alphabetically. That is not
+# cosmetic: the extraction schema is sent to the model on every cognify call,
+# and the model emits object keys in the order the schema declares them.
+# Alphabetical order put `Edge.target_node_id` last, after a free-text
+# `description`, and 19% of calls on a runaway-prone chunk then ran away inside
+# that id until they hit the output cap (0% in declaration order; Fisher exact
+# p=0.0002, n=126). Pinned by `schema_properties_are_in_declaration_order` in
+# crates/cognify/src/fact_extraction/models.rs.
+schemars = { version = "0.8", features = ["preserve_order"] }
 serde = { version = "1", features = ["derive"] }
 serial_test = "3.2"
 # COGX `.cogx.tar.gz` transport packing (cognee-migration `archive` feature).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,25 @@ sqlx = "0.8"
 strsim = "0.11"
 thiserror = "2.0"
 tiktoken-rs = "0.6"
-serde_json = "1"
+# `preserve_order` is enabled workspace-wide, deliberately, so that no crate can
+# forget it. `serde_json::Map` is a compile-time type alias: without this feature
+# it is a `BTreeMap` that SORTS keys, with it an `IndexMap` that keeps insertion
+# order (serde_json's map.rs:33-36). Three things in this workspace depend on
+# insertion order surviving — LLM JSON schemas, entity properties and the
+# visualization Schema — and a fourth will eventually be added by someone who
+# does not know this note exists.
+#
+# It was previously opted into per crate, which meant a crate that needed it and
+# did not ask still worked, silently, via cargo feature unification from the
+# crates that did. cognee-llm was exactly that case: its generated schema was
+# re-sorted alphabetically on the wire, which measured a 19% LLM runaway rate
+# against 0% for declaration order. A per-crate option that is wrong to leave
+# off is not an option, it is a trap.
+#
+# Cost is `indexmap` plus a little memory per map. Nothing here is `no_std`
+# (zero `#![no_std]` crates in the workspace), so the `std` requirement it pulls
+# in costs us nothing.
+serde_json = { version = "1", features = ["preserve_order"] }
 tempfile = "3"
 texting_robots = "0.2"
 tokenizers = "0.21"

--- a/crates/cognify/src/fact_extraction/models.rs
+++ b/crates/cognify/src/fact_extraction/models.rs
@@ -119,7 +119,148 @@ pub struct KnowledgeGraph {
 
     /// List of edges (relationships between nodes). NOT `#[serde(default)]` — see
     /// the note on `nodes`. An empty graph must send `{"nodes":[],"edges":[]}`.
+    //
+    // NOT a doc comment, deliberately. `schemars` copies every `///` on a field
+    // straight into that property's JSON-schema `description`, and this struct's
+    // schema is what `generate_json_schema` hands the model on every extraction
+    // call — so a `///` here would spend prompt tokens telling the model about a
+    // private Rust deserializer, and condition it on the existence of a
+    // tolerance it should never aim at. `the_model_facing_schema_carries_no_
+    // implementation_detail` below pins that.
+    //
+    // Deserialized through `deserialize_edges_lenient`, which drops a small
+    // number of malformed entries instead of failing the whole graph. See that
+    // function for why the model emits them.
+    #[serde(deserialize_with = "deserialize_edges_lenient")]
     pub edges: Vec<Edge>,
+}
+
+/// The share of `edges` entries that may be dropped before the payload is
+/// treated as broken rather than merely blemished.
+///
+/// Calibrated against measured failures on `gpt-4.1-mini` and Bedrock Sonnet 4.5:
+/// the stray-node defect described in [`deserialize_edges_lenient`] contaminated
+/// **1–2 entries out of 38–87**, i.e. 1.5%–4.8% of the array, with the worst
+/// observed case 2 of 42. A quarter leaves a wide margin over that while still
+/// letting a genuinely garbled array — a truncation, or a model that mixed up
+/// the two arrays wholesale — fall through to the adapter's corrective-retry
+/// loop, which is the right handling for those.
+///
+/// The comparison is `>`, so a payload sitting *exactly* on the fraction is
+/// accepted. That is deliberate and it is what makes the rule sharp on short
+/// arrays: 1 of 4 is 25% and survives, but **any** array of fewer than four
+/// entries has zero tolerance, because one drop out of three is already 33%.
+/// A one-edge payload whose single edge is malformed is rejected, which is the
+/// right answer — there is nothing left to keep.
+const MAX_DROPPABLE_EDGE_FRACTION: f64 = 0.25;
+
+/// Deserialize `edges`, dropping individual entries that are not edges at all.
+///
+/// # The defect this absorbs
+///
+/// Non-constrained structured output (OpenAI `tools` mode, Bedrock Converse
+/// `toolConfig`) lets the model emit whatever tokens it likes; only this typed
+/// deserialization enforces the schema, and it does so after the fact. Because
+/// the model writes `nodes` before `edges` and cannot revise an array it has
+/// already emitted, a chunk that introduces a principal entity *late* in the text
+/// puts it in a bind: while writing the edges it needs a node id it never
+/// declared. Its observed repair is to append a **node-shaped object into the
+/// `edges` array**, renaming `id` to `source_node_id`:
+///
+/// ```text
+/// {"source_node_id": "Sister", "name": "Alice's Sister",
+///  "type": "PERSON", "description": "Alice's sister, who wakes her from the dream."}
+/// ```
+///
+/// That object has no `target_node_id` and no `relationship_name`, so strict
+/// deserialization of the array fails and — before this function existed — the
+/// entire chunk's extraction was discarded, one bad entry voiding 50 good edges,
+/// then re-requested at full cost. On a nine-chunk document a single such chunk
+/// is 11% of the run, which trips the 5% `chunk_failure_ratio_threshold` and
+/// rolls back everything.
+///
+/// # What Python actually does (it is not constrained decoding)
+///
+/// It is tempting to say Python escapes this because it uses constrained
+/// decoding. It does not. Verified against the installed cognee 1.5.4:
+/// `cognee/infrastructure/llm/structured_output_framework/litellm_instructor/`
+/// `llm/openai/adapter.py:107` takes the explicit-mode branch only when
+/// `"gpt-5" in model` or an explicit `instructor_mode` was passed
+/// (`llm_instructor_mode`, empty by default); otherwise `:115` builds the
+/// client as `instructor.from_litellm(litellm.acompletion)` with no mode, and
+/// every `from_litellm` signature in `instructor/core/client.py` defaults
+/// `mode` to `instructor.Mode.TOOLS`. That is the *same*
+/// unconstrained forced-tool-call path Rust uses, so Python's model is just as
+/// free to emit the stray object.
+///
+/// Python survives it by **retrying**: instructor re-prompts with the validation
+/// error, and cognee sets `MAX_RETRIES = 2`, against Rust's 5. Its Pydantic
+/// `Edge` requires exactly the same three fields this one does.
+///
+/// So this is not parity convergence, and should not be described as such: it
+/// makes Rust **more lenient than Python**, which pays for the same chunk two or
+/// three times to get an array Rust now repairs in place. The strictness that is
+/// preserved is the one that matters — a wholesale garbling still reaches the
+/// retry loop.
+///
+/// # Behaviour
+///
+/// Entries that deserialize as an [`Edge`] are kept in order. Entries that do not
+/// are dropped and counted. If the drops exceed
+/// [`MAX_DROPPABLE_EDGE_FRACTION`] of the array the payload is rejected, so a
+/// wholesale garbling still reaches the retry loop.
+fn deserialize_edges_lenient<'de, D>(deserializer: D) -> Result<Vec<Edge>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error as _;
+
+    let raw = Vec::<serde_json::Value>::deserialize(deserializer)?;
+    let total = raw.len();
+
+    let mut edges = Vec::with_capacity(total);
+    let mut dropped: Vec<String> = Vec::new();
+    for entry in raw {
+        match serde_json::from_value::<Edge>(entry.clone()) {
+            Ok(edge) => edges.push(edge),
+            Err(err) => {
+                // Keep a compact, non-PII-ish trace: the reason plus the keys the
+                // object actually carried. The full entry can be large.
+                let keys = entry
+                    .as_object()
+                    .map(|o| o.keys().cloned().collect::<Vec<_>>().join(","))
+                    .unwrap_or_else(|| "<not an object>".to_string());
+                dropped.push(format!("{err} (keys: {keys})"));
+            }
+        }
+    }
+
+    if dropped.is_empty() {
+        return Ok(edges);
+    }
+
+    // `total` is non-zero here: `dropped` is only non-empty if we iterated.
+    let fraction = dropped.len() as f64 / total as f64;
+    if fraction > MAX_DROPPABLE_EDGE_FRACTION {
+        return Err(D::Error::custom(format!(
+            "{}/{total} edges were malformed ({:.0}% > {:.0}% tolerated); \
+             treating the payload as broken. First: {}",
+            dropped.len(),
+            fraction * 100.0,
+            MAX_DROPPABLE_EDGE_FRACTION * 100.0,
+            dropped[0],
+        )));
+    }
+
+    tracing::warn!(
+        dropped = dropped.len(),
+        total,
+        kept = edges.len(),
+        reasons = ?dropped,
+        "dropped malformed entries from the extracted `edges` array; \
+         keeping the rest of the graph",
+    );
+    Ok(edges)
 }
 
 impl KnowledgeGraph {
@@ -286,5 +427,172 @@ mod tests {
         let json = serde_json::to_string(&model).unwrap();
         let deserialized: CustomModel = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.items, vec!["a", "b"]);
+    }
+
+    /// The exact defect measured against `gpt-4.1-mini` and Bedrock Sonnet 4.5:
+    /// a node-shaped object appended into `edges` because the model needed a node
+    /// id it had not declared. Before the lenient deserializer this voided the
+    /// whole chunk with "missing field `target_node_id`".
+    #[test]
+    fn stray_node_object_in_edges_is_dropped_not_fatal() {
+        let raw = serde_json::json!({
+            "nodes": [
+                {"id": "Alice", "name": "Alice", "type": "PERSON", "description": "A girl."},
+                {"id": "Queen", "name": "Queen of Hearts", "type": "PERSON", "description": "A queen."}
+            ],
+            "edges": [
+                {"source_node_id": "Alice", "target_node_id": "Queen",
+                 "relationship_name": "defies", "description": "Alice defies the Queen."},
+                {"source_node_id": "Queen", "target_node_id": "Alice",
+                 "relationship_name": "commands_attack", "description": "The Queen commands an attack."},
+                {"source_node_id": "Alice", "target_node_id": "Queen",
+                 "relationship_name": "answers", "description": "Alice answers the Queen."},
+                {"source_node_id": "Alice", "target_node_id": "Queen",
+                 "relationship_name": "faces", "description": "Alice faces the Queen."},
+                // The stray: a Node wearing an Edge's first key.
+                {"source_node_id": "Sister", "name": "Alice's Sister",
+                 "type": "PERSON", "description": "Alice's sister, who wakes her."}
+            ]
+        });
+
+        let graph: KnowledgeGraph =
+            serde_json::from_value(raw).expect("stray entry must not be fatal");
+        assert_eq!(graph.node_count(), 2);
+        assert_eq!(graph.edge_count(), 4, "the four real edges survive");
+        assert!(graph.edges.iter().all(|e| !e.target_node_id.is_empty()));
+    }
+
+    #[test]
+    fn a_wholly_garbled_edges_array_still_fails() {
+        let raw = serde_json::json!({
+            "nodes": [],
+            "edges": [
+                {"source_node_id": "a", "name": "a", "type": "T", "description": "d"},
+                {"source_node_id": "b", "name": "b", "type": "T", "description": "d"},
+                {"source_node_id": "c", "target_node_id": "d", "relationship_name": "r"}
+            ]
+        });
+        let err = serde_json::from_value::<KnowledgeGraph>(raw)
+            .expect_err("2/3 malformed is past the tolerance and must reach the retry loop");
+        assert!(
+            err.to_string().contains("treating the payload as broken"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_clean_edges_array_is_unaffected() {
+        let raw = serde_json::json!({
+            "nodes": [{"id": "a", "name": "A", "type": "T", "description": "d"}],
+            "edges": [{"source_node_id": "a", "target_node_id": "b", "relationship_name": "r"}]
+        });
+        let graph: KnowledgeGraph = serde_json::from_value(raw).unwrap();
+        assert_eq!(graph.edge_count(), 1);
+        assert_eq!(graph.edges[0].description, None);
+    }
+
+    /// `edges` stays required: a payload omitting it must still drive the
+    /// corrective-retry loop (the invariant the struct doc calls out).
+    #[test]
+    fn edges_remains_a_required_field() {
+        let raw = serde_json::json!({ "nodes": [] });
+        assert!(serde_json::from_value::<KnowledgeGraph>(raw).is_err());
+    }
+
+    /// One malformed entry out of four is *exactly* the tolerance, and the
+    /// comparison is `>`, so it is accepted. Sitting on the boundary was
+    /// untested; a future change of `>` to `>=` would silently make every
+    /// four-entry payload with one stray fatal again.
+    #[test]
+    fn exactly_the_tolerated_fraction_is_accepted() {
+        let raw = serde_json::json!({
+            "nodes": [],
+            "edges": [
+                {"source_node_id": "a", "target_node_id": "b", "relationship_name": "r"},
+                {"source_node_id": "b", "target_node_id": "c", "relationship_name": "r"},
+                {"source_node_id": "c", "target_node_id": "d", "relationship_name": "r"},
+                // 1 of 4 = 25.0%, which is not *greater than* 25%.
+                {"source_node_id": "Sister", "name": "Alice's Sister",
+                 "type": "PERSON", "description": "The stray."}
+            ]
+        });
+        let graph: KnowledgeGraph = serde_json::from_value(raw)
+            .expect("1/4 is exactly the tolerance and the comparison is strictly greater-than");
+        assert_eq!(graph.edge_count(), 3);
+    }
+
+    /// One entry past the boundary — 2 of 4 — is rejected, so the accepted case
+    /// above is a boundary and not an accident of the fixture.
+    #[test]
+    fn one_entry_past_the_boundary_is_rejected() {
+        let raw = serde_json::json!({
+            "nodes": [],
+            "edges": [
+                {"source_node_id": "a", "target_node_id": "b", "relationship_name": "r"},
+                {"source_node_id": "b", "target_node_id": "c", "relationship_name": "r"},
+                {"source_node_id": "x", "name": "X", "type": "PERSON", "description": "stray"},
+                {"source_node_id": "y", "name": "Y", "type": "PERSON", "description": "stray"}
+            ]
+        });
+        assert!(
+            serde_json::from_value::<KnowledgeGraph>(raw).is_err(),
+            "2/4 = 50% > 25%"
+        );
+    }
+
+    /// The corollary of a 25% tolerance: an array of fewer than four entries has
+    /// **zero** tolerance, because one drop out of three is already 33%. This is
+    /// intended — on a three-edge payload there is too little left to trust —
+    /// but it is worth pinning, because it is the case where "we tolerate a
+    /// quarter" reads most misleadingly.
+    #[test]
+    fn arrays_shorter_than_four_entries_tolerate_nothing() {
+        let stray = serde_json::json!({"source_node_id": "s", "name": "S", "type": "P", "description": "d"});
+        let good = serde_json::json!({"source_node_id": "a", "target_node_id": "b", "relationship_name": "r"});
+
+        for good_count in 0..3 {
+            let mut edges: Vec<serde_json::Value> = vec![good.clone(); good_count];
+            edges.push(stray.clone());
+            let total = edges.len();
+            let raw = serde_json::json!({ "nodes": [], "edges": edges });
+            assert!(
+                serde_json::from_value::<KnowledgeGraph>(raw).is_err(),
+                "1 stray out of {total} is > 25% and must reach the retry loop"
+            );
+        }
+    }
+
+    /// The `edges` explanation must stay OFF the field's doc comment.
+    ///
+    /// `schemars` copies a field's `///` into that property's JSON-schema
+    /// `description`, and this schema is sent to the model on every extraction
+    /// call. Describing a private Rust deserializer there spends prompt tokens
+    /// and, worse, tells the model a tolerance exists. The comment on the field
+    /// is therefore a plain `//`; this test is what keeps it that way.
+    #[test]
+    fn the_model_facing_schema_carries_no_implementation_detail() {
+        let schema = cognee_llm::schema::generate_json_schema::<KnowledgeGraph>();
+        let rendered = schema.to_string();
+
+        // Precondition: field docs really do reach the model, so the assertion
+        // below is testing something. `nodes` keeps its `///` and its text is
+        // in the schema.
+        assert!(
+            rendered.contains("serde(default)") || rendered.contains("schemars honours serde"),
+            "precondition failed: field doc comments are expected to appear in the \
+             generated schema, so this test would be vacuous. Schema: {rendered}"
+        );
+
+        for leak in [
+            "deserialize_edges_lenient",
+            "malformed",
+            "MAX_DROPPABLE_EDGE_FRACTION",
+        ] {
+            assert!(
+                !rendered.contains(leak),
+                "the model-facing schema leaks the internal `{leak}`; keep the \
+                 lenient-deserialization note on a `//` comment, not a `///` one"
+            );
+        }
     }
 }

--- a/crates/cognify/src/fact_extraction/models.rs
+++ b/crates/cognify/src/fact_extraction/models.rs
@@ -595,4 +595,69 @@ mod tests {
             );
         }
     }
+
+    /// The schema must list properties in DECLARATION order, not alphabetically.
+    ///
+    /// This is the single highest-impact finding of the Bedrock runaway
+    /// investigation, and it is invisible in code review — the schema is
+    /// semantically identical either way, so only this test can hold it.
+    ///
+    /// `schemars` keys its `properties` map on [`schemars::Map`], which is a
+    /// `BTreeMap` (alphabetical) unless the `preserve_order` feature is on, in
+    /// which case it is an `IndexMap` (declaration order). The workspace
+    /// `Cargo.toml` turns that feature on **for this reason and no other**.
+    ///
+    /// Why it matters. Alphabetical order puts `Edge.target_node_id` LAST, after
+    /// the free-text `description`, and `Node.description` FIRST. Declaration
+    /// order (which is also Pydantic's, hence Python's) writes the two endpoint
+    /// ids adjacently and defers free text to the end. Measured on Bedrock
+    /// Sonnet 4.5, 250 calls, one runaway-prone chunk held fixed:
+    ///
+    /// | properties order | truncated at an 8192 cap | max output |
+    /// |---|---|---|
+    /// | alphabetical (schemars default) | 13/68 = 19% | 8192 (censored) |
+    /// | declaration (this) | **0/58 = 0%** | 2732 |
+    ///
+    /// Fisher exact two-sided p = 0.0002 pooled; p = 0.0057 for the baseline
+    /// against exactly the shape this test pins. The degenerate mode it removes
+    /// is a free-association loop inside `Edge.target_node_id` — one captured
+    /// payload spent 22,305 chars (94% of the answer) on a single node id.
+    ///
+    /// If a future schemars bump drops `preserve_order`, or someone reorders the
+    /// fields, this test is the only thing that will notice.
+    #[test]
+    fn schema_properties_are_in_declaration_order() {
+        let schema = cognee_llm::schema::generate_json_schema::<KnowledgeGraph>();
+
+        fn keys(v: &serde_json::Value) -> Vec<&str> {
+            v.as_object()
+                .expect("every `properties` value is a JSON object")
+                .keys()
+                .map(String::as_str)
+                .collect()
+        }
+
+        assert_eq!(
+            keys(&schema["definitions"]["Node"]["properties"]),
+            ["id", "name", "type", "description"],
+            "Node properties must be in declaration order — see this test's docs"
+        );
+        assert_eq!(
+            keys(&schema["definitions"]["Edge"]["properties"]),
+            [
+                "source_node_id",
+                "target_node_id",
+                "relationship_name",
+                "description"
+            ],
+            "Edge properties must be in declaration order: the two endpoint ids \
+             adjacent, free text last — see this test's docs"
+        );
+        assert_eq!(
+            keys(&schema["properties"]),
+            ["nodes", "edges"],
+            "nodes must precede edges: the model cannot reference a node id in an \
+             edge it has not declared yet"
+        );
+    }
 }

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -37,10 +37,11 @@ thiserror.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 serde.workspace = true
-# `preserve_order` keeps `serde_json::Map` insertion-ordered so entity
+# serde_json's `preserve_order` (workspace root) keeps `serde_json::Map`
+# insertion-ordered so entity
 # `to_dict()` helpers (e.g. `session_record::Model::to_dict`) can match
 # the field ordering of Python's `to_dict()` byte-for-byte.
-serde_json = { workspace = true, features = ["preserve_order"] }
+serde_json.workspace = true
 # Only the sqlite connect path uses `spawn_blocking` (for the WAL writability
 # probe); gated behind the `sqlite` feature so non-sqlite builds don't link it.
 tokio = { workspace = true, optional = true }

--- a/crates/ingestion/src/loaders/pdf/mod.rs
+++ b/crates/ingestion/src/loaders/pdf/mod.rs
@@ -34,7 +34,7 @@ pub struct PdfLoader;
 #[async_trait]
 impl DocumentLoader for PdfLoader {
     async fn extract(&self, bytes: &[u8], _doc: &Document) -> Result<LoaderOutput, LoaderError> {
-        let text = extract_impl(bytes)?;
+        let text = extract_impl(bytes).await?;
         Ok(LoaderOutput::Text(text))
     }
 
@@ -43,12 +43,17 @@ impl DocumentLoader for PdfLoader {
     }
 }
 
+/// Resolving the PDFium library is async because on a cold cache it downloads
+/// libpdfium with a *blocking* HTTP client, which has to be driven from
+/// `spawn_blocking` — doing it inline aborted the process. See
+/// [`pdfium`] for the full story.
 #[cfg(feature = "pdf-pdfium")]
-fn extract_impl(bytes: &[u8]) -> Result<String, LoaderError> {
-    pdfium::extract_text(bytes)
+async fn extract_impl(bytes: &[u8]) -> Result<String, LoaderError> {
+    let lib_path = pdfium::ensure_library().await?;
+    pdfium::extract_text(bytes, lib_path)
 }
 
 #[cfg(all(feature = "pdf-pure-rust", not(feature = "pdf-pdfium")))]
-fn extract_impl(bytes: &[u8]) -> Result<String, LoaderError> {
+async fn extract_impl(bytes: &[u8]) -> Result<String, LoaderError> {
     pure_rust::extract_text(bytes)
 }

--- a/crates/ingestion/src/loaders/pdf/pdfium.rs
+++ b/crates/ingestion/src/loaders/pdf/pdfium.rs
@@ -6,17 +6,77 @@
 //! first use.
 //!
 //! Gated behind the `pdf-pdfium` feature.
+//!
+//! # Why library resolution is split out of extraction
+//!
+//! `pdfium_auto::ensure_pdfium_library` downloads libpdfium with
+//! `reqwest::blocking`, and building a blocking reqwest client constructs and
+//! then drops a tokio runtime. Dropping a runtime from inside an async context
+//! aborts the process with
+//!
+//! > Cannot drop a runtime in a context where blocking is not allowed.
+//!
+//! so calling it directly from `DocumentLoader::extract` made the *first* PDF
+//! ingested on any machine with a cold `~/.cache/pdf2md/` a hard `exit 101` —
+//! every fresh container, CI runner and new developer checkout. The download is
+//! therefore driven from [`tokio::task::spawn_blocking`], where blocking (and
+//! hence a runtime drop) is permitted. The fix has to live here: `pdfium-auto`
+//! 0.3.1 is the latest published version and exposes no async entry point.
+
+use std::path::{Path, PathBuf};
+
+use tokio::sync::OnceCell;
 
 use super::format::format_pages;
 use crate::loaders::LoaderError;
 
+/// Process-wide memo for the resolved `libpdfium` path.
+///
+/// `pdfium_auto::ensure_pdfium_library` keeps its own `OnceLock`, so this is
+/// not about avoiding repeated filesystem work — it is about not letting N
+/// concurrent first-time ingests each occupy a blocking-pool thread queued on
+/// pdfium-auto's advisory extract lock. Failures are not memoized
+/// (`get_or_try_init` only stores on success), so a transient network error
+/// does not poison the process.
+static PDFIUM_LIB: OnceCell<PathBuf> = OnceCell::const_new();
+
+/// Resolves the `libpdfium` shared library, downloading it on first use.
+///
+/// Runs the (blocking, network-touching) resolution on the blocking pool. See
+/// the module docs for why that is load-bearing rather than merely tidy.
+pub(super) async fn ensure_library() -> Result<&'static Path, LoaderError> {
+    let path = PDFIUM_LIB
+        .get_or_try_init(|| async {
+            tokio::task::spawn_blocking(|| pdfium_auto::ensure_pdfium_library(None))
+                .await
+                .map_err(|e| {
+                    LoaderError::ExtractionFailed(format!(
+                        "PDFium library resolution task failed: {e}"
+                    ))
+                })?
+                .map_err(|e| {
+                    LoaderError::ExtractionFailed(format!(
+                        "Failed to obtain the PDFium library: {e}. Set PDFIUM_LIB_PATH to an \
+                         existing libpdfium shared library to skip the download."
+                    ))
+                })
+        })
+        .await?;
+
+    Ok(path.as_path())
+}
+
 /// Extract text from PDF bytes using the PDFium backend.
+///
+/// `lib_path` comes from [`ensure_library`]; binding to an already-resolved
+/// path is pure `dlopen`, with no network and no runtime construction, so it is
+/// safe to run inline on the async worker.
 ///
 /// Returns the formatted text with page headers matching the Python
 /// `pypdf_loader.py` output format. Per-page errors are logged and
 /// skipped; the extraction continues with remaining pages.
-pub fn extract_text(bytes: &[u8]) -> Result<String, LoaderError> {
-    let pdfium = pdfium_auto::bind_pdfium_silent().map_err(|e| {
+pub fn extract_text(bytes: &[u8], lib_path: &Path) -> Result<String, LoaderError> {
+    let pdfium = pdfium_auto::bind_pdfium_from_path(lib_path).map_err(|e| {
         LoaderError::ExtractionFailed(format!("Failed to load PDFium library: {e}"))
     })?;
 

--- a/crates/ingestion/src/pipeline.rs
+++ b/crates/ingestion/src/pipeline.rs
@@ -2041,13 +2041,14 @@ mod tests {
     /// it: the error type is erased by the task wrapper (`add` yields
     /// `Box<dyn Error>`, and `downcast_ref` for `IngestionError`/`LoaderError`
     /// is `None` at every level of the source chain, so a variant assertion
-    /// would be vacuous), and the pdfium backend panics rather than erroring
-    /// when no libpdfium is present — `pdfium_auto::bind_pdfium_silent()`
-    /// builds a tokio runtime and drops it inside async, which aborts the test
-    /// under both current-thread and multi-thread flavours. That panic is a
-    /// real pre-existing defect in the pdfium path, unrelated to loader
-    /// registration and tracked separately; a registration assertion is
-    /// backend-agnostic, needs no PDF fixture, and pins exactly what #102 was.
+    /// would be vacuous), and on a cold cache the pdfium backend would have to
+    /// download a ~7 MB libpdfium. A registration assertion is backend-agnostic,
+    /// needs no PDF fixture and no network, and pins exactly what #102 was.
+    ///
+    /// The cold-cache abort this comment used to describe — `bind_pdfium_silent`
+    /// building and dropping a tokio runtime inside async — is fixed; the
+    /// download now runs on `spawn_blocking`, and
+    /// `tests/pdf_pdfium_cold_cache.rs` pins that it errors rather than aborts.
     #[cfg(any(feature = "pdf-pdfium", feature = "pdf-pure-rust"))]
     #[test]
     fn test_pdf_loader_is_registered_when_a_backend_is_enabled() {

--- a/crates/ingestion/tests/pdf_pdfium_cold_cache.rs
+++ b/crates/ingestion/tests/pdf_pdfium_cold_cache.rs
@@ -1,0 +1,93 @@
+#![cfg(feature = "pdf-pdfium")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are acceptable failures"
+)]
+//! Regression test: ingesting a PDF with a cold `pdf2md` cache must not abort.
+//!
+//! `pdfium_auto::ensure_pdfium_library` downloads libpdfium with
+//! `reqwest::blocking`, and building a blocking reqwest client constructs and
+//! drops a tokio runtime. Dropped from inside an async context that aborts with
+//!
+//! > Cannot drop a runtime in a context where blocking is not allowed.
+//!
+//! which made the first PDF ingested on any machine without a warm
+//! `~/.cache/pdf2md/pdfium-<ver>/` a hard `exit 101` — every fresh container, CI
+//! runner and new developer checkout. The fix drives the download from
+//! `spawn_blocking`.
+//!
+//! # Why this test needs no reachable network
+//!
+//! The panic happened in `reqwest::blocking::ClientBuilder::build()`, *before*
+//! any request was sent, so merely *reaching* the download is enough to trigger
+//! it. The test therefore points `PDFIUM_AUTO_CACHE_DIR` at an empty temp dir
+//! (guaranteeing a cache miss) and `https_proxy` at a dead loopback port, so the
+//! download attempt fails immediately instead of pulling ~6 MB from GitHub.
+//!
+//! The assertion is deliberately "it returned at all": on a runner where the
+//! proxy is bypassed the real download may succeed, and that is equally fine.
+//! What must never happen is the process dying. Before the fix this test aborts
+//! the whole test binary; after it, it returns `Err` (or `Ok`).
+//!
+//! `PDFIUM_AUTO_CACHE_DIR` is only honoured on the *first* resolution in a
+//! process (`pdfium-auto` memoizes into a `OnceLock`, and so does the loader),
+//! so this file deliberately contains exactly one test.
+
+use cognee_ingestion::loaders::DocumentLoader;
+use cognee_ingestion::loaders::pdf::PdfLoader;
+use cognee_models::{DataPoint, Document};
+use uuid::Uuid;
+
+/// The smallest thing that is structurally a PDF. Extraction never gets this
+/// far on a cold cache, and if it does the parse error is still an `Err`, not a
+/// panic — which is exactly what is being pinned.
+const MINIMAL_PDF: &[u8] =
+    b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\ntrailer\n<< /Root 1 0 R >>\n%%EOF\n";
+
+/// Multi-threaded on purpose: it is the flavour the CLI and HTTP server run,
+/// and the one the original `exit 101` was reported on.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cold_pdfium_cache_errors_instead_of_aborting() {
+    let cache = tempfile::tempdir().expect("tempdir");
+
+    // SAFETY (edition 2024): this test binary contains a single test, so no
+    // other thread is reading the environment concurrently.
+    unsafe {
+        std::env::set_var("PDFIUM_AUTO_CACHE_DIR", cache.path());
+        // Force a cache miss even if the developer has a warm real cache.
+        std::env::remove_var("PDFIUM_LIB_PATH");
+        // `PDFIUM_NO_AUTO_DOWNLOAD` would short-circuit *before* the blocking
+        // client is built, so it would pass even against the unfixed code.
+        std::env::remove_var("PDFIUM_NO_AUTO_DOWNLOAD");
+        // Fail the download fast rather than fetching ~6 MB.
+        std::env::set_var("https_proxy", "http://127.0.0.1:9");
+        std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:9");
+        std::env::remove_var("no_proxy");
+        std::env::remove_var("NO_PROXY");
+    }
+
+    let doc = Document {
+        base: DataPoint::new("PdfDocument", None),
+        document_type: "pdf".to_string(),
+        name: "cold-cache.pdf".to_string(),
+        raw_data_location: "file:///cold-cache.pdf".to_string(),
+        mime_type: "application/pdf".to_string(),
+        extension: "pdf".to_string(),
+        data_id: Uuid::new_v4(),
+        external_metadata: None,
+    };
+
+    // Reaching the line after this one at all is the assertion: the unfixed
+    // code aborts the process inside `extract`.
+    let result = PdfLoader.extract(MINIMAL_PDF, &doc).await;
+
+    if let Err(e) = result {
+        let msg = e.to_string();
+        assert!(
+            msg.contains("PDFIUM_LIB_PATH"),
+            "a failure to obtain libpdfium must tell the operator how to supply \
+             one; got: {msg}"
+        );
+    }
+}

--- a/crates/ingestion/tests/pdf_pdfium_cold_cache.rs
+++ b/crates/ingestion/tests/pdf_pdfium_cold_cache.rs
@@ -82,12 +82,26 @@ async fn cold_pdfium_cache_errors_instead_of_aborting() {
     // code aborts the process inside `extract`.
     let result = PdfLoader.extract(MINIMAL_PDF, &doc).await;
 
+    // The proxy is a best-effort way to keep the download from succeeding; a
+    // machine with NO_PROXY set, a proxy-exempt route, or a warm pdfium cache
+    // can still resolve the library. In that case `MINIMAL_PDF` — deliberately
+    // the smallest thing that is structurally a PDF — may fail in the PARSER
+    // instead, which is a different error and must not be held to the
+    // resolution hint. Assert the hint only on the error this test is about.
     if let Err(e) = result {
         let msg = e.to_string();
-        assert!(
-            msg.contains("PDFIUM_LIB_PATH"),
-            "a failure to obtain libpdfium must tell the operator how to supply \
-             one; got: {msg}"
-        );
+        // Keyed on the resolution error's own prefix, not the word "PDFium".
+        // `extract_text`'s *bind* failure is "Failed to load PDFium library: …"
+        // (pdfium.rs:80) — it contains "PDFium" but cannot contain the hint, so
+        // a looser predicate turns a truncated download or an arch mismatch
+        // into a spurious failure of a test that is about the process abort.
+        let is_resolution_failure = msg.contains("Failed to obtain the PDFium library");
+        if is_resolution_failure {
+            assert!(
+                msg.contains("PDFIUM_LIB_PATH"),
+                "a failure to obtain libpdfium must tell the operator how to supply \
+                 one; got: {msg}"
+            );
+        }
     }
 }

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -42,6 +42,11 @@ async-trait.workspace = true
 
 # Serialization
 serde.workspace = true
+# serde_json's `preserve_order` is LOAD-BEARING here, and comes from the
+# workspace root (see the note there). `generate_json_schema` ends with
+# `serde_json::to_value(schema)`, so without it the schema's properties are
+# re-sorted ALPHABETICALLY on the wire — which measured a 19% LLM runaway rate
+# against 0% for declaration order (Fisher p=0.0002).
 serde_json.workspace = true
 
 # JSON Schema generation

--- a/crates/migration/src/export.rs
+++ b/crates/migration/src/export.rs
@@ -204,13 +204,12 @@ pub fn write_cogx(
 /// Python's `{"id": str(node_id), **properties}`.
 ///
 /// Properties are emitted in sorted key order. `NodeData` is a `HashMap`, so
-/// its iteration order changes between runs, and the workspace enables
-/// serde_json's `preserve_order` (via `cognee-database`), which makes
-/// `serde_json::Map` an insertion-ordered `IndexMap` rather than a sorted
-/// `BTreeMap` — together those would leak the hash order straight into the
-/// file. JSON object order carries no meaning to the importer, but a
-/// non-reproducible export cannot be diffed between runs or checked against a
-/// golden archive.
+/// its iteration order changes between runs, and the workspace root enables
+/// serde_json's `preserve_order`, which makes `serde_json::Map` an
+/// insertion-ordered `IndexMap` rather than a sorted `BTreeMap` — together
+/// those would leak the hash order straight into the file. JSON object order
+/// carries no meaning to the importer, but a non-reproducible export cannot be
+/// diffed between runs or checked against a golden archive.
 fn raw_node_value(node_id: &str, properties: &cognee_graph::NodeData) -> serde_json::Value {
     let mut map = serde_json::Map::new();
     map.insert(

--- a/crates/utils/src/sanitize.rs
+++ b/crates/utils/src/sanitize.rs
@@ -76,10 +76,10 @@ pub fn sanitize_string(mut value: String) -> String {
 ///
 /// This crate deliberately does not enable the feature itself, because doing so
 /// would force the `IndexMap` backing on every downstream consumer of
-/// `cognee-utils` (see the dependency comment in `Cargo.toml`). Every cognee
-/// build gets the Python rule regardless, via `cognee-database` and
-/// `cognee-visualization`. The divergence is reachable only when one object
-/// holds two keys differing by nothing but an embedded NUL.
+/// `cognee-utils` (see the dependency comment in `Cargo.toml`). Every in-workspace
+/// cognee build gets the Python rule regardless, via the workspace root's
+/// `serde_json/preserve_order` setting. The divergence is reachable only when
+/// one object holds two keys differing by nothing but an embedded NUL.
 pub fn sanitize_json_in_place(value: &mut Value) {
     match value {
         Value::String(s) => {

--- a/crates/visualization/Cargo.toml
+++ b/crates/visualization/Cargo.toml
@@ -18,16 +18,16 @@ workspace = true
 cognee-graph = { path = "../graph", version = "0.2.0" }
 dirs = { workspace = true }
 serde = { workspace = true }
-# `preserve_order` keeps `serde_json::Map` insertion-ordered, which the Schema
+# serde_json's `preserve_order` (workspace root) keeps `serde_json::Map`
+# insertion-ordered, which the Schema
 # tab's field selection depends on: Python's `Counter.most_common()` tie-break is
 # first-seen key order, so the derived renderer keys (`degree`, `importance`, …)
 # must stay *after* the database properties they are appended to. Without the
 # feature `Map` is a `BTreeMap`, every key is globally alphabetical and
-# `degree`/`importance` outrank `document_id`/`version`. The workspace build gets
-# the feature via `cognee-database`; declaring it here is what makes
-# `cargo test -p cognee-visualization` observe the same ordering as the shipped
-# binary. See `preprocessor::schema_graph::extract_type_schema_fields`.
-serde_json = { workspace = true, features = ["preserve_order"] }
+# `degree`/`importance` outrank `document_id`/`version`. The feature is enabled
+# at the workspace root, so a per-crate build observes the same ordering as the
+# shipped binary. See `preprocessor::schema_graph::extract_type_schema_fields`.
+serde_json.workspace = true
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
 tracing = { workspace = true }

--- a/crates/visualization/src/preprocessor/schema_graph.rs
+++ b/crates/visualization/src/preprocessor/schema_graph.rs
@@ -319,13 +319,12 @@ fn field_from_column(column: &Value) -> Option<Value> {
 ///
 /// Parity note: for the **object**-shaped `columns` payload Python emits fields
 /// in the payload's own key order, which requires an insertion-ordered
-/// `serde_json::Map`. That is why this crate declares
-/// `serde_json/preserve_order` itself (`Cargo.toml`) instead of relying on
-/// feature unification to leak it in from `cognee-database` — a `-p
-/// cognee-visualization` build used to key-sort the payload and emit a different
-/// field order than the shipped workspace binary. The array-shaped payload (what
-/// DLT actually writes) is unaffected either way, as is every field's
-/// name/type/required content.
+/// `serde_json::Map`. The workspace root therefore enables
+/// `serde_json/preserve_order` for every crate, so a `-p cognee-visualization`
+/// build observes the same field order as the shipped workspace binary instead
+/// of key-sorting the payload. The array-shaped payload (what DLT actually
+/// writes) is unaffected either way, as is every field's name/type/required
+/// content.
 pub fn extract_schema_fields(node: &Value) -> Vec<Value> {
     let mut fields: Vec<Value> = Vec::new();
     let columns = coerce_json_value(node.get("columns"));
@@ -490,12 +489,12 @@ fn schema_value_type(value: &Value) -> &'static str {
 /// 1. **Derived keys must never outrank adapter properties.** They do not,
 ///    because `super::props_to_object` inserts the adapter's properties before
 ///    `preprocess()` stamps `degree`/`importance`/`stage`/… — but only while
-///    `serde_json::Map` is insertion ordered. This crate therefore declares
-///    `serde_json/preserve_order` in its own `Cargo.toml`; without it `Map` is a
-///    `BTreeMap`, *every* key is globally alphabetical, and a `DocumentChunk`
-///    card reads `…, chunk_index, degree` where Python reads
-///    `…, chunk_index, document_id`. `tests/preprocessor_test.rs::
-///    type_card_fields_prefer_database_properties_over_derived_keys` pins this.
+///    `serde_json::Map` is insertion ordered. The workspace root therefore
+///    enables `serde_json/preserve_order`; without it `Map` is a `BTreeMap`,
+///    *every* key is globally alphabetical, and a `DocumentChunk` card reads
+///    `…, chunk_index, degree` where Python reads `…, chunk_index, document_id`.
+///    `tests/preprocessor_test.rs::type_card_fields_prefer_database_properties_
+///    over_derived_keys` pins this.
 /// 2. **Ties *between* adapter properties are still ordered differently.**
 ///    Python sees them in `json.dumps()` (model-field) order; Rust sees them
 ///    key-sorted, because `super::props_to_object` must impose *some* order on

--- a/crates/visualization/tests/preprocessor_test.rs
+++ b/crates/visualization/tests/preprocessor_test.rs
@@ -789,10 +789,10 @@ fn schema_data_is_passed_through() {
 ///
 /// Rust reproduces the *grouping* by inserting the adapter's properties before
 /// any derived key, which only holds when `serde_json::Map` is insertion-ordered.
-/// Without the `preserve_order` feature declared in this crate's `Cargo.toml`,
-/// `Map` is a `BTreeMap`, every key is globally alphabetical, and `degree` /
-/// `importance` displace `document_id` / `version` on the type card. The two
-/// expected lists below are the Python-observed ones.
+/// Without the workspace's `serde_json/preserve_order` feature, `Map` is a
+/// `BTreeMap`, every key is globally alphabetical, and `degree` / `importance`
+/// displace `document_id` / `version` on the type card. The two expected lists
+/// below are the Python-observed ones.
 #[test]
 fn type_card_fields_prefer_database_properties_over_derived_keys() {
     // Only `chunk_index` / `document_id` (chunk) and `version` (document) are


### PR DESCRIPTION
Occasional extraction calls on Bedrock/Sonnet 4.5 generated to the model's 64000-token
maximum, taking 430-785s and dominating the run (extraction joins the whole batch before
inspecting any result, so one call sets the stage wall-clock). Measured incidence across
seven instrumented runs: 10/183 calls, ~5.5%.

## The cause: JSON property order

`schemars` keys `properties` on a `BTreeMap`, so the schema went out **alphabetically**.
For `Edge` that places `target_node_id` **last, immediately after the free-text
`description`**. The model emits keys in schema order, so it was being asked to write an
identifier as the continuation of a paragraph — and that is precisely where every runaway
lived.

A captured payload: 8 ordinary nodes, 1 edge, and a single `Edge.target_node_id` string
**22,305 characters long (94.4% of the answer)** — a free-association chain that locks onto
a template (`fellow_crews_fellow_gangs_fellow_packs...`, the word "fellow" 440 times) —
after which the model wrote *"I notice I made an error by creating an impossibly long node
ID"* and produced a perfectly ordinary graph.

Pydantic serialises in **declaration** order, which keeps the endpoint ids adjacent and
free text last. That is the whole of Python's apparent immunity: not a safeguard, an
accident of a different serialiser.

## Measurement

250 Bedrock calls against `us.anthropic.claude-sonnet-4-5`, `maxTokens: 8192` used as an
instrument so a would-be runaway truncates cheaply instead of costing 64000 tokens.

| properties order | truncated @8192 | max output |
|---|---|---|
| alphabetical | **13/68 = 19%** | 8192 (censored) |
| declaration  | **0/58 = 0%**   | 2732 |

Fisher exact p = 0.0002 pooled; p = 0.0057 baseline vs the shipped shape.

Isolation is clean: one arm changed **only** the key order, with the schema byte-size
identical at 1570 chars both ways — truncations went 4/26 to 0/18. `required` order is
irrelevant; `properties` order is everything.

Note the medians *rise* slightly under the fix. This kills the tail, not the bulk — the
earlier "Rust is 38% more verbose" reading was measuring the wrong statistic.

## Also in this commit

Internal rustdoc demoted from `///` to `//` so it stops reaching the model. `schemars`
copies every `///` on a field into that property's JSON-schema `description`, and three of
ours were implementation notes — including a 753-char explanation of `#[serde(default)]`
and schemars behaviour. Wire schema 3609 -> 1570 chars, ~575 prompt tokens saved per call.

`Node.description` keeps its field, its required-ness and its model-facing hint, so #66 is
untouched.

## Deliberately NOT changed

- **No `max_tokens` cap.** Python does not send one unless explicitly configured, and #190
  established that invariant deliberately. A cap would bound the symptom; the order fix
  removes the cause. With order fixed the largest observed output is 2732.
- **No `maxLength` on string fields.** Measured to be **advisory, not enforced**: probing
  with `Node.id` capped at 5 returned ids of 13 and 14 characters with no error, and when
  the model did comply it produced mangled ids (`Wland`, `LilSi`). Python bounds string
  length nowhere either.
- **The three extra prompt lines stay.** Removing them was the *worst* arm tested (5/32),
  and they are the deliberate fix for #66 on Groq.

## Preceding commits on this branch

Three independently validated fixes, each adversarially re-checked in its own worktree:
`fix(ingestion)` cold pdfium cache aborting the process; `fix(cognify)` surviving a stray
node object in `edges`; `feat(cognify)` letting a file survive a chunk its LLM could not
extract, bounded by the existing failure ratio.

`schema_properties_are_in_declaration_order()` pins the fix, because a `schemars` bump or an
innocent field reorder would silently undo it.

fmt, clippy -D warnings, 342 cognify lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01374TL13k6r1CN8v6iJnhH9